### PR TITLE
Fix: GLA Battle Bus second life visual bug

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18421,12 +18421,18 @@ Object Chem_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ; Set after our first death, natch
       Model = UVBATTBUS_D1
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE
     
     ConditionState = RUBBLE
@@ -18464,6 +18470,10 @@ Object Chem_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01
@@ -18471,7 +18481,9 @@ Object Chem_GLAVehicleBattleBus
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_ONE
@@ -18507,13 +18519,19 @@ Object Chem_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01 BUSUP02
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO 
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_TWO

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20672,6 +20672,10 @@ Object Demo_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01
@@ -20679,11 +20683,6 @@ Object Demo_GLAVehicleBattleBus
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
-
-    ; @bugfix - hanfield
-    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
-    ; 22/08/2021
-
     AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
@@ -20722,17 +20721,16 @@ Object Demo_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01 BUSUP02
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
-
-    ; @bugfix - hanfield
-    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
-    ; 22/08/2021
-
     AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO 
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20623,12 +20623,18 @@ Object Demo_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ; Set after our first death, natch
       Model = UVBATTBUS_D1
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE
     
     ConditionState = RUBBLE
@@ -20673,7 +20679,14 @@ Object Demo_GLAVehicleBattleBus
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_ONE
@@ -20715,7 +20728,14 @@ Object Demo_GLAVehicleBattleBus
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO 
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_TWO

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6058,12 +6058,18 @@ Object GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ; Set after our first death, natch
       Model = UVBATTBUS_D1
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE
     
     ConditionState = RUBBLE
@@ -6101,6 +6107,10 @@ Object GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01
@@ -6108,7 +6118,9 @@ Object GLAVehicleBattleBus
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_ONE
@@ -6144,13 +6156,19 @@ Object GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01 BUSUP02
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO 
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_TWO

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19929,12 +19929,18 @@ Object Slth_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ; Set after our first death, natch
       Model = UVBATTBUS_D1
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE
     
     ConditionState = RUBBLE
@@ -19972,6 +19978,10 @@ Object Slth_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01
@@ -19979,7 +19989,9 @@ Object Slth_GLAVehicleBattleBus
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_ONE
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_ONE
@@ -20015,13 +20027,19 @@ Object Slth_GLAVehicleBattleBus
       AnimationMode = LOOP
     End
 
+    ; @bugfix - hanfield
+    ; Added two extra AliasConditionStates so the Bus uses the right model when ordered to move in bunker mode.
+    ; 22/08/2021
+
     ConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
       Model = UVBATTBUS_D1
       ShowSubObject = BUSUP01 BUSUP02
       Animation = UVBATTBUS_D1.UVBATTBUS_D1
       AnimationMode = MANUAL
     End
+    AliasConditionState = SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO 
+    AliasConditionState = REALLYDAMAGED SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO MOVING
     AliasConditionState = RUBBLE SECOND_LIFE ARMORSET_CRATEUPGRADE_TWO
     
     ConditionState = RUBBLE ARMORSET_CRATEUPGRADE_TWO


### PR DESCRIPTION
Battle Buses, when reduced to bunker state and ordered to move, will use the default-undamaged-model for a split second. This commit fixes this across all GLA buses.