### PR TITLE
Fix: China Tank and China Nuke Listening Outpost attack behavior

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4745,7 +4745,7 @@ Object Nuke_ChinaVehicleListeningOutpost
   ; @bugfix - hanfield
   ; Replaced the AssaultTransportAIUpdate module with TransportAIUpdate.
   ; This should make the Listening Outpost behave better in combat.
-  ; d/y/2021
+  ; 22/08/2021
 
   ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
   ;  MembersGetHealedAtLifeRatio = 0.5

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4742,9 +4742,19 @@ Object Nuke_ChinaVehicleListeningOutpost
     IRParticleSysBone         = IRFX
   End
 
-  Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
-    MembersGetHealedAtLifeRatio = 0.5
+  ; @bugfix - hanfield
+  ; Replaced the AssaultTransportAIUpdate module with TransportAIUpdate.
+  ; This should make the Listening Outpost behave better in combat.
+  ; d/y/2021
+
+  ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
+  ;  MembersGetHealedAtLifeRatio = 0.5
+  ;End
+
+  Behavior = TransportAIUpdate ModuleTag_FixedAI
+    AutoAcquireEnemiesWhenIdle = No ; let the contained do it for themselves
   End
+
   Behavior = StealthUpdate ModuleTag_04
     StealthDelay                = 2000 ; msec
     StealthForbiddenConditions  = MOVING RIDERS_ATTACKING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4876,7 +4876,7 @@ Object Tank_ChinaVehicleListeningOutpost
   ; @bugfix - hanfield
   ; Replaced the AssaultTransportAIUpdate module with TransportAIUpdate.
   ; This should make the Listening Outpost behave better in combat.
-  ; d/y/2021
+  ; 22/08/2021
 
   ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
   ;  MembersGetHealedAtLifeRatio = 0.5
@@ -4885,7 +4885,7 @@ Object Tank_ChinaVehicleListeningOutpost
   Behavior = TransportAIUpdate ModuleTag_FixedAI
     AutoAcquireEnemiesWhenIdle = No ; let the contained do it for themselves
   End
-  
+
   Behavior = StealthUpdate ModuleTag_04
     StealthDelay                = 2000 ; msec
     StealthForbiddenConditions  = MOVING RIDERS_ATTACKING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4873,9 +4873,19 @@ Object Tank_ChinaVehicleListeningOutpost
     IRParticleSysBone         = IRFX
   End
 
-  Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
-    MembersGetHealedAtLifeRatio = 0.5
+  ; @bugfix - hanfield
+  ; Replaced the AssaultTransportAIUpdate module with TransportAIUpdate.
+  ; This should make the Listening Outpost behave better in combat.
+  ; d/y/2021
+
+  ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
+  ;  MembersGetHealedAtLifeRatio = 0.5
+  ;End
+
+  Behavior = TransportAIUpdate ModuleTag_FixedAI
+    AutoAcquireEnemiesWhenIdle = No ; let the contained do it for themselves
   End
+  
   Behavior = StealthUpdate ModuleTag_04
     StealthDelay                = 2000 ; msec
     StealthForbiddenConditions  = MOVING RIDERS_ATTACKING


### PR DESCRIPTION
Tank and Nuke Listening Outposts could not force fire and acted erratic in combat. This commit should fix it.