### PR TITLE
Fix: USA and China Microwave Tank negative power bug

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -9677,11 +9677,24 @@ Object AirF_AmericaPowerPlant
   EnergyBonus      = 5
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions     = None
-    Armor          = StructureArmor
-    DamageFX       = StructureDamageFXNoShake
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
+    DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+
   CommandSet       = AirF_AmericaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
@@ -9751,6 +9764,23 @@ Object AirF_AmericaPowerPlant
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+  
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -9769,18 +9769,18 @@ Object AirF_AmericaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   Geometry            = BOX
@@ -14598,18 +14598,18 @@ Object AirF_AmericaSupplyDropZone
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 22/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
   
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -4820,11 +4820,24 @@ Object AmericaPowerPlant
   EnergyBonus      = 5
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions     = None
-    Armor          = StructureArmor
-    DamageFX       = StructureDamageFXNoShake
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
+    DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+
   CommandSet       = AmericaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
@@ -4894,6 +4907,23 @@ Object AmericaPowerPlant
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
   End
 
   Geometry            = BOX
@@ -17888,11 +17918,25 @@ Object ChinaPowerPlant
   EnergyBonus         = 5              ; for the overcharge bonus
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions        = None
-    Armor             = StructureArmor
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
     DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+
+
   CommandSet          = ChinaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
  
@@ -17978,7 +18022,30 @@ Object ChinaPowerPlant
     CommandSet = ChinaPowerPlantCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines
   End
-  Behavior = ArmorUpgrade ModuleTag_26
+
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+  End
+
+  ; @bugfix - hanfield
+  ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
+  ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
+  ; 23/08/2021
+
+  Behavior = WeaponSetUpgrade ModuleTag_NeutronMineDummy
     TriggeredBy = Upgrade_ChinaEMPMines
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -4912,18 +4912,18 @@ Object AmericaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   Geometry            = BOX
@@ -18026,18 +18026,18 @@ Object ChinaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   ; @bugfix - hanfield
@@ -19425,7 +19425,7 @@ Object AmericaSupplyDropZone
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 22/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -8300,11 +8300,24 @@ Object Infa_ChinaPowerPlant
   EnergyBonus         = 5              ; for the overcharge bonus
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions        = None
-    Armor             = StructureArmor
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
     DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+
   CommandSet          = Infa_ChinaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
  
@@ -8390,10 +8403,33 @@ Object Infa_ChinaPowerPlant
     CommandSet = ChinaPowerPlantCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines
   End
-  Behavior = ArmorUpgrade ModuleTag_26
-    TriggeredBy = Upgrade_ChinaEMPMines
+
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+  End
+
+  ; @bugfix - hanfield
+  ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
+  ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
+  ; 23/08/2021
+
+  Behavior = WeaponSetUpgrade ModuleTag_NeutronMineDummy
+    TriggeredBy = Upgrade_ChinaEMPMines
+  End
+  
   Geometry            = BOX
   GeometryMajorRadius = 27.0
   GeometryMinorRadius = 34.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -8407,18 +8407,18 @@ Object Infa_ChinaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   ; @bugfix - hanfield

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -9377,11 +9377,24 @@ Object Lazr_AmericaPowerPlant
   EnergyBonus      = 8
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions     = None
-    Armor          = StructureArmor
-    DamageFX       = StructureDamageFXNoShake
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
+    DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+
   CommandSet       = Lazr_AmericaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
@@ -9451,6 +9464,23 @@ Object Lazr_AmericaPowerPlant
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -9469,18 +9469,18 @@ Object Lazr_AmericaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   Geometry            = BOX
@@ -14282,18 +14282,18 @@ Object Lazr_AmericaSupplyDropZone
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 22/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -10114,18 +10114,18 @@ Object Nuke_ChinaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   ; @bugfix - hanfield

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -10007,11 +10007,24 @@ Object Nuke_ChinaPowerPlant
   EnergyBonus         = 9              ; for the overcharge bonus
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions        = None
-    Armor             = StructureArmor
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
     DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+  
   CommandSet          = ChinaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
  
@@ -10097,7 +10110,30 @@ Object Nuke_ChinaPowerPlant
     CommandSet = ChinaPowerPlantCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines
   End
-  Behavior = ArmorUpgrade ModuleTag_26
+
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+  End
+
+  ; @bugfix - hanfield
+  ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
+  ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
+  ; 23/08/2021
+
+  Behavior = WeaponSetUpgrade ModuleTag_NeutronMineDummy
     TriggeredBy = Upgrade_ChinaEMPMines
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13690,18 +13690,18 @@ Object SupW_AmericaSupplyDropZone
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 22/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
   
   Geometry            = BOX
@@ -17417,18 +17417,18 @@ Object SupW_AmericaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -17335,11 +17335,24 @@ Object SupW_AmericaPowerPlant
   EnergyBonus      = 15
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions     = None
-    Armor          = StructureArmor
-    DamageFX       = StructureDamageFXNoShake
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
+    DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+
   CommandSet       = SupW_AmericaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
   ; *** AUDIO Parameters ***
@@ -17400,6 +17413,24 @@ Object SupW_AmericaPowerPlant
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
+
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+  End
+
 
   Geometry            = BOX
   GeometryMajorRadius = 22.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -8030,18 +8030,18 @@ Object Tank_ChinaPowerPlant
   ; @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
-  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
   ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
   ;
   ; 23/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   ; @bugfix - hanfield

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -7923,11 +7923,24 @@ Object Tank_ChinaPowerPlant
   EnergyBonus         = 5              ; for the overcharge bonus
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
+
+  ; @bugfix - hanfield
+  ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
+  ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
+  ; 23/08/2021
+
   ArmorSet
-    Conditions        = None
-    Armor             = StructureArmor
+    Conditions        = None                           ; Default state while being constructed.
+    Armor             = StructureArmor_NoSubdualDamage ; Cannot be targeted by Microwave Tanks.
     DamageFX          = StructureDamageFXNoShake
   End
+
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE ; Upgrade is granted immediately once construction is complete.
+    Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
+    DamageFX          = StructureDamageFXNoShake
+  End
+  
   CommandSet          = ChinaPowerPlantCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
  
@@ -8013,9 +8026,33 @@ Object Tank_ChinaPowerPlant
     CommandSet = ChinaPowerPlantCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines
   End
-  Behavior = ArmorUpgrade ModuleTag_26
+
+  ; @bugfix - hanfield
+  ; Added two extra modules for Microwave Tank bug fix.
+  ;
+  ; MicrowaveTankFix01 grants an object-class upgrade once the building is complete.
+  ; MicrowaveTankFix02 upgrades the armor with said upgrade and allows subdual once again.
+  ;
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
+    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
+    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+  End
+
+  ; @bugfix - hanfield
+  ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
+  ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
+  ; 23/08/2021
+
+  Behavior = WeaponSetUpgrade ModuleTag_NeutronMineDummy
     TriggeredBy = Upgrade_ChinaEMPMines
   End
+
 
   Geometry            = BOX
   GeometryMajorRadius = 27.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -806,3 +806,14 @@ Upgrade RocketBuggyToxinUpgrade
   BuildTime          = 60.0
   BuildCost          = 1000
 End
+
+; @bugfix - hanfield
+; Added a new dummy object-class upgrade for use in places where a local upgrade is required.
+; 23/08/2021
+
+;----------------------------
+Upgrade Upgrade_DummyUpgrade
+  Type               = OBJECT
+  BuildTime          = 0.0
+  BuildCost          = 0
+End


### PR DESCRIPTION
USA and China Power Plants, if disabled by a Microwave Tank, will suppress their power production until the Microwave Tank stops.

If they are disabled while being built, however, they will lose power that they never produced. Once construction is complete, the power plant will produce net zero power, upgrades and overcharge notwithstanding, and if that-or any-power plant is sold, the player will have permanent negative power.

This commit fixes that: It will no longer be possible to disable power plants while they are being built.