### PR TITLE
Fixes Microwave Tank emitter heat radius

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -28768,7 +28768,7 @@ ParticleSystem MicrowaveRotisserie
   Gravity = 0.00
   Lifetime = 32.00 32.00
   SystemLifetime = 0
-  Size = 50.00 60.00
+  Size = 100.00 105.00
   StartSizeRate = 0.00 0.00
   SizeRate = 0.20 0.30
   SizeRateDamping = 1.00 1.00


### PR DESCRIPTION
Previously the MicrowaveRotisserie effect radius was half of its actual damage radius.  This commit makes it much closer.