### PR TITLE
Fix WB assert for MultiplayerBeacon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -29,6 +29,14 @@ CommandSet StopOnlyGenericCommandSet
   14 = Command_Stop
 End
 
+
+; @bugfix - hanfield
+; Added an empty commandset for things that require no buttons at all.
+; 23/08/2021
+
+CommandSet EmptyCommandSet
+End
+
 ; Dozer Command Sets ----------------------------------------------------------
 CommandSet AmericaDozerCommandSet
   1  = Command_ConstructAmericaPowerPlant

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionProp.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionProp.ini
@@ -27,6 +27,17 @@ Object MultiplayerBeacon
   ; Patch104p: Add IMMOBILE to satisfiy Game Engine expectation that structure is immobile.
   KindOf = UNATTACKABLE SELECTABLE NO_COLLIDE ALWAYS_VISIBLE ALWAYS_SELECTABLE STRUCTURE IMMOBILE
 
+
+  ; @bugfix - hanfield
+  ; Added a token ArmorSet to fix Worldbuilder assert regarding missing DamageFX.
+  ; 23/08/2021
+
+  ArmorSet        
+    Conditions      = None
+    Armor           = InvulnerableAllArmor
+    DamageFX        = DamageFX_Empty
+  End
+
   ClientUpdate = BeaconClientUpdate ModuleTag_02
     RadarPulseFrequency = 1000
     RadarPulseDuration = 500


### PR DESCRIPTION
Missing DamageFX throws a non-fatal assert in Worldbuilder.  This adds a token ArmorSet that resolves the issue.