### PR TITLE
Update TankGeneral.ini with scaffold building exploit fix

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -8075,7 +8075,7 @@ Object Tank_ChinaPowerPlant
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix1
     TriggeredBy = Upgrade_DummyUpgrade
-    CommandSet = AmericaBarracksCommandSet
+    CommandSet = ChinaPowerPlantCommandSet
   End
 
   ; @bugfix - hanfield

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -6332,7 +6332,13 @@ Object Tank_ChinaNuclearMissileLauncher
   ShroudClearingRange = 200
   ShroudRevealToAllRange = 60  ; Reveals shroud to all players at a specific amount which can be different. 
                                ; Using same value? Then use KINDOF_REVEAL_TO_ALL instead!
-  CommandSet       = Tank_ChinaNuclearMissileCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet
   ArmorSet
     Conditions      = None
     Armor           = StructureArmorTough
@@ -6444,7 +6450,21 @@ Object Tank_ChinaNuclearMissileLauncher
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Tank_ChinaNuclearMissileCommandSet
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 45.0
   GeometryMinorRadius = 55.0
@@ -7940,8 +7960,13 @@ Object Tank_ChinaPowerPlant
     Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
     DamageFX          = StructureDamageFXNoShake
   End
-  
-  CommandSet          = ChinaPowerPlantCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet  
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
  
   ; *** AUDIO Parameters ***
@@ -8042,6 +8067,15 @@ Object Tank_ChinaPowerPlant
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
     TriggeredBy = Upgrade_DummyUpgrade
+  End
+
+  ; @bugfix - hanfield
+  ; This modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix1
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = AmericaBarracksCommandSet
   End
 
   ; @bugfix - hanfield
@@ -8616,7 +8650,13 @@ Object Tank_ChinaSupplyCenter
   RefundValue      = 450 ; With nothing (or zero) listed, we sell for half price. 
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Tank_ChinaSupplyCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -8714,6 +8754,20 @@ Object Tank_ChinaSupplyCenter
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Tank_ChinaSupplyCenterCommandSet
   End
 
   Geometry            = BOX
@@ -9289,7 +9343,13 @@ Object Tank_ChinaBarracks
   BuildCost        = 500
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = 0
-  CommandSet       = Tank_ChinaBarracksCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -9382,6 +9442,20 @@ Object Tank_ChinaBarracks
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Tank_ChinaBarracksCommandSet
   End
 
   Geometry            = BOX
@@ -10390,7 +10464,13 @@ Object Tank_ChinaAirfield
   BuildCost        = 1000
   BuildTime        = 30.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Tank_ChinaAirfieldCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -10482,6 +10562,20 @@ Object Tank_ChinaAirfield
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Tank_ChinaAirfieldCommandSet
   End
 
   Geometry            = BOX
@@ -11439,7 +11533,13 @@ Object Tank_ChinaWarFactory
   BuildCost        = 2000
   BuildTime        = 15.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Tank_ChinaWarFactoryCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -11530,6 +11630,20 @@ Object Tank_ChinaWarFactory
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Tank_ChinaWarFactoryCommandSet
   End
 
   Geometry            = BOX
@@ -13180,7 +13294,13 @@ Object Tank_ChinaPropagandaCenter
     Armor             = StructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = Tank_ChinaPropagandaCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
 
@@ -13246,6 +13366,20 @@ Object Tank_ChinaPropagandaCenter
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Tank_ChinaPropagandaCenterCommandSet
   End
 
   Geometry            = BOX
@@ -15253,7 +15387,13 @@ Object Tank_ChinaInternetCenter
   BuildCost         = 1750
   BuildTime         = 30.0           ; in seconds
   EnergyProduction  = 0  
-  CommandSet        = ChinaInternetCenterCommandSetOne
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 23/08/2021
+
+  CommandSet          = EmptyCommandSet
   VisionRange       = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -15389,6 +15529,20 @@ Object Tank_ChinaInternetCenter
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 23/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = ChinaInternetCenterCommandSetOne
   End
 
   Geometry            = BOX


### PR DESCRIPTION
Tank General buildings that produce upgrades or units should no longer be susceptible to building scaffold exploit.