### PR TITLE
Updated 3 factions with building scaffold fixes

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -8499,7 +8499,14 @@ Object AirF_AmericaCommandCenter
   BuildCost             = 2000
   BuildTime             = 45.0           ; in seconds
   EnergyProduction      = 0   ;Command Center should be free
-  CommandSet            = AirF_AmericaCommandCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange           = 300.0           ; Shroud clearing distance
   ShroudClearingRange   = 300
   ArmorSet
@@ -8697,6 +8704,20 @@ Object AirF_AmericaCommandCenter
   Behavior = GrantScienceUpgrade ModuleTag_Science
     GrantScience = SCIENCE_MOAB
     TriggeredBy = Upgrade_AmericaMOAB
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = AirF_AmericaCommandCenterCommandSet
   End
 
   Geometry            = BOX
@@ -11843,7 +11864,14 @@ Object AirF_AmericaStrategyCenter
   Prerequisites
     Object = AirF_AmericaWarFactory AirF_AmericaAirfield
   End
-  CommandSet          = AirF_AmericaStrategyCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   BuildCost           = 2500
   BuildTime           = 60.0           ; in seconds
   EnergyProduction    = -2
@@ -12022,6 +12050,19 @@ Object AirF_AmericaStrategyCenter
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
   End 
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = AirF_AmericaStrategyCenterCommandSet
+  End
 
   Geometry            = BOX
   GeometryMajorRadius = 62.0
@@ -13139,7 +13180,14 @@ Object AirF_AmericaAirfield
   BuildCost           = 800
   BuildTime           = 30.0           ; in seconds
   EnergyProduction    = -1
-  CommandSet          = AirF_AmericaAirfieldCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -13218,6 +13266,20 @@ Object AirF_AmericaAirfield
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = AirF_AmericaAirfieldCommandSet
   End
 
   Geometry            = BOX
@@ -13955,7 +14017,14 @@ Object AirF_AmericaSupplyCenter
   RefundValue      = 400 ; With nothing (or zero) listed, we sell for half price. 
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = AirF_AmericaSupplyCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -14041,7 +14110,21 @@ Object AirF_AmericaSupplyCenter
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
-  
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = AirF_AmericaSupplyCenterCommandSet
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 44.0
   GeometryMinorRadius = 45.0
@@ -15177,7 +15260,14 @@ Object AirF_AmericaBarracks
   BuildCost           = 600
   BuildTime           = 10.0           ; in seconds
   EnergyProduction    = 0
-  CommandSet          = AirF_AmericaBarracksCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -15258,6 +15348,20 @@ Object AirF_AmericaBarracks
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = AirF_AmericaBarracksCommandSet
   End
 
   Geometry             = BOX
@@ -16159,7 +16263,14 @@ Object AirF_AmericaWarFactory
   BuildTime        = 15.0           ; in seconds
 
   EnergyProduction = -1
-  CommandSet       = AirF_AmericaWarFactoryCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -16247,6 +16358,20 @@ Object AirF_AmericaWarFactory
   
   Behavior             = DestroyDie ModuleTag_22
     ;nothing
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = AirF_AmericaWarFactoryCommandSet
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -724,7 +724,14 @@ Object Chem_GLACommandCenter
   BuildCost           = 2000
   BuildTime           = 45.0           ; in seconds
   EnergyProduction    = 0  ;Command center should be free
-  CommandSet          = Chem_GLACommandCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 300.0           ; Shroud clearing distance
   ShroudClearingRange = 300
   ArmorSet
@@ -871,6 +878,20 @@ Object Chem_GLACommandCenter
 
   Behavior = GrantUpgradeCreate ModuleTag_24
     UpgradeToGrant = Upgrade_GLAAnthraxBeta
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLACommandCenterCommandSet
   End
 
   Geometry            = BOX
@@ -2219,7 +2240,14 @@ Object Chem_GLABlackMarket
   BuildCost           = 2500
   BuildTime           = 30.0           ; in seconds
   EnergyProduction    = 0
-  CommandSet          = Chem_GLABlackMarketCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -2303,6 +2331,20 @@ Object Chem_GLABlackMarket
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLABlackMarketCommandSet
   End
 
   Geometry            = BOX
@@ -5846,7 +5888,14 @@ Object Chem_GLAPalace
     Armor             = GLAUpgradedStructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet = Chem_GLAPalaceCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 300 300 300 300  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -5920,6 +5969,20 @@ Object Chem_GLAPalace
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLAPalaceCommandSet
   End
 
   Geometry            = BOX
@@ -6508,7 +6571,14 @@ Object Chem_GLASupplyStash
   RefundValue         = 650 ; With nothing (or zero) listed, we sell for half price. 
   BuildTime           = 10.0           ; in seconds
   EnergyProduction    = 0
-  CommandSet          = Chem_GLASupplyStashCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -6607,6 +6677,20 @@ Object Chem_GLASupplyStash
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLASupplyStashCommandSet
   End
 
   ;Dont forget to edit the GLA Hole geometry for this object too
@@ -7876,7 +7960,14 @@ Object Chem_GLABarracks
   BuildCost        = 500
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = 0
-  CommandSet       = Chem_GLABarracksCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -7973,6 +8064,19 @@ Object Chem_GLABarracks
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLABarracksCommandSet
+  End
 
   Geometry            = BOX
   GeometryMajorRadius = 42.0
@@ -9471,7 +9575,14 @@ Object Chem_GLAArmsDealer
   BuildCost        = 2500
   BuildTime        = 15.0           ; in seconds
   EnergyProduction = 0
-  CommandSet       = Chem_GLAArmsDealerCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -9561,6 +9672,20 @@ Object Chem_GLAArmsDealer
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLAArmsDealerCommandSet
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -858,7 +858,14 @@ Object Demo_GLACommandCenter
   BuildCost           = 2000
   BuildTime           = 45.0           ; in seconds
   EnergyProduction    = 0  ;Command center should be free
-  CommandSet          = Demo_GLACommandCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 300.0           ; Shroud clearing distance
   ShroudClearingRange = 300
   ArmorSet
@@ -1003,6 +1010,20 @@ Object Demo_GLACommandCenter
   Behavior = GrantUpgradeCreate ModuleTag_23
     UpgradeToGrant           = Upgrade_GLAInfantryRebelBoobyTrapAttack
     ExemptStatus      = UNDER_CONSTRUCTION
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLACommandCenterCommandSet
   End
 
   Geometry            = BOX
@@ -2351,7 +2372,14 @@ Object Demo_GLABlackMarket
   BuildCost           = 2500
   BuildTime           = 30.0           ; in seconds
   EnergyProduction    = 0
-  CommandSet          = Demo_GLABlackMarketCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -2435,6 +2463,20 @@ Object Demo_GLABlackMarket
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLABlackMarketCommandSet
   End
 
   Geometry            = BOX
@@ -6578,7 +6620,14 @@ Object Demo_GLAPalace
     Armor             = GLAUpgradedStructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet = Demo_GLAPalaceCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 300 300 300 300  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -6650,6 +6699,20 @@ Object Demo_GLAPalace
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLAPalaceCommandSet
   End
 
   Geometry            = BOX
@@ -7238,7 +7301,14 @@ Object Demo_GLASupplyStash
   RefundValue         = 650 ; With nothing (or zero) listed, we sell for half price. 
   BuildTime           = 10.0           ; in seconds
   EnergyProduction    = 0
-  CommandSet          = Demo_GLASupplyStashCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -7336,6 +7406,20 @@ Object Demo_GLASupplyStash
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLASupplyStashCommandSet
   End
 
   ;Dont forget to edit the GLA Hole geometry for this object too
@@ -8605,7 +8689,14 @@ Object Demo_GLABarracks
   BuildCost        = 500
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = 0
-  CommandSet       = Demo_GLABarracksCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   WeaponSet
@@ -8730,6 +8821,20 @@ Object Demo_GLABarracks
     TriggeredBy = Upgrade_GLAWorkerRealCommandSet
     RemovesUpgrades = Upgrade_GLAWorkerFakeCommandSet Upgrade_GLAWorkerRealCommandSet
     CommandSet = Demo_GLAWorkerCommandSet
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLABarracksCommandSet
   End
 
   Geometry            = BOX
@@ -10229,7 +10334,14 @@ Object Demo_GLAArmsDealer
   BuildCost        = 2500
   BuildTime        = 15.0           ; in seconds
   EnergyProduction = 0
-  CommandSet       = Demo_GLAArmsDealerCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 25/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -10319,6 +10431,20 @@ Object Demo_GLAArmsDealer
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 25/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLAArmsDealerCommandSet
   End
 
   Geometry            = BOX


### PR DESCRIPTION
Airforce, Demo and Toxin General buildings should now be immune to building scaffold exploits.