### PR TITLE
Updated Infantry, Nuke and Laser General buildings

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -4085,7 +4085,14 @@ Object Infa_ChinaCommandCenter
   BuildCost         = 2000
   BuildTime         = 45.0           ; in seconds
   EnergyProduction  = 0  ;Command center should be free
-  CommandSet        = Infa_ChinaCommandCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange       = 300.0           ; Shroud clearing distance
   ShroudClearingRange = 300
   ArmorSet
@@ -4251,6 +4258,19 @@ Object Infa_ChinaCommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaCommandCenterCommandSet
+  End
 
   Geometry            = BOX
   FactoryExitWidth    = 25
@@ -5245,7 +5265,14 @@ Object Infa_ChinaAirfield
   BuildCost        = 1000
   BuildTime        = 30.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Infa_ChinaAirfieldCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -5337,6 +5364,20 @@ Object Infa_ChinaAirfield
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaAirfieldCommandSet
   End
 
   Geometry            = BOX
@@ -6709,7 +6750,14 @@ Object Infa_ChinaNuclearMissileLauncher
   ShroudClearingRange = 200
   ShroudRevealToAllRange = 60  ; Reveals shroud to all players at a specific amount which can be different. 
                                ; Using same value? Then use KINDOF_REVEAL_TO_ALL instead!
-  CommandSet       = Infa_ChinaNuclearMissileCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ArmorSet
     Conditions      = None
     Armor           = StructureArmorTough
@@ -6821,7 +6869,21 @@ Object Infa_ChinaNuclearMissileLauncher
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaNuclearMissileCommandSet
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 45.0
   GeometryMinorRadius = 55.0
@@ -8992,7 +9054,14 @@ Object Infa_ChinaSupplyCenter
   RefundValue      = 450 ; With nothing (or zero) listed, we sell for half price. 
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Infa_ChinaSupplyCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -9090,6 +9159,20 @@ Object Infa_ChinaSupplyCenter
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaSupplyCenterCommandSet
   End
 
   Geometry            = BOX
@@ -9665,7 +9748,14 @@ Object Infa_ChinaBarracks
   BuildCost        = 500
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = 0
-  CommandSet       = Infa_ChinaBarracksCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -9763,6 +9853,20 @@ Object Infa_ChinaBarracks
   Behavior = GrantUpgradeCreate ModuleTag_27
     UpgradeToGrant           = Upgrade_Nationalism
     ExemptStatus      = UNDER_CONSTRUCTION
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaBarracksCommandSet
   End
 
   Geometry            = BOX
@@ -10722,7 +10826,14 @@ Object Infa_ChinaWarFactory
   BuildCost        = 2000
   BuildTime        = 15.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Infa_ChinaWarFactoryCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -10818,6 +10929,20 @@ Object Infa_ChinaWarFactory
   Behavior = GrantUpgradeCreate ModuleTag_27
     UpgradeToGrant           = Upgrade_Nationalism
     ExemptStatus      = UNDER_CONSTRUCTION
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaWarFactoryCommandSet
   End
 
   Geometry            = BOX
@@ -11629,7 +11754,14 @@ Object Infa_ChinaPropagandaCenter
     Armor             = StructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = Infa_ChinaPropagandaCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
 
@@ -11695,6 +11827,20 @@ Object Infa_ChinaPropagandaCenter
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaPropagandaCenterCommandSet
   End
 
   Geometry            = BOX
@@ -13702,7 +13848,14 @@ Object Infa_ChinaInternetCenter
   BuildCost         = 1750
   BuildTime         = 30.0           ; in seconds
   EnergyProduction  = 0  
-  CommandSet        = Infa_ChinaInternetCenterCommandSetOne
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange       = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -13838,6 +13991,20 @@ Object Infa_ChinaInternetCenter
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Infa_ChinaInternetCenterCommandSetOne
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -8220,7 +8220,14 @@ Object Lazr_AmericaCommandCenter
   BuildCost             = 2000
   BuildTime             = 45.0           ; in seconds
   EnergyProduction      = 0   ;Command Center should be free
-  CommandSet            = Lazr_AmericaCommandCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange           = 300.0           ; Shroud clearing distance
   ShroudClearingRange   = 300
   ArmorSet
@@ -8396,6 +8403,20 @@ Object Lazr_AmericaCommandCenter
   Behavior = GrantScienceUpgrade ModuleTag_Science
     GrantScience = SCIENCE_MOAB
     TriggeredBy = Upgrade_AmericaMOAB
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Lazr_AmericaCommandCenterCommandSet
   End
 
   Geometry            = BOX
@@ -9394,8 +9415,13 @@ Object Lazr_AmericaPowerPlant
     Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
     DamageFX          = StructureDamageFXNoShake
   End
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
 
-  CommandSet       = Lazr_AmericaPowerPlantCommandSet
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -9481,6 +9507,15 @@ Object Lazr_AmericaPowerPlant
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
     TriggeredBy = Upgrade_DummyUpgrade
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Lazr_AmericaPowerPlantCommandSet
   End
 
   Geometry            = BOX
@@ -11531,7 +11566,14 @@ Object Lazr_AmericaStrategyCenter
   Prerequisites
     Object = Lazr_AmericaWarFactory Lazr_AmericaAirfield
   End
-  CommandSet          = Lazr_AmericaStrategyCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   BuildCost           = 2500
   BuildTime           = 60.0           ; in seconds
   EnergyProduction    = -2
@@ -11703,6 +11745,19 @@ Object Lazr_AmericaStrategyCenter
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
   End
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Lazr_AmericaStrategyCenterCommandSet
+  End
 
   Geometry            = BOX
   GeometryMajorRadius = 62.0
@@ -12820,7 +12875,14 @@ Object Lazr_AmericaAirfield
   BuildCost           = 800
   BuildTime           = 30.0           ; in seconds
   EnergyProduction    = -1
-  CommandSet          = Lazr_AmericaAirfieldCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -12899,6 +12961,20 @@ Object Lazr_AmericaAirfield
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Lazr_AmericaAirfieldCommandSet
   End
 
   Geometry            = BOX
@@ -13640,7 +13716,14 @@ Object Lazr_AmericaSupplyCenter
   RefundValue      = 400 ; With nothing (or zero) listed, we sell for half price. 
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Lazr_AmericaSupplyCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -13726,7 +13809,21 @@ Object Lazr_AmericaSupplyCenter
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
-  
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Lazr_AmericaSupplyCenterCommandSet
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 44.0
   GeometryMinorRadius = 45.0
@@ -14863,7 +14960,14 @@ Object Lazr_AmericaBarracks
   BuildCost           = 600
   BuildTime           = 10.0           ; in seconds
   EnergyProduction    = 0
-  CommandSet          = Lazr_AmericaBarracksCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange         = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -14944,6 +15048,20 @@ Object Lazr_AmericaBarracks
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Lazr_AmericaBarracksCommandSet
   End
 
   Geometry             = BOX
@@ -15846,7 +15964,14 @@ Object Lazr_AmericaWarFactory
   BuildTime        = 15.0           ; in seconds
 
   EnergyProduction = -1
-  CommandSet       = Lazr_AmericaWarFactoryCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -15934,6 +16059,20 @@ Object Lazr_AmericaWarFactory
   
   Behavior             = DestroyDie ModuleTag_22
     ;nothing
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Lazr_AmericaWarFactoryCommandSet
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -5807,7 +5807,14 @@ Object Nuke_ChinaCommandCenter
   BuildCost         = 2000
   BuildTime         = 45.0           ; in seconds
   EnergyProduction  = 0  ;Command center should be free
-  CommandSet        = Nuke_ChinaCommandCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange       = 300.0           ; Shroud clearing distance
   ShroudClearingRange = 300
   ArmorSet
@@ -5957,6 +5964,20 @@ Object Nuke_ChinaCommandCenter
     UpgradeOCL           = SCIENCE_Frenzy2 SUPERWEAPON_Frenzy2
     OCL                  = SUPERWEAPON_Frenzy1
     CreateLocation       = CREATE_AT_LOCATION
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaCommandCenterCommandSet
   End
 
   Geometry            = BOX
@@ -6952,7 +6973,14 @@ Object Nuke_ChinaAirfield
   BuildCost        = 1000
   BuildTime        = 30.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Nuke_ChinaAirfieldCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -7044,6 +7072,20 @@ Object Nuke_ChinaAirfield
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaAirfieldCommandSet
   End
 
   Geometry            = BOX
@@ -8416,7 +8458,14 @@ Object Nuke_ChinaNuclearMissileLauncher
   ShroudClearingRange = 200
   ShroudRevealToAllRange = 60  ; Reveals shroud to all players at a specific amount which can be different. 
                                ; Using same value? Then use KINDOF_REVEAL_TO_ALL instead!
-  CommandSet       = Nuke_ChinaNuclearMissileCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ArmorSet
     Conditions      = None
     Armor           = StructureArmorTough
@@ -8528,7 +8577,21 @@ Object Nuke_ChinaNuclearMissileLauncher
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaNuclearMissileCommandSet
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 45.0
   GeometryMinorRadius = 55.0
@@ -10024,8 +10087,14 @@ Object Nuke_ChinaPowerPlant
     Armor             = StructureArmor ; Can be disabled by Microwave Tanks normally.
     DamageFX          = StructureDamageFXNoShake
   End
-  
-  CommandSet          = ChinaPowerPlantCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
  
   ; *** AUDIO Parameters ***
@@ -10135,6 +10204,15 @@ Object Nuke_ChinaPowerPlant
 
   Behavior = WeaponSetUpgrade ModuleTag_NeutronMineDummy
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = ChinaPowerPlantCommandSet
   End
 
   Geometry            = BOX
@@ -10699,7 +10777,14 @@ Object Nuke_ChinaSupplyCenter
   RefundValue      = 450 ; With nothing (or zero) listed, we sell for half price. 
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Nuke_ChinaSupplyCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -10797,6 +10882,20 @@ Object Nuke_ChinaSupplyCenter
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaSupplyCenterCommandSet
   End
 
   Geometry            = BOX
@@ -11372,7 +11471,14 @@ Object Nuke_ChinaBarracks
   BuildCost        = 500
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = 0
-  CommandSet       = Nuke_ChinaBarracksCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -11465,6 +11571,20 @@ Object Nuke_ChinaBarracks
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaBarracksCommandSet
   End
 
   Geometry            = BOX
@@ -12424,7 +12544,14 @@ Object Nuke_ChinaWarFactory
   BuildCost        = 2000
   BuildTime        = 15.0           ; in seconds
   EnergyProduction = -1
-  CommandSet       = Nuke_ChinaWarFactoryCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -12515,6 +12642,20 @@ Object Nuke_ChinaWarFactory
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaWarFactoryCommandSet
   End
 
   Geometry            = BOX
@@ -14165,7 +14306,14 @@ Object Nuke_ChinaPropagandaCenter
     Armor             = StructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = Nuke_ChinaPropagandaCenterCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
 
@@ -14231,6 +14379,20 @@ Object Nuke_ChinaPropagandaCenter
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaPropagandaCenterCommandSet
   End
 
   Geometry            = BOX
@@ -16237,7 +16399,14 @@ Object Nuke_ChinaInternetCenter
   BuildCost         = 1750
   BuildTime         = 30.0           ; in seconds
   EnergyProduction  = 0  
-  CommandSet        = ChinaInternetCenterCommandSetOne
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   VisionRange       = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
   ArmorSet
@@ -16373,6 +16542,20 @@ Object Nuke_ChinaInternetCenter
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = ChinaInternetCenterCommandSetOne
   End
 
   Geometry            = BOX


### PR DESCRIPTION
Infantry, Nuke and Laser General buildings should now have the scaffold building exploit fix.