### PR TITLE
Finishes adding scaffold exploit fixes to all outstanding buildings

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5068,7 +5068,14 @@ Object Chem_GLAStingerSite
     Armor             = StingerSiteArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = Chem_GLAStingerSiteCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -5158,6 +5165,20 @@ Object Chem_GLAStingerSite
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLAStingerSiteCommandSet
+  End
+  
   Geometry            = CYLINDER
   GeometryMajorRadius = 36.0
   GeometryHeight      = 9.0    
@@ -19329,7 +19350,13 @@ Object Chem_GLATunnelNetwork
     Weapon            = PRIMARY     Chem_TunnelNetworkGunGamma
   End
 
-  CommandSet       = Chem_GLATunnelNetworkCommandSet
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -19429,6 +19456,19 @@ Object Chem_GLATunnelNetwork
   Behavior = ProductionUpdate ModuleTag_18
   End
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Chem_GLATunnelNetworkCommandSet
+  End
 
   Geometry = CYLINDER
   GeometryMajorRadius = 25.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -5155,7 +5155,13 @@ Object Demo_GLATunnelNetwork
     AutoChooseSources = TERTIARY NONE
   End
 
-  CommandSet       = Demo_GLATunnelNetworkCommandSet
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -5305,6 +5311,19 @@ Object Demo_GLATunnelNetwork
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLATunnelNetworkCommandSet
+  End
 
   Geometry = CYLINDER
   GeometryMajorRadius = 25.0
@@ -5769,7 +5788,14 @@ Object Demo_GLAStingerSite
     Armor             = StingerSiteArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = Demo_GLAStingerSiteCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -5889,6 +5915,20 @@ Object Demo_GLAStingerSite
     AutoAcquireEnemiesWhenIdle = No
   End
 
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Demo_GLAStingerSiteCommandSet
+  End
+  
   Geometry            = CYLINDER
   GeometryMajorRadius = 36.0
   GeometryHeight      = 9.0    

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -16409,7 +16409,14 @@ Object GLAStingerSite
     Armor             = StingerSiteArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = GLAStingerSiteCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -16494,6 +16501,20 @@ Object GLAStingerSite
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = GLAStingerSiteCommandSet
   End
 
   Geometry            = CYLINDER
@@ -32960,7 +32981,14 @@ Object GLAStingerSiteNoHole
     Armor             = StingerSiteArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = GLAStingerSiteCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -33031,6 +33059,20 @@ Object GLAStingerSiteNoHole
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = GLAStingerSiteCommandSet
   End
 
   Geometry            = CYLINDER

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -12808,7 +12808,13 @@ Object Infa_ChinaGattlingCannon
     Armor          = BaseDefenseArmor
     DamageFX       = StructureDamageFXNoShake
   End
-  CommandSet       = ChinaGattlingCannonCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
 
   ;Behavior = AIUpdateInterface ModuleTag_20
   ;  AutoAcquireEnemiesWhenIdle = Yes ;ATTACK_BUILDINGS
@@ -12923,6 +12929,20 @@ Object Infa_ChinaGattlingCannon
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = ChinaGattlingCannonCommandSet
   End
 
   Geometry            = BOX
@@ -14768,7 +14788,19 @@ Object Infa_ChinaBunker
     Armor           = StructureArmorTough
     DamageFX        = StructureDamageFXNoShake
   End
-  CommandSet       = Infa_ChinaBunkerCommandSetUpgrade
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; @note - hanfield
+  ; Infantry General's Bunker is a special case: It has a similar setup as the fix!
+  ; It is granted Upgrade_ChinaMines once construction is complete, and this upgrades
+  ; the commandset. 
+  ; This means we can ignore adding ScaffoldBuildingFix modules, as this is already
+  ; done by Modules 11 and 25, and simply make his default commandset blank.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
 
   ; *** AUDIO Parameters ***
   VoiceSelect       = BunkerSelect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -9143,7 +9143,14 @@ Object Nuke_ChinaSpeakerTower
   Prerequisites
     Object            = Nuke_ChinaPropagandaCenter
   End
-  CommandSet          = ChinaSpeakerTowerCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 50 50 50 50  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -9223,6 +9230,20 @@ Object Nuke_ChinaSpeakerTower
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = ChinaSpeakerTowerCommandSet
   End
 
   Geometry             = BOX
@@ -13419,7 +13440,13 @@ Object Nuke_ChinaBunker
     Armor           = StructureArmor
     DamageFX        = StructureDamageFXNoShake
   End
-  CommandSet       = Nuke_ChinaBunkerCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
 
   ; *** AUDIO Parameters ***
   VoiceSelect       = BunkerSelect
@@ -13501,6 +13528,20 @@ Object Nuke_ChinaBunker
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Nuke_ChinaBunkerCommandSet
   End
 
   Geometry            = BOX
@@ -15360,7 +15401,13 @@ Object Nuke_ChinaGattlingCannon
     Armor          = BaseDefenseArmor
     DamageFX       = StructureDamageFXNoShake
   End
-  CommandSet       = ChinaGattlingCannonCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
 
   ;Behavior = AIUpdateInterface ModuleTag_20
   ;  AutoAcquireEnemiesWhenIdle = Yes ;ATTACK_BUILDINGS
@@ -15475,6 +15522,20 @@ Object Nuke_ChinaGattlingCannon
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = ChinaGattlingCannonCommandSet
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5079,7 +5079,13 @@ Object Slth_GLATunnelNetwork
     Weapon = PRIMARY TunnelNetworkGun
   End
 
-  CommandSet       = Slth_GLATunnelNetworkCommandSet
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -5184,6 +5190,20 @@ Object Slth_GLATunnelNetwork
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Slth_GLATunnelNetworkCommandSet
   End
 
   Geometry = CYLINDER
@@ -5646,7 +5666,14 @@ Object Slth_GLAStingerSite
     Armor             = StingerSiteArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = Slth_GLAStingerSiteCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -5731,6 +5758,20 @@ Object Slth_GLAStingerSite
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Slth_GLAStingerSiteCommandSet
   End
 
   Geometry            = CYLINDER

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -7016,7 +7016,14 @@ Object Tank_ChinaSpeakerTower
   Prerequisites
     Object            = Tank_ChinaPropagandaCenter
   End
-  CommandSet          = ChinaSpeakerTowerCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
+
   ExperienceValue     = 50 50 50 50  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -7096,6 +7103,20 @@ Object Tank_ChinaSpeakerTower
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = ChinaSpeakerTowerCommandSet
   End
 
   Geometry             = BOX
@@ -14347,7 +14368,13 @@ Object Tank_ChinaGattlingCannon
     Armor          = BaseDefenseArmor
     DamageFX       = StructureDamageFXNoShake
   End
-  CommandSet       = Tank_ChinaGattlingCannonCommandSet
+
+  ; @bugfix - hanfield
+  ; Changed CommandSet to EmptyCommandSet to make in-progress buildings not have a commandset.
+  ; This prevents building units from scaffolds.
+  ; 26/08/2021
+
+  CommandSet          = EmptyCommandSet
 
   ;Behavior = AIUpdateInterface ModuleTag_20
   ;  AutoAcquireEnemiesWhenIdle = Yes ;ATTACK_BUILDINGS
@@ -14462,6 +14489,20 @@ Object Tank_ChinaGattlingCannon
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
+  End
+
+  ; @bugfix - hanfield
+  ; These modules will grant the building its intended commandset once construction is complete.
+  ; 26/08/2021
+
+  Behavior = GrantUpgradeCreate ModuleTag_ScaffoldBuildFix1
+    UpgradeToGrant = Upgrade_DummyUpgrade
+    ExemptStatus = UNDER_CONSTRUCTION
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
+    TriggeredBy = Upgrade_DummyUpgrade
+    CommandSet = Tank_ChinaGattlingCannonCommandSet
   End
 
   Geometry            = BOX


### PR DESCRIPTION
Now every structure that can produce an upgrade or a unit should be immune to the scaffold building exploit.