### PR TITLE
Added global upgrade dummy requirement for all building scaffold fix …

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -8716,7 +8716,8 @@ Object AirF_AmericaCommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AirF_AmericaCommandCenterCommandSet
   End
 
@@ -12060,7 +12061,8 @@ Object AirF_AmericaStrategyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AirF_AmericaStrategyCenterCommandSet
   End
 
@@ -13278,7 +13280,8 @@ Object AirF_AmericaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AirF_AmericaAirfieldCommandSet
   End
 
@@ -14121,7 +14124,8 @@ Object AirF_AmericaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AirF_AmericaSupplyCenterCommandSet
   End
 
@@ -15360,7 +15364,8 @@ Object AirF_AmericaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AirF_AmericaBarracksCommandSet
   End
 
@@ -16370,7 +16375,8 @@ Object AirF_AmericaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AirF_AmericaWarFactoryCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -890,7 +890,8 @@ Object Chem_GLACommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLACommandCenterCommandSet
   End
 
@@ -2343,7 +2344,8 @@ Object Chem_GLABlackMarket
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLABlackMarketCommandSet
   End
 
@@ -5175,7 +5177,8 @@ Object Chem_GLAStingerSite
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLAStingerSiteCommandSet
   End
 
@@ -6002,7 +6005,8 @@ Object Chem_GLAPalace
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLAPalaceCommandSet
   End
 
@@ -6710,7 +6714,8 @@ Object Chem_GLASupplyStash
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLASupplyStashCommandSet
   End
 
@@ -8095,7 +8100,8 @@ Object Chem_GLABarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLABarracksCommandSet
   End
 
@@ -9705,7 +9711,8 @@ Object Chem_GLAArmsDealer
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLAArmsDealerCommandSet
   End
 
@@ -19466,7 +19473,8 @@ Object Chem_GLATunnelNetwork
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Chem_GLATunnelNetworkCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1022,7 +1022,8 @@ Object Demo_GLACommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLACommandCenterCommandSet
   End
 
@@ -2475,7 +2476,8 @@ Object Demo_GLABlackMarket
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLABlackMarketCommandSet
   End
 
@@ -5321,7 +5323,8 @@ Object Demo_GLATunnelNetwork
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLATunnelNetworkCommandSet
   End
 
@@ -5925,7 +5928,8 @@ Object Demo_GLAStingerSite
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLAStingerSiteCommandSet
   End
 
@@ -6751,7 +6755,8 @@ Object Demo_GLAPalace
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLAPalaceCommandSet
   End
 
@@ -7458,7 +7463,8 @@ Object Demo_GLASupplyStash
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLASupplyStashCommandSet
   End
 
@@ -8873,7 +8879,8 @@ Object Demo_GLABarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLABarracksCommandSet
   End
 
@@ -10483,7 +10490,8 @@ Object Demo_GLAArmsDealer
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Demo_GLAArmsDealerCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -1337,7 +1337,8 @@ Object AmericaCommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AmericaCommandCenterCommandSet
   End
 
@@ -2079,7 +2080,8 @@ Object GLACommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLACommandCenterCommandSet
   End
 
@@ -2813,7 +2815,8 @@ Object FakeGLACommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = FakeGLACommandCenterCommandSet
   End
 
@@ -3923,7 +3926,8 @@ Object ChinaCommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaCommandCenterCommandSet
   End
 
@@ -5026,7 +5030,8 @@ Object AmericaPowerPlant
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AmericaPowerPlantCommandSet
   End
 
@@ -7275,7 +7280,8 @@ Object AmericaStrategyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AmericaStrategyCenterCommandSet
   End
 
@@ -8493,7 +8499,8 @@ Object AmericaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AmericaAirfieldCommandSet
   End
 
@@ -9599,7 +9606,8 @@ Object ChinaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaAirfieldCommandSet
   End
 
@@ -10391,7 +10399,8 @@ Object GLABlackMarket
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLABlackMarketCommandSet
   End
 
@@ -13989,7 +13998,8 @@ Object ChinaNuclearMissileLauncher
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaNuclearMissileCommandSet
   End
 
@@ -14643,7 +14653,8 @@ Object ChinaSpeakerTower
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaSpeakerTowerCommandSet
   End
 
@@ -15426,7 +15437,8 @@ Object GLATunnelNetwork
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLATunnelNetworkCommandSet
   End
 
@@ -16513,7 +16525,8 @@ Object GLAStingerSite
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLAStingerSiteCommandSet
   End
 
@@ -17341,7 +17354,8 @@ Object GLAPalace
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLAPalaceCommandSet
   End
 
@@ -18355,7 +18369,8 @@ Object ChinaPowerPlant
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaPowerPlantCommandSet
   End
 
@@ -19197,7 +19212,8 @@ Object AmericaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AmericaSupplyCenterCommandSet
   End
 
@@ -20435,7 +20451,8 @@ Object GLASupplyStash
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLASupplyStashCommandSet
   End
 
@@ -21789,7 +21806,8 @@ Object ChinaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaSupplyCenterCommandSet
   End
 
@@ -22458,7 +22476,8 @@ Object AmericaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AmericaBarracksCommandSet
   End
 
@@ -23154,7 +23173,8 @@ Object GLABarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLABarracksCommandSet
   End
 
@@ -24554,7 +24574,8 @@ Object ChinaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaBarracksCommandSet
   End
 
@@ -25563,7 +25584,8 @@ Object AmericaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = AmericaWarFactoryCommandSet
   End
 
@@ -26454,7 +26476,8 @@ Object GLAArmsDealer
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLAArmsDealerCommandSet
   End
 
@@ -28427,7 +28450,8 @@ Object ChinaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaWarFactoryCommandSet
   End
 
@@ -30396,7 +30420,8 @@ Object ChinaBunker
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaBunkerCommandSet
   End
 
@@ -31288,7 +31313,8 @@ Object ChinaPropagandaCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaPropagandaCenterCommandSet
   End
 
@@ -32390,7 +32416,8 @@ Object ChinaGattlingCannon
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaGattlingCannonCommandSet
   End
 
@@ -33071,7 +33098,8 @@ Object GLAStingerSiteNoHole
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLAStingerSiteCommandSet
   End
 
@@ -34779,7 +34807,8 @@ Object ChinaInternetCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaInternetCenterCommandSetOne
   End
 
@@ -36050,7 +36079,8 @@ Object GLAArmsDealerNoHole
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = GLAArmsDealerCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -4268,7 +4268,8 @@ Object Infa_ChinaCommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaCommandCenterCommandSet
   End
 
@@ -5376,7 +5377,8 @@ Object Infa_ChinaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaAirfieldCommandSet
   End
 
@@ -6880,7 +6882,8 @@ Object Infa_ChinaNuclearMissileLauncher
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaNuclearMissileCommandSet
   End
 
@@ -9171,7 +9174,8 @@ Object Infa_ChinaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaSupplyCenterCommandSet
   End
 
@@ -9865,7 +9869,8 @@ Object Infa_ChinaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaBarracksCommandSet
   End
 
@@ -10941,7 +10946,8 @@ Object Infa_ChinaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaWarFactoryCommandSet
   End
 
@@ -11839,7 +11845,8 @@ Object Infa_ChinaPropagandaCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaPropagandaCenterCommandSet
   End
 
@@ -12941,7 +12948,8 @@ Object Infa_ChinaGattlingCannon
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaGattlingCannonCommandSet
   End
 
@@ -14023,7 +14031,8 @@ Object Infa_ChinaInternetCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Infa_ChinaInternetCenterCommandSetOne
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -8415,7 +8415,8 @@ Object Lazr_AmericaCommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Lazr_AmericaCommandCenterCommandSet
   End
 
@@ -9514,7 +9515,8 @@ Object Lazr_AmericaPowerPlant
   ; 26/08/2021
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Lazr_AmericaPowerPlantCommandSet
   End
 
@@ -11755,7 +11757,8 @@ Object Lazr_AmericaStrategyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Lazr_AmericaStrategyCenterCommandSet
   End
 
@@ -12973,7 +12976,8 @@ Object Lazr_AmericaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Lazr_AmericaAirfieldCommandSet
   End
 
@@ -13820,7 +13824,8 @@ Object Lazr_AmericaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Lazr_AmericaSupplyCenterCommandSet
   End
 
@@ -15060,7 +15065,8 @@ Object Lazr_AmericaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Lazr_AmericaBarracksCommandSet
   End
 
@@ -16071,7 +16077,8 @@ Object Lazr_AmericaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Lazr_AmericaWarFactoryCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -5976,7 +5976,8 @@ Object Nuke_ChinaCommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaCommandCenterCommandSet
   End
 
@@ -7084,7 +7085,8 @@ Object Nuke_ChinaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaAirfieldCommandSet
   End
 
@@ -8588,7 +8590,8 @@ Object Nuke_ChinaNuclearMissileLauncher
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaNuclearMissileCommandSet
   End
 
@@ -9242,7 +9245,8 @@ Object Nuke_ChinaSpeakerTower
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaSpeakerTowerCommandSet
   End
 
@@ -10232,7 +10236,8 @@ Object Nuke_ChinaPowerPlant
   ; 26/08/2021
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaPowerPlantCommandSet
   End
 
@@ -10915,7 +10920,8 @@ Object Nuke_ChinaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaSupplyCenterCommandSet
   End
 
@@ -11604,7 +11610,8 @@ Object Nuke_ChinaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaBarracksCommandSet
   End
 
@@ -12675,7 +12682,8 @@ Object Nuke_ChinaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaWarFactoryCommandSet
   End
 
@@ -13540,7 +13548,8 @@ Object Nuke_ChinaBunker
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaBunkerCommandSet
   End
 
@@ -14432,7 +14441,8 @@ Object Nuke_ChinaPropagandaCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Nuke_ChinaPropagandaCenterCommandSet
   End
 
@@ -15534,7 +15544,8 @@ Object Nuke_ChinaGattlingCannon
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaGattlingCannonCommandSet
   End
 
@@ -16615,7 +16626,8 @@ Object Nuke_ChinaInternetCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaInternetCenterCommandSetOne
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -894,7 +894,8 @@ Object Slth_GLACommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLACommandCenterCommandSet
   End
 
@@ -2370,7 +2371,8 @@ Object Slth_GLABlackMarket
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLABlackMarketCommandSet
   End
 
@@ -5202,7 +5204,8 @@ Object Slth_GLATunnelNetwork
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLATunnelNetworkCommandSet
   End
 
@@ -5770,7 +5773,8 @@ Object Slth_GLAStingerSite
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLAStingerSiteCommandSet
   End
 
@@ -6605,7 +6609,8 @@ Object Slth_GLAPalace
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLAPalaceCommandSet
   End
 
@@ -7324,7 +7329,8 @@ Object Slth_GLASupplyStash
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLASupplyStashCommandSet
   End
 
@@ -8741,7 +8747,8 @@ Object Slth_GLABarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLABarracksCommandSet
   End
 
@@ -10378,7 +10385,8 @@ Object Slth_GLAArmsDealer
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Slth_GLAArmsDealerCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -8909,7 +8909,8 @@ Object SupW_AmericaCommandCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = SupW_AmericaCommandCenterCommandSet
   End
 
@@ -11147,7 +11148,8 @@ Object SupW_AmericaStrategyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = SupW_AmericaStrategyCenterCommandSet
   End
 
@@ -12365,7 +12367,8 @@ Object SupW_AmericaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = SupW_AmericaAirfieldCommandSet
   End
 
@@ -13214,7 +13217,8 @@ Object SupW_AmericaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = SupW_AmericaSupplyCenterCommandSet
   End
 
@@ -14454,7 +14458,8 @@ Object SupW_AmericaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = SupW_AmericaBarracksCommandSet
   End
 
@@ -15465,7 +15470,8 @@ Object SupW_AmericaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = SupW_AmericaWarFactoryCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -6461,7 +6461,8 @@ Object Tank_ChinaNuclearMissileLauncher
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Tank_ChinaNuclearMissileCommandSet
   End
 
@@ -7115,7 +7116,8 @@ Object Tank_ChinaSpeakerTower
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaSpeakerTowerCommandSet
   End
 
@@ -8787,7 +8789,8 @@ Object Tank_ChinaSupplyCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Tank_ChinaSupplyCenterCommandSet
   End
 
@@ -9475,7 +9478,8 @@ Object Tank_ChinaBarracks
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Tank_ChinaBarracksCommandSet
   End
 
@@ -10595,7 +10599,8 @@ Object Tank_ChinaAirfield
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Tank_ChinaAirfieldCommandSet
   End
 
@@ -11663,7 +11668,8 @@ Object Tank_ChinaWarFactory
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Tank_ChinaWarFactoryCommandSet
   End
 
@@ -13399,7 +13405,8 @@ Object Tank_ChinaPropagandaCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Tank_ChinaPropagandaCenterCommandSet
   End
 
@@ -14501,7 +14508,8 @@ Object Tank_ChinaGattlingCannon
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = Tank_ChinaGattlingCannonCommandSet
   End
 
@@ -15582,7 +15590,8 @@ Object Tank_ChinaInternetCenter
   End
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
-    TriggeredBy = Upgrade_DummyUpgrade
+    TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
+    RequiresAllTriggers = Yes
     CommandSet = ChinaInternetCenterCommandSetOne
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -59,6 +59,7 @@ PlayerTemplate FactionAmerica
   DisplayName       = INI:FactionAmerica
   StartingBuilding  = AmericaCommandCenter
   StartingUnit0     = AmericaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -93,6 +94,7 @@ PlayerTemplate FactionChina
   DisplayName       = INI:FactionChina
   StartingBuilding  = ChinaCommandCenter
   StartingUnit0     = ChinaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -127,6 +129,7 @@ PlayerTemplate FactionGLA
   DisplayName       = INI:FactionGLA
   StartingBuilding  = GLACommandCenter
   StartingUnit0     = GLAInfantryWorker
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -162,6 +165,7 @@ PlayerTemplate FactionAmericaSuperWeaponGeneral
   DisplayName       = INI:FactionAmericaSuperWeaponGeneral
   StartingBuilding  = SupW_AmericaCommandCenter
   StartingUnit0     = SupW_AmericaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -196,6 +200,7 @@ PlayerTemplate FactionAmericaLaserGeneral
   DisplayName       = INI:FactionAmericaLaserGeneral
   StartingBuilding  = Lazr_AmericaCommandCenter
   StartingUnit0     = Lazr_AmericaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -230,6 +235,7 @@ PlayerTemplate FactionAmericaAirForceGeneral
   DisplayName       = INI:FactionAmericaAirForceGeneral
   StartingBuilding  = AirF_AmericaCommandCenter
   StartingUnit0     = AirF_AmericaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -264,6 +270,7 @@ PlayerTemplate FactionChinaTankGeneral
   DisplayName       = INI:FactionChinaTankGeneral
   StartingBuilding  = Tank_ChinaCommandCenter
   StartingUnit0     = Tank_ChinaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -298,6 +305,7 @@ PlayerTemplate FactionChinaInfantryGeneral
   DisplayName       = INI:FactionChinaInfantryGeneral
   StartingBuilding  = Infa_ChinaCommandCenter
   StartingUnit0     = Infa_ChinaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -333,6 +341,7 @@ PlayerTemplate FactionChinaNukeGeneral
   DisplayName       = INI:FactionChinaNukeGeneral
   StartingBuilding  = Nuke_ChinaCommandCenter
   StartingUnit0     = Nuke_ChinaVehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -368,6 +377,7 @@ PlayerTemplate FactionGLAToxinGeneral
   DisplayName       = INI:FactionGLAToxinGeneral
   StartingBuilding  = Chem_GLACommandCenter
   StartingUnit0     = Chem_GLAInfantryWorker
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -403,6 +413,7 @@ PlayerTemplate FactionGLADemolitionGeneral
   DisplayName       = INI:FactionGLADemolitionGeneral
   StartingBuilding  = Demo_GLACommandCenter
   StartingUnit0     = Demo_GLAInfantryWorker
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -438,6 +449,7 @@ PlayerTemplate FactionGLAStealthGeneral
   DisplayName       = INI:FactionGLAStealthGeneral
   StartingBuilding  = Slth_GLACommandCenter
   StartingUnit0     = Slth_GLAInfantryWorker
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -472,6 +484,7 @@ PlayerTemplate FactionBossGeneral
   DisplayName       = INI:FactionBossGeneral
   StartingBuilding  = Boss_CommandCenter
   StartingUnit0     = Boss_VehicleDozer
+  StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China


### PR DESCRIPTION
…modules

ModuleTag_ScaffoldBuildFix2 now requires an extra global dummy upgrade that is granted to every faction via PlayerTemplate. This will have no effect on campaigns.