### PR TITLE
Particle Cannon ranger spawn fix

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -154,7 +154,7 @@ https://github.com/commy2/zerohour/issues/64  [MAYBE]                 Battle Dro
 https://github.com/commy2/zerohour/issues/63  [MAYBE]                 Paladins And Microwaves Gain Slightly Less Than Intended From Composite Armor
 https://github.com/commy2/zerohour/issues/62  [MAYBE]                 Crusader And Laser Tanks Receive Composite Armor Health Bonus Twice
 https://github.com/commy2/zerohour/issues/61  [NOTRELEVANT]           Destroyed American Boss Buildings Spawn Wrong Ranger Type
-https://github.com/commy2/zerohour/issues/60  [IMPROVEMENT][NPROJECT] Destroyed Particle Cannons Spawn Wrong Ranger Type
+https://github.com/commy2/zerohour/issues/60  [DONE] Destroyed Particle Cannons Spawn Wrong Ranger Type
 https://github.com/commy2/zerohour/issues/59  [IMPROVEMENT]           Air Force General Name Misspelling
 https://github.com/commy2/zerohour/issues/58  [IMPROVEMENT]           Some Combat Bikes Missing DoorOpenTime Entry
 https://github.com/commy2/zerohour/issues/57  [IMPROVEMENT]           Broken Combat Bike Animations

--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -7,7 +7,7 @@ https://github.com/commy2/zerohour/issues/224 [IMPROVEMENT]           Mixing Bat
 https://github.com/commy2/zerohour/issues/223 [IMPROVEMENT]           Sentry Drone Lacks Voice Line When Leaving Factory
 https://github.com/commy2/zerohour/issues/222 [MAYBE]                 Poison Fields Can Clear Poison Fields
 https://github.com/commy2/zerohour/issues/221 [IMPROVEMENT]           Units Sometimes Waste Shots On Overlord Debris
-https://github.com/commy2/zerohour/issues/220 [IMPROVEMENT][NPROJECT] Units Sometimes Waste Shots On Poisoned Or Burned Infantry
+https://github.com/commy2/zerohour/issues/220 [DONE] Units Sometimes Waste Shots On Poisoned Or Burned Infantry
 https://github.com/commy2/zerohour/issues/219 [MAYBE]                 Stinger Site Does Not Benefit From AP Rockets When Engaging Airborne Targets
 https://github.com/commy2/zerohour/issues/218 [NOTRELEVANT]           Hackers Are Bad Late Game Eco
 https://github.com/commy2/zerohour/issues/217 [MAYBE]                 Scud Launchers Missing Upgrade Icon For AP Rockets

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -10710,7 +10710,7 @@ Object AirF_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_AirF_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Airforce General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -10430,7 +10430,7 @@ Object Lazr_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19
@@ -18157,7 +18157,7 @@ Object Lazr_AmericaLaserCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19
@@ -19109,7 +19109,7 @@ Object Lazr_AmericaLaserCannon
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -9821,7 +9821,7 @@ Object SupW_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_SupW_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Superweapon General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -1259,7 +1259,7 @@ Object FlamingInfantry
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY
+  KindOf = CAN_CAST_REFLECTIONS INFANTRY UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0
@@ -1338,7 +1338,7 @@ Object ToxicInfantry
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY
+  KindOf = CAN_CAST_REFLECTIONS INFANTRY UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -2324,6 +2324,324 @@ ObjectCreationList OCL_ParticleUplinkDeathFinal
   End
 End
 
+; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Airforce General Particle Cannon.
+
+; ----------------------------------------------
+ObjectCreationList OCL_AirF_ParticleUplinkDeathFinal
+; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
+  CreateObject
+    ObjectNames = AirF_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 6
+    RequiresLivePlayer = Yes
+  End
+
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:15
+
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:25
+    Mass = 30.0
+    Count = 10
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d21 ABPwrPlant_d22 ABPwrPlant_d23 ABPwrPlant_d24 ABPwrPlant_d25 ABPwrPlant_d26 ABPwrPlant_d27 ABPwrPlant_d28 ABPwrPlant_d29 ABPwrPlant_d30
+    Offset = X:0 Y:0 Z:40
+    Mass = 30.0
+    Count = 5
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+End
+
+; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Laser General Particle Cannon.
+
+; ----------------------------------------------
+ObjectCreationList OCL_Lazr_ParticleUplinkDeathFinal
+; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
+  CreateObject
+    ObjectNames = Lazr_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 6
+    RequiresLivePlayer = Yes
+  End
+
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:15
+
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:25
+    Mass = 30.0
+    Count = 10
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d21 ABPwrPlant_d22 ABPwrPlant_d23 ABPwrPlant_d24 ABPwrPlant_d25 ABPwrPlant_d26 ABPwrPlant_d27 ABPwrPlant_d28 ABPwrPlant_d29 ABPwrPlant_d30
+    Offset = X:0 Y:0 Z:40
+    Mass = 30.0
+    Count = 5
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+End
+
+; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Superweapon General Particle Cannon.
+
+; ----------------------------------------------
+ObjectCreationList OCL_SupW_ParticleUplinkDeathFinal
+; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
+  CreateObject
+    ObjectNames = SupW_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 6
+    RequiresLivePlayer = Yes
+  End
+
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:15
+
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:25
+    Mass = 30.0
+    Count = 10
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d21 ABPwrPlant_d22 ABPwrPlant_d23 ABPwrPlant_d24 ABPwrPlant_d25 ABPwrPlant_d26 ABPwrPlant_d27 ABPwrPlant_d28 ABPwrPlant_d29 ABPwrPlant_d30
+    Offset = X:0 Y:0 Z:40
+    Mass = 30.0
+    Count = 5
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+End
+
 ; ----------------------------------------------
 ObjectCreationList OCL_GenericWallSegmentDebris
 ; @todo srj -- nothing for now.


### PR DESCRIPTION
All Particle Cannons should now spawn rangers that belong to their respective generals.