### PR TITLE
Fixes Stealth General Palace Reveal Issue

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -203,7 +203,7 @@ https://github.com/commy2/zerohour/issues/13  [IMPROVEMENT]           Destroyed 
 https://github.com/commy2/zerohour/issues/12  [IMPROVEMENT]           Destroyed Scud Storm Always Creates Green Poison Cloud
 https://github.com/commy2/zerohour/issues/11  [IMPROVEMENT]           Scud Storm Always Creates Green Particles When Firing
 https://github.com/commy2/zerohour/issues/10  [IMPROVEMENT]           Quad Cannon-ECM-Bug
-https://github.com/commy2/zerohour/issues/9   [IMPROVEMENT][NPROJECT] Camo-Netted Palace Not Revealed When Garrisoned Troops Fire
+https://github.com/commy2/zerohour/issues/9   [DONE]                  Camo-Netted Palace Not Revealed When Garrisoned Troops Fire
 https://github.com/commy2/zerohour/issues/8   [IMPROVEMENT][NPROJECT] Supply Truck Has Extremely Low Mass
 https://github.com/commy2/zerohour/issues/7   [IMPROVEMENT][NPROJECT] Mini-Gunner Has Broken Squish Detection
 https://github.com/commy2/zerohour/issues/6   [IMPROVEMENT]           Mini-Gunner Has Broken Sound And Fire Animation When Aiming At Airborne Targets

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -6591,7 +6591,7 @@ Object Slth_GLAPalace
 
   Behavior = StealthUpdate ModuleStealth_09
     StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE
+    StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE RIDERS_ATTACKING ; Patch104p @bugfix hanfield 26/08/2021 Added RIDERS_ATTACKING to forbidden stealth condition to make the Palace reveal itself when its garrison opens fire.
     InnateStealth               = No ;Requires upgrade first
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End


### PR DESCRIPTION
Stealth General's Palace should now reveal itself when its garrison attacks enemies.