### PR TITLE
Fix: GLA defense hole survival

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -154,7 +154,7 @@ https://github.com/commy2/zerohour/issues/64  [MAYBE]                 Battle Dro
 https://github.com/commy2/zerohour/issues/63  [MAYBE]                 Paladins And Microwaves Gain Slightly Less Than Intended From Composite Armor
 https://github.com/commy2/zerohour/issues/62  [MAYBE]                 Crusader And Laser Tanks Receive Composite Armor Health Bonus Twice
 https://github.com/commy2/zerohour/issues/61  [NOTRELEVANT]           Destroyed American Boss Buildings Spawn Wrong Ranger Type
-https://github.com/commy2/zerohour/issues/60  [IMPROVEMENT][NPROJECT] Destroyed Particle Cannons Spawn Wrong Ranger Type
+https://github.com/commy2/zerohour/issues/60  [DONE] Destroyed Particle Cannons Spawn Wrong Ranger Type
 https://github.com/commy2/zerohour/issues/59  [IMPROVEMENT]           Air Force General Name Misspelling
 https://github.com/commy2/zerohour/issues/58  [IMPROVEMENT]           Some Combat Bikes Missing DoorOpenTime Entry
 https://github.com/commy2/zerohour/issues/57  [IMPROVEMENT]           Broken Combat Bike Animations

--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -7,7 +7,7 @@ https://github.com/commy2/zerohour/issues/224 [IMPROVEMENT]           Mixing Bat
 https://github.com/commy2/zerohour/issues/223 [IMPROVEMENT]           Sentry Drone Lacks Voice Line When Leaving Factory
 https://github.com/commy2/zerohour/issues/222 [MAYBE]                 Poison Fields Can Clear Poison Fields
 https://github.com/commy2/zerohour/issues/221 [IMPROVEMENT]           Units Sometimes Waste Shots On Overlord Debris
-https://github.com/commy2/zerohour/issues/220 [IMPROVEMENT][NPROJECT] Units Sometimes Waste Shots On Poisoned Or Burned Infantry
+https://github.com/commy2/zerohour/issues/220 [DONE] Units Sometimes Waste Shots On Poisoned Or Burned Infantry
 https://github.com/commy2/zerohour/issues/219 [MAYBE]                 Stinger Site Does Not Benefit From AP Rockets When Engaging Airborne Targets
 https://github.com/commy2/zerohour/issues/218 [NOTRELEVANT]           Hackers Are Bad Late Game Eco
 https://github.com/commy2/zerohour/issues/217 [MAYBE]                 Scud Launchers Missing Upgrade Icon For AP Rockets

--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -203,7 +203,7 @@ https://github.com/commy2/zerohour/issues/13  [IMPROVEMENT]           Destroyed 
 https://github.com/commy2/zerohour/issues/12  [IMPROVEMENT]           Destroyed Scud Storm Always Creates Green Poison Cloud
 https://github.com/commy2/zerohour/issues/11  [IMPROVEMENT]           Scud Storm Always Creates Green Particles When Firing
 https://github.com/commy2/zerohour/issues/10  [IMPROVEMENT]           Quad Cannon-ECM-Bug
-https://github.com/commy2/zerohour/issues/9   [IMPROVEMENT][NPROJECT] Camo-Netted Palace Not Revealed When Garrisoned Troops Fire
+https://github.com/commy2/zerohour/issues/9   [DONE]                  Camo-Netted Palace Not Revealed When Garrisoned Troops Fire
 https://github.com/commy2/zerohour/issues/8   [IMPROVEMENT][NPROJECT] Supply Truck Has Extremely Low Mass
 https://github.com/commy2/zerohour/issues/7   [IMPROVEMENT][NPROJECT] Mini-Gunner Has Broken Squish Detection
 https://github.com/commy2/zerohour/issues/6   [IMPROVEMENT]           Mini-Gunner Has Broken Sound And Fire Animation When Aiming At Airborne Targets

--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -183,7 +183,7 @@ https://github.com/commy2/zerohour/issues/33  [MAYBE]                 Air Force 
 https://github.com/commy2/zerohour/issues/32  [MAYBE]                 Non-vanilla USA Avengers Benefit From Composite Armor
 https://github.com/commy2/zerohour/issues/31  [IMPROVEMENT]           Some Avengers Can Retaliate
 https://github.com/commy2/zerohour/issues/30  [IMPROVEMENT]           Crushing Marauder With Overlord Creates Indestructible Wreck
-https://github.com/commy2/zerohour/issues/29  [IMPROVEMENT][NPROJECT] GLA Base Defense Hole Sufficient For Player Survival
+https://github.com/commy2/zerohour/issues/29  [DONE]                  GLA Base Defense Hole Sufficient For Player Survival
 https://github.com/commy2/zerohour/issues/28  [MAYBE]                 Demo General Terrorist Does Not Explode When Crushed, Burned Or Blown Up
 https://github.com/commy2/zerohour/issues/27  [IMPROVEMENT][NPROJECT] Scud Storm Does Not Damage Itself
 https://github.com/commy2/zerohour/issues/26  [IMPROVEMENT]           Saboteur Uses Wrong Art For Sabotage Building-Ability

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -10710,7 +10710,7 @@ Object AirF_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_AirF_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Airforce General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -151,6 +151,162 @@ Object Chem_GLAHole
 
 End
 
+  ; Patch104p @bugfix hanfield 27/08/2021 Added new hole object for defences.
+  ; Hole objects must always be defined before any object that would require it.
+
+;------------------------------------------------------------------------------
+Object Chem_GLAHole_Defences
+
+  ; *** ART Parameters ***
+  SelectPortrait           = SUHole_L
+  ButtonImage              = SUHole_L
+  Draw                     = W3DModelDraw  ModuleTag_01
+    OkToChangeModelColor   = Yes
+    ConditionState         = NONE
+      Model                = UBHole
+    End
+    ConditionState         = DAMAGED
+      Model                = UBHole_D
+      ParticleSysBone      = Smoke01 SteamVent
+    End
+    ConditionState         = REALLYDAMAGED
+      Model                = UBHole_E
+      ParticleSysBone      = Smoke01 SteamVent
+      ParticleSysBone      = Smoke02 SteamVent
+      ParticleSysBone      = Fire01 GLAPowerPlantFlame
+      ParticleSysBone      = Fire02 GLAPowerPlantFlame
+      ParticleSysBone      = Fire03 GLAPowerPlantFlame
+    End
+  End
+
+; ----------------- the door -------------------
+  Draw                = W3DModelDraw ModuleTag_02
+    OkToChangeModelColor   = Yes
+    DefaultConditionState
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = SOLD
+      Model           = NONE
+    End
+    ConditionState  = SOLD SNOW
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT SNOW
+       Model   = NONE
+    End
+    ConditionState    = DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_CLOSING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_CLOSING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+  PlacementViewAngle       = -135
+
+  ; ***DESIGN parameters ***
+  DisplayName       = OBJECT:GLAHole
+  Side              = GLAToxinGeneral
+  EditorSorting     = SYSTEM
+  Prerequisites
+    Object = Chem_GLACommandCenter
+  End
+  BuildCost         = 100
+  BuildTime         = 10.0           ; in seconds
+  EnergyProduction  = 0
+  VisionRange       = 50.0           ; Shroud clearing distance
+  ShroudClearingRange = 50
+  ArmorSet
+    Conditions      = None
+    Armor           = StructureArmor
+    DamageFX        = StructureDamageFXNoShake
+  End
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect = TunnelNetworkSelect
+  SoundOnDamaged        = BuildingDamagedStateLight
+  SoundOnReallyDamaged  = BuildingDestroy
+
+  UnitSpecificSounds
+    UnderConstruction     = UnderConstructionLoop
+  End
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority     = STRUCTURE
+  KindOf            = PRELOAD STRUCTURE SELECTABLE IMMOBILE REBUILD_HOLE CAN_SEE_THROUGH_STRUCTURE IMMUNE_TO_CAPTURE SCORE_DESTROY
+  Body              = StructureBody ModuleTag_03
+    ; To set the health for a particular hole, edit the entry in the object
+    ; that will leave the hole behind (edit the RebuildHoleExposeDie entry)
+    MaxHealth       = 9999999.9  ;bigger than anything realistic we use
+    InitialHealth   = 9999999.9  ;bigger than anything realistic we use
+  End
+  Behavior                    = RebuildHoleBehavior ModuleTag_04
+    WorkerObjectName          = GLAInfantryWorker
+    WorkerRespawnDelay        = 20000 ;in milliseconds
+    HoleHealthRegen%PerSecond = 0.5%    ;regen this % of HoleMaxHealth per second
+  End
+
+  Behavior             = CreateObjectDie ModuleTag_13
+    CreationList  = OCL_LargeStructureDebris
+  End
+  Behavior             = FXListDie ModuleTag_14
+    DeathFX       = FX_StructureSmallDeath
+  End
+
+
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 25.0
+  GeometryHeight      = 5.0
+  GeometryIsSmall     = No
+  Shadow              = SHADOW_VOLUME
+  BuildCompletion     = PLACED_BY_PLAYER
+
+End
 
 
 
@@ -4613,7 +4769,7 @@ Object Chem_GLADemoTrap
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Chem_GLAHoleDemoTrap Chem_GLAHole
+ObjectReskin Chem_GLAHoleDemoTrap Chem_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -5192,7 +5348,7 @@ Object Chem_GLAStingerSite
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Chem_GLAHoleStingerSite Chem_GLAHole
+ObjectReskin Chem_GLAHoleStingerSite Chem_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -286,6 +286,163 @@ End
 
 
 
+; Patch104p @bugfix hanfield 27/08/2021 Added new hole object for defences.
+; Hole objects must always be defined before any object that would require it.
+;------------------------------------------------------------------------------------------------
+Object Demo_GLAHole_Defences
+
+  ; *** ART Parameters ***
+  SelectPortrait           = SUHole_L
+  ButtonImage              = SUHole_L
+  Draw                     = W3DModelDraw  ModuleTag_01
+    OkToChangeModelColor   = Yes
+    ConditionState         = NONE
+      Model                = UBHole
+    End
+    ConditionState         = DAMAGED
+      Model                = UBHole_D
+      ParticleSysBone      = Smoke01 SteamVent
+    End
+    ConditionState         = REALLYDAMAGED
+      Model                = UBHole_E
+      ParticleSysBone      = Smoke01 SteamVent
+      ParticleSysBone      = Smoke02 SteamVent
+      ParticleSysBone      = Fire01 GLAPowerPlantFlame
+      ParticleSysBone      = Fire02 GLAPowerPlantFlame
+      ParticleSysBone      = Fire03 GLAPowerPlantFlame
+    End
+  End
+
+; ----------------- the door -------------------
+  Draw                = W3DModelDraw ModuleTag_02
+    OkToChangeModelColor   = Yes
+    DefaultConditionState
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = SOLD
+      Model           = NONE
+    End
+    ConditionState  = SOLD SNOW
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT SNOW
+       Model   = NONE
+    End
+    ConditionState    = DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_CLOSING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_CLOSING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+  PlacementViewAngle       = -135
+
+  ; ***DESIGN parameters ***
+  DisplayName       = OBJECT:GLAHole
+  Side              = GLADemolitionGeneral
+  EditorSorting     = SYSTEM
+  Prerequisites
+    Object = Demo_GLACommandCenter
+  End
+  BuildCost         = 100
+  BuildTime         = 10.0           ; in seconds
+  EnergyProduction  = 0
+  VisionRange       = 50.0           ; Shroud clearing distance
+  ShroudClearingRange = 50
+  ArmorSet
+    Conditions      = None
+    Armor           = StructureArmor
+    DamageFX        = StructureDamageFXNoShake
+  End
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect = TunnelNetworkSelect
+  SoundOnDamaged        = BuildingDamagedStateLight
+  SoundOnReallyDamaged  = BuildingDestroy
+
+  UnitSpecificSounds
+    UnderConstruction     = UnderConstructionLoop
+  End
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority     = STRUCTURE
+  KindOf            = PRELOAD STRUCTURE SELECTABLE IMMOBILE REBUILD_HOLE CAN_SEE_THROUGH_STRUCTURE IMMUNE_TO_CAPTURE SCORE_DESTROY
+  Body              = StructureBody ModuleTag_03
+    ; To set the health for a particular hole, edit the entry in the object
+    ; that will leave the hole behind (edit the RebuildHoleExposeDie entry)
+    MaxHealth       = 9999999.9  ;bigger than anything realistic we use
+    InitialHealth   = 9999999.9  ;bigger than anything realistic we use
+  End
+  Behavior                    = RebuildHoleBehavior ModuleTag_04
+    WorkerObjectName          = Demo_GLAInfantryWorker
+    WorkerRespawnDelay        = 20000 ;in milliseconds
+    HoleHealthRegen%PerSecond = 0.5%    ;regen this % of HoleMaxHealth per second
+  End
+
+  Behavior             = CreateObjectDie ModuleTag_13
+    CreationList  = OCL_LargeStructureDebris
+  End
+  Behavior             = FXListDie ModuleTag_14
+    DeathFX       = FX_StructureSmallDeath
+  End
+
+
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 25.0
+  GeometryHeight      = 5.0
+  GeometryIsSmall     = No
+  Shadow              = SHADOW_VOLUME
+  BuildCompletion     = PLACED_BY_PLAYER
+
+End
+
+
 
 
 
@@ -4733,7 +4890,7 @@ Object Demo_GLADemoTrap
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Demo_GLAHoleDemoTrap Demo_GLAHole
+ObjectReskin Demo_GLAHoleDemoTrap Demo_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -5338,7 +5495,7 @@ Object Demo_GLATunnelNetwork
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Demo_GLAHoleTunnelNetwork Demo_GLAHole
+ObjectReskin Demo_GLAHoleTunnelNetwork Demo_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -5943,7 +6100,7 @@ Object Demo_GLAStingerSite
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Demo_GLAHoleStingerSite Demo_GLAHole
+ObjectReskin Demo_GLAHoleStingerSite Demo_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -162,6 +162,163 @@ Object GLAHole
 
 End
 
+
+; Patch104p @bugfix hanfield 27/08/2021 Added new hole object for defences.
+; Hole objects must always be defined before any object that would require it.
+;------------------------------------------------------------------------------
+Object GLAHole_Defences
+
+  ; *** ART Parameters ***
+  SelectPortrait           = SUHole_L
+  ButtonImage              = SUHole_L
+  Draw                     = W3DModelDraw  ModuleTag_01
+    OkToChangeModelColor   = Yes
+    ConditionState         = NONE
+      Model                = UBHole
+    End
+    ConditionState         = DAMAGED
+      Model                = UBHole_D
+      ParticleSysBone      = Smoke01 SteamVent
+    End
+    ConditionState         = REALLYDAMAGED
+      Model                = UBHole_E
+      ParticleSysBone      = Smoke01 SteamVent
+      ParticleSysBone      = Smoke02 SteamVent
+      ParticleSysBone      = Fire01 GLAPowerPlantFlame
+      ParticleSysBone      = Fire02 GLAPowerPlantFlame
+      ParticleSysBone      = Fire03 GLAPowerPlantFlame
+    End
+  End
+
+; ----------------- the door -------------------
+  Draw                = W3DModelDraw ModuleTag_02
+    OkToChangeModelColor   = Yes
+    DefaultConditionState
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = SOLD
+      Model           = NONE
+    End
+    ConditionState  = SOLD SNOW
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT SNOW
+       Model   = NONE
+    End
+    ConditionState    = DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_CLOSING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_CLOSING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+  PlacementViewAngle       = -135
+
+  ; ***DESIGN parameters ***
+  DisplayName       = OBJECT:GLAHole
+  Side              = GLA
+  EditorSorting     = SYSTEM
+  Prerequisites
+    Object = GLACommandCenter
+  End
+  BuildCost         = 100
+  BuildTime         = 10.0           ; in seconds
+  EnergyProduction  = 0
+  VisionRange       = 50.0           ; Shroud clearing distance
+  ShroudClearingRange = 50
+  ArmorSet
+    Conditions      = None
+    Armor           = StructureArmor
+    DamageFX        = StructureDamageFXNoShake
+  End
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect = TunnelNetworkSelect
+  SoundOnDamaged        = BuildingDamagedStateLight
+  SoundOnReallyDamaged  = BuildingDestroy
+
+  UnitSpecificSounds
+    UnderConstruction     = UnderConstructionLoop
+  End
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority     = STRUCTURE
+  KindOf            = PRELOAD STRUCTURE SELECTABLE IMMOBILE REBUILD_HOLE CAN_SEE_THROUGH_STRUCTURE IMMUNE_TO_CAPTURE SCORE_DESTROY
+  Body              = StructureBody ModuleTag_03
+    ; To set the health for a particular hole, edit the entry in the object
+    ; that will leave the hole behind (edit the RebuildHoleExposeDie entry)
+    MaxHealth       = 9999999.9  ;bigger than anything realistic we use
+    InitialHealth   = 9999999.9  ;bigger than anything realistic we use
+  End
+  Behavior                    = RebuildHoleBehavior ModuleTag_04
+    WorkerObjectName          = GLAInfantryWorker
+    WorkerRespawnDelay        = 20000 ;in milliseconds
+    HoleHealthRegen%PerSecond = 0.5%    ;regen this % of HoleMaxHealth per second
+  End
+
+  Behavior             = CreateObjectDie ModuleTag_13
+    CreationList  = OCL_LargeStructureDebris
+  End
+  Behavior             = FXListDie ModuleTag_14
+    DeathFX       = FX_StructureSmallDeath
+  End
+
+
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 25.0
+  GeometryHeight      = 5.0
+  GeometryIsSmall     = No
+  Shadow              = SHADOW_VOLUME
+  BuildCompletion     = PLACED_BY_PLAYER
+
+End
+
 ;------------------------------------------------------------------------------
 Object AmericaCommandCenter
 
@@ -14844,7 +15001,7 @@ Object GLADemoTrap
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin GLAHoleDemoTrap GLAHole
+ObjectReskin GLAHoleDemoTrap GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -15452,7 +15609,7 @@ Object GLATunnelNetwork
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin GLAHoleTunnelNetwork GLAHole
+ObjectReskin GLAHoleTunnelNetwork GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -15970,7 +16127,7 @@ Object GLATunnelNetworkNoSpawn
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin GLAHoleTunnelNetworkNoSpawn GLAHole
+ObjectReskin GLAHoleTunnelNetworkNoSpawn GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -16540,7 +16697,7 @@ Object GLAStingerSite
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin GLAHoleStingerSite GLAHole
+ObjectReskin GLAHoleStingerSite GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -10430,7 +10430,7 @@ Object Lazr_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19
@@ -18157,7 +18157,7 @@ Object Lazr_AmericaLaserCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19
@@ -19109,7 +19109,7 @@ Object Lazr_AmericaLaserCannon
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -151,7 +151,161 @@ Object Slth_GLAHole
 
 End
 
+; Patch104p @bugfix hanfield 27/08/2021 Added new hole object for defences.
+; Hole objects must always be defined before any object that would require it.
+;-----------------------------------------------------------------------------
+Object Slth_GLAHole_Defences
 
+  ; *** ART Parameters ***
+  SelectPortrait           = SUHole_L
+  ButtonImage              = SUHole_L
+  Draw                     = W3DModelDraw  ModuleTag_01
+    OkToChangeModelColor   = Yes
+    ConditionState         = NONE
+      Model                = UBHole
+    End
+    ConditionState         = DAMAGED
+      Model                = UBHole_D
+      ParticleSysBone      = Smoke01 SteamVent
+    End
+    ConditionState         = REALLYDAMAGED
+      Model                = UBHole_E
+      ParticleSysBone      = Smoke01 SteamVent
+      ParticleSysBone      = Smoke02 SteamVent
+      ParticleSysBone      = Fire01 GLAPowerPlantFlame
+      ParticleSysBone      = Fire02 GLAPowerPlantFlame
+      ParticleSysBone      = Fire03 GLAPowerPlantFlame
+    End
+  End
+
+; ----------------- the door -------------------
+  Draw                = W3DModelDraw ModuleTag_02
+    OkToChangeModelColor   = Yes
+    DefaultConditionState
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = SOLD
+      Model           = NONE
+    End
+    ConditionState  = SOLD SNOW
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT
+       Model   = NONE
+    End
+
+    ConditionState  = SOLD NIGHT SNOW
+       Model   = NONE
+    End
+    ConditionState    = DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_OPENING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState    = DOOR_1_CLOSING
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_CLOSING DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN
+      Model           = UBHole_A1
+      Animation       = UBHole_A1.UBHole_A1
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+    ConditionState    = DOOR_1_WAITING_OPEN DAMAGED
+      Model           = UBHole_A1D
+      Animation       = UBHole_A1D.UBHole_A1D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+  PlacementViewAngle       = -135
+
+  ; ***DESIGN parameters ***
+  DisplayName       = OBJECT:GLAHole
+  Side              = GLAStealthGeneral
+  EditorSorting     = SYSTEM
+  Prerequisites
+    Object = Slth_GLACommandCenter
+  End
+  BuildCost         = 100
+  BuildTime         = 10.0           ; in seconds
+  EnergyProduction  = 0
+  VisionRange       = 50.0           ; Shroud clearing distance
+  ShroudClearingRange = 50
+  ArmorSet
+    Conditions      = None
+    Armor           = StructureArmor
+    DamageFX        = StructureDamageFXNoShake
+  End
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect = TunnelNetworkSelect
+  SoundOnDamaged        = BuildingDamagedStateLight
+  SoundOnReallyDamaged  = BuildingDestroy
+
+  UnitSpecificSounds
+    UnderConstruction     = UnderConstructionLoop
+  End
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority     = STRUCTURE
+  KindOf            = PRELOAD STRUCTURE SELECTABLE IMMOBILE REBUILD_HOLE CAN_SEE_THROUGH_STRUCTURE IMMUNE_TO_CAPTURE SCORE_DESTROY
+  Body              = StructureBody ModuleTag_03
+    ; To set the health for a particular hole, edit the entry in the object
+    ; that will leave the hole behind (edit the RebuildHoleExposeDie entry)
+    MaxHealth       = 9999999.9  ;bigger than anything realistic we use
+    InitialHealth   = 9999999.9  ;bigger than anything realistic we use
+  End
+  Behavior                    = RebuildHoleBehavior ModuleTag_04
+    WorkerObjectName          = GLAInfantryWorker
+    WorkerRespawnDelay        = 20000 ;in milliseconds
+    HoleHealthRegen%PerSecond = 0.5%    ;regen this % of HoleMaxHealth per second
+  End
+
+  Behavior             = CreateObjectDie ModuleTag_13
+    CreationList  = OCL_LargeStructureDebris
+  End
+  Behavior             = FXListDie ModuleTag_14
+    DeathFX       = FX_StructureSmallDeath
+  End
+
+
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 25.0
+  GeometryHeight      = 5.0
+  GeometryIsSmall     = No
+  Shadow              = SHADOW_VOLUME
+  BuildCompletion     = PLACED_BY_PLAYER
+
+End
 
 
 
@@ -4660,7 +4814,7 @@ Object Slth_GLADemoTrap
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Slth_GLAHoleDemoTrap Slth_GLAHole
+ObjectReskin Slth_GLAHoleDemoTrap Slth_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -5219,7 +5373,7 @@ Object Slth_GLATunnelNetwork
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Slth_GLAHoleTunnelNetwork Slth_GLAHole
+ObjectReskin Slth_GLAHoleTunnelNetwork Slth_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -5788,7 +5942,7 @@ Object Slth_GLAStingerSite
 End
 
 ;------------------------------------------------------------------------------
-ObjectReskin Slth_GLAHoleStingerSite Slth_GLAHole
+ObjectReskin Slth_GLAHoleStingerSite Slth_GLAHole_Defences
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -6591,7 +6591,7 @@ Object Slth_GLAPalace
 
   Behavior = StealthUpdate ModuleStealth_09
     StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE
+    StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE RIDERS_ATTACKING ; Patch104p @bugfix hanfield 26/08/2021 Added RIDERS_ATTACKING to forbidden stealth condition to make the Palace reveal itself when its garrison opens fire.
     InnateStealth               = No ;Requires upgrade first
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -9821,7 +9821,7 @@ Object SupW_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   OCL_SupW_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Superweapon General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -1259,7 +1259,7 @@ Object FlamingInfantry
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY
+  KindOf = CAN_CAST_REFLECTIONS INFANTRY UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0
@@ -1338,7 +1338,7 @@ Object ToxicInfantry
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY
+  KindOf = CAN_CAST_REFLECTIONS INFANTRY UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -2324,6 +2324,324 @@ ObjectCreationList OCL_ParticleUplinkDeathFinal
   End
 End
 
+; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Airforce General Particle Cannon.
+
+; ----------------------------------------------
+ObjectCreationList OCL_AirF_ParticleUplinkDeathFinal
+; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
+  CreateObject
+    ObjectNames = AirF_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 6
+    RequiresLivePlayer = Yes
+  End
+
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:15
+
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:25
+    Mass = 30.0
+    Count = 10
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d21 ABPwrPlant_d22 ABPwrPlant_d23 ABPwrPlant_d24 ABPwrPlant_d25 ABPwrPlant_d26 ABPwrPlant_d27 ABPwrPlant_d28 ABPwrPlant_d29 ABPwrPlant_d30
+    Offset = X:0 Y:0 Z:40
+    Mass = 30.0
+    Count = 5
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+End
+
+; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Laser General Particle Cannon.
+
+; ----------------------------------------------
+ObjectCreationList OCL_Lazr_ParticleUplinkDeathFinal
+; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
+  CreateObject
+    ObjectNames = Lazr_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 6
+    RequiresLivePlayer = Yes
+  End
+
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:15
+
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:25
+    Mass = 30.0
+    Count = 10
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d21 ABPwrPlant_d22 ABPwrPlant_d23 ABPwrPlant_d24 ABPwrPlant_d25 ABPwrPlant_d26 ABPwrPlant_d27 ABPwrPlant_d28 ABPwrPlant_d29 ABPwrPlant_d30
+    Offset = X:0 Y:0 Z:40
+    Mass = 30.0
+    Count = 5
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+End
+
+; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Superweapon General Particle Cannon.
+
+; ----------------------------------------------
+ObjectCreationList OCL_SupW_ParticleUplinkDeathFinal
+; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
+  CreateObject
+    ObjectNames = SupW_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 6
+    RequiresLivePlayer = Yes
+  End
+
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:15
+
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:25
+    Mass = 30.0
+    Count = 10
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d21 ABPwrPlant_d22 ABPwrPlant_d23 ABPwrPlant_d24 ABPwrPlant_d25 ABPwrPlant_d26 ABPwrPlant_d27 ABPwrPlant_d28 ABPwrPlant_d29 ABPwrPlant_d30
+    Offset = X:0 Y:0 Z:40
+    Mass = 30.0
+    Count = 5
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+End
+
 ; ----------------------------------------------
 ObjectCreationList OCL_GenericWallSegmentDebris
 ; @todo srj -- nothing for now.


### PR DESCRIPTION
GLA Defence Holes will no longer let the player survive if he is reduced to nothing but holes spawned from defences.