### PR TITLE
Fix: Destroyed Heroic Toxin Tractor Creates Green Poison Cloud Without Anthrax Beta Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -52,7 +52,7 @@ https://github.com/commy2/zerohour/issues/175 [IMPROVEMENT]           Stinger Si
 https://github.com/commy2/zerohour/issues/174 [IMPROVEMENT]           Stinger Site Can Double Fire
 https://github.com/commy2/zerohour/issues/173 [IMPROVEMENT]           Humvee Without TOW Missiles Upgrade Freezes When Attack Moving Into Airborne Targets
 https://github.com/commy2/zerohour/issues/172 [IMPROVEMENT]           Extended Range Exploit
-https://github.com/commy2/zerohour/issues/163 [IMPROVEMENT]           Destroyed Heroic Toxin Tractor Creates Green Poison Cloud Without Anthrax Beta Upgrade
+https://github.com/commy2/zerohour/issues/163 [DONE]                  Destroyed Heroic Toxin Tractor Creates Green Poison Cloud Without Anthrax Beta Upgrade
 https://github.com/commy2/zerohour/issues/162 [NOTRELEVANT]           Boss General Has Some Conflicting Hotkeys
 https://github.com/commy2/zerohour/issues/161 [MAYBE]                 Terrorist And Terror Bike Have To Force-Fire Ground To Detonate
 https://github.com/commy2/zerohour/issues/160 [MAYBE]                 Slow Units Can Outrun Comanche Missiles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16533,12 +16533,12 @@ Object Chem_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
+    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn off un-upgraded puddle when gaining vet 3.
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = Chem_ToxinShellWeaponGamma
     StartsActive  = No
-    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
+    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16533,12 +16533,12 @@ Object Chem_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = Chem_ToxinShellWeaponGamma
     StartsActive  = No
-    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma
+    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -18594,12 +18594,12 @@ Object Demo_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn off un-upgraded puddle when gaining vet 3.
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = ToxinShellWeaponUpgraded
     StartsActive  = No
-    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -18594,12 +18594,12 @@ Object Demo_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta
+    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = ToxinShellWeaponUpgraded
     StartsActive  = No
-    TriggeredBy = Upgrade_GLAAnthraxBeta
+    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1575,12 +1575,12 @@ Object GC_Chem_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
+    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn off un-upgraded puddle when gaining vet 3.
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = Chem_ToxinShellWeaponGamma
     StartsActive  = No
-    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
+    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1575,12 +1575,12 @@ Object GC_Chem_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = Chem_ToxinShellWeaponGamma
     StartsActive  = No
-    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma
+    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma Upgrade_Veterancy_HEROIC
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3714,12 +3714,12 @@ Object GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn off un-upgraded puddle when gaining vet 3.
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = ToxinShellWeaponUpgraded
     StartsActive  = No
-    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3714,12 +3714,12 @@ Object GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta
+    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = ToxinShellWeaponUpgraded
     StartsActive  = No
-    TriggeredBy = Upgrade_GLAAnthraxBeta
+    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17958,12 +17958,12 @@ Object Slth_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta
+    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = ToxinShellWeaponUpgraded
     StartsActive  = No
-    TriggeredBy = Upgrade_GLAAnthraxBeta
+    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17958,12 +17958,12 @@ Object Slth_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn off un-upgraded puddle when gaining vet 3.
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = ToxinShellWeaponUpgraded
     StartsActive  = No
-    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
   End
 
   Geometry = BOX


### PR DESCRIPTION
related to https://github.com/xezon/GeneralsGamePatch/pull/77

Ranking up a Toxin Tractor to vet 3 does upgrade the weapon, but it does not upgrade the destruction affect accordingly. This change "synchronizes" veterancy and Anthrax upgrades and makes the Tractor use the correct effect regardless of veterancy.