### PR TITLE
Fix: Toxin Shells Lose Projectile Explosion Effect After Anthrax Beta Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -198,7 +198,7 @@ https://github.com/commy2/zerohour/issues/18  [MAYBE]                 Toxin Gene
 https://github.com/commy2/zerohour/issues/17  [MAYBE]                 Toxin General Terrorist Does Extra Damage Before Anthrax Gamma Upgrade
 https://github.com/commy2/zerohour/issues/16  [IMPROVEMENT]           Toxin Demo Trap Creates Poison Cloud Before It Explodes
 https://github.com/commy2/zerohour/issues/15  [IMPROVEMENT]           Gamma Toxin Streams Create Green Particles When Clearing Buildings
-https://github.com/commy2/zerohour/issues/14  [IMPROVEMENT]           Toxin Shells Lose Projectile Explosion Effect After Anthrax Upgrade
+https://github.com/commy2/zerohour/issues/14  [DONE]                  Toxin Shells Lose Projectile Explosion Effect After Anthrax Upgrade
 https://github.com/commy2/zerohour/issues/13  [DONE]                  Destroyed Toxin Tractor Always Creates Green Particles
 https://github.com/commy2/zerohour/issues/12  [DONE]                  Destroyed Scud Storm Always Creates Green Poison Cloud
 https://github.com/commy2/zerohour/issues/11  [DONE]                  Scud Storm Always Creates Green Particles When Firing

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -3,10 +3,25 @@
 ;//////////////////////////////////////////////////////////////////////////////
 
 ; ----------------------------------------------
-
 FXList WeaponFX_ToxinShellWeapon
   ParticleSystem
     Name = ToxicShellExplosion
+  End
+End
+
+; Patch104p @bugfix commy2 28/08/2021 Effects used for Toxin Shell with Anthrax upgrades.
+
+; ----------------------------------------------
+FXList WeaponFX_ToxinShellWeaponUpgraded
+  ParticleSystem
+    Name = ToxicShellExplosionAnthrax
+  End
+End
+
+; ----------------------------------------------
+FXList Chem_WeaponFX_ToxinShellWeaponGamma
+  ParticleSystem
+    Name = Chem_ToxicShellExplosionGamma
   End
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -51610,6 +51610,122 @@ ParticleSystem ToxicShellExplosion
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @bugfix commy2 28/08/2021 Effects used for Toxin Shell with Anthrax upgrades.
+
+ParticleSystem ToxicShellExplosionAnthrax
+  Priority = WEAPON_EXPLOSION
+  IsOneShot = No
+  Shader = ADDITIVE
+  Type = PARTICLE
+  ParticleName = EXexplo03.tga
+  AngleZ = -15.00 15.00
+  AngularRateZ = -0.02 0.02
+  AngularDamping = 1.00 1.00
+  VelocityDamping = 0.98 0.98
+  Gravity = 0.00
+  Lifetime = 30.00 30.00
+  SystemLifetime = 10
+  Size = 2.00 2.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 3.00 3.00
+  SizeRateDamping = 0.90 0.85
+  Alpha1 = 1.00 1.00 0
+  Alpha2 = 0.00 0.00 0
+  Alpha3 = 0.00 0.00 0
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:0 G:0 B:0 0
+  Color2 = R:125 G:125 B:255 5
+  Color3 = R:0 G:0 B:0 30
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 20.00 20.00
+  BurstCount = 1.00 1.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.08 Y:0.16 Z:0.01
+  VelocityType = OUTWARD
+  VelOutward = 0.08 0.10
+  VelOutwardOther = 0.00 0.50
+  VolumeType = CYLINDER
+  VolCylinderRadius = 2.00
+  VolCylinderLength = 0.00
+  IsHollow = No
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = Yes
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
+ParticleSystem Chem_ToxicShellExplosionGamma
+  Priority = WEAPON_EXPLOSION
+  IsOneShot = No
+  Shader = ADDITIVE
+  Type = PARTICLE
+  ParticleName = EXexplo03.tga
+  AngleZ = -15.00 15.00
+  AngularRateZ = -0.02 0.02
+  AngularDamping = 1.00 1.00
+  VelocityDamping = 0.98 0.98
+  Gravity = 0.00
+  Lifetime = 30.00 30.00
+  SystemLifetime = 10
+  Size = 2.00 2.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 3.00 3.00
+  SizeRateDamping = 0.90 0.85
+  Alpha1 = 1.00 1.00 0
+  Alpha2 = 0.00 0.00 0
+  Alpha3 = 0.00 0.00 0
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:0 G:0 B:0 0
+  Color2 = R:255 G:125 B:255 5
+  Color3 = R:0 G:0 B:0 30
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 20.00 20.00
+  BurstCount = 1.00 1.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.08 Y:0.16 Z:0.01
+  VelocityType = OUTWARD
+  VelOutward = 0.08 0.10
+  VelOutwardOther = 0.00 0.50
+  VolumeType = CYLINDER
+  VolCylinderRadius = 2.00
+  VolCylinderLength = 0.00
+  IsHollow = No
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = Yes
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
 ParticleSystem FlamethrowerTarget
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1487,7 +1487,7 @@ Weapon ToxinShellWeaponUpgraded ; No extra damage, just lays down a damage field
   DeathType = EXPLODED
   WeaponSpeed = 99999.0
   ProjectileObject = NONE
-;  FireFX = WeaponFX_NapalmMissileDetonation
+  FireFX = WeaponFX_ToxinShellWeaponUpgraded  ; Patch104p @bugfix commy2 28/08/2021 Fixes Toxin Shells losing impact effect after Anthrax upgrade.
   FireOCL = OCL_PoisonFieldUpgradedSmall
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 0                   ; time between shots, msec
@@ -5985,7 +5985,7 @@ Weapon Chem_ToxinShellWeaponGamma ; No extra damage, just lays down a damage fie
   DeathType = EXPLODED
   WeaponSpeed = 99999.0
   ProjectileObject = NONE
-;  FireFX = WeaponFX_NapalmMissileDetonation
+  FireFX = Chem_WeaponFX_ToxinShellWeaponGamma  ; Patch104p @bugfix commy2 28/08/2021 Fixes Toxin Shells losing impact effect after Anthrax upgrade.
   FireOCL = OCL_PoisonFieldGammaSmall
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 0                   ; time between shots, msec


### PR DESCRIPTION
ZH 1.04:

- Toxin Shells are missing the explosion particle effect once upgraded to Anthrax Beta or Anthrax Gamma.

After this patch:

- Toxin Shells use the same effect on impact as with green poison, but recoloured to match the current Anthrax upgrade.