### PR TITLE
Fix: Gamma Toxin Streams Create Green Particles When Clearing Buildings

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -197,7 +197,7 @@ https://github.com/commy2/zerohour/issues/19  [IMPROVEMENT]           Emerging S
 https://github.com/commy2/zerohour/issues/18  [MAYBE]                 Toxin General Terrorist Without Anthrax Beta Upgrade Creates No Poison Cloud
 https://github.com/commy2/zerohour/issues/17  [MAYBE]                 Toxin General Terrorist Does Extra Damage Before Anthrax Gamma Upgrade
 https://github.com/commy2/zerohour/issues/16  [IMPROVEMENT]           Toxin Demo Trap Creates Poison Cloud Before It Explodes
-https://github.com/commy2/zerohour/issues/15  [IMPROVEMENT]           Gamma Toxin Streams Create Green Particles When Clearing Buildings
+https://github.com/commy2/zerohour/issues/15  [DONE]                  Gamma Toxin Streams Create Green Particles When Clearing Buildings
 https://github.com/commy2/zerohour/issues/14  [IMPROVEMENT]           Toxin Shells Lose Projectile Explosion Effect After Anthrax Upgrade
 https://github.com/commy2/zerohour/issues/13  [DONE]                  Destroyed Toxin Tractor Always Creates Green Particles
 https://github.com/commy2/zerohour/issues/12  [DONE]                  Destroyed Scud Storm Always Creates Green Poison Cloud

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -5615,6 +5615,25 @@ FXList FX_ToxinUpgradedBuildingClear
 
 End
 
+; Patch104p @bugfix commy2 28/08/2021 Effects used when Gamma toxin stream clears garrisoned building.
+
+;------------------------------------------------------------------------------
+; FX played when a building gets cleared by the Gamma Toxin Truck
+;------------------------------------------------------------------------------
+
+FXList Chem_FX_ToxinGammaBuildingClear
+
+  ParticleSystem
+    Name           = Chem_ToxinGammaBuildingClearSpray
+    OrientToObject = yes
+  End
+
+;  Sound
+;    Name           = RaptorDie
+;  End
+
+End
+
 ;------------------------------------------------------------------------------
 ; FX played when a building gets cleared by the Dragon Tank
 ;------------------------------------------------------------------------------
@@ -5678,6 +5697,34 @@ FXList FX_ToxinStreamUpgradedGarrisonBuildingHit
 
   FXListAtBonePos
     FX = FX_ToxinUpgradedBuildingClear
+    BoneName = FIREPOINT
+    OrientToBone = Yes
+  End
+
+End
+
+; Patch104p @bugfix commy2 28/08/2021 Effects used when Gamma toxin stream hits garrisoned building.
+
+; -----------------------------------------------------------------------------------
+; FX played when a Gamma Toxin Stream hits a garrisoned building and does Urban Combat Bldg clearing
+; -----------------------------------------------------------------------------------
+
+FXList Chem_FX_ToxinStreamGammaGarrisonBuildingHit
+
+  LightPulse
+    Color = R:255 G:255 B:255
+    Radius = 100
+    RadiusAsPercentOfObjectSize = 150%
+    IncreaseTime = 0
+    DecreaseTime = 2000
+  End
+
+  Sound
+    Name = TankDie
+  End
+
+  FXListAtBonePos
+    FX = Chem_FX_ToxinGammaBuildingClear
     BoneName = FIREPOINT
     OrientToBone = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -21356,7 +21356,7 @@ Object Chem_ToxinStreamProjectile
     GarrisonHitKillRequiredKindOf   = INFANTRY
     GarrisonHitKillForbiddenKindOf  = NONE
     GarrisonHitKillCount            = 2
-    GarrisonHitKillFX               = FX_ToxinStreamGarrisonBuildingHit
+    GarrisonHitKillFX               = Chem_FX_ToxinStreamGammaGarrisonBuildingHit   ; Patch104p @bugfix commy2 28/08/2021 Fix Gamma Anthrax effect to use pink instead of green color.
   End
 
   Locomotor = SET_NORMAL ToxinTruckStreamLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -987,7 +987,7 @@ Object GC_Chem_ToxinStreamProjectile
     GarrisonHitKillRequiredKindOf   = INFANTRY
     GarrisonHitKillForbiddenKindOf  = NONE
     GarrisonHitKillCount            = 2
-    GarrisonHitKillFX               = FX_ToxinStreamGarrisonBuildingHit
+    GarrisonHitKillFX               = Chem_FX_ToxinStreamGammaGarrisonBuildingHit   ; Patch104p @bugfix commy2 28/08/2021 Fix Gamma Anthrax effect to use pink instead of green color.
   End
 
   Locomotor = SET_NORMAL ToxinTruckStreamLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -6294,6 +6294,64 @@ ParticleSystem ToxinUpgradedBuildingClearSpray
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @bugfix commy2 28/08/2021 Particle created when Gamma toxin stream hits building.
+
+ParticleSystem Chem_ToxinGammaBuildingClearSpray
+  Priority = UNIT_DAMAGE_FX
+  IsOneShot = No
+  Shader = ALPHA
+  Type = STREAK
+  ParticleName = EXWater05.tga
+  AngleZ = -7.00 7.00
+  AngularRateZ = -0.10 0.10
+  AngularDamping = 1.00 1.00
+  VelocityDamping = 0.95 0.90
+  Gravity = -0.10
+  Lifetime = 40.00 40.00
+  SystemLifetime = 1
+  Size = 2.00 5.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 0.50 1.00
+  SizeRateDamping = 0.99 0.95
+  Alpha1 = 0.00 0.00 1
+  Alpha2 = 0.25 0.25 5
+  Alpha3 = 0.00 0.00 40
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:128 G:55 B:217 0
+  Color2 = R:0 G:0 B:0 0
+  Color3 = R:0 G:0 B:0 0
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 0.00 1.00
+  BurstCount = 1.00 1.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.00
+  VelocityType = ORTHO
+  VelOrthoX = 1.00 8.00
+  VelOrthoY = -4.00 4.00
+  VelOrthoZ = 1.00 1.00
+  VolumeType = POINT
+  IsHollow = No
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
 ParticleSystem HackFlare
   Priority = WEAPON_TRAIL
   IsOneShot = No


### PR DESCRIPTION
ZH 1.04:

- When clearing a building as Toxin General, green particles are created when upgraded with Anthrax Gamma. Without Anthrax Gamma, the particles were already blue.

With this patch:

- A new effect is used that recolours the particles to pink, meaning that green, blue or pink particles now match the current Anthrax upgrade state.