### PR TITLE
Fix: Toxin General Demo Trap Creates Explosion And Poison Cloud Before It Triggers

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -196,7 +196,7 @@ https://github.com/commy2/zerohour/issues/20  [IMPROVEMENT]           Demo Rocke
 https://github.com/commy2/zerohour/issues/19  [IMPROVEMENT]           Emerging Sneak Attack Uses Tunnel Network Portrait
 https://github.com/commy2/zerohour/issues/18  [MAYBE]                 Toxin General Terrorist Without Anthrax Beta Upgrade Creates No Poison Cloud
 https://github.com/commy2/zerohour/issues/17  [MAYBE]                 Toxin General Terrorist Does Extra Damage Before Anthrax Gamma Upgrade
-https://github.com/commy2/zerohour/issues/16  [IMPROVEMENT]           Toxin Demo Trap Creates Poison Cloud Before It Explodes
+https://github.com/commy2/zerohour/issues/16  [DONE]                  Toxin Demo Trap Creates Poison Cloud Before It Explodes
 https://github.com/commy2/zerohour/issues/15  [IMPROVEMENT]           Gamma Toxin Streams Create Green Particles When Clearing Buildings
 https://github.com/commy2/zerohour/issues/14  [IMPROVEMENT]           Toxin Shells Lose Projectile Explosion Effect After Anthrax Upgrade
 https://github.com/commy2/zerohour/issues/13  [DONE]                  Destroyed Toxin Tractor Always Creates Green Particles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5444,23 +5444,26 @@ Object Chem_GLADemoTrap
     DetonateWhenKilled        = Yes
   End
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix Toxin Demo Trap exploding before the warning delay unlike other Demo Traps.
+
   Behavior = SlowDeathBehavior ModuleTag_05
-    ExemptStatus = UNDER_CONSTRUCTION
+    ExemptStatus = UNDER_CONSTRUCTION STATUS_RIDER1
     DestructionDelay = 1000
     FX = INITIAL FX_GLADemoTrapWarning
-;   Weapon = FINAL Chem_DemoTrapDetonationWeaponBeta
+    Weapon = FINAL Chem_DemoTrapDetonationWeaponBeta
   End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Chem01
-    DeathWeapon   = Chem_DemoTrapDetonationWeaponBeta
-    StartsActive  = Yes
-    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+  Behavior = SlowDeathBehavior ModuleTag_05Anthrax
+    ExemptStatus = UNDER_CONSTRUCTION
+    RequiredStatus = STATUS_RIDER1
+    DestructionDelay = 1000
+    FX = INITIAL FX_GLADemoTrapWarning
+    Weapon = FINAL Chem_DemoTrapDetonationWeaponGamma
   End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Chem02
-    DeathWeapon   = Chem_DemoTrapDetonationWeaponGamma
-    StartsActive  = No                      ; turned on by upgrade
-    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
+  Behavior = StatusBitsUpgrade ModuleTag_05Upgrade
+    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma
+    StatusToSet = STATUS_RIDER1
   End
 
   Behavior = FlammableUpdate ModuleTag_07


### PR DESCRIPTION
ZH 1.04:

- The Toxin General's Demo Trap explodes and creates the poison cloud immediately and before even the trigger sound plays.

After this patch:

- The explosion happens properly after the warning delay like every other Demo Trap.
