### PR TITLE
Fix: Emerging Sneak Attack Uses Tunnel Network Portrait

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -193,7 +193,7 @@ https://github.com/commy2/zerohour/issues/23  [IMPROVEMENT]           Demo Gener
 https://github.com/commy2/zerohour/issues/22  [IMPROVEMENT]           Build Scorpion Tank-Button Misspelling
 https://github.com/commy2/zerohour/issues/21  [IMPROVEMENT]           Demo And Tox Rebel Ambush Tooltips Are Wrong
 https://github.com/commy2/zerohour/issues/20  [IMPROVEMENT]           Demo Rocket Buggy Loses Red Missile Detonation Effect After Buggy Ammo Upgrade
-https://github.com/commy2/zerohour/issues/19  [IMPROVEMENT]           Emerging Sneak Attack Uses Tunnel Network Portrait
+https://github.com/commy2/zerohour/issues/19  [DONE]                  Emerging Sneak Attack Uses Tunnel Network Portrait
 https://github.com/commy2/zerohour/issues/18  [MAYBE]                 Toxin General Terrorist Without Anthrax Beta Upgrade Creates No Poison Cloud
 https://github.com/commy2/zerohour/issues/17  [MAYBE]                 Toxin General Terrorist Does Extra Damage Before Anthrax Gamma Upgrade
 https://github.com/commy2/zerohour/issues/16  [IMPROVEMENT]           Toxin Demo Trap Creates Poison Cloud Before It Explodes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -11514,10 +11514,12 @@ End
 
 Object Chem_GLASneakAttackTunnelNetworkStart
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix portrait used by emerging Sneak Attack.
+
   ; *** ART Parameters ***
 
-  SelectPortrait         = SUTunnel_L
-  ButtonImage            = SUTunnel
+  SelectPortrait         = SUSneakAttack_L
+  ButtonImage            = SUSneakAttack
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -11483,10 +11483,12 @@ End
 
 Object Demo_GLASneakAttackTunnelNetworkStart
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix portrait used by emerging Sneak Attack.
+
   ; *** ART Parameters ***
 
-  SelectPortrait         = SUTunnel_L
-  ButtonImage            = SUTunnel
+  SelectPortrait         = SUSneakAttack_L
+  ButtonImage            = SUSneakAttack
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -34266,10 +34266,12 @@ End
 
 Object GLASneakAttackTunnelNetworkStart
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix portrait used by emerging Sneak Attack.
+
   ; *** ART Parameters ***
 
-  SelectPortrait         = SUTunnel_L
-  ButtonImage            = SUTunnel
+  SelectPortrait         = SUSneakAttack_L
+  ButtonImage            = SUSneakAttack
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -12198,10 +12198,12 @@ End
 
 Object Slth_GLASneakAttackTunnelNetworkStart
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix portrait used by emerging Sneak Attack.
+
   ; *** ART Parameters ***
 
-  SelectPortrait         = SUTunnel_L
-  ButtonImage            = SUTunnel
+  SelectPortrait         = SUSneakAttack_L
+  ButtonImage            = SUSneakAttack
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 


### PR DESCRIPTION
ZH 1.04:

-  The emerging Sneak Attack uses the portrait of a Tunnel Network instead of a Sneak Attack.

After this patch:

- The Sneak Attack uses the same portrait before and after it has been completed.