### PR TITLE
Fix: Demo General Rocket Buggy Loses Red Missile Detonation Effect After Buggy Ammo Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -192,7 +192,7 @@ https://github.com/commy2/zerohour/issues/24  [IMPROVEMENT]           GLA Buildi
 https://github.com/commy2/zerohour/issues/23  [IMPROVEMENT]           Demo General Jarmen Kell Repeats Voice Line When Planting Timed Demo Charge
 https://github.com/commy2/zerohour/issues/22  [IMPROVEMENT]           Build Scorpion Tank-Button Misspelling
 https://github.com/commy2/zerohour/issues/21  [IMPROVEMENT]           Demo And Tox Rebel Ambush Tooltips Are Wrong
-https://github.com/commy2/zerohour/issues/20  [IMPROVEMENT]           Demo Rocket Buggy Loses Red Missile Detonation Effect After Buggy Ammo Upgrade
+https://github.com/commy2/zerohour/issues/20  [DONE]                  Demo Rocket Buggy Loses Red Missile Detonation Effect After Buggy Ammo Upgrade
 https://github.com/commy2/zerohour/issues/19  [IMPROVEMENT]           Emerging Sneak Attack Uses Tunnel Network Portrait
 https://github.com/commy2/zerohour/issues/18  [MAYBE]                 Toxin General Terrorist Without Anthrax Beta Upgrade Creates No Poison Cloud
 https://github.com/commy2/zerohour/issues/17  [MAYBE]                 Toxin General Terrorist Does Extra Damage Before Anthrax Gamma Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16795,7 +16795,7 @@ Object Demo_GLAVehicleRocketBuggy
   End
   WeaponSet
     Conditions = PLAYER_UPGRADE
-    Weapon = PRIMARY BuggyRocketWeaponUpgraded
+    Weapon = PRIMARY BuggyRocketREDWeaponUpgraded   ; Patch104p @bugfix commy2 28/08/2021 Fixes Demo General Rocket Buggy losing special red particle effect after Buggy Ammo upgrade.
     Weapon = TERTIARY TerroristSuicideNotARealWeapon
     AutoChooseSources = TERTIARY NONE
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2173,7 +2173,6 @@ Weapon BuggyRocketWeaponUpgraded
   FireFX                      = FX_BuggyMissileIgnition
   FireSound                   = RocketBuggyWeapon
   WeaponBonus                 = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
-  ProjectileDetonationFX      = WeaponFX_RocketBuggyMissileDetonation
   ProjectileCollidesWith      = STRUCTURES
   MissileCallsOnDie           = Yes
 End
@@ -8062,8 +8061,8 @@ Weapon Nuke_MiGMissileWeapon
   AntiAirborneInfantry        = No
   ShowsAmmoPips               = Yes
 End
-;---------------------------------------------------------------------------------
 
+;---------------------------------------------------------------------------------
 Weapon BuggyRocketREDWeapon
   PrimaryDamage               = 20.0
   PrimaryDamageRadius         = 0.0
@@ -8092,8 +8091,40 @@ Weapon BuggyRocketREDWeapon
   ProjectileCollidesWith      = STRUCTURES
   MissileCallsOnDie           = Yes
 End
-;------------------------------------------------------------------------------
 
+; Patch104p @bugfix commy2 28/08/2021 Weapon used when Demo General Rocket Buggy is upgraded with Buggy Ammo.
+
+;---------------------------------------------------------------------------------
+Weapon BuggyRocketREDWeaponUpgraded
+  PrimaryDamage               = 20.0
+  PrimaryDamageRadius         = 0.0
+  ScatterRadiusVsInfantry     = 20.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  SecondaryDamage             = 5.0
+  SecondaryDamageRadius       = 10.0
+  AttackRange                 = 300.0
+  MinimumAttackRange          = 50.0 ;150.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
+  DamageType                  = EXPLOSION          ; ignored for projectile weapons
+  DeathType                   = EXPLODED
+  WeaponSpeed                 = 600               ; ignored for projectile weapons
+  ProjectileObject            = RocketBuggyMissile
+  ProjectileExhaust           = MissileExhaust
+  VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
+  ProjectileDetonationFX      = WeaponFX_DEMOGENRocketBuggyMissileDetonation
+  RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
+  ScatterRadius               = 0      ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly
+  DelayBetweenShots           = 200  ; time between shots, msec
+  ClipSize                    = 12            ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 6000    ; how long to reload a Clip, msec
+  AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 6100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
+  FireFX                      = FX_BuggyMissileIgnition
+  FireSound                   = RocketBuggyWeapon
+  WeaponBonus                 = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
+  ProjectileCollidesWith      = STRUCTURES
+  MissileCallsOnDie           = Yes
+End
+
+;------------------------------------------------------------------------------
 Weapon REDMarauderTankGun
   PrimaryDamage = 60.0
   PrimaryDamageRadius = 5.0


### PR DESCRIPTION
ZH 1.04:

- The Demo General's Rocket Buggy loses the red missile explosion effect when upgraded with Buggy Ammo.

After this patch:

- The Demo General's Rocket Buggy keeps his effect even after the Buggy Ammo upgrade.
