### PR TITLE
Fix: Demo General Jarmen Kell Repeats Voice Line When Planting Timed Demo Charge

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -189,7 +189,7 @@ https://github.com/commy2/zerohour/issues/27  [IMPROVEMENT][NPROJECT] Scud Storm
 https://github.com/commy2/zerohour/issues/26  [IMPROVEMENT]           Saboteur Uses Wrong Art For Sabotage Building-Ability
 https://github.com/commy2/zerohour/issues/25  [NOTRELEVANT]           Boss Tomahawk Launcher Never Drops Scrap
 https://github.com/commy2/zerohour/issues/24  [IMPROVEMENT]           GLA Buildings Don't Create Scrap
-https://github.com/commy2/zerohour/issues/23  [IMPROVEMENT]           Demo General Jarmen Kell Repeats Voice Line When Planting Timed Demo Charge
+https://github.com/commy2/zerohour/issues/23  [DONE]                  Demo General Jarmen Kell Repeats Voice Line When Planting Timed Demo Charge
 https://github.com/commy2/zerohour/issues/22  [IMPROVEMENT]           Build Scorpion Tank-Button Misspelling
 https://github.com/commy2/zerohour/issues/21  [IMPROVEMENT]           Demo And Tox Rebel Ambush Tooltips Are Wrong
 https://github.com/commy2/zerohour/issues/20  [IMPROVEMENT]           Demo Rocket Buggy Loses Red Missile Detonation Effect After Buggy Ammo Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12725,7 +12725,7 @@ Object Demo_GLAInfantryJarmenKell
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = DemoKellVoiceAttackDemo
+    UnpackSound               = ColonelBurtonPlantCharge  ; Patch104p @bugfix commy2 28/08/2021 Play expected sound effect instead of repeating the voice line.
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End


### PR DESCRIPTION
ZH 1.04:

- When using the Timed Demo Charge, Jarmen Kell erroneously repeats a voice line when he arrives at the target.

After this patch:

- Instead of the repeated voice line, the "planting a demo charge beep" sound effect is played.