### PR TITLE
Fix: GLA Buildings Sometimes Don't Create Scrap When They Destroy Enemy Vehicles

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -188,7 +188,7 @@ https://github.com/commy2/zerohour/issues/28  [MAYBE]                 Demo Gener
 https://github.com/commy2/zerohour/issues/27  [IMPROVEMENT][NPROJECT] Scud Storm Does Not Damage Itself
 https://github.com/commy2/zerohour/issues/26  [IMPROVEMENT]           Saboteur Uses Wrong Art For Sabotage Building-Ability
 https://github.com/commy2/zerohour/issues/25  [NOTRELEVANT]           Boss Tomahawk Launcher Never Drops Scrap
-https://github.com/commy2/zerohour/issues/24  [IMPROVEMENT]           GLA Buildings Don't Create Scrap
+https://github.com/commy2/zerohour/issues/24  [DONE]                  GLA Buildings Don't Create Scrap
 https://github.com/commy2/zerohour/issues/23  [IMPROVEMENT]           Demo General Jarmen Kell Repeats Voice Line When Planting Timed Demo Charge
 https://github.com/commy2/zerohour/issues/22  [IMPROVEMENT]           Build Scorpion Tank-Button Misspelling
 https://github.com/commy2/zerohour/issues/21  [IMPROVEMENT]           Demo And Tox Rebel Ambush Tooltips Are Wrong

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -6551,7 +6551,7 @@ Object Boss_ScudStorm
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON SALVAGER  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0
@@ -9309,7 +9309,7 @@ Object Boss_TunnelNetwork
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5211,7 +5211,7 @@ Object Chem_GLAScudStorm
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON SALVAGER  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0
@@ -5420,7 +5420,7 @@ Object Chem_GLADemoTrap
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP SALVAGER ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -5964,7 +5964,7 @@ Object Chem_GLAStingerSite
 
   ; *** ENGINEERING Parameters ***
   RadarPriority        = STRUCTURE
-  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE
+  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
 
   Body                 = HiveStructureBody ModuleTag_04 ;Requires SpawnBehavior!
     MaxHealth          = 1000.0
@@ -20273,7 +20273,7 @@ Object Chem_GLATunnelNetwork
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4547,7 +4547,7 @@ Object Demo_GLAScudStorm
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON SALVAGER  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0
@@ -4741,7 +4741,7 @@ Object Demo_GLADemoTrap
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP SALVAGER ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -5243,7 +5243,7 @@ Object Demo_GLATunnelNetwork
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
@@ -5875,7 +5875,7 @@ Object Demo_GLAStingerSite
 
   ; *** ENGINEERING Parameters ***
   RadarPriority        = STRUCTURE
-  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE
+  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
 
   Body                 = HiveStructureBody ModuleTag_04 ;Requires SpawnBehavior!
     MaxHealth          = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13267,7 +13267,7 @@ Object GLAScudStorm
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON SALVAGER  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0
@@ -15661,7 +15661,7 @@ Object GLADemoTrap
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP SALVAGER ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -16209,7 +16209,7 @@ Object GLATunnelNetwork
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
@@ -16757,7 +16757,7 @@ Object GLATunnelNetworkNoSpawn
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
@@ -17314,7 +17314,7 @@ Object GLAStingerSite
 
   ; *** ENGINEERING Parameters ***
   RadarPriority        = STRUCTURE
-  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE
+  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
 
   Body                 = HiveStructureBody ModuleTag_04 ;Requires SpawnBehavior!
     MaxHealth          = 1000.0
@@ -33901,7 +33901,7 @@ Object GLAStingerSiteNoHole
 
   ; *** ENGINEERING Parameters ***
   RadarPriority        = STRUCTURE
-  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE
+  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
 
   Body                 = HiveStructureBody ModuleTag_04 ;Requires SpawnBehavior!
     MaxHealth          = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -406,7 +406,7 @@ Object GC_Chem_GLATunnelNetwork
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
@@ -919,7 +919,7 @@ Object GC_Chem_GLAStingerSite
 
   ; *** ENGINEERING Parameters ***
   RadarPriority        = STRUCTURE
-  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE
+  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
 
   Body                 = HiveStructureBody ModuleTag_04 ;Requires SpawnBehavior!
     MaxHealth          = 1000.0
@@ -1125,7 +1125,7 @@ Object GC_Chem_GLADemoTrap
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP SALVAGER ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -7365,7 +7365,7 @@ Object GC_Chem_GLAScudStorm
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON SALVAGER  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -2585,7 +2585,7 @@ Object GC_Slth_GLAStingerSite
 
   ; *** ENGINEERING Parameters ***
   RadarPriority        = STRUCTURE
-  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE
+  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
 
   Body                 = HiveStructureBody ModuleTag_04 ;Requires SpawnBehavior!
     MaxHealth          = 1000.0
@@ -3108,7 +3108,7 @@ Object GC_Slth_GLATunnelNetwork
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
@@ -5695,7 +5695,7 @@ Object GC_Slth_GLADemoTrap
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP SALVAGER ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -7710,7 +7710,7 @@ Object GC_Slth_GLAScudStorm
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON SALVAGER  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5249,7 +5249,7 @@ Object Slth_GLAScudStorm
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_SUPERWEAPON SALVAGER  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0
@@ -5475,7 +5475,7 @@ Object Slth_GLADemoTrap
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE IMMUNE_TO_CAPTURE DEMOTRAP SALVAGER ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -5974,7 +5974,7 @@ Object Slth_GLATunnelNetwork
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT
+  KindOf          = PRELOAD STRUCTURE SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SCORE_CREATE AUTO_RALLYPOINT  ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
@@ -6560,7 +6560,7 @@ Object Slth_GLAStingerSite
 
   ; *** ENGINEERING Parameters ***
   RadarPriority        = STRUCTURE
-  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE
+  KindOf               = PRELOAD STRUCTURE SELECTABLE IMMOBILE FS_BASE_DEFENSE SALVAGER IMMUNE_TO_CAPTURE SPAWNS_ARE_THE_WEAPONS SCORE_CREATE ; Patch104p @bugfix commy2 28/08/2021 Let GLA building create scrap piles when it destroys an enemy vehicle.
 
   Body                 = HiveStructureBody ModuleTag_04 ;Requires SpawnBehavior!
     MaxHealth          = 1000.0


### PR DESCRIPTION
ZH 1.04:

- GLA buildings do not create scrap consistently. A Tunnel Network will not create scrap while a Stinger Site does... sometimes. Except a Demo Stinger Site when kills by Suicide. And except ... bla bla

With this patch:

- GLA buildings create scrap when they kill enemy vehicles no questions asked.
