### PR TITLE
Fix: Crushing Marauder With Overlord Creates Indestructible Wreck

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -182,7 +182,7 @@ https://github.com/commy2/zerohour/issues/34  [NOTRELEVANT]           Boss Aveng
 https://github.com/commy2/zerohour/issues/33  [MAYBE]                 Air Force General Avenger Receives 30% More Damage From Jet Missiles
 https://github.com/commy2/zerohour/issues/32  [MAYBE]                 Non-vanilla USA Avengers Benefit From Composite Armor
 https://github.com/commy2/zerohour/issues/31  [IMPROVEMENT]           Some Avengers Can Retaliate
-https://github.com/commy2/zerohour/issues/30  [IMPROVEMENT]           Crushing Marauder With Overlord Creates Indestructible Wreck
+https://github.com/commy2/zerohour/issues/30  [DONE]                  Crushing Marauder With Overlord Creates Indestructible Wreck
 https://github.com/commy2/zerohour/issues/29  [DONE]                  GLA Base Defense Hole Sufficient For Player Survival
 https://github.com/commy2/zerohour/issues/28  [MAYBE]                 Demo General Terrorist Does Not Explode When Crushed, Burned Or Blown Up
 https://github.com/commy2/zerohour/issues/27  [IMPROVEMENT][NPROJECT] Scud Storm Does Not Damage Itself

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19199,6 +19199,16 @@ Object Chem_GLATankMarauder
     DeathFX = FX_CarCrush
   End
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix lingering wreck when crushed by Overlord.
+
+  Behavior = CreateObjectDie ModuleTag_10
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_CrusaderTank_CrushEffect
+  End
+  Behavior = DestroyDie ModuleTag_11
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
   Behavior = FlammableUpdate ModuleTag_21
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 3       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20551,6 +20551,16 @@ Object Demo_GLATankMarauder
     DeathFX = FX_CarCrush
   End
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix lingering wreck when crushed by Overlord.
+
+  Behavior = CreateObjectDie ModuleTag_10
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_CrusaderTank_CrushEffect
+  End
+  Behavior = DestroyDie ModuleTag_11
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
   Behavior = FlammableUpdate ModuleTag_21
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 3       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -5819,6 +5819,16 @@ Object GLATankMarauder
     DeathFX = FX_CarCrush
   End
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix lingering wreck when crushed by Overlord.
+
+  Behavior = CreateObjectDie ModuleTag_10
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_CrusaderTank_CrushEffect
+  End
+  Behavior = DestroyDie ModuleTag_11
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
   Behavior = FlammableUpdate ModuleTag_21
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 3       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20725,6 +20725,16 @@ Object Slth_GLATankMarauder
     DeathFX = FX_CarCrush
   End
 
+  ; Patch104p @bugfix commy2 28/08/2021 Fix lingering wreck when crushed by Overlord.
+
+  Behavior = CreateObjectDie ModuleTag_10
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_CrusaderTank_CrushEffect
+  End
+  Behavior = DestroyDie ModuleTag_11
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
   Behavior = FlammableUpdate ModuleTag_21
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 3       ; taking this much damage...


### PR DESCRIPTION
ZH 1.04

- A crushed Marauder lingers indefinitely on the map. It can still fire and move, and even run over enemy infantry. It can be deleted by placing a scaffold over it.

After this patch:

- The Marauder is properly destroyed when crushed, like any other vehicle.
