### PR TITLE
Fix: Saboteur Uses Wrong Art For Sabotage Building-Ability

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -186,7 +186,7 @@ https://github.com/commy2/zerohour/issues/30  [IMPROVEMENT]           Crushing M
 https://github.com/commy2/zerohour/issues/29  [DONE]                  GLA Base Defense Hole Sufficient For Player Survival
 https://github.com/commy2/zerohour/issues/28  [MAYBE]                 Demo General Terrorist Does Not Explode When Crushed, Burned Or Blown Up
 https://github.com/commy2/zerohour/issues/27  [IMPROVEMENT][NPROJECT] Scud Storm Does Not Damage Itself
-https://github.com/commy2/zerohour/issues/26  [IMPROVEMENT]           Saboteur Uses Wrong Art For Sabotage Building-Ability
+https://github.com/commy2/zerohour/issues/26  [DONE]                  Saboteur Uses Wrong Art For Sabotage Building-Ability
 https://github.com/commy2/zerohour/issues/25  [NOTRELEVANT]           Boss Tomahawk Launcher Never Drops Scrap
 https://github.com/commy2/zerohour/issues/24  [IMPROVEMENT]           GLA Buildings Don't Create Scrap
 https://github.com/commy2/zerohour/issues/23  [IMPROVEMENT]           Demo General Jarmen Kell Repeats Voice Line When Planting Timed Demo Charge

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1926,7 +1926,7 @@ CommandButton Command_SabotageBuilding
   Options                 = OK_FOR_MULTI_SELECT CONTEXTMODE_COMMAND NEED_TARGET_ENEMY_OBJECT ;Kris: Contextmode command options require code support!
   Upgrade                 = None
   TextLabel               = CONTROLBAR:SabotageBuilding
-  ButtonImage             = SUSaboteur
+  ButtonImage             = SUEnterbldg   ; Patch104p @bugfix commy2 28/08/2021 Use intended artwork for ability instead of unit portrait.
   CursorName              = EnterAggressive
   InvalidCursorName       = GenericInvalid
   ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is


### PR DESCRIPTION
ZH 1.04:

- The Sabotage Building ability does not use the intended artwork, but is a duplicate of the Saboteur's portrait instead.

After this patch:

- The intended artwork is used.