### PR TITLE
Fix: Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -110,7 +110,7 @@ https://github.com/commy2/zerohour/issues/109 [IMPROVEMENT]           Some Helix
 https://github.com/commy2/zerohour/issues/108 [IMPROVEMENT]           Chinook and Supply Center Upgrade Icons
 https://github.com/commy2/zerohour/issues/107 [IMPROVEMENT]           Pilots Have Misleading Upgrade Icons
 https://github.com/commy2/zerohour/issues/106 [NOTRELEVANT]           Cargo Planes With Countermeasures Are Missing Hit Effects
-https://github.com/commy2/zerohour/issues/105 [IMPROVEMENT]           Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned
+https://github.com/commy2/zerohour/issues/105 [DONE]                  Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned
 https://github.com/commy2/zerohour/issues/104 [IMPROVEMENT]           China Command Center Missing Radar Upgrade Icon
 https://github.com/commy2/zerohour/issues/103 [IMPROVEMENT]           Some Special Power Buttons Disappear From Command Center After Mines Upgrade
 https://github.com/commy2/zerohour/issues/102 [IMPROVEMENT]           Tank Hunter Missing Patriotism Upgrade Icon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -3284,7 +3284,7 @@ Object AirF_AmericaInfantryColonelBurton
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -3794,7 +3794,7 @@ Object AirF_AmericaInfantryRanger
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1209,7 +1209,7 @@ Object Infa_ChinaInfantryTankHunter
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -1530,7 +1530,7 @@ Object Infa_ChinaInfantryHacker
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -2852,7 +2852,7 @@ Object Lazr_AmericaInfantryColonelBurton
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -3361,7 +3361,7 @@ Object Lazr_AmericaInfantryRanger
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -3710,7 +3710,7 @@ Object Lazr_AmericaInfantryMissileDefender
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -3960,7 +3960,7 @@ Object Lazr_AmericaInfantryPilot
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -4249,7 +4249,7 @@ Object Lazr_AmericaInfantryPathfinder
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1786,7 +1786,7 @@ Object Nuke_ChinaInfantryRedguard
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -2225,7 +2225,7 @@ Object Nuke_ChinaInfantryBlackLotus
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinFemale  ; Patch104p @bugfix commy2 28/08/2021 Use correct voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -2516,7 +2516,7 @@ Object Nuke_ChinaInfantryTankHunter
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -2823,7 +2823,7 @@ Object Nuke_ChinaInfantryHacker
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -3324,7 +3324,7 @@ Object SupW_AmericaInfantryColonelBurton
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -3833,7 +3833,7 @@ Object SupW_AmericaInfantryRanger
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -4189,7 +4189,7 @@ Object SupW_AmericaInfantryMissileDefender
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -4439,7 +4439,7 @@ Object SupW_AmericaInfantryPilot
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -4728,7 +4728,7 @@ Object SupW_AmericaInfantryPathfinder
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinUSA  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1514,7 +1514,7 @@ Object Tank_ChinaInfantryRedguard
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -1953,7 +1953,7 @@ Object Tank_ChinaInfantryBlackLotus
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinFemale  ; Patch104p @bugfix commy2 28/08/2021 Use correct voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -2244,7 +2244,7 @@ Object Tank_ChinaInfantryTankHunter
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
@@ -2551,7 +2551,7 @@ Object Tank_ChinaInfantryHacker
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
+    FX                  = INITIAL FX_DieByToxinChina  ; Patch104p @bugfix commy2 28/08/2021 Use correct faction voice line.
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---


### PR DESCRIPTION
ZH 1.04:

- When poisoned with Anthrax Gamma only (pink puddles), some units use the GLA death scream instead of the intended USA or China death scream.

After this patch:

- All units use the correct scream when dying by Anthrax Gamma poison.