### PR TITLE
Fix: GLA Demo Trap base defense scaffold bait exploit

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -62,7 +62,7 @@ https://github.com/commy2/zerohour/issues/157 [NOTRELEVANT]           Boss Gener
 https://github.com/commy2/zerohour/issues/156 [NOTRELEVANT]           Some Boss Infantry Units Lack Chemical Suits Upgrade Icon
 https://github.com/commy2/zerohour/issues/155 [NOTRELEVANT]           Boss General Scud Storm Cannot Upgrade Neutron Mines
 https://github.com/commy2/zerohour/issues/154 [IMPROVEMENT][NPROJECT] Fake Command Centers Lose Sub-Faction Decal After Fortified Structures Upgrade
-https://github.com/commy2/zerohour/issues/153 [IMPROVEMENT][NPROJECT] Base Defense Scaffolds Set Off Demo Traps
+https://github.com/commy2/zerohour/issues/153 [DONE]                  Base Defense Scaffolds Set Off Demo Traps
 https://github.com/commy2/zerohour/issues/152 [IMPROVEMENT]           Aurora And Carpet Bomb Model Is Extremely Low Poly
 https://github.com/commy2/zerohour/issues/151 [MAYBE]                 Uranium Shells Leave No Radiation Field
 https://github.com/commy2/zerohour/issues/150 [MAYBE]                 Anthrax Gamma Bomb Does The Same Amount Of Damage As Normal Blue Anthrax Bomb

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5433,8 +5433,8 @@ Object Chem_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
   
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
-  ; Demo Traps will no longer be triggered by base defense scaffolds.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense and building scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -5442,7 +5442,7 @@ Object Chem_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
     DetonateWhenKilled        = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5432,6 +5432,9 @@ Object Chem_GLADemoTrap
     FriendlyOpacityMin = 100.0%
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
+  
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -5439,7 +5442,7 @@ Object Chem_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
     DetonateWhenKilled        = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4753,6 +4753,9 @@ Object Demo_GLADemoTrap
     FriendlyOpacityMin = 100.0%
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
+  
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -4760,7 +4763,7 @@ Object Demo_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4754,8 +4754,8 @@ Object Demo_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
   
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
-  ; Demo Traps will no longer be triggered by base defense scaffolds.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense and building scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -4763,7 +4763,7 @@ Object Demo_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -15674,8 +15674,8 @@ Object GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
   
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
-  ; Demo Traps will no longer be triggered by base defense scaffolds.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense and building scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -15683,7 +15683,7 @@ Object GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -15673,6 +15673,9 @@ Object GLADemoTrap
     FriendlyOpacityMin = 100.0%
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
+  
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -15680,7 +15683,7 @@ Object GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5487,6 +5487,9 @@ Object Slth_GLADemoTrap
     FriendlyOpacityMin = 100.0%
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
+  
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -5494,7 +5497,7 @@ Object Slth_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5488,8 +5488,8 @@ Object Slth_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
   
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE to list of ignored target types.
-  ; Demo Traps will no longer be triggered by base defense scaffolds.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Demo Traps will no longer be triggered by base defense and building scaffolds.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -5497,7 +5497,7 @@ Object Slth_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes


### PR DESCRIPTION
Demo Traps should no longer be triggered by base defense scaffolds.