### PR TITLE
Fix: GLA Stealth Saboteur Death Scream

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -104,7 +104,7 @@ https://github.com/commy2/zerohour/issues/115 [IMPROVEMENT]           Early And 
 https://github.com/commy2/zerohour/issues/114 [IMPROVEMENT]           Hitting Battle Bus In Hull Mode Causes Screen Shake
 https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs Cannot Target Stinger Sites
 https://github.com/commy2/zerohour/issues/112 [IMPROVEMENT]           Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon
-https://github.com/commy2/zerohour/issues/111 [IMPROVEMENT][NPROJECT] Stealth General Saboteur Uses Rebel Death Scream
+https://github.com/commy2/zerohour/issues/111 [DONE]                  Stealth General Saboteur Uses Rebel Death Scream
 https://github.com/commy2/zerohour/issues/110 [IMPROVEMENT]           Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects
 https://github.com/commy2/zerohour/issues/109 [IMPROVEMENT]           Some Helixes Missing Napalm Bomb Upgrade Icon
 https://github.com/commy2/zerohour/issues/108 [IMPROVEMENT]           Chinook and Supply Center Upgrade Icons

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -16617,13 +16617,15 @@ Object Slth_GLAInfantrySaboteur
     SabotageDuration = 30000
   End
 
+  ; Patch104p @bugfix hanfield 28/08/2021 Replaced FX_RebelDie with FX_SaboteurDie.
+
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
     DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_RebelDie
+    FX                  = INITIAL FX_SaboteurDie
   End
   Behavior = SlowDeathBehavior ModuleTag_Death02
     DeathTypes          = NONE +CRUSHED +SPLATTED
@@ -16632,12 +16634,15 @@ Object Slth_GLAInfantrySaboteur
     DestructionDelay    = 8000
     FX                  = INITIAL FX_GIDieCrushed
   End
+
+  ; Patch104p @bugfix hanfield 28/08/2021 Replaced FX_RebelDie with FX_SaboteurDie.
+
   Behavior = SlowDeathBehavior ModuleTag_Death03
     DeathTypes          = NONE +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_RebelDie
+    FX                  = INITIAL FX_SaboteurDie
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60


### PR DESCRIPTION
Stealth General Saboteur now uses the Saboteur death effect instead of the Rebel.