### PR TITLE
Speaker Towers No Longer Ensure Player Survival

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -123,7 +123,7 @@ https://github.com/commy2/zerohour/issues/96  [IMPROVEMENT]           Vanilla Ch
 https://github.com/commy2/zerohour/issues/95  [IMPROVEMENT]           Inconsistent Outpost Geometry
 https://github.com/commy2/zerohour/issues/94  [DONE]                  Tank And Nuke Outposts Fail To Attack Buildings
 https://github.com/commy2/zerohour/issues/93  [IMPROVEMENT]           Vanilla China Outposts Missing Detection Effect
-https://github.com/commy2/zerohour/issues/92  [IMPROVEMENT][NPROJECT] Speaker Tower Sufficient For Player Survival
+https://github.com/commy2/zerohour/issues/92  [DONE]                  Speaker Tower Sufficient For Player Survival
 https://github.com/commy2/zerohour/issues/91  [MAYBE]                 Flashbangs Can Clear Mines
 https://github.com/commy2/zerohour/issues/90  [NOTRELEVANT]           Jarmen Kell Can Snipe Landed Chinooks And Helixes
 https://github.com/commy2/zerohour/issues/89  [IMPROVEMENT]           Non-Vanilla USA Fire Bases Use Patriot Sound Effect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -15447,7 +15447,10 @@ Object ChinaSpeakerTower
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE MP_COUNT_FOR_VICTORY
+
+  ; Patch104p @bugfix hanfield 28/08/2021 Removed MP_COUNT_FOR_VICTORY KINDOF
+  ; This makes the Speaker Tower not count towards the player's survival.
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE
 
   Body            = StructureBody ModuleTag_05
     MaxHealth     = 300.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -7452,7 +7452,10 @@ Object Infa_ChinaSpeakerTower
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE MP_COUNT_FOR_VICTORY
+
+  ; Patch104p @bugfix hanfield 28/08/2021 Removed MP_COUNT_FOR_VICTORY KINDOF
+  ; This makes the Speaker Tower not count towards the player's survival.
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE
 
   Body            = StructureBody ModuleTag_05
     MaxHealth     = 300.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -9167,7 +9167,10 @@ Object Nuke_ChinaSpeakerTower
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE MP_COUNT_FOR_VICTORY
+  
+  ; Patch104p @bugfix hanfield 28/08/2021 Removed MP_COUNT_FOR_VICTORY KINDOF
+  ; This makes the Speaker Tower not count towards the player's survival.
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE
 
   Body            = StructureBody ModuleTag_05
     MaxHealth     = 300.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -7038,7 +7038,10 @@ Object Tank_ChinaSpeakerTower
 
   ; *** ENGINEERING Parameters ***
   RadarPriority   = STRUCTURE
-  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE MP_COUNT_FOR_VICTORY
+  
+  ; Patch104p @bugfix hanfield 28/08/2021 Removed MP_COUNT_FOR_VICTORY KINDOF
+  ; This makes the Speaker Tower not count towards the player's survival.
+  KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE FS_BASE_DEFENSE POWERED IMMUNE_TO_CAPTURE
 
   Body            = StructureBody ModuleTag_05
     MaxHealth     = 300.0


### PR DESCRIPTION
Chinese Speaker Towers no longer contribute towards a player's survival. If a player is reduced to a Speaker Tower - he is defeated.