### PR TITLE
Fix: Demo General Vehicle Destruction Effect Glitches

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -164,7 +164,7 @@ https://github.com/commy2/zerohour/issues/54  [IMPROVEMENT]           Vanilla GL
 https://github.com/commy2/zerohour/issues/53  [MAYBE]                 Veteran Quad Cannons Deal Less Damage When Scrapped
 https://github.com/commy2/zerohour/issues/52  [NOTRELEVANT]           Boss Base Defense Inconsistencies
 https://github.com/commy2/zerohour/issues/51  [IMPROVEMENT]           Demo General Worker On Bike Missing Demo Generals Bike Destruction Effect
-https://github.com/commy2/zerohour/issues/50  [IMPROVEMENT]           Demo General Vehicle Destruction Effect Glitches
+https://github.com/commy2/zerohour/issues/50  [DONE]                  Demo General Vehicle Destruction Effect Glitches
 https://github.com/commy2/zerohour/issues/49  [IMPROVEMENT]           Demo General Infantry Play Terrorist Sound Effect When Killed
 https://github.com/commy2/zerohour/issues/48  [MAYBE]                 Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed
 https://github.com/commy2/zerohour/issues/47  [IMPROVEMENT]           Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16610,7 +16610,7 @@ Object Demo_GLATankScorpion
 
   ; Catch fire, and explode death
   Behavior = SlowDeathBehavior ModuleTag_06
-    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 50
     DestructionDelay = 2000
     DestructionDelayVariance = 300
@@ -16653,12 +16653,13 @@ Object Demo_GLATankScorpion
     AflameDamageDelay = 500       ; this often.
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
   Behavior = SlowDeathBehavior ModuleTag_Death17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
+    DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   OCL_ScorpionTankDeathEffect
+    FX                  = FINAL   FX_BattleMasterExplosionOneFinal
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -16869,7 +16870,7 @@ Object Demo_GLAVehicleRocketBuggy
 
 ; The pop up AirDeath
   Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
@@ -16917,12 +16918,13 @@ Object Demo_GLAVehicleRocketBuggy
     AflameDamageDelay = 500       ; this often.
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
   Behavior = SlowDeathBehavior ModuleTag_Death17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
+    DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   OCL_RocketBuggyAirDeathStart
+    FX                  = FINAL   FX_BuggyNewDeathExplosion
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -18180,7 +18182,7 @@ Object Demo_GLAVehicleQuadCannon
 
   ; Catch fire, and explode death
   Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 411
     DestructionDelay = 150
     DestructionDelayVariance = 250
@@ -18226,12 +18228,13 @@ Object Demo_GLAVehicleQuadCannon
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
   Behavior = SlowDeathBehavior ModuleTag_Death_14
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
+    DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   OCL_QuadCannonDeathEffect
+    FX                  = FINAL   FX_BattleMasterExplosionOneFinal
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -18593,7 +18596,7 @@ Object Demo_GLAVehicleToxinTruck
   End
 
   Behavior                    = SlowDeathBehavior  ModuleTag_05
-    DeathTypes                = ALL -CRUSHED -SPLATTED
+    DeathTypes                = ALL -CRUSHED -SPLATTED -SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ExemptStatus              = STATUS_RIDER1   ; Patch104p @bugfix commy2 27/08/2021 Disable effect once upgraded with Anthrax. commy2 27/08/2021
     ProbabilityModifier       = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
@@ -18611,7 +18614,7 @@ Object Demo_GLAVehicleToxinTruck
 
   ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021
   Behavior                    = SlowDeathBehavior  ModuleTag_05Anthrax
-    DeathTypes                = ALL -CRUSHED -SPLATTED
+    DeathTypes                = ALL -CRUSHED -SPLATTED -SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     RequiredStatus            = STATUS_RIDER1
     ProbabilityModifier       = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
@@ -18684,12 +18687,13 @@ Object Demo_GLAVehicleToxinTruck
     TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
   Behavior = SlowDeathBehavior ModuleTag_Death_14
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
+    DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   OCL_ToxinTractorDeathEffect
+    FX                  = FINAL   FX_ToxinTruckExplosionOneFinal
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -19224,7 +19228,7 @@ Object Demo_GLAVehicleScudLauncher
 
   ; Catch fire, and explode death
   Behavior = SlowDeathBehavior ModuleTag_09
-    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 50
     DestructionDelay = 2000
     DestructionDelayVariance = 300
@@ -19265,7 +19269,20 @@ Object Demo_GLAVehicleScudLauncher
 ;  Behavior = LockWeaponCreate ModuleTag_24
 ;    SlotToLock = PRIMARY ; Prevents indeterminate state plus two unpickable weapons equaling no attack.
 ;  End
-;
+
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
+  Behavior = SlowDeathBehavior ModuleTag_Death24
+    DeathTypes          = NONE +SUICIDED
+    FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   OCL_SCUDLauncherDeathEffect
+    FX                  = FINAL   FX_ScudLauncherExplosionOneFinal
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+
 ;  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death24
 ;    DeathWeapon   = Demo_SuicideDynamitePack
 ;    StartsActive  = Yes                      ; turned on by upgrade
@@ -19736,7 +19753,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
   End
 
   Behavior = SlowDeathBehavior ModuleTag_15
-    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     DestructionDelay = 500
     DestructionDelayVariance = 1500
     OCL = INITIAL OCL_TechnicalAirDeathStart
@@ -19756,12 +19773,17 @@ Object Demo_GLAVehicleTechnicalChassisOne
     TriggeredBy = Upgrade_GLAAPBullets
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
   Behavior = SlowDeathBehavior ModuleTag_Death_18
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    DeathTypes          = NONE +SUICIDED
+    DestructionDelay    = 500
+    DestructionDelayVariance = 1500
+   ;FX                  = INITIAL FX_TerroristExplode
+    OCL                 = INITIAL OCL_TechnicalAirDeathStart
+    FX                  = INITIAL FX_TechnicalAirDeathGroundPart
+    OCL                 = FINAL   OCL_RocketBuggyAirDeath
+    FX                  = FINAL   FX_RocketBuggyAirDeathAirPart
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -20524,7 +20546,7 @@ Object Demo_GLATankMarauder
 
   ; Catch fire, and explode death
   Behavior = SlowDeathBehavior ModuleTag_06
-    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 50
     DestructionDelay = 1000
     DestructionDelayVariance = 300
@@ -20557,12 +20579,13 @@ Object Demo_GLATankMarauder
     AflameDamageDelay = 500       ; this often.
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
   Behavior = SlowDeathBehavior ModuleTag_Death_22
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
+    DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   OCL_MarauderTankDeathEffect
+    FX                  = FINAL   FX_BattleMasterExplosionOneFinal
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -20752,7 +20775,7 @@ Object Demo_GLAVehicleRadarVan
 
 ; The default explosion
   Behavior = SlowDeathBehavior  ModuleTag_11
-    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
@@ -20799,12 +20822,13 @@ Object Demo_GLAVehicleRadarVan
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CrusaderDamageTransition
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
+
   Behavior = SlowDeathBehavior ModuleTag_Death_20
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
+    DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL OCL_RadarVanDeathEffect
+    FX                  = FINAL FX_BuggyNewDeathExplosion
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -21226,10 +21250,17 @@ Object Demo_GLAVehicleBattleBus
     DestructionDelay = 5000
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Fix bus disappearing when SUICIDED.
+
   Behavior = SlowDeathBehavior ModuleTag_35 // Sorry, because the terrorist does Suicide damage to others, we cannot tell if it is a legit suicide (us killing self)
-    DeathTypes = NONE +SUICIDED
-    DestructionDelay = 1
-    FX = FINAL FX_BuggyNewDeathExplosion
+    DeathTypes          = NONE +SUICIDED
+    FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   OCL_BattleBusDeath
+    FX                  = FINAL   FX_BuggyNewDeathExplosion
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
 
   Behavior                 = TransitionDamageFX ModuleTag_36


### PR DESCRIPTION
1.04

- Blowing up Demo General's vehicles does not correctly produce wrecks and is very inconsistent. Some of them are flung around randomly on death like a Terrorist.

After:

- All smooth and as expected.

## Original

https://user-images.githubusercontent.com/4720891/184708158-730c5ca3-a12d-4671-88e5-53f186682b8f.mp4

## Patched

https://user-images.githubusercontent.com/4720891/184708173-80396061-5fd2-4e06-b07f-02d0f76d779c.mp4
