### PR TITLE
Fix: Demo General Infantry Play Terrorist Sound Effect When Killed

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -164,7 +164,7 @@ https://github.com/commy2/zerohour/issues/54  [IMPROVEMENT]           Vanilla GL
 https://github.com/commy2/zerohour/issues/53  [MAYBE]                 Veteran Quad Cannons Deal Less Damage When Scrapped
 https://github.com/commy2/zerohour/issues/52  [NOTRELEVANT]           Boss Base Defense Inconsistencies
 https://github.com/commy2/zerohour/issues/51  [IMPROVEMENT]           Demo General Worker On Bike Missing Demo Generals Bike Destruction Effect
-https://github.com/commy2/zerohour/issues/50  [IMPROVEMENT]           Demo General Vehicle Destruction Effect Glitches
+https://github.com/commy2/zerohour/issues/50  [DONE]                  Demo General Vehicle Destruction Effect Glitches
 https://github.com/commy2/zerohour/issues/49  [DONE]                  Demo General Infantry Play Terrorist Sound Effect When Killed
 https://github.com/commy2/zerohour/issues/48  [MAYBE]                 Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed
 https://github.com/commy2/zerohour/issues/47  [IMPROVEMENT]           Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided

--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -165,7 +165,7 @@ https://github.com/commy2/zerohour/issues/53  [MAYBE]                 Veteran Qu
 https://github.com/commy2/zerohour/issues/52  [NOTRELEVANT]           Boss Base Defense Inconsistencies
 https://github.com/commy2/zerohour/issues/51  [IMPROVEMENT]           Demo General Worker On Bike Missing Demo Generals Bike Destruction Effect
 https://github.com/commy2/zerohour/issues/50  [IMPROVEMENT]           Demo General Vehicle Destruction Effect Glitches
-https://github.com/commy2/zerohour/issues/49  [IMPROVEMENT]           Demo General Infantry Play Terrorist Sound Effect When Killed
+https://github.com/commy2/zerohour/issues/49  [DONE]                  Demo General Infantry Play Terrorist Sound Effect When Killed
 https://github.com/commy2/zerohour/issues/48  [MAYBE]                 Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed
 https://github.com/commy2/zerohour/issues/47  [IMPROVEMENT]           Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided
 https://github.com/commy2/zerohour/issues/46  [IMPROVEMENT]           Technical Has To Recenter Turret To Suicide

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12134,7 +12134,7 @@ Object Demo_GLAInfantryRebel
     FX                  = INITIAL FX_GIDieCrushed
   End
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +EXPLODED -SUICIDED
+    DeathTypes          = NONE +EXPLODED  ; Patch104p @bugfix commy2 29/08/2021 Fix cannot subtract death type from NONE.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -12227,7 +12227,7 @@ Object Demo_GLAInfantryRebel
 
   ; I have just pulled my ripcord, and this ain't no parachute!
   Behavior = SlowDeathBehavior ModuleTag_Death17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -12572,7 +12572,7 @@ Object Demo_GLAInfantryJarmenKell
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA -SUICIDED ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -12628,7 +12628,7 @@ Object Demo_GLAInfantryJarmenKell
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death15
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -12912,7 +12912,7 @@ Object Demo_GLAInfantryTunnelDefender
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA -SUICIDED ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -12968,7 +12968,7 @@ Object Demo_GLAInfantryTunnelDefender
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death13
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -13201,7 +13201,7 @@ Object Demo_GLAInfantryStingerSoldier
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA -SUICIDED ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -13257,7 +13257,7 @@ Object Demo_GLAInfantryStingerSoldier
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death15
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14016,7 +14016,7 @@ Object Demo_GLAInfantryAngryMobPistol01
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior DeathTag_01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA -SUICIDED ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14072,7 +14072,7 @@ Object Demo_GLAInfantryAngryMobPistol01
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death_06
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14365,7 +14365,7 @@ Object Demo_GLAInfantryAngryMobRock02
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA -SUICIDED ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14421,7 +14421,7 @@ Object Demo_GLAInfantryAngryMobRock02
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -15310,7 +15310,7 @@ Object Demo_GLAInfantryAngryMobMolotov02
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA -SUICIDED ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -15366,7 +15366,7 @@ Object Demo_GLAInfantryAngryMobMolotov02
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -15591,7 +15591,7 @@ Object Demo_GLAInfantryHijacker
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA -SUICIDED ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -15647,7 +15647,7 @@ Object Demo_GLAInfantryHijacker
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death_17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -16020,7 +16020,7 @@ Object Demo_GLAInfantryWorker
     FX                  = INITIAL FX_GIDieCrushed
   End
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +EXPLODED -SUICIDED
+    DeathTypes          = NONE +EXPLODED  ; Patch104p @bugfix commy2 29/08/2021 Fix cannot subtract death type from NONE.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -16086,7 +16086,7 @@ Object Demo_GLAInfantryWorker
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death_17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix EXPLODED death being overloaded.
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -16352,6 +16352,20 @@ Object Demo_GLAInfantrySaboteur
   Behavior = PoisonedBehavior ModuleTag_16
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
     PoisonDuration = 3000       ; ... for this long after last hit by poison damage
+  End
+
+  ; Patch104p @bugfix commy2 29/08/2021 Fix unit not handling SUICIDED death type.
+
+  Behavior = SlowDeathBehavior ModuleTag_Death_17
+    DeathTypes          = NONE +SUICIDED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_TerroristExplode
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
 
 


### PR DESCRIPTION
ZH 1.04:

- Demo General's Infantry units play the blown up Terrorist sound effect when killed with an explosive, despite not doing any additional damage. This is confusing to players, because that sound effect also indicates usage of the Suicide/Demolitions ability.

After this patch:

- Blowing up the unit with explosives uses the same death effect as blowing up any other unit, while using the Suicide ability plays the Terrorist sound effect. Therefore: Sound effect heard => damage dealt.