### PR TITLE
Fix: Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -167,7 +167,7 @@ https://github.com/commy2/zerohour/issues/51  [IMPROVEMENT]           Demo Gener
 https://github.com/commy2/zerohour/issues/50  [IMPROVEMENT]           Demo General Vehicle Destruction Effect Glitches
 https://github.com/commy2/zerohour/issues/49  [IMPROVEMENT]           Demo General Infantry Play Terrorist Sound Effect When Killed
 https://github.com/commy2/zerohour/issues/48  [MAYBE]                 Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed
-https://github.com/commy2/zerohour/issues/47  [IMPROVEMENT]           Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided
+https://github.com/commy2/zerohour/issues/47  [DONE]                  Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided
 https://github.com/commy2/zerohour/issues/46  [IMPROVEMENT]           Technical Has To Recenter Turret To Suicide
 https://github.com/commy2/zerohour/issues/45  [IMPROVEMENT]           Combat Bike Has Disabled Suicide Ability Button
 https://github.com/commy2/zerohour/issues/44  [MAYBE]                 Terrorist And Bomb Truck Missing Suicide Ability

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -21147,6 +21147,7 @@ Object Demo_GLAVehicleBattleBus
     ; Part the second, normal fields of a SlowDeathBehavior
     DestructionDelay = 0
     DestructionDelayVariance = 200
+    OCL = INITIAL Demo_OCL_BattleBusDeathWeaponDummy  ; Patch104p @bugfix commy2 29/08/2021 Spawns dummy object to let Battle Bus deal small damage when passively killed after Demolitions upgrade.
     FX = FINAL FX_BuggyNewDeathExplosion
     OCL = FINAL OCL_BattleBusDeath
   End
@@ -21199,20 +21200,6 @@ Object Demo_GLAVehicleBattleBus
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag998
-    DeathWeapon   = Demo_SuicideDynamitePackPlusFire
-    StartsActive  = No
-    TriggeredBy   = Demo_Upgrade_SuicideBomb
-    DeathTypes = NONE +SUICIDED
-  End;
-
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag999
-    DeathWeapon   = Demo_DestroyedWeapon
-    StartsActive  = No
-    TriggeredBy   = Demo_Upgrade_SuicideBomb
-    DeathTypes = ALL -SUICIDED
-  End
-
   Behavior = CommandSetUpgrade ModuleTag_33
     CommandSet = Demo_GLAVehicleBattleBusCommandSetUpgrade
     TriggeredBy = Demo_Upgrade_SuicideBomb
@@ -21228,6 +21215,7 @@ Object Demo_GLAVehicleBattleBus
 
   Behavior = SlowDeathBehavior ModuleTag_35 // Sorry, because the terrorist does Suicide damage to others, we cannot tell if it is a legit suicide (us killing self)
     DeathTypes = NONE +SUICIDED
+    OCL                 = INITIAL Demo_OCL_BattleBusDeathWeaponDummySuicide ; Patch104p @bugfix commy2 29/08/2021 Spawns dummy object to let Battle Bus deal damage by suicide.
     DestructionDelay = 1
     FX = FINAL FX_BuggyNewDeathExplosion
   End
@@ -21253,3 +21241,54 @@ End
 
 
 
+; Patch104p @bugfix commy2 29/08/2021 Dummies used to fire regular Demolitions upgrade explosion weapons after "suicide death" and "passive death".
+
+;------------------------------------------------------------------------------
+Object Demo_GLAVehicleBattleBusDeathWeaponDummySuicide
+
+  ; ***DESIGN parameters ***
+  EditorSorting   = SYSTEM
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
+
+  ; *** ENGINEERING Parameters ***
+  Body = HighlanderBody ModuleTag_01
+    MaxHealth = 1.0
+    InitialHealth = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 1   ; min lifetime in msec
+    MaxLifetime = 1   ; max lifetime in msec
+  End
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag998
+    DeathWeapon   = Demo_SuicideDynamitePackPlusFire
+    StartsActive  = No
+    TriggeredBy   = Demo_Upgrade_SuicideBomb
+  End
+End
+
+;------------------------------------------------------------------------------
+Object Demo_GLAVehicleBattleBusDeathWeaponDummy
+
+  ; ***DESIGN parameters ***
+  EditorSorting   = SYSTEM
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
+
+  ; *** ENGINEERING Parameters ***
+  Body = HighlanderBody ModuleTag_01
+    MaxHealth = 1.0
+    InitialHealth = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 1   ; min lifetime in msec
+    MaxLifetime = 1   ; max lifetime in msec
+  End
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag999
+    DeathWeapon   = Demo_DestroyedWeapon
+    StartsActive  = No
+    TriggeredBy   = Demo_Upgrade_SuicideBomb
+  End
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -8614,3 +8614,23 @@ End
 
 
 
+; Patch104p @bugfix commy2 29/08/2021 Creates dummies used to handle Demolitions upgrade with the Battle Bus.
+
+; -----------------------------------------------------------------------------
+; Demolitions General
+; -----------------------------------------------------------------------------
+
+ObjectCreationList Demo_OCL_BattleBusDeathWeaponDummy
+  CreateObject
+    ObjectNames = Demo_GLAVehicleBattleBusDeathWeaponDummy
+    Disposition = LIKE_EXISTING
+  End
+End
+
+; -----------------------------------------------------------------------------
+ObjectCreationList Demo_OCL_BattleBusDeathWeaponDummySuicide
+  CreateObject
+    ObjectNames = Demo_GLAVehicleBattleBusDeathWeaponDummySuicide
+    Disposition = LIKE_EXISTING
+  End
+End


### PR DESCRIPTION
ZH 1.04

- Using the Suicide ability with the Battle Bus does no damage and just deletes the vehicle without wreck.
- Blowing up the Battle Bus with a Terrorist deletes the Bus entirely.

After this patch:

- The Battle Bus now behaves exactly like other Demo General units.
