### PR TITLE
Fix: Demo General Worker On Bike Missing Demo General Bike Destruction Effect

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -163,7 +163,7 @@ https://github.com/commy2/zerohour/issues/55  [IMPROVEMENT]           Vanilla GL
 https://github.com/commy2/zerohour/issues/54  [IMPROVEMENT]           Vanilla GLA Hijacker And Saboteur Can Ride Toxin Generals Combat Bike
 https://github.com/commy2/zerohour/issues/53  [MAYBE]                 Veteran Quad Cannons Deal Less Damage When Scrapped
 https://github.com/commy2/zerohour/issues/52  [NOTRELEVANT]           Boss Base Defense Inconsistencies
-https://github.com/commy2/zerohour/issues/51  [IMPROVEMENT]           Demo General Worker On Bike Missing Demo Generals Bike Destruction Effect
+https://github.com/commy2/zerohour/issues/51  [DONE]                  Demo General Worker On Bike Missing Demo Generals Bike Destruction Effect
 https://github.com/commy2/zerohour/issues/50  [IMPROVEMENT]           Demo General Vehicle Destruction Effect Glitches
 https://github.com/commy2/zerohour/issues/49  [IMPROVEMENT]           Demo General Infantry Play Terrorist Sound Effect When Killed
 https://github.com/commy2/zerohour/issues/48  [MAYBE]                 Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17705,7 +17705,7 @@ Object Demo_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER1
     DeathTypes = ALL -CRUSHED -SPLATTED -TOPPLED
     DestructionDelay = 0
-    FX = INITIAL FX_DEMOBuggyNewDeathExplosion  ; Patch104p @bugfix hanfield 27/08/2021 Fix Worker was making Bike use a different death effect.
+    FX = INITIAL FX_DEMOBuggyNewDeathExplosion  ; Patch104p @bugfix commy2 29/08/2021 Fix Worker was making Bike use a different death effect.
     OCL = INITIAL OCL_WorkerFlyingOffBikeDeathStart
     OCL = FINAL OCL_CombatBikeAirDeathStart
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17705,7 +17705,7 @@ Object Demo_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER1
     DeathTypes = ALL -CRUSHED -SPLATTED -TOPPLED
     DestructionDelay = 0
-    FX = INITIAL FX_BuggyNewDeathExplosion
+    FX = INITIAL FX_DEMOBuggyNewDeathExplosion  ; Patch104p @bugfix hanfield 27/08/2021 Fix Worker was making Bike use a different death effect.
     OCL = INITIAL OCL_WorkerFlyingOffBikeDeathStart
     OCL = FINAL OCL_CombatBikeAirDeathStart
   End


### PR DESCRIPTION
Zero Hour 1.04:

- Blowing up a Demo General's Bike with a Worker does not produce the same red effect as any other rider does.

After this patch:

- Bike uses the same effect no matter what rider.