### PR TITLE
Fix: Helix and Overlord addons are now colored red when affected by Frenzy

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -505,6 +505,11 @@ Object ChinaHelixPropagandaTower
     Armor          = InvulnerableAllArmor ; We can't be hurt on the field.  We share damage from the Overlord with his damage module
   End
   VisionRange     = 200
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Propaganda Tower.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
 
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
@@ -598,6 +603,12 @@ Object ChinaHelixBattleBunker
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Battle Bunker.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
     TurretMoveStart = NoSound
@@ -606,7 +617,9 @@ Object ChinaHelixBattleBunker
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -643,6 +643,12 @@ Object ChinaTankOverlordPropagandaTower
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Propaganda Tower.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
    TurretMoveStart = NoSound
@@ -740,6 +746,13 @@ Object ChinaTankOverlordBattleBunker
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Battle Bunker.
+
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
     TurretMoveStart = NoSound
@@ -748,7 +761,8 @@ Object ChinaTankOverlordBattleBunker
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16263,6 +16263,12 @@ Object Infa_ChinaHelixBattleBunker
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Battle Bunker.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
     TurretMoveStart = NoSound
@@ -16271,7 +16277,8 @@ Object Infa_ChinaHelixBattleBunker
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -790,6 +790,11 @@ Object Nuke_ChinaHelixPropagandaTower
     Armor          = InvulnerableAllArmor ; We can't be hurt on the field.  We share damage from the Overlord with his damage module
   End
   VisionRange     = 200
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Propaganda Tower.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
 
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
@@ -888,6 +893,12 @@ Object Nuke_ChinaHelixBattleBunker
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Propaganda Tower.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
     TurretMoveStart = NoSound
@@ -896,7 +907,8 @@ Object Nuke_ChinaHelixBattleBunker
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -17262,6 +17274,12 @@ Object Nuke_ChinaTankOverlordPropagandaTower
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Propaganda Tower.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
    TurretMoveStart = NoSound
@@ -17359,6 +17377,12 @@ Object Nuke_ChinaTankOverlordBattleBunker
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Battle Bunker.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
     TurretMoveStart = NoSound
@@ -17367,7 +17391,8 @@ Object Nuke_ChinaTankOverlordBattleBunker
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -517,6 +517,12 @@ Object Tank_ChinaHelixPropagandaTower
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Propaganda Tower.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
    TurretMoveStart = NoSound
@@ -614,6 +620,12 @@ Object Tank_ChinaHelixBattleBunker
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Battle Bunker.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
     TurretMoveStart = NoSound
@@ -622,7 +634,9 @@ Object Tank_ChinaHelixBattleBunker
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -3345,6 +3359,12 @@ Object Tank_ChinaTankOverlordPropagandaTower
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Propaganda Tower.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
    TurretMoveStart = NoSound
@@ -3447,6 +3467,12 @@ Object Tank_ChinaTankOverlordBattleBunker
   End
   VisionRange     = 200
 
+  ; Patch104p @bugfix hanfield 01/09/2021 Added dummy weaponset to make Frenzy affect the Battle Bunker.
+  WeaponSet
+    Conditions          = None
+    Weapon              = PRIMARY   DummyWeapon
+  End
+
   ; *** AUDIO Parameters ***
   UnitSpecificSounds
     TurretMoveStart = NoSound
@@ -3455,7 +3481,8 @@ Object Tank_ChinaTankOverlordBattleBunker
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1196,6 +1196,10 @@ Weapon GattlingBuildingGun
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these  bonuses, you shoot at (40, 20, 10)
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
+  ; Patch104p @bugfix hanfield 01/09/2021 Added WeaponBonus parameters for Frenzy that nullify the bonus but allow it to color the Gattling Cannon.
+  WeaponBonus           = FRENZY_ONE DAMAGE 90%
+  WeaponBonus           = FRENZY_TWO DAMAGE 80%
+  WeaponBonus           = FRENZY_THREE DAMAGE 70%
   AntiAirborneVehicle   = No
   AntiAirborneInfantry  = No
   AntiSmallMissile      = No
@@ -1285,6 +1289,10 @@ Weapon GattlingBuildingGunAir
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
+  ; Patch104p @bugfix hanfield 01/09/2021 Added WeaponBonus parameters for Frenzy that nullify the bonus but allow it to color the Gattling Cannon.
+  WeaponBonus           = FRENZY_ONE DAMAGE 90%
+  WeaponBonus           = FRENZY_TWO DAMAGE 80%
+  WeaponBonus           = FRENZY_THREE DAMAGE 70%
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = Yes
   AntiSmallMissile      = No


### PR DESCRIPTION
With these changes, the Helix and Overlord addons will now be properly tinted red when their parent unit is affected by Frenzy.