### PR TITLE
Fix: Missing RadarPriority on Bunkers and Propaganda Centers fixed

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13155,6 +13155,9 @@ Object Boss_Bunker
   PlacementViewAngle     = -135
 
   ; ***DESIGN parameters ***
+  
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   DisplayName      = OBJECT:Bunker
   Side = Boss
   EditorSorting     = STRUCTURE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -31178,6 +31178,9 @@ Object ChinaBunker
   PlacementViewAngle     = -135
 
   ; ***DESIGN parameters ***
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   DisplayName      = OBJECT:Bunker
   Side = China
   EditorSorting     = STRUCTURE
@@ -32124,6 +32127,9 @@ Object ChinaPropagandaCenter
   End
 
   ; *** ENGINEERING Parameters ***
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -11783,6 +11783,9 @@ Object Infa_ChinaPropagandaCenter
   End
 
   ; *** ENGINEERING Parameters ***
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0
@@ -14823,6 +14826,9 @@ Object Infa_ChinaBunker
   End
 
   ; *** ENGINEERING Parameters ***
+  
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   KindOf            = PRELOAD STRUCTURE SELECTABLE STICK_TO_TERRAIN_SLOPE IMMOBILE SCORE FS_BASE_DEFENSE GARRISONABLE_UNTIL_DESTROYED IMMUNE_TO_CAPTURE
   Body              = StructureBody ModuleTag_05
     MaxHealth       = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -13468,6 +13468,9 @@ Object Nuke_ChinaBunker
   End
 
   ; *** ENGINEERING Parameters ***
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   KindOf            = PRELOAD STRUCTURE SELECTABLE STICK_TO_TERRAIN_SLOPE IMMOBILE SCORE FS_BASE_DEFENSE GARRISONABLE_UNTIL_DESTROYED IMMUNE_TO_CAPTURE
   Body              = StructureBody ModuleTag_05
     MaxHealth       = 1000.0
@@ -14379,6 +14382,9 @@ Object Nuke_ChinaPropagandaCenter
   End
 
   ; *** ENGINEERING Parameters ***
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -12448,6 +12448,9 @@ Object Tank_ChinaBunker
   End
 
   ; *** ENGINEERING Parameters ***
+  
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   KindOf            = PRELOAD STRUCTURE SELECTABLE STICK_TO_TERRAIN_SLOPE IMMOBILE SCORE FS_BASE_DEFENSE GARRISONABLE_UNTIL_DESTROYED IMMUNE_TO_CAPTURE
   Body              = StructureBody ModuleTag_05
     MaxHealth       = 1000.0
@@ -13343,6 +13346,9 @@ Object Tank_ChinaPropagandaCenter
   End
 
   ; *** ENGINEERING Parameters ***
+
+  ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
+  RadarPriority     = STRUCTURE
   KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0


### PR DESCRIPTION
NProject fix:  Bunkers and Propaganda Centers now have RadarPriority.