### PR TITLE
Fix: Standardised Toxin Tractor primary weapon minimum range

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3027,7 +3027,7 @@ Weapon ToxinTruckGun
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
-  MinimumAttackRange          = 0 ;20.0
+  MinimumAttackRange          = 10.0 ;20.0
   DamageType                  = POISON
   DeathType                   = POISONED
   WeaponSpeed                 = 600                     ;  dist/sec
@@ -3127,7 +3127,7 @@ Weapon ToxinTruckGunPlusOne
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
-  MinimumAttackRange          = 0 ;20.0
+  MinimumAttackRange          = 10.0 ;20.0
   DamageType                  = POISON
   DeathType                   = POISONED
   WeaponSpeed                 = 600                     ;  dist/sec
@@ -3227,7 +3227,7 @@ Weapon ToxinTruckGunPlusTwo
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
-  MinimumAttackRange          = 0 ;20.0
+  MinimumAttackRange          = 10.0 ;20.0
   DamageType                  = POISON
   DeathType                   = POISONED
   WeaponSpeed                 = 600                     ;  dist/sec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3027,7 +3027,7 @@ Weapon ToxinTruckGun
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
-  MinimumAttackRange          = 10.0 ;20.0
+  MinimumAttackRange          = 10.0 ;20.0 ; Patch104p @bugfix Stubbjax 01/09/2021 Standardised min range with the beta / gamma variants.
   DamageType                  = POISON
   DeathType                   = POISONED
   WeaponSpeed                 = 600                     ;  dist/sec
@@ -3127,7 +3127,7 @@ Weapon ToxinTruckGunPlusOne
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
-  MinimumAttackRange          = 10.0 ;20.0
+  MinimumAttackRange          = 10.0 ;20.0 ; Patch104p @bugfix Stubbjax 01/09/2021 Standardised min range with the beta / gamma variants.
   DamageType                  = POISON
   DeathType                   = POISONED
   WeaponSpeed                 = 600                     ;  dist/sec
@@ -3227,7 +3227,7 @@ Weapon ToxinTruckGunPlusTwo
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
-  MinimumAttackRange          = 10.0 ;20.0
+  MinimumAttackRange          = 10.0 ;20.0 ; Patch104p @bugfix Stubbjax 01/09/2021 Standardised min range with the beta / gamma variants.
   DamageType                  = POISON
   DeathType                   = POISONED
   WeaponSpeed                 = 600                     ;  dist/sec


### PR DESCRIPTION
# Description

The minimum attack range for all toxin tractor primary weapons is now consistent. It did not make sense that the beta / gamma (blue / purple) variants had a minimum range of 10 while the standard weapon (green) has a minimum range of 0.

Old:

Weapon | Range | Min Range
-- | -- | --
ToxinTruckGun | 100 | 0
ToxinTruckGunPlusOne | 100 | 0
ToxinTruckGunPlusTwo | 100 | 0
ToxinTruckGunUpgraded | 100 | 10
ToxinTruckGunUpgradedPlusOne | 100 | 10
ToxinTruckGunUpgradedPlusTwo | 100 | 10
Chem_ToxinTruckGunGamma | 100 | 10
Chem_ToxinTruckGunGammaPlusOne | 100 | 10
Chem_ToxinTruckGunGammaPlusTwo | 100 | 10

New:

Weapon | Range | Min Range
-- | -- | --
ToxinTruckGun | 100 | 10
ToxinTruckGunPlusOne | 100 | 10
ToxinTruckGunPlusTwo | 100 | 10
ToxinTruckGunUpgraded | 100 | 10
ToxinTruckGunUpgradedPlusOne | 100 | 10
ToxinTruckGunUpgradedPlusTwo | 100 | 10
Chem_ToxinTruckGunGamma | 100 | 10
Chem_ToxinTruckGunGammaPlusOne | 100 | 10
Chem_ToxinTruckGunGammaPlusTwo | 100 | 10