### PR TITLE
Fix: Non-Vanilla USA Avengers Attempt To Retaliate With Their Blue Laser

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -181,7 +181,7 @@ https://github.com/commy2/zerohour/issues/35  [NOTRELEVANT]           Boss Infan
 https://github.com/commy2/zerohour/issues/34  [NOTRELEVANT]           Boss Avenger Inconsistencies
 https://github.com/commy2/zerohour/issues/33  [MAYBE]                 Air Force General Avenger Receives 30% More Damage From Jet Missiles
 https://github.com/commy2/zerohour/issues/32  [MAYBE]                 Non-vanilla USA Avengers Benefit From Composite Armor
-https://github.com/commy2/zerohour/issues/31  [IMPROVEMENT]           Some Avengers Can Retaliate
+https://github.com/commy2/zerohour/issues/31  [DONE]                  Some Avengers Can Retaliate
 https://github.com/commy2/zerohour/issues/30  [DONE]                  Crushing Marauder With Overlord Creates Indestructible Wreck
 https://github.com/commy2/zerohour/issues/29  [DONE][NPROJECT]        GLA Base Defense Hole Sufficient For Player Survival
 https://github.com/commy2/zerohour/issues/28  [MAYBE]                 Demo General Terrorist Does Not Explode When Crushed, Burned Or Blown Up

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7120,7 +7120,7 @@ Object AirF_AmericaTankAvenger
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE CANNOT_RETALIATE  ; Patch104p @bugfix commy2 03/09/2021 This Avenger would retaliate unlike the normal USA Avenger.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 300.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19954,7 +19954,7 @@ Object Boss_TankAvenger
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE CANNOT_RETALIATE  ; Patch104p @bugfix commy2 03/09/2021 This Avenger would retaliate unlike the normal USA Avenger.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 500.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6824,7 +6824,7 @@ Object Lazr_AmericaTankAvenger
   End
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE CANNOT_RETALIATE  ; Patch104p @bugfix commy2 03/09/2021 This Avenger would retaliate unlike the normal USA Avenger.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 300.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7298,7 +7298,7 @@ Object SupW_AmericaTankAvenger
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE CANNOT_RETALIATE  ; Patch104p @bugfix commy2 03/09/2021 This Avenger would retaliate unlike the normal USA Avenger.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 300.0


### PR DESCRIPTION
ZH 1.04

- The vUSA Avenger will never retaliate. The other Avengers will retaliate if the option is enabled.

After this patch:

- All Avengers behave the same. None of the Avengers will retaliate.

For the uninitiated:

"Retaliatiation" only happens if the respective option is enabled in the ingame OPTIONS menu. Retaliation is enabled by default. A unit that can retaliate will - if the option is enabled - automatically engage enemies !when attacked! while idle (meaning, standing and not in Guard mode).

This is bad for the Avenger, because it tries to mark the enemy that hit it with the blue laser, causing it to move closer and run into its death. The main purpose however is the passive PDL, which works best if the unit standing behind your other units.

For this reason EA disabled Retaliation for the Avenger, similar to how they disabled automatically engaging enemies in general for the ECM tank, however due to the rushed devolopment, that change never made it to the Laser, Airforce, Superweapon and Boss General variants of the Avenger.