### PR TITLE
Fix: Demo General Base Defenses Missing Demolitons Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -173,7 +173,7 @@ https://github.com/commy2/zerohour/issues/45  [IMPROVEMENT]           Combat Bik
 https://github.com/commy2/zerohour/issues/44  [MAYBE]                 Terrorist And Bomb Truck Missing Suicide Ability
 https://github.com/commy2/zerohour/issues/43  [IMPROVEMENT]           Suicide Ability Button Is Placed Inconsistently
 https://github.com/commy2/zerohour/issues/42  [IMPROVEMENT]           Worker Has Disabled Suicide Button Before Demolitions Upgrade
-https://github.com/commy2/zerohour/issues/41  [IMPROVEMENT]           Base Defenses Missing Demoliton Upgrade Icon
+https://github.com/commy2/zerohour/issues/41  [DONE]                  Base Defenses Missing Demoliton Upgrade Icon
 https://github.com/commy2/zerohour/issues/38  [IMPROVEMENT]           Detached Floating Object Orbits Avenger Model When Moving
 https://github.com/commy2/zerohour/issues/37  [IMPROVEMENT]           Tomahawk Launchers Have Reversed Order For Battle And Scout Drone Upgrade
 https://github.com/commy2/zerohour/issues/36  [NOTRELEVANT]           Boss Helix Inconsistencies

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4842,7 +4842,9 @@ Object Demo_GLATunnelNetwork
   SelectPortrait         = SUTunnel_L
   ButtonImage            = SUTunnel
 
-  ;UpgradeCameo1           = Upgrade_GLACamoNetting
+  ; Patch104p @bugfix commy2 03/09/2021 Fix missing Demolitions upgrade icon on Base defense.
+
+  UpgradeCameo1           = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo2           = NONE
   ;UpgradeCameo3           = NONE
   ;UpgradeCameo4           = NONE
@@ -5443,8 +5445,11 @@ Object Demo_GLAStingerSite
   ; *** ART Parameters ***
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
+
+  ; Patch104p @bugfix commy2 03/09/2021 Fix missing Demolitions upgrade icon on Base defense.
+
   UpgradeCameo1          = Upgrade_GLAAPRockets
-  ;UpgradeCameo2          = Upgrade_GLACamoNetting
+  UpgradeCameo2          = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo3          = NONE
   ;UpgradeCameo4          = NONE
   ;UpgradeCameo5          = NONE


### PR DESCRIPTION
ZH 1.04:

- The Demo General's Tunnel Networks and Stinger Sites are missing the upgrade icon for the Demolition upgrade.

Patch:

- Not anymore.