### PR TITLE
Fix: Pilots no longer have Chemical Suits and Advanced Training cameo and no longer slow down

### DIFF
--- a/Patch104pZH/Design/Tasks/nproject_tasks.txt
+++ b/Patch104pZH/Design/Tasks/nproject_tasks.txt
@@ -270,8 +270,8 @@ the list of known bugs and how to prevent them. If you encounter bugs that not l
  - [NOTRELEVANT] Colonel Burton healthpoint increased from 200 to 220
 
  PILOTS:
- - [IMPROVEMENT] Pilots will not reduce their movement speed when in heroic veterancy
- - [IMPROVEMENT] Pilots never affected by Chemical Suits upgrade anymore due to unfixable bug in the game engine itself
+ - [DONE] Pilots will not reduce their movement speed when in heroic veterancy
+ - [DONE] Pilots never affected by Chemical Suits upgrade anymore due to unfixable bug in the game engine itself
  - [MAYBE] Pilots no longer can promote Combat Bikes!
 
  CRUSADER:

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4183,8 +4183,9 @@ Object AirF_AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
+  ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
+  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -4340,15 +4341,17 @@ Object AirF_AmericaInfantryPilot
   End
 
   Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
-  Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
+
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor since it made pilots slower.
+  ;Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
 
   Behavior = PhysicsBehavior ModuleTag_08
     Mass = 5.0
   End
-
-  Behavior = LocomotorSetUpgrade ModuleTag_10
-    TriggeredBy = Upgrade_Veterancy_HEROIC
-  End
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor upgrade since it made pilots slower.
+  ;Behavior = LocomotorSetUpgrade ModuleTag_10
+  ;  TriggeredBy = Upgrade_Veterancy_HEROIC
+  ;End
 
   Behavior = SquishCollide ModuleTag_11
     ;nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4183,9 +4183,9 @@ Object AirF_AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit and Advanced Training cameos since it never benefited from either.
   ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
+  ;UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -6588,15 +6588,18 @@ Object CINE_AmericaInfantryPilot
   End
 
   Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
-  Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
+
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor since it made pilots slower.
+  ;Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
 
   Behavior = PhysicsBehavior ModuleTag_08
     Mass = 5.0
   End
 
-  Behavior = LocomotorSetUpgrade ModuleTag_10
-    TriggeredBy = Upgrade_Veterancy_HEROIC
-  End
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor since it made pilots slower.
+  ;Behavior = LocomotorSetUpgrade ModuleTag_10
+  ;  TriggeredBy = Upgrade_Veterancy_HEROIC
+  ;End
 
   Behavior = SquishCollide ModuleTag_11
     ;nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1393,9 +1393,9 @@ Object AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit and Advanced Training cameos since it never benefited from either.
   ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
+  ;UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1393,8 +1393,9 @@ Object AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
+  ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
+  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -1550,15 +1551,18 @@ Object AmericaInfantryPilot
   End
 
   Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
-  Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
+
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor since it made pilots slower.
+  ;Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25 
 
   Behavior = PhysicsBehavior ModuleTag_08
     Mass = 5.0
   End
 
-  Behavior = LocomotorSetUpgrade ModuleTag_10
-    TriggeredBy = Upgrade_Veterancy_HEROIC
-  End
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor upgrade since it made pilots slower.
+  ;Behavior = LocomotorSetUpgrade ModuleTag_10
+  ;  TriggeredBy = Upgrade_Veterancy_HEROIC
+  ;End
 
   Behavior = SquishCollide ModuleTag_11
     ;nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -3741,9 +3741,9 @@ Object Lazr_AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit and Advanced Training cameos since it never benefited from either.
   ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
+  ;UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -3741,8 +3741,9 @@ Object Lazr_AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
+  ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
+  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -3898,15 +3899,18 @@ Object Lazr_AmericaInfantryPilot
   End
 
   Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
-  Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
+
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor since it made pilots slower.
+  ;Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
 
   Behavior = PhysicsBehavior ModuleTag_08
     Mass = 5.0
   End
 
-  Behavior = LocomotorSetUpgrade ModuleTag_10
-    TriggeredBy = Upgrade_Veterancy_HEROIC
-  End
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor upgrade since it made pilots slower.
+  ;Behavior = LocomotorSetUpgrade ModuleTag_10
+  ;  TriggeredBy = Upgrade_Veterancy_HEROIC
+  ;End
 
   Behavior = SquishCollide ModuleTag_11
     ;nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4220,8 +4220,9 @@ Object SupW_AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
+ ; UpgradeCameo1 = Upgrade_AmericaChemicalSuits
+  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -4377,15 +4378,18 @@ Object SupW_AmericaInfantryPilot
   End
 
   Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
-  Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
+
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor since it made pilots slower.
+  ;Locomotor = SET_NORMAL_UPGRADED BasicHumanLocomotorPlus25
 
   Behavior = PhysicsBehavior ModuleTag_08
     Mass = 5.0
   End
 
-  Behavior = LocomotorSetUpgrade ModuleTag_10
-    TriggeredBy = Upgrade_Veterancy_HEROIC
-  End
+  ; Patch104p @bugfix hanfield 03/09/2021 Removed heroic locomotor upgrade since it made pilots slower.
+  ;Behavior = LocomotorSetUpgrade ModuleTag_10
+  ;  TriggeredBy = Upgrade_Veterancy_HEROIC
+  ;End
 
   Behavior = SquishCollide ModuleTag_11
     ;nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4220,9 +4220,9 @@ Object SupW_AmericaInfantryPilot
   SelectPortrait         = SAPilot_L
   ButtonImage            = SAPilot
 
-  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit cameo since it didn't benefit. Also moved Advanced Training to be the first cameo.
- ; UpgradeCameo1 = Upgrade_AmericaChemicalSuits
-  UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
+  ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit and Advanced Training cameos since it never benefited from either.
+  ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
+  ;UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE


### PR DESCRIPTION
Pilots never had Chemical Suits active, and activating them makes the game crash, so they had a cameo for something that was never there. Also, upon reaching heroic veterancy, they became slower. This fixes both issues.