### PR TITLE
Fix: Worker Has Disabled Suicide Button Before Demolitions Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -172,7 +172,7 @@ https://github.com/commy2/zerohour/issues/46  [IMPROVEMENT]           Technical 
 https://github.com/commy2/zerohour/issues/45  [IMPROVEMENT]           Combat Bike Has Disabled Suicide Ability Button
 https://github.com/commy2/zerohour/issues/44  [MAYBE]                 Terrorist And Bomb Truck Missing Suicide Ability
 https://github.com/commy2/zerohour/issues/43  [IMPROVEMENT]           Suicide Ability Button Is Placed Inconsistently
-https://github.com/commy2/zerohour/issues/42  [IMPROVEMENT]           Worker Has Disabled Suicide Button Before Demolitions Upgrade
+https://github.com/commy2/zerohour/issues/42  [DONE]                  Worker Has Disabled Suicide Button Before Demolitions Upgrade
 https://github.com/commy2/zerohour/issues/41  [IMPROVEMENT]           Base Defenses Missing Demoliton Upgrade Icon
 https://github.com/commy2/zerohour/issues/38  [IMPROVEMENT]           Detached Floating Object Orbits Avenger Model When Moving
 https://github.com/commy2/zerohour/issues/37  [IMPROVEMENT]           Tomahawk Launchers Have Reversed Order For Battle And Scout Drone Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1967,7 +1967,6 @@ CommandSet Demo_GLAWorkerCommandSet
   8  = Demo_Command_ConstructGLAScudStorm
   9  = Demo_Command_ConstructGLAArmsDealer
  10  = Demo_Command_ConstructGLACommandCenter
- 11  = Demo_Command_TertiarySuicide
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
 End
@@ -1978,7 +1977,6 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   3 = Demo_Command_ConstructFakeGLASupplyStash
   4 = Demo_Command_ConstructFakeGLAArmsDealer
   5 = Demo_Command_ConstructFakeGLABlackMarket
- 11 = Demo_Command_TertiarySuicide
  13 = Command_UpgradeGLAWorkerRealCommandSet
 End
 
@@ -2274,6 +2272,18 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
  11  = Demo_Command_TertiarySuicide
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
+End
+
+; Patch104p @bugfix commy2 03/09/2021 Used for fake buildings after Demolitions upgrade is researched.
+
+CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
+  1 = Demo_Command_ConstructFakeGLACommandCenter
+  2 = Demo_Command_ConstructFakeGLABarracks
+  3 = Demo_Command_ConstructFakeGLASupplyStash
+  4 = Demo_Command_ConstructFakeGLAArmsDealer
+  5 = Demo_Command_ConstructFakeGLABlackMarket
+ 11 = Demo_Command_TertiarySuicide
+ 13 = Command_UpgradeGLAWorkerRealCommandSet
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16074,20 +16074,35 @@ Object Demo_GLAInfantryWorker
     PoisonDuration = 3000       ; ... for this long after last hit by poison damage
   End
 
+  ; Patch104p @bugfix commy2 03/09/2021 Upgrade command set when Demolitions upgrade is researched to hide disabled Suicide ability.
+
   Behavior = CommandSetUpgrade ModuleTag_14
     TriggeredBy = Upgrade_GLAWorkerFakeCommandSet
     RemovesUpgrades = Upgrade_GLAWorkerRealCommandSet
     CommandSet = Demo_GLAWorkerFakeBuildingsCommandSet
+    TriggerAlt = Demo_Upgrade_SuicideBomb
+    CommandSetAlt = Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   End
 
   Behavior = CommandSetUpgrade ModuleTag_15
     TriggeredBy = Upgrade_GLAWorkerRealCommandSet
     RemovesUpgrades = Upgrade_GLAWorkerFakeCommandSet Upgrade_GLAWorkerRealCommandSet
     CommandSet = Demo_GLAWorkerCommandSet
+    TriggerAlt = Demo_Upgrade_SuicideBomb
+    CommandSetAlt = Demo_GLAWorkerCommandSetUpgrade
   End
 
   Behavior = ProductionUpdate ModuleTag_16
     MaxQueueEntries = 1; For the command set switching upgrade
+  End
+
+  ; Patch104p @bugfix commy2 03/09/2021 Handles upgrade of fake command set when Demolitions upgrade is researched.
+
+  Behavior = CommandSetUpgrade ModuleTag_17
+    TriggeredBy = Demo_Upgrade_SuicideBomb
+    CommandSet = Demo_GLAWorkerCommandSetUpgrade
+    TriggerAlt = Upgrade_GLAWorkerFakeCommandSet
+    CommandSetAlt = Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Death_17


### PR DESCRIPTION
ZH 1.04

- The Suicide ability is shown on the Demolition General's Worker before the upgrade was bought, even though it is not shown on most other units.

After patch

- The Suicide ability is only shown after the Demolitions upgrade has been bought, like on other units.