### PR TITLE
Fix: Inconsistent Suicide Ability Button Placement

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -171,7 +171,7 @@ https://github.com/commy2/zerohour/issues/47  [DONE]                  Demo Gener
 https://github.com/commy2/zerohour/issues/46  [IMPROVEMENT]           Technical Has To Recenter Turret To Suicide
 https://github.com/commy2/zerohour/issues/45  [IMPROVEMENT]           Combat Bike Has Disabled Suicide Ability Button
 https://github.com/commy2/zerohour/issues/44  [MAYBE]                 Terrorist And Bomb Truck Missing Suicide Ability
-https://github.com/commy2/zerohour/issues/43  [IMPROVEMENT]           Suicide Ability Button Is Placed Inconsistently
+https://github.com/commy2/zerohour/issues/43  [DONE]                  Suicide Ability Button Is Placed Inconsistently
 https://github.com/commy2/zerohour/issues/42  [IMPROVEMENT]           Worker Has Disabled Suicide Button Before Demolitions Upgrade
 https://github.com/commy2/zerohour/issues/41  [IMPROVEMENT]           Base Defenses Missing Demoliton Upgrade Icon
 https://github.com/commy2/zerohour/issues/38  [IMPROVEMENT]           Detached Floating Object Orbits Avenger Model When Moving

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1916,6 +1916,8 @@ End
 
 
 
+; Patch104p @bugfix commy2 03/09/2021 Move all Suicide ability buttons to same slot.
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;  NEW Demo General Commands
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2219,8 +2221,8 @@ End
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
-  9  = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2231,31 +2233,31 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  9  = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
   10 = Command_Evacuate
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   1  = Command_GLAToxinTractorContaminateGround
-  9  = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
-  9  = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
-  9  = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2271,26 +2273,36 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   8  = Demo_Command_ConstructGLAScudStorm
   9  = Demo_Command_ConstructGLAArmsDealer
  10  = Demo_Command_ConstructGLACommandCenter
- 11  = Demo_Command_TertiarySuicide
+ 12  = Demo_Command_TertiarySuicide
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
 End
 
+CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
+  1 = Demo_Command_ConstructFakeGLACommandCenter
+  2 = Demo_Command_ConstructFakeGLABarracks
+  3 = Demo_Command_ConstructFakeGLASupplyStash
+  4 = Demo_Command_ConstructFakeGLAArmsDealer
+  5 = Demo_Command_ConstructFakeGLABlackMarket
+ 12 = Demo_Command_TertiarySuicide
+ 13 = Command_UpgradeGLAWorkerRealCommandSet
+End
+
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
   1  = Demo_Command_ConstructGLAWorker
-  3  = Demo_Command_TertiarySuicide
   4  = Command_GPSScrambler
   5  = Demo_Command_Ambush
   6  = Command_EmergencyRepair
   7  = Command_AnthraxBomb
   8  = Command_SneakAttack
+  12 = Demo_Command_TertiarySuicide
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
   1  = Demo_Command_ConstructGLAWorker
-  2  = Demo_Command_TertiarySuicide
+  12 = Demo_Command_TertiarySuicide
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
@@ -2305,7 +2317,7 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   7  = Command_UpgradeGLAFortifiedStructure
   8  = Command_UpgradeGLAArmTheMob
 ; 12 = Demo_Command_UpgradeGLADemoTrapHighExplosiveBomb
-  13 = Demo_Command_TertiarySuicide
+  12 = Demo_Command_TertiarySuicide
   14 = Command_Sell
 End
 
@@ -2326,21 +2338,21 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   1  = Command_UpgradeGLAAPBullets
   2  = Command_UpgradeGLAAPRockets
   3  = Command_UpgradeGLAJunkRepair
-  4  = Demo_Command_TertiarySuicide
   5  = Command_UpgradeGLARadarVanScan
   6  = Command_UpgradeGLAWorkerShoes
+  12 = Demo_Command_TertiarySuicide
   14 = Command_Sell
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
-  1  = Demo_Command_TertiarySuicide
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Stop
   14 = Command_Sell
 End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
   1  = Command_ScudStorm
-  2  = Demo_Command_TertiarySuicide
+  12 = Demo_Command_TertiarySuicide
   14 = Command_Sell
 End
 
@@ -2381,22 +2393,22 @@ End
 CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   1 = Command_GLAInfantryRebelCaptureBuilding
   2 = Command_GLAInfantryRebelBoobyTrapAttack
-  3 = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
-  1 = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
-  1 = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2406,21 +2418,21 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   2 = Demo_Command_KellTimedDemoCharge
   3 = Demo_Command_KellRemoteDemoCharge
   4 = Demo_Command_KellDetonateCharges
-  5 = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   1 = Command_RadarVanScan
-  2 = Demo_Command_TertiarySuicide
+  12 = Demo_Command_TertiarySuicide
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
-  1 = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2436,7 +2448,7 @@ End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   1 = Command_GLAInfantryHijack
-  2 = Demo_Command_TertiarySuicide
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2450,24 +2462,24 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Demo_Command_TertiarySuicide
   10 = Command_Evacuate
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
-  1 = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
   1  = Command_ScuttleCombatBike
-  2  = Demo_Command_TertiarySuicide
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End


### PR DESCRIPTION
ZH 1.04

- Different unit types may or may not use the same slot for the Suicide ability, which means the button to Suicide may be missing when multiple units are selected.

After patch:

- The button is placed on the same slot for all units, so the player can always* suicide as long as only Demo General units are selected.

* The Terrorist and Bomb Truck do not get a Suicide button with this PR, thus meaning that these two still shadow the button.
