### PR TITLE
Fix: Demo General Technical Has To Recenter Turret To Suicide

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -168,7 +168,7 @@ https://github.com/commy2/zerohour/issues/50  [DONE]                  Demo Gener
 https://github.com/commy2/zerohour/issues/49  [DONE]                  Demo General Infantry Play Terrorist Sound Effect When Killed
 https://github.com/commy2/zerohour/issues/48  [MAYBE]                 Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed
 https://github.com/commy2/zerohour/issues/47  [DONE]                  Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided
-https://github.com/commy2/zerohour/issues/46  [IMPROVEMENT]           Technical Has To Recenter Turret To Suicide
+https://github.com/commy2/zerohour/issues/46  [DONE]                  Technical Has To Recenter Turret To Suicide
 https://github.com/commy2/zerohour/issues/45  [IMPROVEMENT]           Combat Bike Has Disabled Suicide Ability Button
 https://github.com/commy2/zerohour/issues/44  [MAYBE]                 Terrorist And Bomb Truck Missing Suicide Ability
 https://github.com/commy2/zerohour/issues/43  [IMPROVEMENT]           Suicide Ability Button Is Placed Inconsistently

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19727,7 +19727,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
       MaxIdleScanAngle = 60      ; in degrees off the natural turret angle
       MinIdleScanInterval = 5000 ; in milliseconds
       MaxIdleScanInterval = 10000 ; in milliseconds
-      ControlledWeaponSlots = PRIMARY SECONDARY TERTIARY
+      ControlledWeaponSlots = PRIMARY ; Patch104p @bugfix commy2 03/09/2021 Fix having to recenter turret before suiciding via ability.
     End
     AutoAcquireEnemiesWhenIdle = Yes
   End


### PR DESCRIPTION
ZH 1.04

- When ordering the Technical to suicide, the turret has to re-allign to face directly forward before the vehicle explodes.
- It may take up to 0.75 seconds before the Technical explodes in case it was just firing at something directly behind it.
- This is not an issue with any other unit.

Reproduce:

- Force-fire the ground behind the Technical and then use the Suicide ability.

After this patch:

- The Technical explodes immediately without delay - just like any other unit.

