### PR TITLE
Fix: Inconsistent Evacuate Button Placement

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -148,7 +148,7 @@ https://github.com/commy2/zerohour/issues/70  [NOTRELEVANT]           Boss Sentr
 https://github.com/commy2/zerohour/issues/69  [IMPROVEMENT]           Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds
 https://github.com/commy2/zerohour/issues/68  [IMPROVEMENT]           Spy Drone Seleced By Q-Shortcut
 https://github.com/commy2/zerohour/issues/67  [IMPROVEMENT]           Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility
-https://github.com/commy2/zerohour/issues/66  [IMPROVEMENT]           Evacuate Buttons Are Not Aligned
+https://github.com/commy2/zerohour/issues/66  [DONE]                  Evacuate Buttons Are Not Aligned
 https://github.com/commy2/zerohour/issues/65  [IMPROVEMENT]           Laser General Humvee Has Duplicated Infantry Enter And Exit Sound Effect
 https://github.com/commy2/zerohour/issues/64  [MAYBE]                 Battle Drone Gains Double The Intended Bonus From Drone Armor
 https://github.com/commy2/zerohour/issues/63  [MAYBE]                 Paladins And Microwaves Gain Slightly Less Than Intended From Composite Armor

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -18,6 +18,9 @@
 ;+--+--+--+--+--+--+--+
 ;
 ;------------------------------------------------------------------------------
+
+; Patch104p @bugfix commy2 03/09/2021 Align evacuate buttons on same slot.
+
 ; Many things just want these three buttons.
 CommandSet GenericCommandSet
   11 = Command_AttackMove
@@ -365,8 +368,8 @@ CommandSet GLAVehicleBattleBusCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
+  9 = Command_Evacuate
   11 = Command_AttackMove
-  10 = Command_Evacuate
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -384,8 +387,8 @@ CommandSet GLAVehicleTechnicalCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  9 = Command_Evacuate
   11 = Command_AttackMove
-  10 = Command_Evacuate
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -444,14 +447,15 @@ CommandSet ChinaTroopCrawlerCommandSet
   8 = Command_TransportExit
   9 = Command_EmptyCrawler
   11 = Command_AttackMove
+ ;13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet ChinaListeningOutpostCommandSet
   1 = Command_TransportExit
   2 = Command_TransportExit
+  9 = Command_EmptyCrawler
   11 = Command_AttackMove
-  12 = Command_EmptyCrawler
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -536,7 +540,7 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   5  = Command_TransportExit
   6  = Command_TransportExit
   7  = Command_TransportExit
-  8  = Command_Evacuate
+  9  = Command_Evacuate
   10 = Command_AmbulanceCleanupArea
   11 = Command_AttackMove
   13 = Command_Guard
@@ -2158,7 +2162,7 @@ CommandSet Demo_GLAVehicleBattleBusCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  10 = Command_Evacuate
+  9 = Command_Evacuate
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -2202,8 +2206,8 @@ CommandSet Demo_GLAVehicleTechnicalCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  9 = Command_Evacuate
   11 = Command_AttackMove
-  10 = Command_Evacuate
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2231,9 +2235,9 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  9  = Demo_Command_TertiarySuicide
+  9 = Command_Evacuate
   11 = Command_AttackMove
-  10 = Command_Evacuate
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2450,9 +2454,9 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Demo_Command_TertiarySuicide
-  10 = Command_Evacuate
+  9 = Command_Evacuate
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2726,7 +2730,7 @@ CommandSet Slth_GLAVehicleBattleBusCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  10 = Command_Evacuate
+  9 = Command_Evacuate
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -3301,8 +3305,8 @@ End
 CommandSet Nuke_ChinaListeningOutpostCommandSet
   1 = Command_TransportExit
   2 = Command_TransportExit
+  9 = Command_EmptyCrawler
   11 = Command_AttackMove
-  12 = Command_EmptyCrawler
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -3612,7 +3616,7 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   5  = Command_TransportExit
   6  = Command_TransportExit
   7  = Command_TransportExit
-  8  = Command_Evacuate
+  9  = Command_Evacuate
   10 = Command_AmbulanceCleanupArea
   11 = Command_AttackMove
   13 = Command_Guard
@@ -4020,6 +4024,7 @@ CommandSet Infa_ChinaTroopCrawlerCommandSet
   8 = Command_TransportExit
   9 = Command_EmptyCrawler
   11 = Command_AttackMove
+ ;13 = Command_Guard
   14 = Command_Stop
 End
 
@@ -4032,10 +4037,8 @@ CommandSet Infa_ChinaListeningOutpostCommandSet
    6 = Command_TransportExit
    7 = Command_TransportExit
    8 = Command_TransportExit
-  ; 9 = Command_TransportExit
-  ;10 = Command_TransportExit
+   9 = Command_EmptyCrawler
   11 = Command_AttackMove
-  12 = Command_EmptyCrawler
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -4391,7 +4394,7 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   5  = Command_TransportExit
   6  = Command_TransportExit
   7  = Command_TransportExit
-  8  = Command_Evacuate
+  9  = Command_Evacuate
   10 = Command_AmbulanceCleanupArea
   11 = Command_AttackMove
   13 = Command_Guard


### PR DESCRIPTION
ZH 1.04

- The Evacute buttons on the Humvee and the Ambulance are not at the same position, which means the player can't mass evacuate units if a group of Humvees and Ambulances are selected at once.
- This is not an issue in CCG and was only introduced presumably when the Hellfire Drone was added and the column number was increased from 6 to 7 in ZH 1.0.
- The same happens for the Technicals and Battle Buses.
- The same happens for the Troop Crawlers and Outposts

After patch:

- Same slot is used for all units. No more shadowing.