### PR TITLE
Fix: Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -147,7 +147,7 @@ https://github.com/commy2/zerohour/issues/71  [IMPROVEMENT]           Some Palad
 https://github.com/commy2/zerohour/issues/70  [NOTRELEVANT]           Boss Sentry Drone Inconsistencies
 https://github.com/commy2/zerohour/issues/69  [IMPROVEMENT]           Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds
 https://github.com/commy2/zerohour/issues/68  [IMPROVEMENT]           Spy Drone Seleced By Q-Shortcut
-https://github.com/commy2/zerohour/issues/67  [IMPROVEMENT]           Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility
+https://github.com/commy2/zerohour/issues/67  [DONE]                  Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility
 https://github.com/commy2/zerohour/issues/66  [IMPROVEMENT]           Evacuate Buttons Are Not Aligned
 https://github.com/commy2/zerohour/issues/65  [IMPROVEMENT]           Laser General Humvee Has Duplicated Infantry Enter And Exit Sound Effect
 https://github.com/commy2/zerohour/issues/64  [MAYBE]                 Battle Drone Gains Double The Intended Bonus From Drone Armor

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -3562,28 +3562,30 @@ CommandSet SupW_AmericaInfantryRangerCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @bugfix commy2 03/09/2021 Fix incompatibility of Drone upgrades between USA sub-factions when selecting multiple units.
+
 CommandSet SupW_AmericaTankCrusaderCommandSet
-  1  = SupW_Command_ConstructAmericaVehicleBattleDrone
-  2  = SupW_Command_ConstructAmericaVehicleScoutDrone
-  3  = SupW_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet SupW_AmericaVehicleTomahawkCommandSet
-  1  = SupW_Command_ConstructAmericaVehicleBattleDrone
-  2  = SupW_Command_ConstructAmericaVehicleScoutDrone
-  3  = SupW_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet SupW_AmericaVehicleHumveeCommandSet
-  1 = SupW_Command_ConstructAmericaVehicleBattleDrone
-  2 = SupW_Command_ConstructAmericaVehicleScoutDrone
-  3 = SupW_Command_ConstructAmericaVehicleHellfireDrone
+  1 = Command_ConstructAmericaVehicleBattleDrone
+  2 = Command_ConstructAmericaVehicleScoutDrone
+  3 = Command_ConstructAmericaVehicleHellfireDrone
   4 = Command_TransportExit
   5 = Command_TransportExit
   6 = Command_TransportExit
@@ -3596,18 +3598,18 @@ CommandSet SupW_AmericaVehicleHumveeCommandSet
 End
 
 CommandSet SupW_AmericaTankMicrowaveCommandSet
-  1  = SupW_Command_ConstructAmericaVehicleBattleDrone
-  2  = SupW_Command_ConstructAmericaVehicleScoutDrone
-  3  = SupW_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet SupW_AmericaVehicleAmbulanceCommandSet
-  1  = SupW_Command_ConstructAmericaVehicleBattleDrone
-  2  = SupW_Command_ConstructAmericaVehicleScoutDrone
-  3  = SupW_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   4  = Command_TransportExit
   5  = Command_TransportExit
   6  = Command_TransportExit
@@ -3620,9 +3622,9 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
 End
 
 CommandSet SupW_AmericaTankAvengerCommandSet
-  1  = SupW_Command_ConstructAmericaVehicleBattleDrone
-  2  = SupW_Command_ConstructAmericaVehicleScoutDrone
-  3  = SupW_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -3662,9 +3664,9 @@ CommandSet SupW_AmericaJetAuroraCommandSet
 End
 
 CommandSet SupW_AmericaTankPaladinCommandSet
-  1  = SupW_Command_ConstructAmericaVehicleBattleDrone
-  2  = SupW_Command_ConstructAmericaVehicleScoutDrone
-  3  = SupW_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -4341,28 +4343,30 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
  14 = Command_Stop
 End
 
+; Patch104p @bugfix commy2 03/09/2021 Fix incompatibility of Drone upgrades between USA sub-factions when selecting multiple units.
+
 CommandSet Lazr_AmericaTankAvengerCommandSet
-  1  = Lazr_Command_ConstructAmericaVehicleBattleDrone
-  2  = Lazr_Command_ConstructAmericaVehicleScoutDrone
-  3  = Lazr_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Lazr_AmericaTankCrusaderCommandSet
-  1  = Lazr_Command_ConstructAmericaVehicleBattleDrone
-  2  = Lazr_Command_ConstructAmericaVehicleScoutDrone
-  3  = Lazr_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Lazr_AmericaVehicleHumveeCommandSet
-  1 = Lazr_Command_ConstructAmericaVehicleBattleDrone
-  2 = Lazr_Command_ConstructAmericaVehicleScoutDrone
-  3 = Lazr_Command_ConstructAmericaVehicleHellfireDrone
+  1 = Command_ConstructAmericaVehicleBattleDrone
+  2 = Command_ConstructAmericaVehicleScoutDrone
+  3 = Command_ConstructAmericaVehicleHellfireDrone
   4 = Command_TransportExit
   5 = Command_TransportExit
   6 = Command_TransportExit
@@ -4375,18 +4379,18 @@ CommandSet Lazr_AmericaVehicleHumveeCommandSet
 End
 
 CommandSet Lazr_AmericaTankMicrowaveCommandSet
-  1  = Lazr_Command_ConstructAmericaVehicleBattleDrone
-  2  = Lazr_Command_ConstructAmericaVehicleScoutDrone
-  3  = Lazr_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
-  1  = Lazr_Command_ConstructAmericaVehicleBattleDrone
-  2  = Lazr_Command_ConstructAmericaVehicleScoutDrone
-  3  = Lazr_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   4  = Command_TransportExit
   5  = Command_TransportExit
   6  = Command_TransportExit
@@ -4400,9 +4404,9 @@ End
 
 
 CommandSet Lazr_AmericaTankPaladinCommandSet
-  1  = Lazr_Command_ConstructAmericaVehicleBattleDrone
-  2  = Lazr_Command_ConstructAmericaVehicleScoutDrone
-  3  = Lazr_Command_ConstructAmericaVehicleHellfireDrone
+  1  = Command_ConstructAmericaVehicleBattleDrone
+  2  = Command_ConstructAmericaVehicleScoutDrone
+  3  = Command_ConstructAmericaVehicleHellfireDrone
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop


### PR DESCRIPTION
ZH 1.04

- The vehicles of the Super Weapon General use different buttons to upgrade drones. The same applies to the Laser General. The Airforce General however uses the same buttons as the normal USA. This means that drones cannot be upgraded for multiple vehicles at once if two of the three groups are selected.

Repro:

- Select vehicles from different generals and try to upgrade a Battle Drone.

After patch:

- The drone upgrades are not hidden when the wrong sub-faction units are selected at once.