### PR TITLE
Fix: Vanilla GLA Combat Bike Has Duplicated Death Scream

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -159,7 +159,7 @@ https://github.com/commy2/zerohour/issues/59  [IMPROVEMENT]           Air Force 
 https://github.com/commy2/zerohour/issues/58  [IMPROVEMENT]           Some Combat Bikes Missing DoorOpenTime Entry
 https://github.com/commy2/zerohour/issues/57  [IMPROVEMENT]           Broken Combat Bike Animations
 https://github.com/commy2/zerohour/issues/56  [IMPROVEMENT]           Saboteur Body Disappears From Destroyed Combat Bike
-https://github.com/commy2/zerohour/issues/55  [IMPROVEMENT]           Vanilla GLA Combat Bike Has Duplicated Death Scream
+https://github.com/commy2/zerohour/issues/55  [DONE]                  Vanilla GLA Combat Bike Has Duplicated Death Scream
 https://github.com/commy2/zerohour/issues/54  [IMPROVEMENT]           Vanilla GLA Hijacker And Saboteur Can Ride Toxin Generals Combat Bike
 https://github.com/commy2/zerohour/issues/53  [MAYBE]                 Veteran Quad Cannons Deal Less Damage When Scrapped
 https://github.com/commy2/zerohour/issues/52  [NOTRELEVANT]           Boss Base Defense Inconsistencies

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -1394,14 +1394,16 @@ Object GLAVehicleCombatBike
     AflameDamageDelay = 500       ; this often.
   End
 
-  Behavior = FXListDie ModuleDieSoundTag_22
-    DeathTypes = ALL -TOPPLED ; Not if we are "dying" by being abandoned by our human.  Nobody left to scream
-    DeathFX = FX_CombatCycleDie
-  End
-  Behavior = FXListDie ModuleDieSoundTag_23
-    DeathTypes = NONE +TOPPLED
-    DeathFX = FX_CombatCycleDieNoScream
-  End
+  ; Patch104p @bugfix commy2 03/09/2021 Disable duplicate death scream. Only play unit specific death scream.
+
+  ;Behavior = FXListDie ModuleDieSoundTag_22
+  ;  DeathTypes = ALL -TOPPLED ; Not if we are "dying" by being abandoned by our human.  Nobody left to scream
+  ;  DeathFX = FX_CombatCycleDie
+  ;End
+  ;Behavior = FXListDie ModuleDieSoundTag_23
+  ;  DeathTypes = NONE +TOPPLED
+  ;  DeathFX = FX_CombatCycleDieNoScream
+  ;End
 
 
   Geometry = BOX


### PR DESCRIPTION
ZH 1.04

- When a normal GLA Combat Bike is destroyed, two screams can be heard. A generic scream from the bike, and a rider specific scream (depending on the type of unit).
- This does not happen for any of the other 20 or so Combat Bikes in the code.

After patch:

- Only the unit specific voice line can be heard.
