### PR TITLE
Fix: Laser General Humvee Has Duplicated Infantry Enter And Exit Sound Effect

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -149,7 +149,7 @@ https://github.com/commy2/zerohour/issues/69  [IMPROVEMENT]           Damaged An
 https://github.com/commy2/zerohour/issues/68  [IMPROVEMENT]           Spy Drone Seleced By Q-Shortcut
 https://github.com/commy2/zerohour/issues/67  [DONE]                  Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility
 https://github.com/commy2/zerohour/issues/66  [DONE]                  Evacuate Buttons Are Not Aligned
-https://github.com/commy2/zerohour/issues/65  [IMPROVEMENT]           Laser General Humvee Has Duplicated Infantry Enter And Exit Sound Effect
+https://github.com/commy2/zerohour/issues/65  [DONE]                  Laser General Humvee Has Duplicated Infantry Enter And Exit Sound Effect
 https://github.com/commy2/zerohour/issues/64  [MAYBE]                 Battle Drone Gains Double The Intended Bonus From Drone Armor
 https://github.com/commy2/zerohour/issues/63  [MAYBE]                 Paladins And Microwaves Gain Slightly Less Than Intended From Composite Armor
 https://github.com/commy2/zerohour/issues/62  [MAYBE]                 Crusader And Laser Tanks Receive Composite Armor Health Bonus Twice

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4514,11 +4514,13 @@ Object Lazr_AmericaVehicleHumvee
     Mass = 50.0
   End
 
+  ; Patch104p @bugfix commy2 03/09/2021 Remove module enter and exit sound effects to prevent overlaying with audio parameter effects roughly 50 lines above.
+
   Behavior = TransportContain  ModuleTag_05
     PassengersAllowedToFire = Yes
     Slots             = 5
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+;    EnterSound          = GarrisonEnter
+;    ExitSound           = GarrisonExit
     DamagePercentToUnits = 100% ;10%
     AllowInsideKindOf  = INFANTRY
     ExitDelay = 250


### PR DESCRIPTION
ZH 1.04

- The Laser General's Humvee uses the Humvee entering and leaving sound effects as well as the generic entering and leaving buildings sound effect at once. None of the other Humvees use the generic effect.

After patch:

- All Humvees and Ambulances use the same enter and exit sound effect for infantry, and none have overlaying.

This literally makes the game unplayable btw.