### PR TITLE
Fix: Spy Drone Selected By Q-Shortcut

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -146,7 +146,7 @@ https://github.com/commy2/zerohour/issues/72  [IMPROVEMENT]           Non-Vanill
 https://github.com/commy2/zerohour/issues/71  [IMPROVEMENT]           Some Paladins Missing Hellfire Drone Upgrade Icon
 https://github.com/commy2/zerohour/issues/70  [NOTRELEVANT]           Boss Sentry Drone Inconsistencies
 https://github.com/commy2/zerohour/issues/69  [IMPROVEMENT]           Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds
-https://github.com/commy2/zerohour/issues/68  [IMPROVEMENT]           Spy Drone Seleced By Q-Shortcut
+https://github.com/commy2/zerohour/issues/68  [DONE]                  Spy Drone Seleced By Q-Shortcut
 https://github.com/commy2/zerohour/issues/67  [DONE]                  Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility
 https://github.com/commy2/zerohour/issues/66  [DONE]                  Evacuate Buttons Are Not Aligned
 https://github.com/commy2/zerohour/issues/65  [IMPROVEMENT]           Laser General Humvee Has Duplicated Infantry Enter And Exit Sound Effect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6393,7 +6393,7 @@ Object AirF_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1289,7 +1289,7 @@ Object AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5639,7 +5639,7 @@ Object Lazr_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6116,7 +6116,7 @@ Object SupW_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0


### PR DESCRIPTION
ZH 1.04

- The Spy Drone is selected by the Select All (Q) shortcut, even though it completely ignores any orders.

After patch:

- The Spy Drone is no longer selected by Q, but can still be selected by click or box.

- Closes: #40