### PR TITLE
Fix: Spectre Gunship Selected By W-Shortcut

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -2,6 +2,7 @@ Note: These are issue reports. The titles describe the problem. So the expectati
 
 GAME
 
+https://github.com/commy2/zerohour/issues/228 [DONE]                  Specrte Gunship Seleced By W-Shortcut
 https://github.com/commy2/zerohour/issues/225 [IMPROVEMENT]           Spectre Loses Team Color When Shot Down
 https://github.com/commy2/zerohour/issues/224 [IMPROVEMENT]           Mixing Battle Masters From Different Sub-Factions Does Not Grant Horde Bonus
 https://github.com/commy2/zerohour/issues/223 [IMPROVEMENT]           Sentry Drone Lacks Voice Line When Leaving Factory

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -509,7 +509,7 @@ Object AirF_AmericaJetSpectreGunship1
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED
+  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 04/09/2021 No longer select Spectre with W-shortcut.
 
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 600.0
@@ -830,7 +830,7 @@ Object AirF_AmericaJetSpectreGunship2
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED
+  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 04/09/2021 No longer select Spectre with W-shortcut.
 
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 600.0
@@ -1148,7 +1148,7 @@ Object AirF_AmericaJetSpectreGunship3
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED
+  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 04/09/2021 No longer select Spectre with W-shortcut.
 
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 600.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -185,7 +185,7 @@ Object AmericaJetSpectreGunship
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED
+  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 04/09/2021 No longer select Spectre with W-shortcut.
 
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 600.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -14809,7 +14809,7 @@ Object Boss_JetSpectreGunship
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED
+  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 04/09/2021 No longer select Spectre with W-shortcut.
 
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 600.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -185,7 +185,7 @@ Object Lazr_AmericaJetSpectreGunship
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED
+  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 04/09/2021 No longer select Spectre with W-shortcut.
 
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 600.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -657,7 +657,7 @@ Object SupW_AmericaJetSpectreGunship
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED
+  KindOf = PRELOAD CAN_ATTACK VEHICLE AIRCRAFT SCORE SELECTABLE EMP_HARDENED IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 04/09/2021 No longer select Spectre with W-shortcut.
 
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 600.0


### PR DESCRIPTION
ZH 1.04

- The Spectre Gunship is selected by using the Select Aircraft (W) shortcut. It probably shouldn't.

After patch:

- Pressing W will not select the Spectre.
- close https://github.com/xezon/GeneralsGamePatch/issues/148
