### PR TITLE
Fix: Hitting Battle Bus In Hull Mode Causes Screen Shake

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -102,7 +102,7 @@ https://github.com/commy2/zerohour/issues/118 [MAYBE]                 Some ECM T
 https://github.com/commy2/zerohour/issues/117 [IMPROVEMENT]           Some Rebels Are Missing Upgrade Icons
 https://github.com/commy2/zerohour/issues/116 [MAYBE]                 Tactical Nuke Mig Upgrade Not Buildable While Low On Power
 https://github.com/commy2/zerohour/issues/115 [IMPROVEMENT]           Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub Faction Command Centers
-https://github.com/commy2/zerohour/issues/114 [IMPROVEMENT]           Hitting Battle Bus In Hull Mode Causes Screen Shake
+https://github.com/commy2/zerohour/issues/114 [DONE]                  Hitting Battle Bus In Hull Mode Causes Screen Shake
 https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs Cannot Target Stinger Sites
 https://github.com/commy2/zerohour/issues/112 [IMPROVEMENT]           Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon
 https://github.com/commy2/zerohour/issues/111 [DONE][NPROJECT]        Stealth General Saboteur Uses Rebel Death Scream

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19634,6 +19634,8 @@ Object Chem_GLAVehicleBattleBus
     Weapon              = SECONDARY   BattleBusDummyWeapon
   End
 
+  ; Patch104p @bugfix commy2 04/09/2021 Remove screen shake when bunker mode bus is hit.
+
   ArmorSet
     Conditions      = None
     Armor           = BattleBusTruckArmor
@@ -19642,7 +19644,7 @@ Object Chem_GLAVehicleBattleBus
   ArmorSet
     Conditions      = SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorTough
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -19653,7 +19655,7 @@ Object Chem_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_ONE SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusOne
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -19664,7 +19666,7 @@ Object Chem_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_TWO SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusTwo
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   BuildCost       = 1100

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -21114,6 +21114,8 @@ Object Demo_GLAVehicleBattleBus
     AutoChooseSources = TERTIARY None
   End
 
+  ; Patch104p @bugfix commy2 04/09/2021 Remove screen shake when bunker mode bus is hit.
+
   ArmorSet
     Conditions      = None
     Armor           = BattleBusTruckArmor
@@ -21122,7 +21124,7 @@ Object Demo_GLAVehicleBattleBus
   ArmorSet
     Conditions      = SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorTough
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -21133,7 +21135,7 @@ Object Demo_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_ONE SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusOne
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -21144,7 +21146,7 @@ Object Demo_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_TWO SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusTwo
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   BuildCost       = 1200

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -3877,6 +3877,9 @@ Object GC_Slth_GLAVehicleBattleBus
     Conditions = None
     Weapon = PRIMARY None
   End
+
+  ; Patch104p @bugfix commy2 04/09/2021 Remove screen shake when bunker mode bus is hit.
+
   ArmorSet
     Conditions      = None
     Armor           = BattleBusTruckArmor
@@ -3885,7 +3888,7 @@ Object GC_Slth_GLAVehicleBattleBus
   ArmorSet
     Conditions      = SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorTough
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -3896,7 +3899,7 @@ Object GC_Slth_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_ONE SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusOne
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -3907,7 +3910,7 @@ Object GC_Slth_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_TWO SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusTwo
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   BuildCost       = 1000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -8814,6 +8814,8 @@ Object GLAVehicleBattleBusHighDef
     Weapon = PRIMARY None
   End
 
+  ; Patch104p @bugfix commy2 04/09/2021 Remove screen shake when bunker mode bus is hit.
+
   ArmorSet
     Conditions      = None
     Armor           = BattleBusTruckArmor
@@ -8822,7 +8824,7 @@ Object GLAVehicleBattleBusHighDef
   ArmorSet
     Conditions      = SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorTough
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -8833,7 +8835,7 @@ Object GLAVehicleBattleBusHighDef
   ArmorSet
     Conditions      = CRATE_UPGRADE_ONE SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusOne
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -8844,7 +8846,7 @@ Object GLAVehicleBattleBusHighDef
   ArmorSet
     Conditions      = CRATE_UPGRADE_TWO SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusTwo
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   BuildCost       = 1000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6236,6 +6236,8 @@ Object GLAVehicleBattleBus
     Weapon              = SECONDARY   BattleBusDummyWeapon
   End
 
+  ; Patch104p @bugfix commy2 04/09/2021 Remove screen shake when bunker mode bus is hit.
+
   ArmorSet
     Conditions      = None
     Armor           = BattleBusTruckArmor
@@ -6244,7 +6246,7 @@ Object GLAVehicleBattleBus
   ArmorSet
     Conditions      = SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorTough
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -6255,7 +6257,7 @@ Object GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_ONE SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusOne
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -6266,7 +6268,7 @@ Object GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_TWO SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusTwo
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   BuildCost       = 1000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -21150,6 +21150,8 @@ Object Slth_GLAVehicleBattleBus
     Weapon              = SECONDARY   BattleBusDummyWeapon
   End
 
+  ; Patch104p @bugfix commy2 04/09/2021 Remove screen shake when bunker mode bus is hit.
+
   ArmorSet
     Conditions      = None
     Armor           = BattleBusTruckArmor
@@ -21158,7 +21160,7 @@ Object Slth_GLAVehicleBattleBus
   ArmorSet
     Conditions      = SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorTough
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -21169,7 +21171,7 @@ Object Slth_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_ONE SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusOne
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   ArmorSet
@@ -21180,7 +21182,7 @@ Object Slth_GLAVehicleBattleBus
   ArmorSet
     Conditions      = CRATE_UPGRADE_TWO SECOND_LIFE ; Set after our first death, natch
     Armor           = BattleBusStructureArmorToughPlusTwo
-    DamageFX        = StructureDamageFX
+    DamageFX        = StructureDamageFXNoShake
   End
 
   BuildCost       = 1000


### PR DESCRIPTION
ZH 1.04:

- Hitting a Battle Bus in his second life bunker mode causes the screen to shake.

With patch:

- No more annoying screen shake.

Note that while the Bus is kind of counted as a structure, no other structure is using the `StructureDamageFX` effect. Everyone uses `StructureDamageFXNoShake`, likely because that is way less distracting.