### PR TITLE
Fix: Damaged And Non-Vanilla USA Sentry Drones Are Missing Their Move Start Sounds

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -146,7 +146,7 @@ https://github.com/commy2/zerohour/issues/73  [MAYBE]                 Avenger Tu
 https://github.com/commy2/zerohour/issues/72  [IMPROVEMENT]           Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds
 https://github.com/commy2/zerohour/issues/71  [IMPROVEMENT]           Some Paladins Missing Hellfire Drone Upgrade Icon
 https://github.com/commy2/zerohour/issues/70  [NOTRELEVANT]           Boss Sentry Drone Inconsistencies
-https://github.com/commy2/zerohour/issues/69  [IMPROVEMENT]           Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds
+https://github.com/commy2/zerohour/issues/69  [DONE]                  Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds
 https://github.com/commy2/zerohour/issues/68  [DONE]                  Spy Drone Seleced By Q-Shortcut
 https://github.com/commy2/zerohour/issues/67  [DONE]                  Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility
 https://github.com/commy2/zerohour/issues/66  [DONE]                  Evacuate Buttons Are Not Aligned

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6786,13 +6786,15 @@ Object AirF_AmericaVehicleSentryDrone
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
   VoiceMove             = SentryDroneVoiceMove
   VoiceGuard            = SentryDroneVoiceMove
   VoiceAttack           = SentryDroneVoiceMove
-  SoundMoveStart        = NoSound
-  SoundMoveStartDamaged = NoSound
+  SoundMoveStart        = SentryDroneMoveStart
+  SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2150,13 +2150,15 @@ Object AmericaVehicleSentryDrone
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects when damaged.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
   VoiceMove             = SentryDroneVoiceMove
   VoiceGuard            = SentryDroneVoiceMove
   VoiceAttack           = SentryDroneVoiceMove
   SoundMoveStart        = SentryDroneMoveStart
-  SoundMoveStartDamaged = NoSound
+  SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19715,13 +19715,15 @@ Object Boss_VehicleSentryDrone
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
   VoiceMove             = SentryDroneVoiceMove
   VoiceGuard            = SentryDroneVoiceMove
   VoiceAttack           = SentryDroneVoiceMove
-  SoundMoveStart        = NoSound
-  SoundMoveStartDamaged = NoSound
+  SoundMoveStart        = SentryDroneMoveStart
+  SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6501,13 +6501,15 @@ Object Lazr_AmericaVehicleSentryDrone
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = Lazr_AmericaVehicleSentryDroneCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
   VoiceMove             = SentryDroneVoiceMove
   VoiceGuard            = SentryDroneVoiceMove
   VoiceAttack           = SentryDroneVoiceMove
-  SoundMoveStart        = NoSound
-  SoundMoveStartDamaged = NoSound
+  SoundMoveStart        = SentryDroneMoveStart
+  SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6971,13 +6971,15 @@ Object SupW_AmericaVehicleSentryDrone
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
   VoiceMove             = SentryDroneVoiceMove
   VoiceGuard            = SentryDroneVoiceMove
   VoiceAttack           = SentryDroneVoiceMove
-  SoundMoveStart        = NoSound
-  SoundMoveStartDamaged = NoSound
+  SoundMoveStart        = SentryDroneMoveStart
+  SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = NoSound


### PR DESCRIPTION
ZH 1.04:

- The Airforce, Super Weapon, Laser and Boss General's Sentry Drones are missing the Move Start sounds of the normal USA Sentry Drone. The normal USA Sentry Drone is missing the sound effects as well, but only when damged. No other unit loses this sound effect completely when damaged.

After this patch:

- The move start sound is always used, on every Sentry Drone.