### PR TITLE
Fix: Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -143,7 +143,7 @@ https://github.com/commy2/zerohour/issues/76  [IMPROVEMENT]           Chem Suit 
 https://github.com/commy2/zerohour/issues/75  [IMPROVEMENT]           Some Hellfire Drones Use Scout Drone Model
 https://github.com/commy2/zerohour/issues/74  [IMPROVEMENT]           Avenger Turns Chassis When Turret Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/73  [MAYBE]                 Avenger Turret Inconsistencies
-https://github.com/commy2/zerohour/issues/72  [IMPROVEMENT]           Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds
+https://github.com/commy2/zerohour/issues/72  [DONE]                  Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds
 https://github.com/commy2/zerohour/issues/71  [IMPROVEMENT]           Some Paladins Missing Hellfire Drone Upgrade Icon
 https://github.com/commy2/zerohour/issues/70  [NOTRELEVANT]           Boss Sentry Drone Inconsistencies
 https://github.com/commy2/zerohour/issues/69  [IMPROVEMENT]           Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7353,13 +7353,15 @@ Object AirF_AmericaTankMicrowave
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet             = AmericaTankMicrowaveCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Use move start sound effects from vanilla USA Microwave instead of Humvee.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = MicrowaveTankVoiceSelect
   VoiceMove             = MicrowaveTankVoiceMove
   VoiceGuard            = MicrowaveTankVoiceMove
   VoiceAttack           = MicrowaveTankVoiceAttack
-  SoundMoveStart        = HumveeMoveStart
-  SoundMoveStartDamaged = HumveeMoveStart
+  SoundMoveStart        = MicrowaveTankMoveStart
+  SoundMoveStartDamaged = MicrowaveTankMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = MicrowaveTankVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -7060,13 +7060,15 @@ Object Lazr_AmericaTankMicrowave
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet             = Lazr_AmericaTankMicrowaveCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Use move start sound effects from vanilla USA Microwave instead of Humvee.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = MicrowaveTankVoiceSelect
   VoiceMove             = MicrowaveTankVoiceMove
   VoiceGuard            = MicrowaveTankVoiceMove
   VoiceAttack           = MicrowaveTankVoiceAttack
-  SoundMoveStart        = HumveeMoveStart
-  SoundMoveStartDamaged = HumveeMoveStart
+  SoundMoveStart        = MicrowaveTankMoveStart
+  SoundMoveStartDamaged = MicrowaveTankMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = MicrowaveTankVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7531,13 +7531,15 @@ Object SupW_AmericaTankMicrowave
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet             = SupW_AmericaTankMicrowaveCommandSet
 
+  ; Patch104p @bugfix commy2 04/09/2021 Use move start sound effects from vanilla USA Microwave instead of Humvee.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = MicrowaveTankVoiceSelect
   VoiceMove             = MicrowaveTankVoiceMove
   VoiceGuard            = MicrowaveTankVoiceMove
   VoiceAttack           = MicrowaveTankVoiceAttack
-  SoundMoveStart        = HumveeMoveStart
-  SoundMoveStartDamaged = HumveeMoveStart
+  SoundMoveStart        = MicrowaveTankMoveStart
+  SoundMoveStartDamaged = MicrowaveTankMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = MicrowaveTankVoiceCreate


### PR DESCRIPTION
ZH 1.04

- The Airforce, Super Weapon and Laser General's Microwave tanks do use the Humvee's Move Start sounds instead of the normal USA Microwave ones.

After patch:

- All Microwaves use the intended, custom and unique* move start sound effects.

Fun fact: The same effect is used by the ECM tank.