### PR TITLE
Fix: Non-Vanilla USA Fire Bases Use Patriot Sound Effect When Selected

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -127,7 +127,7 @@ https://github.com/commy2/zerohour/issues/93  [IMPROVEMENT]           Vanilla Ch
 https://github.com/commy2/zerohour/issues/92  [REJECTED][NPROJECT]    Speaker Tower Sufficient For Player Survival
 https://github.com/commy2/zerohour/issues/91  [MAYBE]                 Flashbangs Can Clear Mines
 https://github.com/commy2/zerohour/issues/90  [NOTRELEVANT]           Jarmen Kell Can Snipe Landed Chinooks And Helixes
-https://github.com/commy2/zerohour/issues/89  [IMPROVEMENT]           Non-Vanilla USA Fire Bases Use Patriot Sound Effect
+https://github.com/commy2/zerohour/issues/89  [NONE]                  Non-Vanilla USA Fire Bases Use Patriot Sound Effect
 https://github.com/commy2/zerohour/issues/88  [NOTRELEVANT]           Air Force General Chinook And Combat Chinook Have Different PDL Scan Ranges
 https://github.com/commy2/zerohour/issues/87  [IMPROVEMENT]           Some Chinooks Collect Slower Than Others
 https://github.com/commy2/zerohour/issues/86  [NOTRELEVANT]           Boss King Raptor Inconsistencies

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17314,8 +17314,10 @@ Object AirF_AmericaFireBase
   CommandSet        = AirF_AmericaFireBaseCommandSet
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
+  ; Patch104p @bugfix commy2 04/09/2021 Use selection sound effect from vanilla USA Fire Base instead of Patriot Battery.
+
   ; *** AUDIO Parameters ***
-  VoiceSelect = PatriotBatterySelect
+  VoiceSelect = FireBaseSelect
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -16458,8 +16458,10 @@ Object Lazr_AmericaFireBase
   CommandSet        = Lazr_AmericaFireBaseCommandSet
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
+  ; Patch104p @bugfix commy2 04/09/2021 Use selection sound effect from vanilla USA Fire Base instead of Patriot Battery.
+
   ; *** AUDIO Parameters ***
-  VoiceSelect = PatriotBatterySelect
+  VoiceSelect = FireBaseSelect
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -16359,8 +16359,10 @@ Object SupW_AmericaFireBase
   CommandSet        = SupW_AmericaFireBaseCommandSet
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
+  ; Patch104p @bugfix commy2 04/09/2021 Use selection sound effect from vanilla USA Fire Base instead of Patriot Battery.
+
   ; *** AUDIO Parameters ***
-  VoiceSelect = PatriotBatterySelect
+  VoiceSelect = FireBaseSelect
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 


### PR DESCRIPTION
ZH 1.04

- The Airforce, Super Weapon and Laser General's Fire Bases use the sound effect of the Patriot Battery instead of the unique sound effect of the normal USA Fire Base.

After this patch:

- All Fire Bases use their intended and unqiue sound effect when selected.