### PR TITLE
Fix: Non-Vanilla USA Pilots Are Missing Voice Lines When Garrisoning Buildings

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -138,7 +138,7 @@ https://github.com/commy2/zerohour/issues/82  [?]                     B2 Carpet 
 https://github.com/commy2/zerohour/issues/81  [IMPROVEMENT]           Spectre Missing Portrait And Upgrade Icons
 https://github.com/commy2/zerohour/issues/80  [IMPROVEMENT]           Air Force And Super Weapon Spectre Tooltip Claims 4:00 Cooldown Instead Of True 3:00
 https://github.com/commy2/zerohour/issues/78  [MAYBE]                 Spectre Inconsistencies
-https://github.com/commy2/zerohour/issues/77  [IMPROVEMENT]           Non-Vanilla USA Pilots Are Missing Voice Lines When Garrisoning Buildings
+https://github.com/commy2/zerohour/issues/77  [DONE]                  Non-Vanilla USA Pilots Are Missing Voice Lines When Garrisoning Buildings
 https://github.com/commy2/zerohour/issues/76  [IMPROVEMENT]           Chem Suit Rangers Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/75  [IMPROVEMENT]           Some Hellfire Drones Use Scout Drone Model
 https://github.com/commy2/zerohour/issues/74  [IMPROVEMENT]           Avenger Turns Chassis When Turret Is Aiming At Air Unit

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4288,11 +4288,13 @@ Object AirF_AmericaInfantryPilot
   ShroudClearingRange = 300
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
+  ; Patch104p @bugfix commy2 04/09/2021 Fix missing voice line when ordered to enter a building.
+
   ; *** AUDIO Parameters ***
   VoiceSelect = PilotVoiceSelect
   VoiceMove = PilotVoiceMove
   VoiceAttack = PilotVoiceMove
-  VoiceGarrison = NoSound
+  VoiceGarrison = PilotVoiceMove
   VoiceFear = PilotVoiceFear
   UnitSpecificSounds
     VoiceEnter = PilotVoiceEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -3846,11 +3846,13 @@ Object Lazr_AmericaInfantryPilot
   ShroudClearingRange = 300
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
+  ; Patch104p @bugfix commy2 04/09/2021 Fix missing voice line when ordered to enter a building.
+
   ; *** AUDIO Parameters ***
   VoiceSelect = PilotVoiceSelect
   VoiceMove = PilotVoiceMove
   VoiceAttack = PilotVoiceMove
-  VoiceGarrison = NoSound
+  VoiceGarrison = PilotVoiceMove
   VoiceFear = PilotVoiceFear
   UnitSpecificSounds
     VoiceEnter = PilotVoiceEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4325,11 +4325,13 @@ Object SupW_AmericaInfantryPilot
   ShroudClearingRange = 300
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
+  ; Patch104p @bugfix commy2 04/09/2021 Fix missing voice line when ordered to enter a building.
+
   ; *** AUDIO Parameters ***
   VoiceSelect = PilotVoiceSelect
   VoiceMove = PilotVoiceMove
   VoiceAttack = PilotVoiceMove
-  VoiceGarrison = NoSound
+  VoiceGarrison = PilotVoiceMove
   VoiceFear = PilotVoiceFear
   UnitSpecificSounds
     VoiceEnter = PilotVoiceEnter


### PR DESCRIPTION
ZH 1.04

- The Airforce, Super Weapon and Laser General's Pilots are missing voice lines for entering buildings.

After the patch:

- All Pilots use their normal move order sound effect when ordered to enter a building.
