### PR TITLE
Fix: Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -44,7 +44,7 @@ https://github.com/commy2/zerohour/issues/184 [IMPROVEMENT]           Battle Bus
 https://github.com/commy2/zerohour/issues/183 [IMPROVEMENT]           Battle Bus Turns Towards Target When Loaded Troops Are Ordered To Engage Airborne Units
 https://github.com/commy2/zerohour/issues/182 [IMPROVEMENT]           Listening Outpost Lacks Voice Lines For Attacking Enemies
 https://github.com/commy2/zerohour/issues/181 [IMPROVEMENT]           Some Units Lack Voice Line When Ordered To Attack Airborne Targets
-https://github.com/commy2/zerohour/issues/180 [IMPROVEMENT]           Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding
+https://github.com/commy2/zerohour/issues/180 [DONE]                  Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding
 https://github.com/commy2/zerohour/issues/179 [IMPROVEMENT]           Nuke Cannons May Change Target On Their Own While Unpacking
 https://github.com/commy2/zerohour/issues/178 [IMPROVEMENT]           Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack
 https://github.com/commy2/zerohour/issues/177 [IMPROVEMENT]           Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6290,13 +6290,16 @@ Object GLAVehicleBattleBus
   SoundMoveStartDamaged = BattleBusMoveStart
   SoundEnter = HumveeEnter
   SoundExit = HumveeExit
+
+  ; Patch104p @bugfix commy2 04/09/2021 Fix missing sound effect when "power sliding".
+
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
-    VoiceCreate= BattleBusVoiceCreate
+    VoiceCreate                   = BattleBusVoiceCreate
     TurretMoveStart               = NoSound
     TurretMoveLoop                = NoSound
     TruckLandingSound             = RocketBuggyLand
-    TruckPowerslideSound          = NoSound
+    TruckPowerslideSound          = RocketBuggyPowerslide
     VoiceUnload                   = BattleBusVoiceUnload
   End
 


### PR DESCRIPTION
ZH 1.04

- The normal GLA Battle Bus is missing the sound effect when power sliding that all other Busses have.

After this patch:

- All Buses use the same sound effects when moving / turning.

This sound can be (well or can't) be heard when the Bus is turned via move order while moving at full speed. It's re-used from the Rocket Buggy, but that is what all the other non vanilla Buses use, so should be ok.