### PR TITLE
Fix: Laser General Aurora Uses Tooltip From Microwave Tank

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -38,7 +38,7 @@ https://github.com/commy2/zerohour/issues/190 [IMPROVEMENT]           Black Lotu
 https://github.com/commy2/zerohour/issues/189 [DONE]                  China Dozer Movement Behavior
 https://github.com/commy2/zerohour/issues/188 [NOTRELEVANT]           Upgrading Mig Weapons Reduces Reload Time
 https://github.com/commy2/zerohour/issues/187 [IMPROVEMENT]           Nuke Mig Tooltip Claims Unit Can Create Firestorms
-https://github.com/commy2/zerohour/issues/186 [IMPROVEMENT]           Laser General Aurora Uses Tooltip From Microwave Tank
+https://github.com/commy2/zerohour/issues/186 [DONE]                  Laser General Aurora Uses Tooltip From Microwave Tank
 https://github.com/commy2/zerohour/issues/185 [IMPROVEMENT]           Fake Supply Stash Uses Portrait As Button
 https://github.com/commy2/zerohour/issues/184 [IMPROVEMENT]           Battle Bus With Passengers Freezes When Attacking Airborne Targets
 https://github.com/commy2/zerohour/issues/183 [IMPROVEMENT]           Battle Bus Turns Towards Target When Loaded Troops Are Ordered To Engage Airborne Units

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -7390,7 +7390,7 @@ CommandButton Lazr_Command_ConstructAmericaJetAurora
   TextLabel     = CONTROLBAR:ConstructAmericaJetAurora
   ButtonImage   = SAAurora
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipUSABuildMicrowave
+  DescriptLabel           = CONTROLBAR:ToolTipUSABuildAurora ; Patch104p @bugfix commy2 04/09/2021 Fix wrong tooltip.
 End
 
 CommandButton Lazr_Command_ConstructAmericaJetRaptor


### PR DESCRIPTION
ZH 1.04

- The Laser General's Aurora uses the tooltip of the Microwave tank instead of the generic Aurora tooltip.

After patch:

- The Laser General's Aurora uses the tooltip of the ... Aurora.

Fun fact:
- You played this game for 18 years and never noticed.