### PR TITLE
Fix: Tomahawk Launchers Have Battle And Scout Drone Upgrade Icon Reversed

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -176,7 +176,7 @@ https://github.com/commy2/zerohour/issues/43  [DONE]                  Suicide Ab
 https://github.com/commy2/zerohour/issues/42  [DONE]                  Worker Has Disabled Suicide Button Before Demolitions Upgrade
 https://github.com/commy2/zerohour/issues/41  [DONE]                  Base Defenses Missing Demoliton Upgrade Icon
 https://github.com/commy2/zerohour/issues/38  [DONE]                  Detached Floating Object Orbits Avenger Model When Moving
-https://github.com/commy2/zerohour/issues/37  [IMPROVEMENT]           Tomahawk Launchers Have Reversed Order For Battle And Scout Drone Upgrade
+https://github.com/commy2/zerohour/issues/37  [DONE]                  Tomahawk Launchers Have Reversed Order For Battle And Scout Drone Upgrade
 https://github.com/commy2/zerohour/issues/36  [NOTRELEVANT]           Boss Helix Inconsistencies
 https://github.com/commy2/zerohour/issues/35  [NOTRELEVANT]           Boss Infantry Inconsistencies
 https://github.com/commy2/zerohour/issues/34  [NOTRELEVANT]           Boss Avenger Inconsistencies

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5395,8 +5395,10 @@ Object AirF_AmericaVehicleTomahawk
   SelectPortrait         = SACTomahawk_L
   ButtonImage            = SACTomahawk
 
-  UpgradeCameo1 = Upgrade_AmericaScoutDrone
-  UpgradeCameo2 = Upgrade_AmericaBattleDrone
+  ; Patch104p @bugfix commy2 04/09/2021 Fix order of Drone upgrade icons.
+
+  UpgradeCameo1 = Upgrade_AmericaBattleDrone
+  UpgradeCameo2 = Upgrade_AmericaScoutDrone
   UpgradeCameo3 = Upgrade_AmericaHellfireDrone
   UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo5 = XXX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -288,8 +288,10 @@ Object AmericaVehicleTomahawk
   SelectPortrait         = SACTomahawk_L
   ButtonImage            = SACTomahawk
 
-  UpgradeCameo1 = Upgrade_AmericaScoutDrone
-  UpgradeCameo2 = Upgrade_AmericaBattleDrone
+  ; Patch104p @bugfix commy2 04/09/2021 Fix order of Drone upgrade icons.
+
+  UpgradeCameo1 = Upgrade_AmericaBattleDrone
+  UpgradeCameo2 = Upgrade_AmericaScoutDrone
   UpgradeCameo3 = Upgrade_AmericaHellfireDrone
   UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo5 = XXX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19170,7 +19170,7 @@ Object Boss_VehicleTomahawk
   SelectPortrait         = SACTomahawk_L
   ButtonImage            = SACTomahawk
 
-  ; Patch104p @bugfix commy2 04/09/2021 Fix order of Drone upgrade icons and add missing icons.
+  ; Patch104p @bugfix commy2 04/09/2021 Fix order of Drone upgrade icons.
 
   UpgradeCameo1 = Upgrade_AmericaBattleDrone
   UpgradeCameo2 = Upgrade_AmericaScoutDrone

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19170,10 +19170,12 @@ Object Boss_VehicleTomahawk
   SelectPortrait         = SACTomahawk_L
   ButtonImage            = SACTomahawk
 
-  UpgradeCameo1 = Upgrade_AmericaScoutDrone
-  UpgradeCameo2 = Upgrade_AmericaBattleDrone
-  UpgradeCameo3 = Upgrade_AmericaAdvancedTraining
-  UpgradeCameo4 = Upgrade_AmericaHellfireDrone
+  ; Patch104p @bugfix commy2 04/09/2021 Fix order of Drone upgrade icons and add missing icons.
+
+  UpgradeCameo1 = Upgrade_AmericaBattleDrone
+  UpgradeCameo2 = Upgrade_AmericaScoutDrone
+  UpgradeCameo3 = Upgrade_AmericaHellfireDrone
+  UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo5 = XXX
 
   Draw = W3DTankDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4642,8 +4642,10 @@ Object Lazr_AmericaVehicleTomahawk
   SelectPortrait         = SACTomahawk_L
   ButtonImage            = SACTomahawk
 
-  UpgradeCameo1 = Upgrade_AmericaScoutDrone
-  UpgradeCameo2 = Upgrade_AmericaBattleDrone
+  ; Patch104p @bugfix commy2 04/09/2021 Fix order of Drone upgrade icons.
+
+  UpgradeCameo1 = Upgrade_AmericaBattleDrone
+  UpgradeCameo2 = Upgrade_AmericaScoutDrone
   UpgradeCameo3 = Upgrade_AmericaHellfireDrone
   UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo5 = XXX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5118,8 +5118,10 @@ Object SupW_AmericaVehicleTomahawk
   SelectPortrait         = SACTomahawk_L
   ButtonImage            = SACTomahawk
 
-  UpgradeCameo1 = Upgrade_AmericaScoutDrone
-  UpgradeCameo2 = Upgrade_AmericaBattleDrone
+  ; Patch104p @bugfix commy2 04/09/2021 Fix order of Drone upgrade icons.
+
+  UpgradeCameo1 = Upgrade_AmericaBattleDrone
+  UpgradeCameo2 = Upgrade_AmericaScoutDrone
   UpgradeCameo3 = Upgrade_AmericaHellfireDrone
   UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo5 = XXX


### PR DESCRIPTION
ZH 1.04

- All Tomahawk Launhers have the upgrade icons for Scout Drone and Battle Drone reversed compared to any other USA vehicle.
- The Boss General's Tomahawk Launcher has the upgrade icons for Hellfire Drone and Advanced Training reversed.

After:

- All USA sub-faction vehicles have the drone upgrade icons in the same order.

Not really a bug, but it pisses me off. Other cameo fixes will come soonTM