### PR TITLE
Fix: Scud Launchers Missing Upgrade Icon For AP Rockets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -11,7 +11,7 @@ https://github.com/commy2/zerohour/issues/221 [IMPROVEMENT]           Units Some
 https://github.com/commy2/zerohour/issues/220 [DONE][NPROJECT]        Units Sometimes Waste Shots On Poisoned Or Burned Infantry
 https://github.com/commy2/zerohour/issues/219 [MAYBE]                 Stinger Site Does Not Benefit From AP Rockets When Engaging Airborne Targets
 https://github.com/commy2/zerohour/issues/218 [NOTRELEVANT]           Hackers Are Bad Late Game Eco
-https://github.com/commy2/zerohour/issues/217 [MAYBE]                 Scud Launchers Missing Upgrade Icon For AP Rockets
+https://github.com/commy2/zerohour/issues/217 [DONE]                  Scud Launchers Missing Upgrade Icon For AP Rockets
 https://github.com/commy2/zerohour/issues/216 [IMPROVEMENT]           Nationalism And Patriotism Don't Update For Garrisoned Units
 https://github.com/commy2/zerohour/issues/215 [NOTRELEVANT]           Nationalism And Patriotism Take Effect While Not Horded
 https://github.com/commy2/zerohour/issues/210 [IMPROVEMENT][NPROJECT] Weapons And Animations Broken On HiDef Scud Launcher

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -17749,9 +17749,11 @@ Object Chem_GLAVehicleScudLauncher
   SelectPortrait         = SUScudLauncher_L
   ButtonImage            = SUScudLauncher
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing upgrade icon(s).
+
+  ;UpgradeCameo1 = Upgrade_GLAAPRockets
   UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19071,10 +19071,12 @@ Object Demo_GLAVehicleScudLauncher
   SelectPortrait         = SUScudLauncher_L
   ButtonImage            = SUScudLauncher
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
-  UpgradeCameo2 = Demo_Upgrade_SuicideBomb
-  ;UpgradeCameo3 = NONE
-  ;UpgradeCameo4 = NONE
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing upgrade icon(s).
+
+  UpgradeCameo1 = Upgrade_GLAAPRockets
+  ;UpgradeCameo2 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
+  UpgradeCameo4 = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo5 = NONE
 
   Draw = W3DTruckDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2613,9 +2613,11 @@ Object GC_Chem_GLAVehicleScudLauncher
   SelectPortrait         = SUScudLauncher_L
   ButtonImage            = SUScudLauncher
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
-  UpgradeCameo2 = Upgrade_GLAAnthraxBeta
-  ;UpgradeCameo3 = NONE
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing upgrade icon(s).
+
+  UpgradeCameo1 = Upgrade_GLAAPRockets
+  UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4119,9 +4119,11 @@ Object GLAVehicleScudLauncher
   SelectPortrait         = SUScudLauncher_L
   ButtonImage            = SUScudLauncher
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing upgrade icon(s).
+
+  UpgradeCameo1 = Upgrade_GLAAPRockets
   UpgradeCameo2 = Upgrade_GLAAnthraxBeta
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
@@ -6438,9 +6440,11 @@ Object GLAVehicleScudLauncherHiDef
   SelectPortrait         = SUScudLauncher_L
   ButtonImage            = SUScudLauncher
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing upgrade icon(s).
+
+  UpgradeCameo1 = Upgrade_GLAAPRockets
   UpgradeCameo2 = Upgrade_GLAAnthraxBeta
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19241,9 +19241,11 @@ Object Slth_GLAVehicleScudLauncher
   SelectPortrait         = SUScudLauncher_L
   ButtonImage            = SUScudLauncher
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
+  ; Patch104p @bugfix commy2 04/09/2021 Added missing upgrade icon(s).
+
+  UpgradeCameo1 = Upgrade_GLAAPRockets
   UpgradeCameo2 = Upgrade_GLAAnthraxBeta
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 


### PR DESCRIPTION
ZH 1.04

- The SCUD Launchers are missing the upgrade icon for AP Rockets, despite them getting the damage bonus for high explosive warheads (though not for Anthrax warheads).

After patch:

- The SCUD Launchers have all their upgrade icons, in a order that makes sense compared to other GLA vehicles, and consistent across sub-factions.

Note that this was marked as MAYBE. This seems to me to need fixing though, because the bonus is real, and people should know it is.

As for public relations, we should make clear that this is not a change to the SCUD Launcher - making it benefit from AP Rockets. It already does in 1.04. All we changed was the missing icon.