### PR TITLE
Fix GLA Terrorist passenger crash

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13019,8 +13019,10 @@ Object Chem_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added MASKED status as a requirement for a death without fireworks. This one is used inside of Technicals and Battle Buses.
+  Behavior = SlowDeathBehavior ModuleTag_ContainedDeath_Patch104p
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED +CRUSHED +SPLATTED +LASERED
+    RequiredStatus      = MASKED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -13032,17 +13034,26 @@ Object Chem_GLAInfantryTerrorist
   End
   
   ; Patch104p @bugfix xezon 16/07/2022 Paste death types from other Terrorists to avoid Toxin Terrorists exploding by all kinds of deaths.
-
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
-    DeathWeapon   = SuicideDynamitePack
-    StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added a new death module for when Terrorists are not inside a container. It works as normal.
+  Behavior = SlowDeathBehavior ModuleTag_SuicideDeath
+    Weapon              = INITIAL SuicideDynamitePack
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus        = MASKED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_TerroristExplode
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
-  
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
-    DeathWeapon   = CrushedDynamitePack_Patch104p
-    StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathWeapon         = CrushedDynamitePack_Patch104p
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus        = MASKED
+    StartsActive        = Yes
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag91

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13530,8 +13530,10 @@ Object Demo_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  Behavior = SlowDeathBehavior ModuleTag_Death07
-    DeathTypes          = NONE +SUICIDED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added MASKED status as a requirement for a death without fireworks. This one is used inside of Technicals and Battle Buses.
+  Behavior = SlowDeathBehavior ModuleTag_ContainedDeath_Patch104p
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED +CRUSHED +SPLATTED +LASERED
+    RequiredStatus      = MASKED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -13542,16 +13544,26 @@ Object Demo_GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death08
-    DeathWeapon   = Demo_SuicideDynamitePack
-    StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added a new death module for when Terrorists are not inside a container. It works as normal.
+  Behavior = SlowDeathBehavior ModuleTag_SuicideDeath
+    Weapon              = INITIAL Demo_SuicideDynamitePack
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus        = MASKED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_TerroristExplode
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
-  
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
-    DeathWeapon   = Demo_CrushedDynamitePack_Patch104p
-    StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathWeapon         = Demo_CrushedDynamitePack_Patch104p
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus        = MASKED
+    StartsActive        = Yes
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2258,8 +2258,10 @@ Object GC_Slth_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added MASKED status as a requirement for a death without fireworks. This one is used inside of Technicals and Battle Buses.
+  Behavior = SlowDeathBehavior ModuleTag_ContainedDeath_Patch104p
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED +CRUSHED +SPLATTED +LASERED
+    RequiredStatus      = MASKED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -2270,16 +2272,26 @@ Object GC_Slth_GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
-    DeathWeapon   = SuicideDynamitePack
-    StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added a new death module for when Terrorists are not inside a container. It works as normal.
+  Behavior = SlowDeathBehavior ModuleTag_SuicideDeath
+    Weapon              = INITIAL SuicideDynamitePack
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus        = MASKED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_TerroristExplode
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
-  
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
-    DeathWeapon   = CrushedDynamitePack_Patch104p
-    StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathWeapon         = CrushedDynamitePack_Patch104p
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus        = MASKED
+    StartsActive        = Yes
   End
 
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1436,8 +1436,10 @@ Object GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added MASKED status as a requirement for a death without fireworks. This one is used inside of Technicals and Battle Buses.
+  Behavior = SlowDeathBehavior ModuleTag_ContainedDeath_Patch104p
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED +CRUSHED +SPLATTED +LASERED
+    RequiredStatus      = MASKED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -1448,18 +1450,28 @@ Object GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
-    DeathWeapon   = SuicideDynamitePack
-    StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added a new death module for when Terrorists are not inside a container. It works as normal.
+  Behavior = SlowDeathBehavior ModuleTag_SuicideDeath
+    Weapon              = INITIAL SuicideDynamitePack
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus        = MASKED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_TerroristExplode
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
-  
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
-    DeathWeapon   = CrushedDynamitePack_Patch104p
-    StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathWeapon         = CrushedDynamitePack_Patch104p
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus        = MASKED
+    StartsActive        = Yes
   End
-  
+
 ; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14007,8 +14007,10 @@ Object Slth_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added MASKED status as a requirement for a death without fireworks. This one is used inside of Technicals and Battle Buses.
+  Behavior = SlowDeathBehavior ModuleTag_ContainedDeath_Patch104p
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED +CRUSHED +SPLATTED +LASERED
+    RequiredStatus      = MASKED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14019,16 +14021,26 @@ Object Slth_GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
-    DeathWeapon   = SuicideDynamitePack
-    StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  ; Patch104p @bugfix hanfield 05/09/2021 Added a new death module for when Terrorists are not inside a container. It works as normal.
+  Behavior = SlowDeathBehavior ModuleTag_SuicideDeath
+    Weapon              = INITIAL SuicideDynamitePack
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus        = MASKED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_TerroristExplode
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
-  
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
-    DeathWeapon   = CrushedDynamitePack_Patch104p
-    StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathWeapon         = CrushedDynamitePack_Patch104p
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus        = MASKED
+    StartsActive        = Yes
   End
 ; --- end Death modules ---
 


### PR DESCRIPTION
Terrorists crashed the game in two scenarios. This commit fixes the crash in both instances.