### PR TITLE
Revert: 1.04+ Composite Armor Tweak

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7446,7 +7446,7 @@ Object AirF_AmericaTankMicrowave
 
   Behavior = MaxHealthUpgrade ModuleTag_18
     TriggeredBy   = Upgrade_AmericaCompositeArmor
-    AddMaxHealth  = 120.0
+    AddMaxHealth  = 100.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
   Behavior = ExperienceScalarUpgrade ModuleTag_Upgrade01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1509,7 +1509,7 @@ Object AmericaTankCrusader
     AddXPScalar   = 1.0 ;Increases experience gained by an additional 100%
   End
 
-  ; Patch104p @bugfix commy2 05/09/2021 Bonus is added twice. Instead add twice the bonus once.
+  ; Patch104p @bugfix commy2 05/09/2021 Bonus was added twice. Instead add twice the bonus once.
 
   Behavior = MaxHealthUpgrade ModuleTag_09
     TriggeredBy   = Upgrade_AmericaCompositeArmor
@@ -1573,7 +1573,7 @@ Object AmericaTankCrusader
     VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
-  ; Patch104p @bugfix commy2 05/09/2021 Bonus is added twice. Instead add twice the bonus once.
+  ; Patch104p @bugfix commy2 05/09/2021 Bonus was added twice. Instead add twice the bonus once.
 
   ;Behavior = MaxHealthUpgrade ModuleTag_18
   ;  TriggeredBy   = Upgrade_AmericaCompositeArmor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1508,9 +1508,12 @@ Object AmericaTankCrusader
     TriggeredBy   = Upgrade_AmericaAdvancedTraining
     AddXPScalar   = 1.0 ;Increases experience gained by an additional 100%
   End
+
+  ; Patch104p @bugfix commy2 05/09/2021 Bonus is added twice. Instead add twice the bonus once.
+
   Behavior = MaxHealthUpgrade ModuleTag_09
     TriggeredBy   = Upgrade_AmericaCompositeArmor
-    AddMaxHealth  = 120.0
+    AddMaxHealth  = 200.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -1570,10 +1573,12 @@ Object AmericaTankCrusader
     VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
+  ; Patch104p @bugfix commy2 05/09/2021 Bonus is added twice. Instead add twice the bonus once.
+
   ;Behavior = MaxHealthUpgrade ModuleTag_18
-    ;TriggeredBy   = Upgrade_AmericaCompositeArmor
-    ;AddMaxHealth  = 100.0
-    ;ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
+  ;  TriggeredBy   = Upgrade_AmericaCompositeArmor
+  ;  AddMaxHealth  = 100.0
+  ;  ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   ;End
 
   Behavior = FlammableUpdate ModuleTag_21
@@ -2034,7 +2039,7 @@ Object AmericaTankPaladin
 
   Behavior = MaxHealthUpgrade ModuleTag_18
     TriggeredBy   = Upgrade_AmericaCompositeArmor
-    AddMaxHealth  = 125.0
+    AddMaxHealth  = 100.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -2794,7 +2799,7 @@ Object AmericaTankMicrowave
 
   Behavior = MaxHealthUpgrade ModuleTag_18
     TriggeredBy   = Upgrade_AmericaCompositeArmor
-    AddMaxHealth  = 120.0
+    AddMaxHealth  = 100.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
   Behavior = ExperienceScalarUpgrade ModuleTag_Upgrade01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5858,9 +5858,12 @@ Object Lazr_AmericaTankCrusader
     TriggeredBy   = Upgrade_AmericaAdvancedTraining
     AddXPScalar   = 1.0 ;Increases experience gained by an additional 100%
   End
+
+  ; Patch104p @bugfix commy2 05/09/2021 Bonus was added twice. Instead add twice the bonus once.
+
   Behavior = MaxHealthUpgrade ModuleTag_09
     TriggeredBy   = Upgrade_AmericaCompositeArmor
-    AddMaxHealth  = 120.0
+    AddMaxHealth  = 200.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5919,10 +5922,12 @@ Object Lazr_AmericaTankCrusader
     VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
+  ; Patch104p @bugfix commy2 05/09/2021 Bonus was added twice. Instead add twice the bonus once.
+
   ;Behavior = MaxHealthUpgrade ModuleTag_18
-    ;TriggeredBy   = Upgrade_AmericaCompositeArmor
-    ;AddMaxHealth  = 100.0
-    ;ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
+  ;  TriggeredBy   = Upgrade_AmericaCompositeArmor
+  ;  AddMaxHealth  = 100.0
+  ;  ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   ;End
 
   Behavior = FlammableUpdate ModuleTag_21

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7624,7 +7624,7 @@ Object SupW_AmericaTankMicrowave
 
   Behavior = MaxHealthUpgrade ModuleTag_18
     TriggeredBy   = Upgrade_AmericaCompositeArmor
-    AddMaxHealth  = 120.0
+    AddMaxHealth  = 100.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
   Behavior = ExperienceScalarUpgrade ModuleTag_Upgrade01


### PR DESCRIPTION
- ref https://github.com/xezon/GeneralsGamePatch/pull/213

This PR reverts the Composite Armor tweak from 1.04+ which this project inherited. The tweak seems to be either undesirable or controversial, so ___the original values from 1.04 are now restored.___

This tweak also sort of fixes the bug where Composite Armor is applied twice on the vanilla USA Crusader as well as the Laser Tank (but not the SP only SWG Crusader). Instead double the bonus is applied once, which is identical ingame behaviour, but more explicit code.