### PR TITLE
Fix: Infantry General Tank Hunter Missing Patriotism Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -114,7 +114,7 @@ https://github.com/commy2/zerohour/issues/106 [NOTRELEVANT]           Cargo Plan
 https://github.com/commy2/zerohour/issues/105 [DONE]                  Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned
 https://github.com/commy2/zerohour/issues/104 [IMPROVEMENT]           China Command Center Missing Radar Upgrade Icon
 https://github.com/commy2/zerohour/issues/103 [IMPROVEMENT]           Some Special Power Buttons Disappear From Command Center After Mines Upgrade
-https://github.com/commy2/zerohour/issues/102 [IMPROVEMENT]           Tank Hunter Missing Patriotism Upgrade Icon
+https://github.com/commy2/zerohour/issues/102 [DONE]                  Tank Hunter Missing Patriotism Upgrade Icon
 https://github.com/commy2/zerohour/issues/101 [IMPROVEMENT][NPROJECT] Speaker Tower Lacks Mine Upgrade
 https://github.com/commy2/zerohour/issues/100 [IMPROVEMENT]           Overlord Turns Chassis When Gattling Cannon Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/99  [MAYBE][NPROJECT]       Emperor Overlord Incompatible With Subliminal Messaging

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -947,8 +947,10 @@ Object Infa_ChinaInfantryTankHunter
   SelectPortrait         = SNTankHunter_L
   ButtonImage            = SNTankHunter
 
-  UpgradeCameo1 = UPGRADE:Fanaticism
-  ;UpgradeCameo2 = NONE
+  ; Patch104p @bugfix commy2 05/09/2021 Added missing Nationalism and Patriotism upgrade icons.
+
+  UpgradeCameo1 = Upgrade_Nationalism
+  UpgradeCameo2 = Upgrade_Fanaticism
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -14976,9 +14978,11 @@ Object Infa_ChinaInfantryMiniGunner
   SelectPortrait         = SNMiniGunner_L
   ButtonImage            = SNMiniGunner
 
-  UpgradeCameo1 = Upgrade_Fanaticism
-  UpgradeCameo2 = Upgrade_InfantryCaptureBuilding
-  ;UpgradeCameo3 = NONE
+  ; Patch104p @bugfix commy2 05/09/2021 Added missing Nationalism upgrade icon.
+
+  UpgradeCameo1 = Upgrade_Nationalism
+  UpgradeCameo2 = Upgrade_Fanaticism
+  UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 


### PR DESCRIPTION
ref: https://github.com/xezon/GeneralsGamePatch/pull/213

ZH 1.04:

- The Infantry General's Tank Hunter is missing the upgrade icon for Patriotism.
- The Infantry General's Mingunner and Tank Hunter are missing the upgrade icon for Nationalism, despite benefiting from that upgrade.

After patch:

- Upgrade icons as expected.
