### PR TITLE
Fix: Some Rebels Are Missing Upgrade Icons

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -99,7 +99,7 @@ https://github.com/commy2/zerohour/issues/121 [IMPROVEMENT]           Countermea
 https://github.com/commy2/zerohour/issues/120 [MAYBE]                 Vehicles Can Shoot Out Of Combat Chinook
 https://github.com/commy2/zerohour/issues/119 [IMPROVEMENT]           Car Bomb May Bug Out And Be Unable To Attack
 https://github.com/commy2/zerohour/issues/118 [MAYBE]                 Some ECM Tanks Automatically Engage Enemy Vehicles
-https://github.com/commy2/zerohour/issues/117 [IMPROVEMENT]           Some Rebels Are Missing Upgrade Icons
+https://github.com/commy2/zerohour/issues/117 [DONE]                  Some Rebels Are Missing Upgrade Icons
 https://github.com/commy2/zerohour/issues/116 [MAYBE]                 Tactical Nuke Mig Upgrade Not Buildable While Low On Power
 https://github.com/commy2/zerohour/issues/115 [IMPROVEMENT]           Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub Faction Command Centers
 https://github.com/commy2/zerohour/issues/114 [DONE]                  Hitting Battle Bus In Hull Mode Causes Screen Shake

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -20971,10 +20971,13 @@ Object Chem_GLAInfantryRebel
   SelectPortrait         = SUToxinRebel_L
   ButtonImage            = SUToxinRebel
 
-  UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
-  UpgradeCameo2 = Upgrade_InfantryCaptureBuilding
-  UpgradeCameo3 = Upgrade_GLACamouflage
+  ; Patch104p @bugfix commy2 05/09/2021 Sorted Rebel upgrade icons across sub-factions.
 
+  UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
+  UpgradeCameo2 = Upgrade_GLACamouflage
+  UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
+  ;UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
+  ;UpgradeCameo5 = NONE
 
   Draw = W3DModelDraw ModuleTag_01
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -11879,11 +11879,13 @@ Object Demo_GLAInfantryRebel
   SelectPortrait         = SURebel_L
   ButtonImage            = SURebel
 
+  ; Patch104p @bugfix commy2 05/09/2021 Added missing upgrade icons for Camouflage and Booby Traps. Sorted Rebel upgrade icons across sub-factions.
+
   UpgradeCameo1 = Upgrade_GLAAPBullets
-  UpgradeCameo2 = Upgrade_InfantryCaptureBuilding
-  UpgradeCameo3 = Demo_Upgrade_SuicideBomb
-  ;UpgradeCameo4 = NONE
-  ;UpgradeCameo5 = NONE
+  UpgradeCameo2 = Upgrade_GLACamouflage
+  UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
+  UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
+  UpgradeCameo5 = Demo_Upgrade_SuicideBomb
 
   Draw = W3DModelDraw ModuleTag_01
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -344,9 +344,13 @@ Object GC_Chem_GLAInfantryRebel
   SelectPortrait         = SUToxinRebel_L
   ButtonImage            = SUToxinRebel
 
+  ; Patch104p @bugfix commy2 05/09/2021 Sorted Rebel upgrade icons across sub-factions.
+
   UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
-  UpgradeCameo2 = Upgrade_InfantryCaptureBuilding
-  UpgradeCameo3 = Upgrade_GLACamouflage
+  UpgradeCameo2 = Upgrade_GLACamouflage
+  UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
+  ;UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
+  ;UpgradeCameo5 = NONE
 
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -1627,9 +1627,12 @@ Object GC_Slth_GLAInfantryRebel
   SelectPortrait         = SURebel_L
   ButtonImage            = SURebel
 
+  ; Patch104p @bugfix commy2 05/09/2021 Sorted Rebel upgrade icons across sub-factions.
+
   UpgradeCameo1 = Upgrade_GLAAPBullets
-  UpgradeCameo2 = Upgrade_InfantryCaptureBuilding
-  ;UpgradeCameo4 = NONE
+  ;UpgradeCameo2 = Upgrade_GLACamouflage
+  UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
+  ;UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
   ;UpgradeCameo5 = NONE
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -12589,10 +12589,12 @@ Object Slth_GLAInfantryRebel
   SelectPortrait         = SURebel_L
   ButtonImage            = SURebel
 
+  ; Patch104p @bugfix commy2 05/09/2021 Added missing upgrade icon for Camouflage. Sorted Rebel upgrade icons across sub-factions.
+
   UpgradeCameo1 = Upgrade_GLAAPBullets
-  ;UpgradeCameo2 = Upgrade_GLACamouflage
+  UpgradeCameo2 = Upgrade_GLACamouflage
   UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
-  ;UpgradeCameo4 = NONE
+  ;UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
   ;UpgradeCameo5 = NONE
 
   Draw = W3DModelDraw ModuleTag_01


### PR DESCRIPTION
ref: https://github.com/xezon/GeneralsGamePatch/pull/213

ZH 1.04

- The Demo and Stealth General's Rebels are missing the upgrade icon for Camouflage. 
- The Demo Rebel is missing the upgrade icon for Booby traps.

After patch:

- All Rebels will display all compatible upgrade icons. They will also now be ordered consistently across the sub-factions.

Note:
- Demo and Tox can not buy Camouflage. They still benefit from the upgrade though if they manage to capture vGLA/Stealth tech.
- Stealth cannot buy the upgrade either, but gets the upgrade for free every time a Stealthed Rebel is build.