### PR TITLE
Revert: Demo Terrorist Cannot Enter Civilian Cars

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13490,11 +13490,11 @@ Object Demo_GLAInfantryTerrorist
   End
 
   ;Kris
-  ;Behavior = ConvertToCarBombCrateCollide       ModuleTag_06
-    ;RequiredKindOf    = VEHICLE      ; we only give our bonus to VEHICLEs we collide with
+  Behavior = ConvertToCarBombCrateCollide       ModuleTag_06
+    RequiredKindOf    = VEHICLE      ; we only give our bonus to VEHICLEs we collide with
     ;ForbiddenKindOf  = TRANSPORT DOZER  ; but not to TRANSPORTs or DOZERs!
-    ;FXList            = FX_MakeCarBombSuccess
-  ;End
+    FXList            = FX_MakeCarBombSuccess
+  End
 
   Behavior = SquishCollide ModuleTag_07
     ;nothing


### PR DESCRIPTION
This is a bug in 1.04+ that was ported over to this patch. The Demo General's Terrorist was no longer able to convert civilian cars into carbombs.

This PR fixes that bug and makes the game equal to 1.04 in that aspect.

ref: https://github.com/xezon/GeneralsGamePatch/pull/213