### PR TITLE
Fix: SWG Airfield Cost

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -12278,7 +12278,7 @@ Object SupW_AmericaAirfield
   Prerequisites
     Object = SupW_AmericaSupplyCenter
   End
-  BuildCost           = 1000
+  BuildCost           = 800   ; Patch104p @balance 05/09/2021 Original=1000
   BuildTime           = 30.0           ; in seconds
   EnergyProduction    = -1
 


### PR DESCRIPTION
ref: #213

1.04+ is supposed to reduce the build cost of Arfields to $800 (from $1000). Due to an oversight, the SWG Airfield was not included.