### PR TITLE
Fix: Propaganda effect alignment

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -6702,6 +6702,7 @@ FXList FX_PropagandaTowerSubliminalPulse
 End
 
 ; ----------------------------------------------
+; Patch104p @bugfix Stubbjax 06/09/2021 New Listening Outpost Propaganda effects to fix alignment
 FXList FX_ListeningOutpostPropagandaPulse
   ParticleSystem
     Name = SonicRange
@@ -6720,6 +6721,7 @@ FXList FX_ListeningOutpostSubliminalPulse
 End
 
 ; ----------------------------------------------
+; Patch104p @bugfix Stubbjax 06/09/2021 New Assault Troop Transport Propaganda effects to fix alignment
 FXList FX_AssaultTroopTransportPropagandaPulse
   ParticleSystem
     Name = SonicRange

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -6702,6 +6702,42 @@ FXList FX_PropagandaTowerSubliminalPulse
 End
 
 ; ----------------------------------------------
+FXList FX_ListeningOutpostPropagandaPulse
+  ParticleSystem
+    Name = SonicRange
+    Offset = X:0.0 Y:0.0 Z:18.0
+    OrientToObject = Yes
+  End
+End
+
+; ----------------------------------------------
+FXList FX_ListeningOutpostSubliminalPulse
+  ParticleSystem
+    Name = SonicRangeUpgraded
+    Offset = X:0.0 Y:0.0 Z:18.0
+    OrientToObject = Yes
+  End
+End
+
+; ----------------------------------------------
+FXList FX_AssaultTroopTransportPropagandaPulse
+  ParticleSystem
+    Name = SonicRange
+    Offset = X:0.0 Y:0.0 Z:14.0
+    OrientToObject = Yes
+  End
+End
+
+; ----------------------------------------------
+FXList FX_AssaultTroopTransportSubliminalPulse
+  ParticleSystem
+    Name = SonicRangeUpgraded
+    Offset = X:0.0 Y:0.0 Z:14.0
+    OrientToObject = Yes
+  End
+End
+
+; ----------------------------------------------
 FXList FX_OverlordPropagandaTowerPropagandaPulse
   ParticleSystem
     Name = SonicRange

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15625,10 +15625,10 @@ Object Infa_ChinaVehicleTroopCrawler
     Radius                = 100
     DelayBetweenUpdates   = 4000 ; in milliseconds
     HealPercentEachSecond = 2%   ; get this % of max health every second
-    PulseFX               = FX_PropagandaTowerPropagandaPulse ;plays as often as DelayBetweenUpdates
+    PulseFX               = FX_AssaultTroopTransportPropagandaPulse ;plays as often as DelayBetweenUpdates
     UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
     UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
-    UpgradedPulseFX       = FX_PropagandaTowerSubliminalPulse ;plays as often as DelayBetweenUpdates
+    UpgradedPulseFX       = FX_AssaultTroopTransportSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Geometry = BOX
@@ -15914,10 +15914,10 @@ Object Infa_ChinaVehicleListeningOutpost
     Radius                = 75
     DelayBetweenUpdates   = 4000 ; in milliseconds
     HealPercentEachSecond = 1%   ; get this % of max health every second
-    PulseFX               = FX_PropagandaTowerPropagandaPulse ;plays as often as DelayBetweenUpdates
+    PulseFX               = FX_ListeningOutpostPropagandaPulse ;plays as often as DelayBetweenUpdates
     UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
     UpgradedHealPercentEachSecond = 2%   ; get this % of max health every second
-    UpgradedPulseFX       = FX_PropagandaTowerSubliminalPulse ;plays as often as DelayBetweenUpdates
+    UpgradedPulseFX       = FX_ListeningOutpostSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior = FlammableUpdate ModuleTag_21

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15625,10 +15625,10 @@ Object Infa_ChinaVehicleTroopCrawler
     Radius                = 100
     DelayBetweenUpdates   = 4000 ; in milliseconds
     HealPercentEachSecond = 2%   ; get this % of max health every second
-    PulseFX               = FX_AssaultTroopTransportPropagandaPulse ;plays as often as DelayBetweenUpdates
+    PulseFX               = FX_AssaultTroopTransportPropagandaPulse ;plays as often as DelayBetweenUpdates ; Patch104p @bugfix Stubbjax 06/09/2021 Fixed effect alignment
     UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
     UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
-    UpgradedPulseFX       = FX_AssaultTroopTransportSubliminalPulse ;plays as often as DelayBetweenUpdates
+    UpgradedPulseFX       = FX_AssaultTroopTransportSubliminalPulse ;plays as often as DelayBetweenUpdates ; Patch104p @bugfix Stubbjax 06/09/2021 Fixed effect alignment
   End
 
   Geometry = BOX
@@ -15914,10 +15914,10 @@ Object Infa_ChinaVehicleListeningOutpost
     Radius                = 75
     DelayBetweenUpdates   = 4000 ; in milliseconds
     HealPercentEachSecond = 1%   ; get this % of max health every second
-    PulseFX               = FX_ListeningOutpostPropagandaPulse ;plays as often as DelayBetweenUpdates
+    PulseFX               = FX_ListeningOutpostPropagandaPulse ;plays as often as DelayBetweenUpdates ; Patch104p @bugfix Stubbjax 06/09/2021 Fixed effect alignment
     UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
     UpgradedHealPercentEachSecond = 2%   ; get this % of max health every second
-    UpgradedPulseFX       = FX_ListeningOutpostSubliminalPulse ;plays as often as DelayBetweenUpdates
+    UpgradedPulseFX       = FX_ListeningOutpostSubliminalPulse ;plays as often as DelayBetweenUpdates ; Patch104p @bugfix Stubbjax 06/09/2021 Fixed effect alignment
   End
 
   Behavior = FlammableUpdate ModuleTag_21


### PR DESCRIPTION
The Propaganda effect for the Attack Outpost and Assault Troop Transport were using the Speaker Tower effect, which has a relatively large height offset of 50 and looks strange on these units. This change introduces separate effect definitions for each of these units so that they are no longer offset so much.

![image](https://user-images.githubusercontent.com/11547761/132201296-e6efe34d-72ae-4f53-8591-41a1bfae5541.png)