### PR TITLE
Add missing hotkey for Sell button.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/generals.str
+++ b/Patch104pZH/GameFilesEdited/Data/generals.str
@@ -1,0 +1,25688 @@
+GUI:GameOptions
+"GAME OPTIONS"
+END
+
+GUI:SinglePlayer
+"SOLO PLAY"
+END
+
+GUI:Network
+"NETWORK"
+END
+
+GUI:Options
+"OPTIONS"
+END
+
+GUI:Skirmish
+"SKIRMISH"
+END
+
+GUI:Back
+"BACK"
+END
+
+GUI:StartGame
+"PLAY GAME"
+END
+
+GUI:Color
+"Color"
+END
+
+GUI:Slower
+"Slower"
+END
+
+GUI:Faster
+"Faster"
+END
+
+GUI:Low
+"Low"
+END
+
+GUI:Medium
+"Medium"
+END
+
+GUI:High
+"High"
+END
+
+GUI:None
+"None"
+END
+
+GUI:Random
+"Random"
+END
+
+GUI:Cancel
+"CANCEL"
+END
+
+GUI:Ok
+"OK"
+END
+
+GUI:Delete
+"Remove"
+END
+
+GUI:Description
+"Description"
+END
+
+GUI:Load
+"LOAD"
+END
+
+GUI:Progress
+"Progress"
+END
+
+GUI:Assign
+"Assign"
+END
+
+GUI:CustomizeKeyboard
+"Customize Keyboard"
+END
+
+GUI:Category
+"Category"
+END
+
+GUI:Commands
+"Commands"
+END
+
+GUI:ResetAll
+"Reset All"
+END
+
+GUI:DisplayOptions
+"DISPLAY OPTIONS"
+END
+
+GUI:KeyboardOptions
+"Keyboard Options"
+END
+
+GUI:MainMenu
+"EXIT"
+END
+
+GUI:Units
+"Units"
+END
+
+GUI:Buildings
+"Buildings"
+END
+
+GUI:Players
+"Players"
+END
+
+GUI:Preview
+"Map Preview"
+END
+
+GUI:Save
+"Save"
+END
+
+GUI:Side
+"Army"
+END
+
+GUI:Accept
+"ACCEPT"
+END
+
+GUI:Games
+"Games"
+END
+
+GUI:Join
+"JOIN GAME"
+END
+
+GUI:LoadGame
+"LOAD GAME"
+END
+
+GUI:SaveGame
+"SAVE GAME"
+END
+
+GUI:Score
+"Score"
+END
+
+GUI:Add
+"Add"
+END
+
+GUI:MusicVolume
+"Music Volume"
+END
+
+GUI:VoiceVolume
+"Voice Volume"
+END
+
+GUI:Play
+"Play Game"
+END
+
+GUI:Stop
+"STOP"
+END
+
+GUI:Continue
+"CONTINUE"
+END
+
+GUI:MaxPing
+"Max Ping Allowed:"
+END
+
+GUI:Ladder
+"Ladder"
+END
+
+GUI:Close
+"Close"
+END
+
+GUI:Help
+"Help"
+END
+
+GUI:Rank
+"Rank"
+END
+
+GUI:Password
+"Password"
+END
+
+GUI:Disconnect
+"DISCONNECT"
+END
+
+GUI:No
+"NO"
+END
+
+GUI:Yes
+"YES"
+END
+
+GUI:Blank
+"."
+END
+
+GUI:Open
+"Open"
+END
+
+GUI:Closed
+"Closed"
+END
+
+GUI:Login
+"LOGIN"
+END
+
+GUI:WOLWelcome
+"Welcome General %hs"
+END
+
+GUI:QuickMatch
+"QUICKMATCH"
+END
+
+GUI:CustomMatch
+"CUSTOM MATCH"
+END
+
+GUI:LadderRank
+"Ladder Rank"
+END
+
+GUI:Disconnects
+"Disconnects"
+END
+
+GUI:CreateGame
+"CREATE GAME"
+END
+
+GUI:AutoLogin
+"Auto Login in the Future"
+END
+
+GUI:AddBuddy
+"Add Buddy"
+END
+
+GUI:RemoveBuddy
+"Remove Buddy"
+END
+
+GUI:AudioOptions
+"AUDIO OPTIONS"
+END
+
+GUI:LadderWins
+"Ladder Wins"
+END
+
+GUI:LadderLosses
+"Ladder Losses"
+END
+
+GUI:LadderPoints
+"Ladder Points"
+END
+
+WOL:BuddyOffline
+"%ls is offline"
+END
+
+WOL:Locale00
+"Unknown"
+END
+
+WOL:Locale01
+"Other Location"
+END
+
+WOL:Locale02
+"United States"
+END
+
+WOL:Locale03
+"Canada"
+END
+
+WOL:Locale04
+"United Kingdom"
+END
+
+WOL:Locale05
+"Germany"
+END
+
+WOL:Locale06
+"France"
+END
+
+WOL:Locale07
+"Spain"
+END
+
+WOL:Locale08
+"Netherlands"
+END
+
+WOL:Locale09
+"Belgium"
+END
+
+WOL:Locale10
+"Austria"
+END
+
+WOL:Locale11
+"Switzerland"
+END
+
+WOL:Locale12
+"Italy"
+END
+
+WOL:Locale13
+"Denmark"
+END
+
+WOL:Locale14
+"Sweden"
+END
+
+WOL:Locale15
+"Norway"
+END
+
+WOL:Locale16
+"Finland"
+END
+
+WOL:Locale17
+"Israel"
+END
+
+WOL:Locale18
+"South Africa"
+END
+
+WOL:Locale19
+"Japan"
+END
+
+WOL:Locale20
+"Korea"
+END
+
+WOL:Locale21
+"China"
+END
+
+WOL:Locale22
+"Singapore"
+END
+
+WOL:Locale23
+"Taiwan"
+END
+
+WOL:Locale24
+"Malaysia"
+END
+
+WOL:Locale25
+"Australia"
+END
+
+WOL:Locale26
+"New Zealand"
+END
+
+WOL:Locale27
+"Brazil"
+END
+
+WOL:Locale28
+"Thailand"
+END
+
+WOL:Locale29
+"Argentina"
+END
+
+WOL:Locale30
+"Philippines"
+END
+
+WOL:Locale31
+"Greece"
+END
+
+WOL:Locale32
+"Ireland"
+END
+
+WOL:Locale33
+"Poland"
+END
+
+WOL:Locale34
+"Portugal"
+END
+
+WOL:Locale35
+"Mexico"
+END
+
+WOL:Locale36
+"Russia"
+END
+
+WOL:Locale37
+"Turkey"
+END
+
+GUI:Observer
+"Observer"
+END
+
+GUI:Team
+"Team"
+END
+
+LETTER:G
+"G"
+END
+
+LETTER:L
+"L"
+END
+
+LETTER:M
+"M"
+END
+
+LETTER:S
+"S"
+END
+
+LETTER:O
+"O"
+END
+
+NUMBER:1
+"1"
+END
+
+NUMBER:2
+"2"
+END
+
+NUMBER:3
+"3"
+END
+
+NUMBER:4
+"4"
+END
+
+NUMBER:5
+"5"
+END
+
+NUMBER:6
+"6"
+END
+
+NUMBER:7
+"7"
+END
+
+NUMBER:8
+"8"
+END
+
+NUMBER:9
+"9"
+END
+
+NUMBER:0
+"0"
+END
+
+Color:Gold
+"Gold"
+END
+
+Color:Red
+"Red"
+END
+
+Color:Blue
+"Blue"
+END
+
+Color:Green
+"Green"
+END
+
+Color:Orange
+"Orange"
+END
+
+Color:SkyBlue
+"Cyan"
+END
+
+Color:Purple
+"Purple"
+END
+
+Color:Pink
+"Pink"
+END
+
+MSG:Testing
+"Mary had a little lamb, it's fleece as white as snow"
+END
+
+MSG:Test2
+"And everywhere that Mary when, the lamb was sure to go"
+END
+
+GUI:ShowBehindBuildings
+"Heat signature behind buildings ON"
+END
+
+GUI:HideBehindBuildings
+"Heat signature behind buildings OFF"
+END
+
+GUI:DetailsSetToLowest
+"Low graphics detail"
+END
+
+GUI:ReturnGraphicsToPreviousSettings
+"Setting your graphic details to their previous settings"
+END
+
+GUI:BeaconLabel
+"Type message:"
+END
+
+GUI:Beacon
+"Beacon"
+END
+
+GUI:EACopyright
+"� 2003 ELECTRONIC ARTS INC. ALL RIGHTS RESERVED"
+END
+
+GUI:DeleteBeacon
+"Delete  \n Beacon"
+END
+
+GUI:BeaconPlaced
+"A Beacon was placed by %ls"
+END
+
+GUI:BeaconPlacementFailed
+"Cannot place Beacon here"
+END
+
+GUI:TooManyBeacons
+"Sorry, you can't place any more Beacons"
+END
+
+GUI:EA
+"EA"
+END
+
+GUI:TestBrowser
+"Test Browser"
+END
+
+GUI:Multiplayer
+"MULTIPLAYER"
+END
+
+GUI:GameName
+"Game Name:"
+END
+
+GUI:NoFileSelected
+"PLEASE SELECT A FILE"
+END
+
+GUI:PleaseSelectAFile
+"Please select a file"
+END
+
+GUI:DeleteFile
+"DELETE FILE?"
+END
+
+GUI:AreYouSureDelete
+"Are you sure you would like to delete the selected file?"
+END
+
+GUI:CopyFileToDesktop
+"COPY REPLAY TO DESKTOP?"
+END
+
+GUI:AreYouSureCopy
+"Are you sure you want to copy this file to the Desktop? This will overwrite any file with the same name"
+END
+
+GUI:ErrorCopyingFile
+"THERE WAS AN ERROR COPYING THE FILE"
+END
+
+GUI:LoadReplay
+"LOAD REPLAY"
+END
+
+GUI:DeleteReplay
+"DELETE REPLAY"
+END
+
+GUI:CopyReplay
+"COPY REPLAY"
+END
+
+GUI:ErrorDeletingFile
+"THERE WAS AN ERROR DELETING THE FILE"
+END
+
+GUI:ShortDescription
+"Short description of the game:"
+END
+
+GUI:LadderName
+"Ladder Name:"
+END
+
+GUI:LadderPassword
+"Ladder Password"
+END
+
+GUI:LadderURL
+"Homepage: %hs"
+END
+
+GUI:LadderHasPassword
+"This Ladder is password protected"
+END
+
+GUI:LadderMinWins
+"Minimum wins required: %d"
+END
+
+GUI:LadderMaxWins
+"Maximum wins allowed: %d"
+END
+
+GUI:LadderFactions
+"Allowed army factions:"
+END
+
+GUI:LadderRandomFactions
+"Random army factions:"
+END
+
+GUI:LadderMaps
+"Allowed maps:"
+END
+
+GUI:LadderRandomMaps
+"Random maps:"
+END
+
+GUI:AllowObservers
+"Allow Observers"
+END
+
+GUI:USA
+"USA"
+END
+
+GUI:China
+"China"
+END
+
+GUI:GLA
+"GLA"
+END
+
+GUI:AmericaAllies
+"USA Allies"
+END
+
+GUI:ChinaAllies
+"China Allies"
+END
+
+GUI:GLAAllies
+"GLA Allies"
+END
+
+GUI:AmericaEnemies
+"USA Enemies"
+END
+
+GUI:ChinaEnemies
+"China Enemies"
+END
+
+GUI:GLAEnemies
+"GLA Enemies"
+END
+
+GUI:EndCampaign
+"END CAMPAIGN"
+END
+
+GUI:Retry
+"PLAY AGAIN?"
+END
+
+GUI:RecentSave
+"Recent Save"
+END
+
+GUI:GetUpdate
+"Get Update"
+END
+
+GUI:DirectConnect
+"DIRECT CONNECT"
+END
+
+GUI:WorldBuilder
+"WORLD BUILDER"
+END
+
+GUI:WorldBuilderLoadFailed
+"World Builder failed to load"
+END
+
+GUI:DontUseAccount
+"Don't Use Account"
+END
+
+GUI:UseAccount
+"Use Account"
+END
+
+GUI:ScoreScreen
+"Score Screen"
+END
+
+GUI:Rehost
+"PLAY AGAIN?"
+END
+
+GUI:UnitsBuilt
+"Units  \n Created"
+END
+
+GUI:UnitsLost
+"Units  \n Lost"
+END
+
+GUI:UnitsKilled
+"Units  \n Destroyed"
+END
+
+GUI:BuildingsBuilt
+"Buildings  \n Constructed"
+END
+
+GUI:BuildingsLost
+"Buildings  \n Lost"
+END
+
+GUI:BuildingsKilled
+"Buildings  \n Destroyed"
+END
+
+GUI:ResourcesCollected
+"Supplies  \n Collected"
+END
+
+GUI:QuitPopupTitle
+"EXIT?"
+END
+
+GUI:QuitPopupMessage
+"Are you sure you want to exit?"
+END
+
+GUI:MaxSelectionSize
+"You can only select %d units at one time"
+END
+
+GUI:MessagesOn
+"Messages Enabled"
+END
+
+GUI:MissionDescription
+"Mission Description"
+END
+
+GUI:MOTD
+"Message Of The Day"
+END
+
+GUI:DesyncTitle
+"Out of Synch"
+END
+
+GUI:DesyncText
+"C&C Generals Zero Hour has gone out of synch with the other game participants. It is possible that the other participants have modified their versions. C&C Generals Zero Hour cannot continue, however, you may add players to your Ignore List from your Communicator if you choose not to play with them in the future"
+END
+
+GUI:LadderDetails
+"Ladder Info"
+END
+
+GUI:SystemMaps
+"Official Maps"
+END
+
+GUI:UserMaps
+"Unofficial Maps"
+END
+
+GUI:WaitingToBeginConnection
+"Waiting to begin"
+END
+
+GUI:NetgearDelay
+"Send Delay"
+END
+
+GUI:WaitingForManglerResponse
+"Waiting for external Internet Provider response"
+END
+
+GUI:WaitingForMangledPort
+"Waiting for port number"
+END
+
+GUI:WaitingForResponse
+"Waiting for probe response"
+END
+
+GUI:ConnectionDone
+"Connection is completed"
+END
+
+GUI:ConnectionFailed
+"Connection has failed"
+END
+
+GUI:UnknownConnectionState
+"Status of NAT/Firewall is unknown"
+END
+
+GUI:Logout
+"MAIN MENU"
+END
+
+GUI:CancelMapSelect
+"CANCEL"
+END
+
+GUI:Deny
+"Reject"
+END
+
+GUI:Victory
+"Victory"
+END
+
+GUI:Ignore
+"IGNORE"
+END
+
+GUI:Unignore
+"Unignore"
+END
+
+GUI:Stats
+"Persona"
+END
+
+GUI:GetMapPack
+"Download Map Pack"
+END
+
+GUI:Defeat
+"Defeat"
+END
+
+GUI:YouAreVictorious
+"You are Victorious!"
+END
+
+GUI:YouHaveBeenDefeated
+"You have been Defeated"
+END
+
+GUI:PlayerAlive
+"Playing"
+END
+
+GUI:PlayerDead
+"Defeated"
+END
+
+GUI:PlayerObserver
+"Observing"
+END
+
+GUI:PlayerObserverGone
+"AWOL"
+END
+
+GUI:PlayerGone
+"AWOL"
+END
+
+GUI:PlayerName
+"Player Name"
+END
+
+GUI:Info
+"Player Info"
+END
+
+GUI:Players:
+"Players:"
+END
+
+GUI:GameOptions:
+"Game Options:"
+END
+
+GUI:GameName:
+"Game:"
+END
+
+GUI:MapName:
+"Map:"
+END
+
+GUI:SelectMap
+"SELECT MAP"
+END
+
+GUI:SelectAMap
+"SELECT MAP"
+END
+
+GUI:SelectAGame
+"SELECT GAME"
+END
+
+GUI:Start
+"PLAY GAME"
+END
+
+GUI:Host
+"CREATE GAME"
+END
+
+GUI:LocaleSelect
+"SELECT YOUR LOCALE"
+END
+
+GUI:Command&ConquerGenerals
+"Command & Conquer (TM) Generals Zero Hour"
+END
+
+GUI:Command&Conquer
+"Command & Conquer (TM)"
+END
+
+GUI:Generals
+"Generals Zero Hour"
+END
+
+GUI:GeneralsOnline
+"ONLINE"
+END
+
+GUI:SendDelay
+"Send Delay"
+END
+
+GUI:FirewallRefresh
+"Refresh NAT"
+END
+
+GUI:Exit
+"EXIT GAME"
+END
+
+GUI:X
+"X"
+END
+
+GUI:Campaign
+"CAMPAIGN"
+END
+
+GUI:WestwoodPacific
+"EA Pacific"
+END
+
+GUI:ClickToDisplayGameInfo
+"Click to display game info"
+END
+
+GUI:GameInfo
+"Game Info"
+END
+
+GUI:OptionsDescription
+"Display Game Options Dialog"
+END
+
+GUI:SFXVolume
+"Sound FX Volume"
+END
+
+GUI:3DSound
+"3D Sound"
+END
+
+GUI:ScrollSpeed
+"Scroll Speed"
+END
+
+GUI:Resolution
+"Resolution"
+END
+
+GUI:Resolution0
+"1024x768"
+END
+
+GUI:Resolution1
+"800x600"
+END
+
+GUI:Resolution2
+"640x480"
+END
+
+GUI:Detail
+"Detail"
+END
+
+GUI:???
+"???"
+END
+
+GUI:Faction
+"Army"
+END
+
+GUI:AntiAliasing0
+"Off"
+END
+
+GUI:AntiAliasing1
+"Low"
+END
+
+GUI:AntiAliasing2
+"High"
+END
+
+GUI:IPAddresses
+"LAN IP:"
+END
+
+GUI:MinPointPercent
+"Min Win Percent Required:"
+END
+
+GUI:MaxPointPercent
+"Max Win Percent Allowed:"
+END
+
+GUI:NumPlayers
+"Players:"
+END
+
+GUI:PlayersVersusPlayers
+"%dv%d"
+END
+
+GUI:TimeInMilliseconds
+"%d ms"
+END
+
+GUI:MaxDisconnects
+"Max Disconnects Allowed:"
+END
+
+GUI:Confirm
+"Are you sure?"
+END
+
+GUI:NothingSelected
+"Nothing selected"
+END
+
+GUI:SelectedAcrossScreen
+"Selected across screen"
+END
+
+GUI:SelectedAcrossMap
+"Selected across map"
+END
+
+KEYBOARD:Shift+
+"Shift+"
+END
+
+KEYBOARD:Alt+
+"Alt+"
+END
+
+KEYBOARD:Ctrl+
+"Ctrl+"
+END
+
+TOOLTIP:ScienceCost
+"Cost: %d"
+END
+
+TOOLTIP:Cost
+"Cost: %d"
+END
+
+TOOLTIP:SupplyWarehouse
+" \n $%d remain"
+END
+
+TOOLTIP:LobbyPlayers
+"Players currently in the Game Lobby"
+END
+
+TOOLTIP:StartWorldBuilder
+"Start the World Builder editor"
+END
+
+TOOLTIP:GetUpdate
+"Download game update"
+END
+
+TOOLTIP:GetMapPack
+"Download new map pack"
+END
+
+TOOLTIP:Skirmish
+"Enter Skirmish setup menu"
+END
+
+TOOLTIP:Online
+"Click to join C&C Generals Zero Hour Online. Test your skills against opponents from around the world!"
+END
+
+TOOLTIP:Network
+"Click to Join the Network Lobby. Test your mettle against your friends over a Local Area Network"
+END
+
+TOOLTIP:Options
+"Click to modify the game options. You may adjust your video, audio and game preferences"
+END
+
+TOOLTIP:Exit
+"Exit C&C Generals Zero Hour. Good luck in the field, Commander"
+END
+
+TOOLTIP:ExitGame
+"Exit C&C Generals Zero Hour. Good luck in the field, Commander"
+END
+
+TOOLTIP:LoadGame
+"Click to load the selected game"
+END
+
+TOOLTIP:MapPreviewWindow
+"Map previews can give you a leg up on the battle to come. Make sure to look for your Supply Docks & Tech Buildings. You may also choose your starting point"
+END
+
+TOOLTIP:SaveGame
+"Click to save your game in progress"
+END
+
+TOOLTIP:AcceptButton
+"Accept your current choice"
+END
+
+TOOLTIP:CopyReplayToDesktop
+"Copy selected Replay file to your Desktop"
+END
+
+TOOLTIP:ProviderType
+"Select your Audio Provider"
+END
+
+TOOLTIP:SpeakerType
+"Select your Speaker Configuration"
+END
+
+TOOLTIP:LANPlayer
+"%ls@%ls"
+END
+
+TOOLTIP:Resolution
+"Pick a screen resolution for your game. The higher the resolution, the slower your game is likely to play"
+END
+
+TOOLTIP:CommandCategory
+"Pick a category of keyboard command"
+END
+
+TOOLTIP:CommandDescription
+"The description of your selected command"
+END
+
+TOOLTIP:StartPosition
+"Starting Position"
+END
+
+TOOLTIP:SelectMap
+"Select the battlefield you would like to use"
+END
+
+TOOLTIP:Vote
+"Click to vote player out of game in order for you to continue"
+END
+
+TOOLTIP:NumberOfVotes
+"Votes cast to remove player"
+END
+
+TOOLTIP:QuitMultiplayerGame
+"Exit to game menus"
+END
+
+TOOLTIP:RestartGame
+"Restart game with same preferences"
+END
+
+TOOLTIP:Help
+"."
+END
+
+TOOLTIP:StartLocation
+"Starting position"
+END
+
+TOOLTIP:ReturnToGame
+"RETURN TO GAME"
+END
+
+TOOLTIP:CommandList
+"Available commands for the current category"
+END
+
+TOOLTIP:CurrentHotkey
+"Displays the current Hotkey for this command"
+END
+
+TOOLTIP:AssignHotkey
+"Enter your new command Hotkey here"
+END
+
+TOOLTIP:AssignHotkeyCurrent
+"The command this Hotkey is currently assigned to"
+END
+
+TOOLTIP:AssignButton
+"Assigns your chosen Hotkey command"
+END
+
+TOOLTIP:ResetAll
+"Resets all of your keyboard Hotkeys to default"
+END
+
+TOOLTIP:BackButton
+"Return to previous menu"
+END
+
+TOOLTIP:ProviderSelect
+"Select the 3-D Audio Provider. The game has already chosen your optimal set up but you may manually change if you prefer"
+END
+
+TOOLTIP:SpeakerSelect
+"Select your speaker setup. The game has already chosen your optimal set up but you may manually change if you prefer"
+END
+
+TOOLTIP:DontUseAccount
+"Log in without using your C&C Generals Zero Hour Online Account. You will not be able to access your Player Persona or Communicator"
+END
+
+TOOLTIP:CommunicatorButton
+"Contact your buddies"
+END
+
+TOOLTIP:NameButton
+"Sort by game name"
+END
+
+TOOLTIP:PingButton
+"Sort by Ping"
+END
+
+TOOLTIP:UseAccount
+"Join C&C Generals Zero Hour Online"
+END
+
+TOOLTIP:Login
+"Join C&C Generals Zero Hour Online"
+END
+
+TOOLTIP:CreateAccount
+"Create a new C&C Generals Zero Hour Online account"
+END
+
+TOOLTIP:TOS
+"View the Service Terms agreement"
+END
+
+TOOLTIP:RememberInfo
+"Remember login info. Not recommended for computers with multiple users"
+END
+
+TOOLTIP:Back
+"Return to previous screen"
+END
+
+TOOLTIP:BattleHonors
+"The Battle Honors a player has received  \n Battle Honors are won by achieving certain goals in solo or multiplay"
+END
+
+TOOLTIP:BattleHonorStreak3
+"Streak Honor  \n Player has won 3 Skirmish games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak10
+"Streak Honor  \n Player has won 10 Skirmish games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorLoyaltyUSA
+"USA Loyalty Honor  \n Player has played 20+ games in a row as the USA"
+END
+
+TOOLTIP:BattleHonorLoyaltyChina
+"China Loyalty Honor  \n Player has played 20+ games in a row as China"
+END
+
+TOOLTIP:BattleHonorLoyaltyGLA
+"GLA Loyalty Honor  \n Player has played 20+ games in a row as the GLA"
+END
+
+TOOLTIP:BattleHonorBattleTank
+"Battle Tank Honor  \n Player has built 50+ tanks in a solo or multiplayer online game"
+END
+
+TOOLTIP:BattleHonorAirWing
+"Air Wing Honor  \n Player has built 20+ aircraft in a solo or multiplayer online game"
+END
+
+TOOLTIP:BattleHonorEndurance
+"Endurance Honor  \n Beat every map to earn a Bronze, Silver, or Gold medal"
+END
+
+TOOLTIP:BattleHonorCampaignUSA
+"USA Campaign Honor  \n Complete the USA Campaign to earn this honor  \n Beat the campaign on Hard difficulty to achieve the highest honor"
+END
+
+TOOLTIP:BattleHonorCampaignChina
+"China Campaign Honor  \n Complete the China Campaign to earn this honor  \n Beat the campaign on Hard difficulty to achieve the highest honor"
+END
+
+TOOLTIP:BattleHonorCampaignGLA
+"GLA Campaign Honor  \n Complete the GLA Campaign to earn this honor  \n Beat the campaign on Hard difficulty to achieve the highest honor"
+END
+
+TOOLTIP:BattleHonorChallenge
+"Challenge Honor  \n Player has defeated a Hard computer opponent"
+END
+
+TOOLTIP:ProgressToNextRank
+"Progress until the next rank is acheived"
+END
+
+TOOLTIP:SetLocale
+"Change your current Locale selection"
+END
+
+TOOLTIP:DeleteAccount
+"Delete your current account"
+END
+
+TOOLTIP:AsianText
+"Click to toggle Asian chat, etc"
+END
+
+TOOLTIP:NonAsianText
+"Click to toggle Non Asian chat, etc"
+END
+
+GUI:AreYouSureDeleteAccount
+"Are you sure you want to permanently delete your account and all your saved statistics?"
+END
+
+GUI:NonAsianText
+"Non-Asian Text"
+END
+
+GUI:AsianText
+"Asian Text"
+END
+
+GUI:DeleteAccount
+"DELETE ACCOUNT"
+END
+
+GUI:SetLocale
+"SET LOCALE"
+END
+
+GUI:WinLoss
+"Win/Loss"
+END
+
+GUI:FavSide
+"Favorite Army"
+END
+
+GUI:Discons
+"Disconnects"
+END
+
+GUI:BattleHonors
+"Battle Honors"
+END
+
+GUI:TotalBuddys
+"Total Buddys"
+END
+
+GUI:PlayerStatistics
+"%hs, from %ls"
+END
+
+GUI:TotalBuilt
+"Total Built"
+END
+
+GUI:TotalDeaths
+"Total Deaths"
+END
+
+GUI:TotalKills
+"Total Kills"
+END
+
+GUI:FavoriteUnit
+"Favorite Unit"
+END
+
+GUI:FavoriteSide
+"Favorite Army"
+END
+
+GUI:Loses
+"Losses"
+END
+
+GUI:Wins
+"Wins"
+END
+
+GUI:TotalDesyncs
+"Desyncs"
+END
+
+GUI:TotalDisconnects
+"Disconnects"
+END
+
+GUI:GamesPlayed
+"Games Played"
+END
+
+GUI:TOS
+"SERVICE TERMS"
+END
+
+GUI:RememberInfo
+"Remember my Info"
+END
+
+GUI:HostWantsToStart
+"The Host wants to start. Press the Accept button"
+END
+
+GUI:PlayerNoMap
+"%ls does not have the map %ls"
+END
+
+GUI:LocalPlayerNoMap
+"You do not have the map %ls"
+END
+
+GUI:NeedMorePlayers
+"You need more player(s) to start the game"
+END
+
+GUI:NotifiedStartIntent
+"The other players have been notified that you want to start the game"
+END
+
+GUI:HostLeft
+"The host left the game but C&C Generals Zero Hour will continue"
+END
+
+GUI:HostLeftTitle
+"HOST HAS LEFT"
+END
+
+GUI:WidenSearch
+"WIDEN SEARCH"
+END
+
+GUI:QMAborted
+"Matching aborted"
+END
+
+GUI:DrawScrollAnchor
+"Draw scroll anchor"
+END
+
+GUI:MoveScrollAnchor
+"Move scroll anchor"
+END
+
+GUI:GroupRoom1
+"1 vs 1"
+END
+
+GUI:GroupRoom2
+"2 vs 2"
+END
+
+GUI:GroupRoom3
+"3 vs 3"
+END
+
+GUI:Email
+"Email"
+END
+
+GUI:NoLadder
+"No Ladder"
+END
+
+GUI:ChooseLadder
+"CHOOSE A LADDER"
+END
+
+GUI:UnknownLadder
+"Unknown Ladder"
+END
+
+GUI:WOLLogin
+"GENERALS ONLINE LOG IN"
+END
+
+GUI:PleaseEnterWOLInfo
+"Please enter info"
+END
+
+GUI:Username
+"Nickname"
+END
+
+GUI:Server
+"Server"
+END
+
+GUI:RememberPassword
+"Remember My Password"
+END
+
+GUI:CreateAccount
+"CREATE ACCOUNT"
+END
+
+GUI:TryAgain
+"Try Again"
+END
+
+GUI:NetworkOptions
+"NETWORK OPTIONS"
+END
+
+GUI:GammaAdjustment
+"Brightness"
+END
+
+GUI:HelpDescription
+"Display help dialog"
+END
+
+GUI:ReturnToGame
+"RETURN TO GAME"
+END
+
+GUI:NewGame
+"New Game"
+END
+
+GUI:RestartGame
+"RESTART GAME"
+END
+
+GUI:MatchingProgress
+"QuickMatch Progress"
+END
+
+GUI:Player'sName
+"Opponent's Name"
+END
+
+GUI:AllTimeWins
+"All-Time Wins"
+END
+
+GUI:AllTimeLosses
+"All-Time Losses"
+END
+
+GUI:AllTimePoints
+"All-Time Rank Points"
+END
+
+GUI:AllTimeDisconnects
+"All-Time Disconnects"
+END
+
+GUI:HighestRank
+"All-Time Highest Rank"
+END
+
+GUI:Honor
+"Battle Honors"
+END
+
+GUI:LastUpdated
+"Player Profile Last Updated"
+END
+
+GUI:WOLIconKey
+"Icon Key"
+END
+
+GUI:MyInfo
+"MY PERSONA"
+END
+
+GUI:Buddies
+"COMMUNICATOR"
+END
+
+GUI:Community
+"Daily Army Win Percentages"
+END
+
+GUI:SortAlpha
+"Name"
+END
+
+GUI:SortPing
+"Connection"
+END
+
+GUI:SortBuddies
+"Buddies"
+END
+
+GUI:GSRank0
+"Private"
+END
+
+GUI:GSRank1
+"Corporal"
+END
+
+GUI:GSRank2
+"Sergeant"
+END
+
+GUI:GSRank3
+"Lieutenant"
+END
+
+GUI:GSRank4
+"Captain"
+END
+
+GUI:GSRank5
+"Major"
+END
+
+GUI:GSRank6
+"Colonel"
+END
+
+GUI:GSRank7
+"Brigadier General"
+END
+
+GUI:GSRank8
+"General"
+END
+
+GUI:GSRank9
+"Commander in Chief"
+END
+
+GUI:GSErrorTitle
+"Notification"
+END
+
+GUI:GSDisconnected
+"You have been disconnected from the chat server"
+END
+
+GUI:GSDisconReason1
+"That nickname has already been taken. Please choose another"
+END
+
+GUI:GSDisconReason2
+"That nickname is invalid. Please choose another"
+END
+
+GUI:GSDisconReason3
+"Lost connection to C&C Generals Zero Hour Online"
+END
+
+GUI:GSDisconReason4
+"Could not connect to C&C Generals Zero Hour Online"
+END
+
+GUI:GSDisconReason5
+"Login process has timed out. Please check your internet connection"
+END
+
+GUI:GSDisconReason6
+"That nickname/email combo does not exist. If you want to create an account, click on Create Account"
+END
+
+GUI:GSDisconReason7
+"That email is invalid"
+END
+
+GUI:GSDisconReason8
+"That password is incorrect. Please try again"
+END
+
+GUI:GSDisconReason9
+"Bad profile"
+END
+
+GUI:GSDisconReason10
+"Profile has been deleted"
+END
+
+GUI:GSDisconReason11
+"Buddy server connection was refused"
+END
+
+GUI:GSDisconReason12
+"Buddy server authorization failed"
+END
+
+GUI:GSDisconReason13
+"Serial number is invalid. Please try another"
+END
+
+GUI:GSDisconReason14
+"Registry is corrupt and has been altered"
+END
+
+GUI:GSDisconReason15
+"Serial number is banned"
+END
+
+GUI:GSGroupRoomJoinFail
+"Failed to join chat room"
+END
+
+GUI:JoinFailedRoomFull
+"Failed to join - the room is full"
+END
+
+GUI:JoinFailedInviteOnly
+"Failed to join - the room is invitation only"
+END
+
+GUI:JoinFailedBannedFromRoom
+"Failed to join - you have been banned from the room"
+END
+
+GUI:JoinFailedBadPassword
+"Failed to join - incorrect password"
+END
+
+GUI:JoinFailedAlreadyInRoom
+"Failed to join - you are already in a room"
+END
+
+GUI:JoinFailedNoConnection
+"Failed to join - no connection to chat server"
+END
+
+GUI:JoinFailedCRCMismatch
+"Failed to join - the game is a different version"
+END
+
+GUI:JoinFailedUnknownLadder
+"Failed to join - the game is using an unknown ladder"
+END
+
+GUI:JoinFailedDefault
+"FAILED TO JOIN ROOM"
+END
+
+GUI:GSKicked
+"You were kicked from the room"
+END
+
+GUI:NATNegotiationFailed
+"Unable to connect to other player(s)"
+END
+
+GUI:GPErrorTitle
+"BUDDY ERROR"
+END
+
+GUI:GPDisconnected
+"You have been disconnected from the buddy server. Would you like to reconnect?"
+END
+
+GUI:GPNoProfile
+"You did not log in using a Profile. No Buddy information is available"
+END
+
+GUI:PSErrorTitle
+"PERSISTENT STORAGE ERROR"
+END
+
+GUI:PSCannotConnect
+"Could not connect to the persistent storage server"
+END
+
+Buddy:Offline
+"Offline"
+END
+
+Buddy:Online
+"Online"
+END
+
+Buddy:Chatting
+"Chatting in %ls"
+END
+
+Buddy:Staging
+"Staging in %ls"
+END
+
+Buddy:Loading
+"Loading in %ls"
+END
+
+Buddy:Playing
+"Playing in %ls"
+END
+
+Buddy:Matching
+"QuickMatching"
+END
+
+Buddy:OnlineNotification
+"%hs is now online"
+END
+
+Buddy:OfflineNotification
+"%hs is now offline"
+END
+
+Buddy:AddNotification
+"Add Buddy request from %hs"
+END
+
+Buddy:MessageNotification
+"%hs says:  \n '%s...'"
+END
+
+GUI:Com/Tac
+"Com/Tac"
+END
+
+GUI:MoneySymbol
+"$"
+END
+
+GUI:$$$
+"$$$"
+END
+
+GUI:OverchargeExhausted
+"Overcharge exhausted"
+END
+
+GUI:NotEnoughMoneyToBuild
+"You don't have enough money to build that"
+END
+
+GUI:NotEnoughMoneyToUpgrade
+"You don't have enough money to make upgrade"
+END
+
+GUI:Level
+"Level"
+END
+
+GUI:Tac
+"Tac"
+END
+
+GUI:Strat
+"Strat"
+END
+
+GUI:Struct
+"Struct"
+END
+
+GUI:Waypt
+"Waypt"
+END
+
+GUI:WOLStatus
+"C&C Generals Zero Hour Online Status"
+END
+
+GUI:AIDifficulty
+"Computer Difficulty"
+END
+
+GUI:EasyAI
+"Easy Army"
+END
+
+GUI:MediumAI
+"Medium Army"
+END
+
+GUI:HardAI
+"Hard Army"
+END
+
+GUI:Hide
+"BACK"
+END
+
+GUI:Pause
+"Pause"
+END
+
+GUI:NextFrame
+"Next Frame"
+END
+
+GUI:ReplayMenu
+"LOAD"
+END
+
+GUI:AntiAliasing
+"Anti-Aliasing"
+END
+
+GUI:ScreenCapture
+"Screen Captured to '%s'"
+END
+
+GUI:ScreenshotCapture
+"Screen Capture"
+END
+
+GUI:ScreenshotCaptureDescription
+"Take a snapshot of the game screen"
+END
+
+GUI:Null
+"."
+END
+
+GUI:CRCMismatch
+"Game has detected a mismatch. This means the multiplayer game has lost synchronization data between the players"
+END
+
+GUI:CurrentHotkey
+"Current Hotkey"
+END
+
+GUI:AssignNewHotkey
+"Assign New Hotkey"
+END
+
+GUI:CurrentlyAssignedTo
+"Currently Assigned To"
+END
+
+GUI:Reset
+"Reset"
+END
+
+QM:JOININGQMCHANNEL
+"Joining QuickMatch..."
+END
+
+QM:WORKING
+"There are %d players currently attempting to match..."
+END
+
+QM:POOLSIZE
+"There are %d players currently attempting to match..."
+END
+
+QM:LOOKINGFORBOT
+"Looking for the C&C Generals Zero Hour Online MatchMaker..."
+END
+
+QM:SENTINFO
+"Game info has been sent..."
+END
+
+QM:WIDENINGSEARCH
+"Widening search for opponents closest to your preferences..."
+END
+
+QM:MATCHED
+"Excellent, a match has been found..."
+END
+
+QM:INCHANNEL
+"In channel..."
+END
+
+QM:NEGOTIATINGFIREWALLS
+"Negotiating firewalls..."
+END
+
+QM:STARTINGGAME
+"Starting the game..."
+END
+
+QM:COULDNOTFINDBOT
+"Could not find the MatchMaker"
+END
+
+QM:COULDNOTFINDCHANNEL
+"Could not find QuickMatch channel"
+END
+
+QM:COULDNOTNEGOTIATEFIREWALLS
+"Could not negotiate firewalls"
+END
+
+QM:STOPPED
+"Quickmatch aborted"
+END
+
+QM:WaitingForPlayerToJoin
+"Waiting for opponent to join"
+END
+
+QM:FindingGameChannel
+"Finding opponent's game"
+END
+
+QM:JoinedGameChannel
+"Joined opponent's game"
+END
+
+QM:PlayerJoined
+"Opponent joined"
+END
+
+QM:LookingForMatchChannel
+"Looking for QuickMatch channel"
+END
+
+QM:NoMatchChannel
+"No match QuickMatch channel found"
+END
+
+QM:JoinedMatchChannel
+"QuickMatch channel joined"
+END
+
+QM:NoMatchingBot
+"MatchMaker not found"
+END
+
+QM:GameNotFound
+"QuickMatch could not find your opponent's game not found"
+END
+
+QM:TimeoutOtherPlayer
+"QuickMatch timed out waiting for opponent to join the game"
+END
+
+Version:Format4
+"%d.%02d.%d Build %d %c%c"
+END
+
+Version:Format3
+"Version %d.%02d.%d"
+END
+
+Version:Format2
+"Version %d.%02d"
+END
+
+Version:BuildTime
+"%ls %ls"
+END
+
+Version:BuildMachine
+"Build machine: %ls"
+END
+
+Version:BuildUser
+"By %ls"
+END
+
+GUI:SuperweaponDaisyCutter
+"Fuel Air Bomb"
+END
+
+GUI:SuperweaponParadropAmerica
+"Paradrop"
+END
+
+GUI:SuperweaponClusterMines
+"Cluster Mines"
+END
+
+GUI:SuperweaponEMPPulse
+"EMP Pulse"
+END
+
+GUI:SuperweaponA10ThunderboltMissileStrike
+"A10 Missile Strike"
+END
+
+GUI:SuperweaponCrateDrop
+"Crate Drop"
+END
+
+GUI:SuperweaponCarpetBomb
+"Carpet Bomb"
+END
+
+GUI:SuperweaponNapalmStrike
+"Napalm Strike"
+END
+
+GUI:SuperweaponCashHack
+"Cash Hack"
+END
+
+GUI:SuperweaponNeutronMissile
+"Nuclear Missile"
+END
+
+GUI:SuperweaponScudStorm
+"Scud Storm"
+END
+
+GUI:SuperweaponTerrorCell
+"Terror Cell"
+END
+
+GUI:SuperweaponRebelAmbush
+"Ambush"
+END
+
+GUI:SuperweaponBlackMarketNuke
+"Black Market Nuke"
+END
+
+GUI:SuperweaponAnthraxBomb
+"Anthrax Bomb"
+END
+
+GUI:SuperweaponDemoralize
+"Demoralize"
+END
+
+GUI:SpecialAbilityGuidedMissiles
+"Laser Guided Missile"
+END
+
+GUI:SpecialAbilityDetonateCharges
+"Detonate Charges"
+END
+
+GUI:SuperweaponParticleUplinkCannon
+"Particle Uplink Cannon"
+END
+
+GUI:PatchAvailable
+"UPDATE AVAILABLE"
+END
+
+GUI:MustPatchForOnline
+"You must download the Update to play C&C Generals Zero Hour Online"
+END
+
+GUI:CanPatchForOnline
+"Would you like to download the Update?"
+END
+
+GUI:CheckingForPatches
+"Checking for Updates"
+END
+
+GUI:DownloadErrorTitle
+"DOWNLOAD ERROR"
+END
+
+GUI:DownloadSuccessTitle
+"DOWNLOAD SUCCESS"
+END
+
+GUI:DownloadSuccess
+"Download completed without errors"
+END
+
+GUI:DownloadSuccessMustQuit
+"Click OK to exit Command & Conquer Generals Zero Hour and apply the Update"
+END
+
+GUI:DownloadBytesRatio
+"%d / %d bytes"
+END
+
+GUI:DownloadTimeLeft
+"%d:%02d:%02d remaining"
+END
+
+GUI:DownloadUnknownTime
+"???"
+END
+
+FTP:StatusIdle
+"Idle"
+END
+
+FTP:UnknownError
+"Unknown Error"
+END
+
+FTP:NoSuchServer
+"No Such Server"
+END
+
+FTP:CouldNotConnect
+"Could Not Connect"
+END
+
+FTP:LoginFailed
+"Login Failed"
+END
+
+FTP:NoSuchFile
+"No Such File"
+END
+
+FTP:LocalFileOpenFailed
+"Local File Open Failed"
+END
+
+FTP:TCPError
+"TCP Error"
+END
+
+FTP:DisconnectError
+"Disconnect Error"
+END
+
+FTP:StatusConnecting
+"Connecting"
+END
+
+FTP:StatusLoggingIn
+"Logging In"
+END
+
+FTP:StatusFindingFile
+"Finding File"
+END
+
+FTP:StatusQueryingResume
+"Querying to Resume Download"
+END
+
+FTP:StatusDownloading
+"Downloading"
+END
+
+FTP:StatusDisconnecting
+"Disconnecting"
+END
+
+FTP:StatusFinishing
+"Finishing"
+END
+
+FTP:StatusDone
+"Done"
+END
+
+FTP:StatusNone
+"None"
+END
+
+WOL:InternalError
+"C&C Generals Zero Hour Online Internal Error"
+END
+
+WOL:ServerBan
+"Sorry, you've been banned from C&C Generals Zero Hour Online. Please review the Service Terms"
+END
+
+WOL:DisconnectedError
+"Sorry, you've been banned from C&C Generals Zero Hour Online. Please review the Service Terms"
+END
+
+WOL:NoServers
+"C&C Generals Zero Hour Online not found"
+END
+
+WOL:LoginTimeout
+"Timed out waiting to join C&C Generals Zero Hour Online"
+END
+
+WOL:NoMatchChannel
+"No match channel found"
+END
+
+WOL:NoMatchbot
+"No MatchMaker found"
+END
+
+WOL:BadMatchParams
+"Bad match parameters"
+END
+
+WOL:ChatErrorNickInUse
+"That nickname is already in use"
+END
+
+WOL:ChatErrorBadPass
+"Incorrect password for that name"
+END
+
+WOL:ChatErrorNoneSuch
+"No such user or channel"
+END
+
+WOL:ChatErrorConNetDown
+"Network connection is down"
+END
+
+WOL:ChatErrorConLookupFailed
+"DNS lookup failed"
+END
+
+WOL:ChatErrorConError
+"Fatal network error occurred"
+END
+
+WOL:ChatErrorTimeout
+"Timeout occurred"
+END
+
+WOL:ChatErrorMustPatch
+"You must get the latest Update before joining C&C Generals Zero Hour Online"
+END
+
+WOL:ChatErrorStatusError
+"Internal status error"
+END
+
+WOL:ChatErrorUnknownResponse
+"Unknown response"
+END
+
+WOL:ChatErrorChannelFull
+"Channel is full"
+END
+
+WOL:ChatErrorChannelExists
+"Channel already exists"
+END
+
+WOL:ChatErrorChannelDoesNotExist
+"Channel does not exist"
+END
+
+WOL:ChatErrorBadChannelPassword
+"Bad channel password"
+END
+
+WOL:ChatErrorBanned
+"Sorry, you've been banned from C&C Generals Zero Hour Online. Please review the Service Terms"
+END
+
+WOL:ChatErrorNotOper
+"Cannot perform that operation"
+END
+
+WOL:ChatErrorAccountDisabled
+"Your account has been disabled"
+END
+
+WOL:ChatErrorSerialBanned
+"Your serial number has been banned. Please review the Service Terms"
+END
+
+WOL:ChatErrorSerialDup
+"Your serial is already in use"
+END
+
+WOL:ChatErrorSerialUnknown
+"Your serial is invalid"
+END
+
+WOL:NetUtilErrorGeneric
+"Generic NetUtil error"
+END
+
+WOL:NetUtilErrorBusy
+"Busy"
+END
+
+WOL:NetUtilErrorTimeout
+"Timeout"
+END
+
+WOL:NetUtilErrorInvalidField
+"Invalid field"
+END
+
+WOL:NetUtilErrorCantVerify
+"Can't verify"
+END
+
+WOL:NetUtilFinished
+"Finished"
+END
+
+WOL:UnknownError
+"Unknown error"
+END
+
+WOL:CouldNotCreateChannel
+"Could not create channel"
+END
+
+WOL:ErrorTitle
+"C&C Generals Zero Hour Online Error"
+END
+
+WOL:LoginErrorTitle
+"Login Error"
+END
+
+WOL:CreatingChannel
+"Creating channel"
+END
+
+WOL:ChannelClosed
+"Channel has closed"
+END
+
+WOL:BadChannelPassword
+"Bad channel password"
+END
+
+WOL:ChannelFull
+"Channel full"
+END
+
+WOL:BannedFromChannel
+"You've been banned from the channel"
+END
+
+WOL:CannotJoinChannel
+"Cannot join channel"
+END
+
+WOL:NoWOLAPI
+"Shared Internet Components have not been installed"
+END
+
+WOL:OldWOLAPI
+"Shared Internet Components need to be updated. Please install from the C&C Generals Zero Hour disc"
+END
+
+WOL:BadRegistry
+"C&C Generals Zero Hour Registry is corrupt"
+END
+
+WOL:GotPing
+"Received ping of %dms. The lower the ping, the better the connection"
+END
+
+WOL:ServerListAndVersion
+"Fetching server list"
+END
+
+WOL:GettingPings
+"Getting pings. The lower the ping, the better the connection"
+END
+
+WOL:Connecting
+"Connecting"
+END
+
+WOL:JoinedChannel
+"You joined %ls"
+END
+
+WOL:LeftChannel
+"You left %ls"
+END
+
+WOL:UserKicked
+"%ls kicked %ls out of %ls"
+END
+
+WOL:BeginIgnoreList
+"Begin Ignore List"
+END
+
+WOL:IgnoredUser
+"%ls"
+END
+
+WOL:EndIgnoreList
+"End Ignore List"
+END
+
+WOL:DownloadPatchNow
+"Would you like to download the Update at this time?"
+END
+
+WOL:FindInChannel
+"%ls is in %s"
+END
+
+WOL:FindInChannelOtherServer
+"%ls is in %s on %s"
+END
+
+WOL:FindOffline
+"%ls is not logged in"
+END
+
+WOL:FindHiding
+"%ls is not responding to search"
+END
+
+WOL:FindNotInChannel
+"%ls is not in a channel"
+END
+
+WOL:FindNotInChannelOtherServer
+"%ls is on %s"
+END
+
+WOL:Lob_49_0
+"Main Lobby"
+END
+
+WOL:Lob_49_1
+"Alternate"
+END
+
+WOL:Lob_49_2
+"Reality"
+END
+
+WOL:Lob_41_0
+"QuickMatch"
+END
+
+WOL:UnknownServer
+"unknown server"
+END
+
+WOL:UnknownChannel
+"unknown channel"
+END
+
+WOL:BuddyMatching
+"%ls is QuickMatching"
+END
+
+WOL:BuddyNotInChan
+"%ls is online"
+END
+
+WOL:BuddyInGame
+"%ls is playing a game"
+END
+
+WOL:BuddyInChat
+"%ls is chatting in %ls"
+END
+
+WOL:BuddyGameSetup
+"%ls is in %ls"
+END
+
+WOL:BuddyMatchingOtherServer
+"%ls is QuickMatching on %ls"
+END
+
+WOL:BuddyNotInChanOtherServer
+"%ls is online on %ls"
+END
+
+WOL:BuddyInGameOtherServer
+"%ls is playing a game on %ls"
+END
+
+WOL:BuddyInChatOtherServer
+"%ls is chatting in %ls on %ls"
+END
+
+WOL:BuddyGameSetupOtherServer
+"%ls is in %ls on %ls"
+END
+
+WOL:BuddyHiding
+"%ls is hiding"
+END
+
+Chat:Everyone
+"Everyone Views"
+END
+
+Chat:Allies
+"Only Allies View"
+END
+
+GUI:Clear
+"CLEAR"
+END
+
+LAN:GameStartTimerPlural
+"Game will start in %d seconds"
+END
+
+LAN:GameStartTimerSingular
+"Game will start in %d second"
+END
+
+LAN:HostNotResponding
+"Game exited; the host was not responding"
+END
+
+LAN:PlayerDropped
+"%ls dropped; player was not responding"
+END
+
+LAN:NeedMorePlayers
+"You need more than %d player(s) to start a game"
+END
+
+LAN:NeedMoreTeams
+"You need more than 1 team to start a game"
+END
+
+LAN:TooManyPlayers
+"This map only supports up to %d players"
+END
+
+LAN:OK
+"OK"
+END
+
+LAN:ErrorNoGameSelected
+"Please select a game first"
+END
+
+LAN:ErrorTimeout
+"Connection timed out"
+END
+
+LAN:ErrorGameFull
+"This game is full"
+END
+
+LAN:ErrorDuplicateName
+"Duplicate name already in game"
+END
+
+LAN:ErrorCRCMismatch
+"Game has detected a mismatch. This means the multiplayer game has lost synchronization data between the players. It is possible that your opponent has modified his version and you may want to include him on your Ignore List"
+END
+
+LAN:ErrorGameStarted
+"Sorry, this game has already started"
+END
+
+LAN:ErrorGameExists
+"A game of the same name already exists"
+END
+
+LAN:ErrorGameGone
+"Game has dissappeared"
+END
+
+LAN:ErrorBusy
+"Another operation is pending"
+END
+
+LAN:ErrorUnknown
+"Unknown error"
+END
+
+LAN:JoinFailed
+"JOIN FAILED"
+END
+
+Network:PlayerLeft
+"%ls left the game"
+END
+
+INI:MissingDisplayName
+"MISSING DisplayName for Object '%S'"
+END
+
+INI:FactionDefault
+"Default Army"
+END
+
+INI:FactionObserver
+"Observer"
+END
+
+INI:FactionCivilian
+"Civilian"
+END
+
+INI:FactionAmerica
+"USA"
+END
+
+INI:FactionChina
+"China"
+END
+
+INI:FactionGLA
+"GLA"
+END
+
+INI:FactionChinaHacker
+"Chinese Hacker"
+END
+
+SIDE:America
+"USA"
+END
+
+SIDE:China
+"China"
+END
+
+SIDE:GLA
+"GLA"
+END
+
+INI:RankLevel1
+"1 Star General"
+END
+
+INI:RankLevel2
+"2 Star General"
+END
+
+INI:RankLevel3
+"3 Star General"
+END
+
+INI:RankLevel4
+"4 Star General"
+END
+
+INI:RankLevel5
+"5 Star General"
+END
+
+INI:RankLevel6
+"Mr. Bad Dude (Rank 6)"
+END
+
+INI:RankLevel7
+"Dr. Death (Rank 7)"
+END
+
+INI:RankLevel8
+"Ultimate Deadly Dude (Rank 8)"
+END
+
+TOOLTIP:MyInfo
+"Click to explore your Persona Information. You may view your rank, points, wins, losses, Battle Honors, etc"
+END
+
+TOOLTIP:CustomMatch
+"Click to join the Custom Match Lobby to meet and chat with other players"
+END
+
+TOOLTIP:SelectAll
+"QuickMatch on all available maps"
+END
+
+TOOLTIP:SelectNone
+"QuickMatch on no maps"
+END
+
+TOOLTIP:EnterPassword
+"Please enter a password"
+END
+
+TOOLTIP:Quickmatch
+"Click to begin QuickMatch. QuickMatch will attempt to automatically match you with your closest skill level and preferences"
+END
+
+TOOLTIP:GameLobbys
+"."
+END
+
+TOOLTIP:ClearButton
+"Clear the chat text window"
+END
+
+TOOLTIP:Disconnectbutton
+"Click to disconnect from your current game. Disconnect will be counted toward your overall total"
+END
+
+TOOLTIP:playersonline
+"List of players currently on C&C Generals Zero Hour Online"
+END
+
+TOOLTIP:WidenSearch
+"Click to widen your opponent search criteria. The more specific your criteria is, the more difficult it can be to find an opponent"
+END
+
+TOOLTIP:Emote
+"."
+END
+
+TOOLTIP:JoinGame
+"Click to join the selected game"
+END
+
+TOOLTIP:BuddyButton
+"Sort game list by Buddies"
+END
+
+TOOLTIP:matchingprogress
+"You can watch as QuickMatch searches for your best match. Keep your fingers crossed!"
+END
+
+TOOLTIP:CancelButton
+"Click to cancel the current operation"
+END
+
+TOOLTIP:resizewindows
+"Click and drag vertically to change the size of your Game List window vs. your Chat window"
+END
+
+TOOLTIP:CreateGame
+"Create a new game. The game will be displayed in the Game List window for other players to join"
+END
+
+TOOLTIP:ChatWindow
+"Type and press Enter in the Text Entry box below to send messages to this Chat window. Other players can read and respond"
+END
+
+TOOLTIP:StopSearch
+"Abort your current search"
+END
+
+TOOLTIP:StartSearch
+"Begin searching"
+END
+
+TOOLTIP:UnknownGame
+"Unknown game"
+END
+
+TOOLTIP:textentrybox
+"Type and press Enter in this Text Entry box to send messages to the Chat window above"
+END
+
+TOOLTIP:PlayersInLobby
+"Current players in your lobby"
+END
+
+TOOLTIP:LocalPlayer
+"Current player %s"
+END
+
+TOOLTIP:BuddyPlayer
+"Your buddy %s"
+END
+
+TOOLTIP:ProfiledPlayer
+"%s"
+END
+
+TOOLTIP:GenericPlayer
+"%s"
+END
+
+TOOLTIP:IgnoredModifier
+"(ignored)"
+END
+
+TOOLTIP:PlayerInfo
+" \n Region: %s  \n %d wins/%d losses"
+END
+
+TOOLTIP:GameInfoGameName
+"Game Name: %s"
+END
+
+TOOLTIP:GameInfoLadderName
+" \n Ladder: %s"
+END
+
+TOOLTIP:LadderName
+"Ladder: %s"
+END
+
+TOOLTIP:UnknownLadder
+" \n Unknown ladder"
+END
+
+TOOLTIP:NoLadder
+" \n No ladder"
+END
+
+TOOLTIP:InvalidGameVersionSingleLine
+"This game version is different"
+END
+
+TOOLTIP:InvalidGameVersion
+""
+END
+
+TOOLTIP:GameInfoMap
+" \n Map: %s  \n Players:"
+END
+
+TOOLTIP:GameInfoPlayer
+" \n %s (%d/%d)"
+END
+
+TOOLTIP:FreeForAll
+"Free For All. No teams/allies allowed"
+END
+
+TOOLTIP:ListOfPlayers
+"Players in the current game"
+END
+
+TOOLTIP:MapName
+"Currently selected map"
+END
+
+TOOLTIP:GameName
+"Name of the game"
+END
+
+TOOLTIP:StartGame
+"Begin a multiplayer game"
+END
+
+TOOLTIP:IgnoreButton
+"Ignore player"
+END
+
+TOOLTIP:closeButton
+"."
+END
+
+TOOLTIP:GameOptions
+"Options currently enabled in the game"
+END
+
+TOOLTIP:Crates
+"Bonus crates"
+END
+
+TOOLTIP:SuperWeapons
+"Super Weapons. Particle Cannon, Nuclear Missile, etc"
+END
+
+DOZER:ConstructionComplete
+"Construction Complete: %s"
+END
+
+DOZER:RepairComplete
+"Repair Operation Complete"
+END
+
+UPGRADE:UpgradeComplete
+"Upgrade Complete: %s"
+END
+
+GUI:CantBuildRestrictedTerrain
+"The terrain prevents you from building here"
+END
+
+GUI:CantBuildNotFlatEnough
+"The terrain is not flat enough to build here"
+END
+
+GUI:CantBuildObjectsInTheWay
+"You cannot build there because there are obstacles in the way"
+END
+
+GUI:CantBuildNoClearPath
+"Unit cannot reach construction site"
+END
+
+GUI:CantBuildShroud
+"You must explore there before building"
+END
+
+GUI:CantBuildThere
+"You can't build here"
+END
+
+GUI:RallyPointObjectsInTheWay
+"Unable to set rally point, object(s) are in the way of the destination"
+END
+
+GUI:RallyPointNoPath
+"Unable to set rally point"
+END
+
+GUI:RallyPointSet
+"%s rally point set"
+END
+
+GUI:MouseType
+"Mouse Type"
+END
+
+GUI:Com
+"EAPIM"
+END
+
+GUI:CONTROL
+"Control"
+END
+
+GUI:INFORMATION
+"Information"
+END
+
+GUI:INTERFACE
+"Interface"
+END
+
+GUI:SELECTION
+"Selection"
+END
+
+GUI:TAUNT
+"Taunt"
+END
+
+GUI:MISC
+"Misc"
+END
+
+GUI:DEBUG
+"Debug"
+END
+
+GUI:Cheer
+"Cheer"
+END
+
+GUI:CheerDescription
+"Commands your forces to exult over your great deeds"
+END
+
+GUI:Deploy
+"Deploy Object"
+END
+
+GUI:DeployDescription
+"Deploy selected object(s)"
+END
+
+GUI:Guard
+"Guard"
+END
+
+GUI:GuardDescription
+"Set the selected object(s) into 'guard area' mode"
+END
+
+GUI:CreateFormation
+"Create Formation"
+END
+
+GUI:Follow
+"Follow"
+END
+
+GUI:FollowDescription
+"Toggle follow state of selected object(s)"
+END
+
+GUI:ToggleControlBar
+"Toggle Control Bar"
+END
+
+GUI:ToggleControlBarDescription
+"Toggles the In Game Control Bar on/off"
+END
+
+GUI:ToggleLetterbox
+"Toggle Letter Box"
+END
+
+GUI:ToggleLetterboxDescription
+"Toggles Letterbox Mode on/off"
+END
+
+GUI:Scatter
+"Scatter"
+END
+
+GUI:StopObject
+"Stop Object"
+END
+
+GUI:StopObjectDescription
+"Stop the selected object(s)"
+END
+
+GUI:GoToRadarEvent
+"Go to Radar Event"
+END
+
+GUI:GoToRadarEventDescription
+"Center the tactical view on the last radar event"
+END
+
+GUI:SaveView1
+"Set Bookmark 1"
+END
+
+GUI:SaveView1Description
+"Set view bookmark map position 1"
+END
+
+GUI:SaveView2
+"Set Bookmark 2"
+END
+
+GUI:SaveView2Description
+"Set view bookmark map position 2"
+END
+
+GUI:SaveView3
+"Set Bookmark 3"
+END
+
+GUI:SaveView3Description
+"Set view bookmark map position 3"
+END
+
+GUI:SaveView4
+"Set Bookmark 4"
+END
+
+GUI:SaveView4Description
+"Set view bookmark map position 4"
+END
+
+GUI:ViewView1
+"View Bookmark 1"
+END
+
+GUI:ViewView1Description
+"View bookmarked map position 1"
+END
+
+GUI:ViewView2
+"View Bookmark 2"
+END
+
+GUI:ViewView2Description
+"View bookmarked map position 2"
+END
+
+GUI:ViewView3
+"View Bookmark 3"
+END
+
+GUI:ViewView3Description
+"View bookmarked map position 3"
+END
+
+GUI:ViewView4
+"View Bookmark 4"
+END
+
+GUI:ViewView4Description
+"View bookmarked map position 4"
+END
+
+GUI:CenterBase
+"Center Base"
+END
+
+GUI:CenterBaseDescription
+"Center the view about the player's base"
+END
+
+GUI:SelectNone
+"Select None"
+END
+
+GUI:SelectAll
+"Select All"
+END
+
+GUI:SelectAllDescription
+"Selects all military units"
+END
+
+GUI:SelectNextUnit
+"Next Object"
+END
+
+GUI:SelectNextUnitDescription
+"Select the next object"
+END
+
+GUI:SelectPrevUnit
+"Previous Object"
+END
+
+GUI:SelectPrevUnitDescription
+"Select the previous unit"
+END
+
+GUI:SelectNextWorker
+"Next Worker"
+END
+
+GUI:SelectNextWorkerDescription
+"Select the next Worker"
+END
+
+GUI:SelectPrevWorker
+"Previous Worker"
+END
+
+GUI:SelectPrevWorkerDescription
+"Select the previous Worker"
+END
+
+GUI:TypeSelect
+"Type Select"
+END
+
+GUI:TypeSelectDescription
+"Selects units by type. Double left click a unit to select all of the same type"
+END
+
+GUI:CreateTeam0
+"Create Team 0"
+END
+
+GUI:CreateTeam0Description
+"Creates team 0 from currently selected units"
+END
+
+GUI:CreateTeam1
+"Create Team 1"
+END
+
+GUI:CreateTeam1Description
+"Creates team 1 from currently selected units"
+END
+
+GUI:CreateTeam2
+"Create Team 2"
+END
+
+GUI:CreateTeam2Description
+"Creates team 2 from currently selected units"
+END
+
+GUI:CreateTeam3
+"Create Team 3"
+END
+
+GUI:CreateTeam3Description
+"Creates team 3 from currently selected units"
+END
+
+GUI:CreateTeam4
+"Create Team 4"
+END
+
+GUI:CreateTeam4Description
+"Creates team 4 from currently selected units"
+END
+
+GUI:CreateTeam5
+"Create Team 5"
+END
+
+GUI:CreateTeam5Description
+"Creates team 5 from currently selected units"
+END
+
+GUI:CreateTeam6
+"Create Team 6"
+END
+
+GUI:CreateTeam6Description
+"Creates team 6 from currently selected units"
+END
+
+GUI:CreateTeam7
+"Create Team 7"
+END
+
+GUI:CreateTeam7Description
+"Creates team 7 from currently selected units"
+END
+
+GUI:CreateTeam8
+"Create Team 8"
+END
+
+GUI:CreateTeam8Description
+"Creates team 8 from currently selected units"
+END
+
+GUI:CreateTeam9
+"Create Team 9"
+END
+
+GUI:CreateTeam9Description
+"Creates team 9 from currently selected units"
+END
+
+GUI:SelectTeam0
+"Select Team 0"
+END
+
+GUI:SelectTeam0Description
+"Select members of team 0"
+END
+
+GUI:SelectTeam1
+"Select Team 1"
+END
+
+GUI:SelectTeam1Description
+"Select members of team 1"
+END
+
+GUI:SelectTeam2
+"Select Team 2"
+END
+
+GUI:SelectTeam2Description
+"Select members of team 2"
+END
+
+GUI:SelectTeam3
+"Select Team 3"
+END
+
+GUI:SelectTeam3Description
+"Select members of team 3"
+END
+
+GUI:SelectTeam4
+"Select Team 4"
+END
+
+GUI:SelectTeam4Description
+"Select members of team 4"
+END
+
+GUI:SelectTeam5
+"Select Team 5"
+END
+
+GUI:SelectTeam5Description
+"Select members of team 5"
+END
+
+GUI:SelectTeam6
+"Select Team 6"
+END
+
+GUI:SelectTeam6Description
+"Select members of team 6"
+END
+
+GUI:SelectTeam7
+"Select Team 7"
+END
+
+GUI:SelectTeam7Description
+"Select members of team 7"
+END
+
+GUI:SelectTeam8
+"Select Team 8"
+END
+
+GUI:SelectTeam8Description
+"Select members of team 8"
+END
+
+GUI:SelectTeam9
+"Select Team 9"
+END
+
+GUI:SelectTeam9Description
+"Select members of team 9"
+END
+
+GUI:ViewTeam0
+"Center Team 0"
+END
+
+GUI:ViewTeam0Description
+"Select and center view about team 0"
+END
+
+GUI:ViewTeam1
+"Center Team 1"
+END
+
+GUI:ViewTeam1Description
+"Select and center view about team 1"
+END
+
+GUI:ViewTeam2
+"Center Team 2"
+END
+
+GUI:ViewTeam2Description
+"Select and center view about team 2"
+END
+
+GUI:ViewTeam3
+"Center Team 3"
+END
+
+GUI:ViewTeam3Description
+"Select and center view about team 3"
+END
+
+GUI:ViewTeam4
+"Center Team 4"
+END
+
+GUI:ViewTeam4Description
+"Select and center view about team 4"
+END
+
+GUI:ViewTeam5
+"Center Team 5"
+END
+
+GUI:ViewTeam5Description
+"Select and center view about team 5"
+END
+
+GUI:ViewTeam6
+"Center Team 6"
+END
+
+GUI:ViewTeam6Description
+"Select and center view about team 6"
+END
+
+GUI:ViewTeam7
+"Center Team 7"
+END
+
+GUI:ViewTeam7Description
+"Select and center view about team 7"
+END
+
+GUI:ViewTeam8
+"Center Team 8"
+END
+
+GUI:ViewTeam8Description
+"Select and center view about team 8"
+END
+
+GUI:ViewTeam9
+"Center Team 9"
+END
+
+GUI:ViewTeam9Description
+"Select and center view about team 9"
+END
+
+GUI:LocalIPDesc
+"Local IP"
+END
+
+GUI:RemoteIPDesc
+"Remote IP"
+END
+
+GUI:SaveCamera
+"Save camera in replays"
+END
+
+GUI:UseCamera
+"Use saved camera in replays"
+END
+
+Mouse:Windows
+"Windows Cursor"
+END
+
+Mouse:W3D
+"W3D Cursor"
+END
+
+Mouse:Poly
+"Polygon Cursor"
+END
+
+Mouse:DX8
+"DX8 Cursor"
+END
+
+Mouse:Heal
+"Get Healed"
+END
+
+Mouse:GetRepaired
+"Get Repaired"
+END
+
+Mouse:Dock
+"Dock"
+END
+
+Mouse:DoRepair
+"Repair"
+END
+
+Mouse:ResumeConstruction
+"Resume Construction"
+END
+
+Mouse:Enter
+"Enter"
+END
+
+Mouse:SetRallyPoint
+"Set Rally Point"
+END
+
+Mouse:DisguiseAsVehicle
+"Disguise As This!"
+END
+
+Mouse:Invalid
+"INVALID"
+END
+
+Mouse:FireFlame
+"Burn"
+END
+
+Mouse:FireFlashBang
+"Flash Bang"
+END
+
+Mouse:FireTranqDarts
+"Tranq Darts"
+END
+
+Mouse:FireStunBullets
+"Stun Bullets"
+END
+
+Mouse:MakeCarBomb
+"Make Carbomb"
+END
+
+Mouse:Hijack
+"Hijack"
+END
+
+Mouse:FireBomb
+"Fire  \n Bomb"
+END
+
+Mouse:Defector
+"Make  \n Defector"
+END
+
+Mouse:CaptureBuilding
+"Capture Building"
+END
+
+Mouse:DisableVehicleHack
+"Disable Vehicle"
+END
+
+Mouse:StealCashHack
+"Steal Cash"
+END
+
+Mouse:SnipeVehicle
+"Snipe Vehicle"
+END
+
+Mouse:DisableBuildingHack
+"Disable Building"
+END
+
+Mouse:LaserGuidedMissiles
+"Laser Guided Missiles"
+END
+
+Mouse:TankHunterTNTAttack
+"TNT Attack"
+END
+
+Mouse:A10ThunderboltStrike
+"A10-Strike Location"
+END
+
+Mouse:StabAttack
+"Stab"
+END
+
+Mouse:PlaceRemoteCharge
+"Place Remote Charge"
+END
+
+Mouse:PlaceTimedCharge
+"Place Timed Charge"
+END
+
+Mouse:RepairVehicles
+"&Emergency Repair"
+END
+
+Mouse:Demoralize
+"Demoralize"
+END
+
+Mouse:PickUpPrisoner
+"Pick Up Prisoner"
+END
+
+Mouse:Return
+"Return"
+END
+
+Mouse:PlaceBeacon
+"Place Beacon"
+END
+
+SCRIPT:TestString
+"This is like a test string, dude"
+END
+
+SCRIPT:LongTestString
+"This is like a really long test string, dude. It makes sure that the word wrap and the spacing works"
+END
+
+SCIENCE:GeneralName
+"<Enter Name>"
+END
+
+SCIENCE:SkillPoints
+"Skill Points: %d"
+END
+
+SCIENCE:Rank
+"Level %d"
+END
+
+SCIENCE:TempName
+"Give My Science A Name"
+END
+
+SCIENCE:TempDescription
+"Please take the time to fill out my description located in Science.ini! Thanks a bunch"
+END
+
+SCIENCE:USAPaladin
+"Paladin Tank"
+END
+
+SCIENCE:USAPathFinder
+"Pathfinder"
+END
+
+SCIENCE:USAStealthFighter
+"Stealth Fighter"
+END
+
+SCIENCE:USASpyDrone
+"Spy Drone"
+END
+
+SCIENCE:USAParaDrop1
+"Para Drop 1"
+END
+
+SCIENCE:USAParaDrop2
+"Para Drop 2"
+END
+
+SCIENCE:USAParaDrop3
+"Para Drop 3"
+END
+
+SCIENCE:USAA10Strike1
+"A10 Strike 1"
+END
+
+SCIENCE:USAA10Strike2
+"A10 Strike 2"
+END
+
+SCIENCE:USAA10Strike3
+"A10 Strike 3"
+END
+
+SCIENCE:USADaisyCutter
+"Fuel Air Bomb"
+END
+
+SCIENCE:ChinaNukeLauncher
+"Nuke Cannon"
+END
+
+SCIENCE:ChinaRedGuardTraining
+"Red Guard Training"
+END
+
+SCIENCE:ChinaClusterMines
+"Cluster Mines"
+END
+
+SCIENCE:ChinaArtilleryTraining
+"Artillery Training"
+END
+
+SCIENCE:ChinaArtilleryBarrage
+"Artillery Barrage 1"
+END
+
+SCIENCE:ChinaArtilleryBarrage2
+"Artillery Barrage 2"
+END
+
+SCIENCE:ChinaArtilleryBarrage3
+"Artillery Barrage 3"
+END
+
+SCIENCE:ChinaCashHack1
+"Cash Hack 1"
+END
+
+SCIENCE:ChinaCashHack2
+"Cash Hack 2"
+END
+
+SCIENCE:ChinaCashHack3
+"Cash Hack 3"
+END
+
+SCIENCE:ChinaEMPPulse
+"EMP Pulse"
+END
+
+SCIENCE:GLAHijacker
+"Hijacker"
+END
+
+SCIENCE:GLASCUDLauncher
+"SCUD Launcher"
+END
+
+SCIENCE:GLAMaruaderTank
+"Marauder Tank"
+END
+
+SCIENCE:GLATechnicalTraining
+"Technical Training"
+END
+
+SCIENCE:GLARebelAmbush1
+"Rebel Ambush 1"
+END
+
+SCIENCE:GLARebelAmbush2
+"Rebel Ambush 2"
+END
+
+SCIENCE:GLARebelAmbush3
+"Rebel Ambush 3"
+END
+
+SCIENCE:GLACashBounty1
+"Cash Bounty 1"
+END
+
+SCIENCE:GLACashBounty2
+"Cash Bounty 2"
+END
+
+SCIENCE:GLACashBounty3
+"Cash Bounty 3"
+END
+
+SCIENCE:GLAAnthraxBomb
+"Anthrax Bomb"
+END
+
+CONTROLBAR:Demoralize
+"Demoralize"
+END
+
+CONTROLBAR:CIAIntelligence
+"Intelligen&ce"
+END
+
+CONTROLBAR:CombatDrop
+"&Combat Drop"
+END
+
+CONTROLBAR:Guard
+"&Guard"
+END
+
+CONTROLBAR:GuardWithoutPursuit
+"Guard &Close"
+END
+
+CONTROLBAR:GuardFlyingUnitsOnly
+"Guard Ai&r"
+END
+
+CONTROLBAR:AttackMove
+"&Attack Move"
+END
+
+CONTROLBAR:Stop
+"&Stop"
+END
+
+CONTROLBAR:Waypoints
+"Waypoin&t"
+END
+
+CONTROLBAR:CancelBuild
+"&Cancel Build"
+END
+
+CONTROLBAR:Contaminate
+"&Contaminate"
+END
+
+CONTROLBAR:FireWall
+"&Fire Wall"
+END
+
+CONTROLBAR:UpgradeGLAArmTheMob
+"Arm the &Mob"
+END
+
+CONTROLBAR:UpgradeChinaOverlordGattlingCannon
+"Gattling &Cannon"
+END
+
+CONTROLBAR:UpgradeChinaOverlordPropagandaTower
+"Propaganda &Tower"
+END
+
+CONTROLBAR:UpgradeChinaOverlordBattleBunker
+"Battle &Bunker"
+END
+
+CONTROLBAR:FireBomb
+"&Fire Bomb"
+END
+
+CONTROLBAR:UnderConstructionDesc
+"Building: %.0f%%"
+END
+
+CONTROLBAR:OCLTimerDesc
+"Time Until Next Drop: %d:%d"
+END
+
+CONTROLBAR:OCLTimerDescWithPadding
+"Time Until Next Drop: %d:0%d"
+END
+
+CONTROLBAR:InitiateBattlePlanBombardment
+"&Bombardment Battle Plan"
+END
+
+CONTROLBAR:InitiateBattlePlanHoldTheLine
+"H&old The Line Battle Plan"
+END
+
+CONTROLBAR:InitiateBattlePlanSearchAndDestroy
+"Search and &Destroy Plan"
+END
+
+CONTROLBAR:TempDescription
+"Please take the time to fill out my description located in CommandButton.ini! Thanks a bunch"
+END
+
+CONTROLBAR:CleanupAreaDescription
+"Automatically cleans up bio toxins and radiation in area surrounding target location"
+END
+
+CONTROLBAR:ConstructAmericaCommandCenter
+"&Command Center"
+END
+
+CONTROLBAR:ConstructAmericaPowerPlant
+"Cold Fusion &Reactor"
+END
+
+CONTROLBAR:ConstructAmericaBarracks
+"&Barracks"
+END
+
+CONTROLBAR:ConstructAmericaSupplyCenter
+"S&upply Center"
+END
+
+CONTROLBAR:ConstructAmericaWall
+"Security &Fence"
+END
+
+CONTROLBAR:ConstructAmericaWarFactory
+"W&ar Factory"
+END
+
+CONTROLBAR:ConstructAmericaGuardianControlCenter
+"Guardian  \n Center"
+END
+
+CONTROLBAR:ConstructAmericaPatriotBattery
+"Patriot &Missile System"
+END
+
+CONTROLBAR:ConstructAmericaParticleCannonUplink
+"&Particle Cannon"
+END
+
+CONTROLBAR:ConstructAmericaStrategyCenter
+"Strateg&y Center"
+END
+
+CONTROLBAR:ConstructAmericaSupplyDropZone
+"Supply Drop &Zone"
+END
+
+CONTROLBAR:ConstructAmericaDetentionCamp
+"&Detention Camp"
+END
+
+CONTROLBAR:ConstructAmericaTankCrusader
+"&Crusader"
+END
+
+CONTROLBAR:ConstructAmericaTankPaladin
+"&Paladin"
+END
+
+CONTROLBAR:ConstructAmericaInfantryRanger
+"Ran&ger"
+END
+
+CONTROLBAR:Evacuate
+"E&vacuate"
+END
+
+CONTROLBAR:ExecuteRailedTransport
+"Transport"
+END
+
+CONTROLBAR:TransportExit
+"Exit Transport"
+END
+
+CONTROLBAR:ConstructGLACommandCenter
+"&Command Center"
+END
+
+CONTROLBAR:ConstructGLADemoTrap
+"&Demo Trap"
+END
+
+CONTROLBAR:ConstructGLABarracks
+"&Barracks"
+END
+
+CONTROLBAR:ConstructGLASupplyStash
+"S&upply Stash"
+END
+
+CONTROLBAR:ConstructGLABurningBarricade
+"&Burning Barricade"
+END
+
+CONTROLBAR:ConstructGLAArmsDealer
+"&Arms Dealer"
+END
+
+CONTROLBAR:ConstructChinaCommandCenter
+"&Command Center"
+END
+
+CONTROLBAR:ConstructChinaPowerPlant
+"Nuclear &Reactor"
+END
+
+CONTROLBAR:ConstructChinaBarracks
+"&Barracks"
+END
+
+CONTROLBAR:ConstructChinaSupplyCenter
+"S&upply Center"
+END
+
+CONTROLBAR:ConstructChinaConcreteWall
+"Concrete Wa&ll"
+END
+
+CONTROLBAR:ConstructChinaWarFactory
+"W&ar Factory"
+END
+
+CONTROLBAR:ConstructAmericaDozer
+"Construction &Dozer"
+END
+
+CONTROLBAR:ConstructGLAWorker
+"Wor&ker"
+END
+
+CONTROLBAR:ConstructChinaDozer
+"Construction &Dozer"
+END
+
+CONTROLBAR:ConstructGLATankScorpion
+"&Scorpion"
+END
+
+CONTROLBAR:ConstructGLATankMarauder
+"&Marauder Tank"
+END
+
+CONTROLBAR:ConstructGLAVehicleRocketBuggy
+"Rocket &Buggy"
+END
+
+CONTROLBAR:ConstructGLAVehicleRadarVan
+"Radar &Van"
+END
+
+CONTROLBAR:ConstructChinaTankOverlord
+"&Overlord"
+END
+
+CONTROLBAR:ConstructChinaTankGattling
+"&Gattling Tank"
+END
+
+CONTROLBAR:ConstructGLAInfantryRebel
+"Re&bel"
+END
+
+CONTROLBAR:ConstructChinaInfantryRedguard
+"Red &Guard"
+END
+
+CONTROLBAR:ConstructAmericaVehicleChinook
+"&Chinook"
+END
+
+CONTROLBAR:ConstructGLAVehicleSupplyTruck
+"Supply &Truck"
+END
+
+CONTROLBAR:ConstructChinaVehicleSupplyTruck
+"Supply &Truck"
+END
+
+CONTROLBAR:ConstructAmericaJetRaptor
+"Rap&tor"
+END
+
+CONTROLBAR:ConstructAmericaJetAurora
+"Aurora &Bomber"
+END
+
+CONTROLBAR:ConstructAmericaJetStealthFighter
+"Stealth &Fighter"
+END
+
+CONTROLBAR:ConstructAmericaVehicleStarlifter
+"Starlifter"
+END
+
+CONTROLBAR:ConstructAmericaVehicleComanche
+"&Comanche"
+END
+
+CONTROLBAR:ConstructAmericaInfantryMissileDefender
+"&Missile Defender"
+END
+
+CONTROLBAR:ConstructAmericaInfantryPathfinder
+"&Pathfinder"
+END
+
+CONTROLBAR:ConstructAmericaInfantryColonelBurton
+"Colonel Burto&n"
+END
+
+CONTROLBAR:ConstructAmericaInfantryBiohazardTech
+"Biohazard Tech"
+END
+
+CONTROLBAR:ConstructAmericaVehicleTomahawk
+"&Tomahawk"
+END
+
+CONTROLBAR:ConstructAmericaVehicleMedic
+"&Ambulance"
+END
+
+CONTROLBAR:ConstructAmericaVehicleHumvee
+"Hum&vee"
+END
+
+CONTROLBAR:ConstructAmericaVehicleBattleDrone
+"&Battle Drone"
+END
+
+CONTROLBAR:ConstructAmericaVehicleScoutDrone
+"Scout &Drone"
+END
+
+CONTROLBAR:ConstructChinaJetMIG
+"Mi&G"
+END
+
+CONTROLBAR:ConstructChinaInfantryBlackLotus
+"&Black Lotus"
+END
+
+CONTROLBAR:ConstructChinaInfantryTankHunter
+"&Tank Hunter"
+END
+
+CONTROLBAR:ConstructChinaInfantrySecretPolice
+"Secret  \n Police"
+END
+
+CONTROLBAR:ConstructChinaInfantryHacker
+"H&acker"
+END
+
+CONTROLBAR:ConstructChinaBunker
+"Bun&ker"
+END
+
+CONTROLBAR:ConstructChinaPropagandaCenter
+"&Propaganda Center"
+END
+
+CONTROLBAR:ConstructChinaAirfield
+"Air &Field"
+END
+
+CONTROLBAR:ConstructAmericaAirfield
+"Air &Field"
+END
+
+CONTROLBAR:ConstructChinaGattlingCannon
+"&Gattling Cannon"
+END
+
+CONTROLBAR:ConstructChinaNuclearMissileLauncher
+"Nuclear &Missile"
+END
+
+CONTROLBAR:ConstructChinaSpeakerTower
+"Speaker &Tower"
+END
+
+CONTROLBAR:ConstructChinaVehicleInfernoCannon
+"&Inferno Cannon"
+END
+
+CONTROLBAR:ConstructChinaVehicleNukeLauncher
+"N&uke Cannon"
+END
+
+CONTROLBAR:ConstructChinaVehicleTroopCrawler
+"&Troop Crawler"
+END
+
+CONTROLBAR:ConstructChinaTankSeismic
+"Seismic  \n Tank"
+END
+
+CONTROLBAR:ConstructChinaTankDragon
+"&Dragon Tank"
+END
+
+CONTROLBAR:ConstructChinaVehiclePropagandaBlimp
+"Prop  \n Blimp"
+END
+
+CONTROLBAR:ConstructGLAInfantryTerrorist
+"&Terrorist"
+END
+
+CONTROLBAR:ConstructGLAInfantryRPGTrooper
+"RP&G Trooper"
+END
+
+CONTROLBAR:ConstructGLATunnelNetwork
+"Tunnel &Network"
+END
+
+CONTROLBAR:ConstructGLAPalace
+"&Palace"
+END
+
+CONTROLBAR:ConstructGLABlackMarket
+"Black &Market"
+END
+
+CONTROLBAR:ConstructGLAStingerSite
+"S&tinger Site"
+END
+
+CONTROLBAR:ConstructGLAScudStorm
+"SCUD St&orm"
+END
+
+CONTROLBAR:ConstructGLAPrison
+"P&rison"
+END
+
+CONTROLBAR:ConstructGLAVehicleToxinTruck
+"Toxin Tr&actor"
+END
+
+CONTROLBAR:ConstructGLATankBattleMaster
+"&Battlemaster"
+END
+
+CONTROLBAR:ConstructGLAVehicleTechnical
+"&Technical"
+END
+
+CONTROLBAR:ConstructGLAInfantryHijacker
+"H&ijacker"
+END
+
+CONTROLBAR:ConstructGLAInfantryJarmenKell
+"&Jarmen Kell"
+END
+
+CONTROLBAR:ConstructGLAInfantryAngryMob
+"Angr&y Mob"
+END
+
+CONTROLBAR:ConstructGLAVehicleQuadCannon
+"Q&uad Cannon"
+END
+
+CONTROLBAR:ConstructGLAVehicleBombTruck
+"B&omb Truck"
+END
+
+CONTROLBAR:ConstructGLAVehicleScudLauncher
+"SCUD &Launcher"
+END
+
+CONTROLBAR:UpgradeAmericaAdvancedTraining
+"&Advanced Training"
+END
+
+CONTROLBAR:UpgradeAmericaDroneArmor
+"D&rone Armor"
+END
+
+CONTROLBAR:UpgradeChinaMines
+"&Land Mines"
+END
+
+CONTROLBAR:UpgradeAmericaRadar
+"&Radar"
+END
+
+CONTROLBAR:UpgradeAmericaScoutDrones
+"S&cout Drones"
+END
+
+CONTROLBAR:UpgradeAmericaAdvancedControlRods
+"&Control Rods"
+END
+
+CONTROLBAR:UpgradeAmericaLaserMissiles
+"&Laser Missiles"
+END
+
+CONTROLBAR:UpgradeAmericaExtraFuel
+"Extra &Fuel"
+END
+
+CONTROLBAR:UpgradeAmericaFlashBangGrenade
+"&Flash-Bang Grenades"
+END
+
+CONTROLBAR:UpgradeAmericaCompositeArmor
+"Com&posite Armor"
+END
+
+CONTROLBAR:UpgradeAmericaTomahawkRemoteControl
+"Cruise &Missiles"
+END
+
+CONTROLBAR:UpgradeAmericaAircraftFuel
+"Air Fuel"
+END
+
+CONTROLBAR:UpgradeAmericaTOWMissile
+"TOW M&issile"
+END
+
+CONTROLBAR:UpgradeComancheRocketPods
+"Rocket &Pods"
+END
+
+CONTROLBAR:UpgradeAmericaRailGun
+"Rail  \n Gun"
+END
+
+CONTROLBAR:UpgradeChinaRadar
+"R&adar"
+END
+
+CONTROLBAR:UpgradeChinaNationalism
+"&Nationalism"
+END
+
+CONTROLBAR:UpgradeChinaAntiTankGrenade
+"&Anti-Tank Grenades"
+END
+
+CONTROLBAR:UpgradeChinaVehicleHack
+"&Vehicle Hack"
+END
+
+CONTROLBAR:UpgradeChinaIRGoggles
+"&IR Goggles"
+END
+
+CONTROLBAR:UpgradeChinaBlackNapalm
+"Black &Napalm"
+END
+
+CONTROLBAR:UpgradeChinaChainGuns
+"&Chain Guns"
+END
+
+CONTROLBAR:UpgradeChinaSubliminalMessaging
+"Su&bliminal Messaging"
+END
+
+CONTROLBAR:UpgradeChinaUraniumShells
+"&Uranium Shells"
+END
+
+CONTROLBAR:UpgradeChinaNuclearTanks
+"Nuclear &Tanks"
+END
+
+CONTROLBAR:UpgradeChinaStunBullets
+"Stun &Bullets"
+END
+
+CONTROLBAR:UpgradeGLARadar
+"&Radar"
+END
+
+CONTROLBAR:UpgradeGLARadarVanScan
+"Radar S&can"
+END
+
+CONTROLBAR:UpgradeGLAScorpionRocket
+"Scorpion Roc&ket"
+END
+
+CONTROLBAR:UpgradeGLABuggyAmmo
+"Buggy &Ammo"
+END
+
+CONTROLBAR:UpgradeGLABombTruckBioBomb
+"&BioBombs"
+END
+
+CONTROLBAR:DisguiseAsVehicle
+"&Disguise as Vehicle"
+END
+
+CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb
+"High Explosive B&omb"
+END
+
+CONTROLBAR:UpgradeGLAAnthraxBeta
+"&Anthrax Beta"
+END
+
+CONTROLBAR:UpgradeGLAToxinShells
+"&Toxin Shells"
+END
+
+CONTROLBAR:UpgradeGLAJunkRepair
+"&Junk Repair"
+END
+
+CONTROLBAR:UpgradeGLAAPBullets
+"AP &Bullets"
+END
+
+CONTROLBAR:UpgradeGLAAPRockets
+"AP &Rockets"
+END
+
+CONTROLBAR:UpgradeGLACamouflage
+"&Camouflage"
+END
+
+CONTROLBAR:UpgradeGLATranqDarts
+"&Tranq Darts"
+END
+
+CONTROLBAR:SetRallyPoint
+"&Rally Point"
+END
+
+CONTROLBAR:Sell
+"&Z: Sell"
+END
+
+CONTROLBAR:Overcharge
+"&Overcharge"
+END
+
+CONTROLBAR:DragonFlame
+"F&lame"
+END
+
+CONTROLBAR:PickUpPrisoner
+"&Pick Up  \n Prisoner"
+END
+
+CONTROLBAR:ReturnToPrison
+"&Return"
+END
+
+CONTROLBAR:FireRocket
+"&Fire Rocket"
+END
+
+CONTROLBAR:AnthraxWarhead
+"A&nthrax Warhead"
+END
+
+CONTROLBAR:ExplosiveWarhead
+"Ex&plosive Warhead"
+END
+
+CONTROLBAR:Fire20mmCannon
+"&Fire 20mm Cannon"
+END
+
+CONTROLBAR:FireAntiTankMissiles
+"Fire &Missiles"
+END
+
+CONTROLBAR:FireRocketPods
+"Fire &Rockets"
+END
+
+CONTROLBAR:FireNapalmMissile
+"Fire &Napalm"
+END
+
+CONTROLBAR:DaisyCutter
+"Fuel Air &Bomb"
+END
+
+CONTROLBAR:NeutronMissile
+"&Nuclear Missile"
+END
+
+CONTROLBAR:ScudStorm
+"SC&UD Storm"
+END
+
+CONTROLBAR:NapalmStrike
+"&Napalm Strike"
+END
+
+CONTROLBAR:A10ThunderboltMissileStrike
+"&A10 Missile Strike"
+END
+
+CONTROLBAR:CashHack
+"&Cash Hack"
+END
+
+CONTROLBAR:Ambush
+"&Ambush"
+END
+
+CONTROLBAR:BlackMarketNuke
+"Black Market  \n Nuke"
+END
+
+CONTROLBAR:AnthraxBomb
+"Anthrax &Bomb"
+END
+
+CONTROLBAR:Paradrop
+"Paradr&op"
+END
+
+CONTROLBAR:CarpetBomb
+"Carpe&t Bomb"
+END
+
+CONTROLBAR:ClusterMines
+"Cluster M&ines"
+END
+
+CONTROLBAR:EMPPulse
+"EMP P&ulse"
+END
+
+CONTROLBAR:ArtilleryBarrage
+"Artillery &Barrage"
+END
+
+CONTROLBAR:CrateDrop
+"Crate  \n Drop"
+END
+
+CONTROLBAR:SpySatellite
+"&Spy Satellite"
+END
+
+CONTROLBAR:SpyDrone
+"Sp&y Drone"
+END
+
+CONTROLBAR:RadarVanScan
+"Radar S&can"
+END
+
+CONTROLBAR:Defector
+"&Defector"
+END
+
+CONTROLBAR:Bayonet
+"&Bayonet"
+END
+
+CONTROLBAR:SniperAttack
+"S&niper Attack"
+END
+
+CONTROLBAR:CaptureBuilding
+"&Capture Building"
+END
+
+CONTROLBAR:DisableVehicleHack
+"&Vehicle Hack"
+END
+
+CONTROLBAR:StealCashHack
+"Cash Hac&k"
+END
+
+CONTROLBAR:InternetHack
+"Hack &Internet"
+END
+
+CONTROLBAR:DisableBuildingHack
+"&Disable Building"
+END
+
+CONTROLBAR:CarBomb
+"&Car Bomb"
+END
+
+CONTROLBAR:Hijack
+"Hi&jack"
+END
+
+CONTROLBAR:TNTAttack
+"&TNT Attack"
+END
+
+CONTROLBAR:Requirements
+"Requires: %s"
+END
+
+CONTROLBAR:LaserMissileAttack
+"&Q: Laser Missile Attack"
+END
+
+CONTROLBAR:KnifeAttack
+"&Knife Attack"
+END
+
+CONTROLBAR:ClimbCliff
+"&Climb Cliff"
+END
+
+CONTROLBAR:TimedDemoCharge
+"&Timed Demo Charge"
+END
+
+CONTROLBAR:RemoteDemoCharge
+"&Remote Demo Charge"
+END
+
+CONTROLBAR:DetonateCharges
+"&Detonate Charges"
+END
+
+CONTROLBAR:DetonateNuke
+"Detonate &Nuke"
+END
+
+CONTROLBAR:ManualControl
+"&Manual Control"
+END
+
+CONTROLBAR:ProximityFuse
+"&Proximity Fuse"
+END
+
+CONTROLBAR:Detonate
+"&Detonate!"
+END
+
+CONTROLBAR:EmergencyRepair
+"&Emergency Repair"
+END
+
+CONTROLBAR:FireParticleUplinkCannon
+"&Particle Cannon"
+END
+
+CONTROLBAR:Options
+"In-Game Menu"
+END
+
+CONTROLBAR:OptionsDescription
+"This will open up the In-Game Menu"
+END
+
+CONTROLBAR:IdleWorker
+"Idle Worker"
+END
+
+CONTROLBAR:IdleWorkerDescription
+"Click to select the next idle worker"
+END
+
+CONTROLBAR:Beacon
+"Beacon"
+END
+
+CONTROLBAR:BeaconDescription
+"Click to place a beacon"
+END
+
+CONTROLBAR:Communicator
+"Communicator"
+END
+
+CONTROLBAR:CommunicatorDescription
+"Click to open the Generals Communicator"
+END
+
+CONTROLBAR:AmbulanceCleanupArea
+"&Clean Toxins"
+END
+
+RADAR:UnitUnderAttack
+"Unit under attack"
+END
+
+RADAR:StructureUnderAttack
+"Structure under attack"
+END
+
+RADAR:UnderAttack
+"Under attack"
+END
+
+RADAR:Infiltration
+"Enemy infiltration detected"
+END
+
+UPGRADE:AdvancedTraining
+"Advanced Training"
+END
+
+UPGRADE:AmericaLaserMissiles
+"America Laser Missiles"
+END
+
+UPGRADE:Mines
+"Land Mines"
+END
+
+UPGRADE:Radar
+"Radar"
+END
+
+UPGRADE:OverlordGattlingCannon
+"Overlord Gattling Cannon"
+END
+
+UPGRADE:OverlordPropagandaTower
+"Overlord Propaganda Tower"
+END
+
+UPGRADE:OverlordBattleBunker
+"Overlord Battle Bunker"
+END
+
+UPGRADE:ControlRods
+"Control Rods"
+END
+
+UPGRADE:ScoutDrone
+"Scout Drone"
+END
+
+UPGRADE:BattleDrone
+"Battle Drone"
+END
+
+UPGRADE:RangerFlashBangGrenade
+"Ranger Flash-Bang Grenades"
+END
+
+UPGRADE:HoverTank
+"Hover Tank"
+END
+
+UPGRADE:TomahawkRemoteControl
+"Cruise Missiles"
+END
+
+UPGRADE:AircraftFuel
+"Aircraft Fuel"
+END
+
+UPGRADE:LaserMissiles
+"Laser Missiles"
+END
+
+UPGRADE:TOWMissile
+"TOW Missile"
+END
+
+UPGRADE:ComancheRocketPods
+"Comanche Rocket Pods"
+END
+
+UPGRADE:RailGun
+"Rail Gun"
+END
+
+UPGRADE:Nationalism
+"Nationalism"
+END
+
+UPGRADE:AntiTankGrenade
+"Anti-Tank Grenades"
+END
+
+UPGRADE:VehicleHack
+"Vehicle Hack"
+END
+
+UPGRADE:IRGoggles
+"Infrared Goggles"
+END
+
+UPGRADE:BlackNapalm
+"Black Napalm"
+END
+
+UPGRADE:ChainGuns
+"Chain Guns"
+END
+
+UPGRADE:SubliminalMessaging
+"Subliminal Messaging"
+END
+
+UPGRADE:UraniumShells
+"Uranium Shells"
+END
+
+UPGRADE:NuclearTanks
+"Nuclear Tanks"
+END
+
+UPGRADE:StunBullets
+"Stun Bullets"
+END
+
+UPGRADE:TranqDarts
+"Tranq. Darts"
+END
+
+UPGRADE:APBullets
+"AP Bullets"
+END
+
+UPGRADE:BioBomb
+"Bio-Bomb"
+END
+
+UPGRADE:HighExplosiveBomb
+"High-Explosive Bomb"
+END
+
+UPGRADE:ArmTheMob
+"Arm The Mob"
+END
+
+UPGRADE:ScorpionRocket
+"Scorpion Rocket"
+END
+
+UPGRADE:SCUDLauncherExplosiveWarhead
+"Explosive Warhead"
+END
+
+UPGRADE:SCUDLauncherAnthraxWarhead
+"Anthrax Warhead"
+END
+
+UPGRADE:BuggyAmmo
+"Rocket Buggy Ammo"
+END
+
+UPGRADE:AnthraxBeta
+"Anthrax Beta"
+END
+
+UPGRADE:ToxinShells
+"Toxin Shells"
+END
+
+UPGRADE:JunkRepair
+"Junk Repair"
+END
+
+UPGRADE:Camouflage
+"Camouflage"
+END
+
+UPGRADE:CompositeArmor
+"Composite Armor"
+END
+
+OBJECT:Beacon
+"Beacon"
+END
+
+OBJECT:Dam
+"Dam"
+END
+
+OBJECT:CommandCenter
+"Command Center"
+END
+
+OBJECT:ColdFusionReactor
+"Cold Fusion Reactor"
+END
+
+OBJECT:NuclearReactor
+"Nuclear Reactor"
+END
+
+OBJECT:DemoTrap
+"Demo Trap"
+END
+
+OBJECT:PowerPlant
+"Power Plant"
+END
+
+OBJECT:DetentionCamp
+"Detention Camp"
+END
+
+OBJECT:StrategyCenter
+"Strategy Center"
+END
+
+OBJECT:Airfield
+"Air Field"
+END
+
+OBJECT:SupplyCenter
+"Supply Center"
+END
+
+OBJECT:AmericaSupplyDropZone
+"Supply Drop Zone"
+END
+
+OBJECT:SupplyStash
+"Supply Stash"
+END
+
+OBJECT:Barracks
+"Barracks"
+END
+
+OBJECT:BlackMarket
+"Black Market"
+END
+
+OBJECT:WarFactory
+"War Factory"
+END
+
+OBJECT:ArmsDealer
+"Arms Dealer"
+END
+
+OBJECT:AmmoCache
+"Ammo Cache"
+END
+
+OBJECT:AmphibiousTransport
+"Amphibious Transport"
+END
+
+OBJECT:AutoFerry
+"Automobile Ferry"
+END
+
+OBJECT:TrainGuide
+"Train Guide"
+END
+
+OBJECT:AngryMob
+"Angry Mob"
+END
+
+OBJECT:TankHunter
+"Tank Hunter"
+END
+
+OBJECT:Apartment
+"Apartment"
+END
+
+OBJECT:ChemicalFactory
+"Chemical Factory"
+END
+
+OBJECT:GovBuilding
+"Government Building"
+END
+
+OBJECT:TechHospital
+"Hospital -- Capture to allow all infantry to auto heal"
+END
+
+OBJECT:ApartmentComplex
+"Apartment Complex"
+END
+
+OBJECT:SpyPost
+"Spy Post"
+END
+
+OBJECT:SupplyPile
+"Supply Pile"
+END
+
+OBJECT:TrainStation
+"Train Station"
+END
+
+OBJECT:TechRadioStation
+"Radio Station"
+END
+
+OBJECT:TechOilDerrick
+"Oil Derrick -- Capture to receive additional funds"
+END
+
+OBJECT:Arcade
+"Arcade"
+END
+
+OBJECT:Aurora
+"Aurora Bomber"
+END
+
+OBJECT:A10Thunderbolt
+"A10 Thunderbolt"
+END
+
+OBJECT:AVPOWTRUCK
+"POW Truck"
+END
+
+OBJECT:B52
+"B52"
+END
+
+OBJECT:BMW
+"Car"
+END
+
+OBJECT:Bank
+"Bank"
+END
+
+OBJECT:BarnCoop
+"Barn Coop"
+END
+
+OBJECT:BarnShed
+"Barn Shed"
+END
+
+OBJECT:Barrel
+"Barrel"
+END
+
+OBJECT:BattleDrone
+"Battle Drone"
+END
+
+OBJECT:BattleMaster
+"Battlemaster"
+END
+
+OBJECT:Battleship
+"Battleship"
+END
+
+OBJECT:BigRig
+"Big Rig"
+END
+
+OBJECT:BikeRack
+"Bike Rack"
+END
+
+OBJECT:Billboard
+"Billboard"
+END
+
+OBJECT:Bird
+"Bird"
+END
+
+OBJECT:BombTruck
+"Bomb Truck"
+END
+
+OBJECT:Boulders
+"Boulders"
+END
+
+OBJECT:Boxes
+"Boxes"
+END
+
+OBJECT:BrickWall
+"Brick Wall"
+END
+
+OBJECT:BrokenWall
+"Broken Wall"
+END
+
+OBJECT:Bunker
+"Bunker"
+END
+
+OBJECT:BurningBarricade
+"Burning Barricade"
+END
+
+OBJECT:Checkpoint
+"Checkpoint"
+END
+
+OBJECT:BusStop
+"Bus Stop"
+END
+
+OBJECT:Bush
+"Bush"
+END
+
+OBJECT:Camaro
+"Car"
+END
+
+OBJECT:CarBug
+"Car"
+END
+
+OBJECT:CarSwatchEuro
+"Car"
+END
+
+OBJECT:CargoLoadingCranes
+"Cargo Loading Cranes"
+END
+
+OBJECT:CargoNet
+"Cargo Net"
+END
+
+OBJECT:Cart
+"Cart"
+END
+
+OBJECT:ChainLinkFence
+"Chain-link Fence"
+END
+
+OBJECT:Chalet
+"Chalet"
+END
+
+OBJECT:CheckPointCrossingGuard
+"Checkpoint"
+END
+
+OBJECT:Chinook
+"Chinook"
+END
+
+OBJECT:Church
+"Church"
+END
+
+OBJECT:Clete
+"Cleat"
+END
+
+OBJECT:ClothesLine
+"Clothesline"
+END
+
+OBJECT:Comanche
+"Comanche"
+END
+
+OBJECT:ComancheHull
+"Comanche Hull"
+END
+
+OBJECT:CompactCar
+"Compact Car"
+END
+
+OBJECT:Ambassador
+"Ambassador"
+END
+
+OBJECT:Redguard
+"Red Guard"
+END
+
+OBJECT:ConstructionBarricade
+"Construction Barricade"
+END
+
+OBJECT:ConvenienceStore
+"Convenience Store"
+END
+
+OBJECT:ConvoyTruck
+"Convoy Truck"
+END
+
+OBJECT:Cottage
+"Cottage"
+END
+
+OBJECT:Crate
+"Crate"
+END
+
+OBJECT:CrossingGuard
+"Crossing Guard"
+END
+
+OBJECT:Crusader
+"Crusader"
+END
+
+OBJECT:Paladin
+"Paladin"
+END
+
+OBJECT:DaisyCutterBomb
+"Fuel Air Bomb"
+END
+
+OBJECT:BlackMarketNuke
+"Black Market Nuke"
+END
+
+OBJECT:ToxinTank
+"Toxin Tank"
+END
+
+OBJECT:AnthraxBomb
+"Anthrax Bomb"
+END
+
+OBJECT:CarpetBomb
+"Carpet Bomb"
+END
+
+OBJECT:ClusterMinesBomb
+"Cluster Mines"
+END
+
+OBJECT:EMPPulseBomb
+"EMP Pulse"
+END
+
+OBJECT:NeutronMissile
+"Nuclear Missile"
+END
+
+OBJECT:Dealership
+"Dealership"
+END
+
+OBJECT:Dirt
+"Dirt"
+END
+
+OBJECT:Docks
+"Docks"
+END
+
+OBJECT:DogwoodTree
+"Tree"
+END
+
+OBJECT:Dozer
+"Construction Dozer"
+END
+
+OBJECT:Dragon
+"Dragon Tank"
+END
+
+OBJECT:ElectricRetail
+"Electric Retail"
+END
+
+OBJECT:ElectricalTransformer
+"Electrical Transformer"
+END
+
+OBJECT:FireHydrant
+"Fire Hydrant"
+END
+
+OBJECT:StructureMine
+"Mine"
+END
+
+OBJECT:ClusterMine
+"Mine"
+END
+
+OBJECT:FireStorm
+"Fire Storm"
+END
+
+OBJECT:FlamingInfantry
+"Flaming Infantry"
+END
+
+OBJECT:ToxicInfantry
+"Toxic Infantry"
+END
+
+OBJECT:FoodCart
+"Food Cart"
+END
+
+OBJECT:Fountain
+"Fountain"
+END
+
+OBJECT:FruitStand
+"Fruit Stand"
+END
+
+OBJECT:Gargoyle
+"Gargoyle"
+END
+
+OBJECT:GasStation
+"Gas Station"
+END
+
+OBJECT:GasStorageFacility
+"Gas Storage Facility"
+END
+
+OBJECT:GattlingTank
+"Gattling Tank"
+END
+
+OBJECT:GrassHut
+"Grass Hut"
+END
+
+OBJECT:Gravel
+"Gravel"
+END
+
+OBJECT:FlashBangGrenade
+"Flash-Bang Grenade"
+END
+
+OBJECT:TankShell
+"Tank Shell"
+END
+
+OBJECT:Rebel
+"Rebel"
+END
+
+OBJECT:JarmenKell
+"Jarmen Kell"
+END
+
+OBJECT:GuardTower
+"Guard Tower"
+END
+
+OBJECT:GuardianControlCenter
+"Guardian Control Center"
+END
+
+OBJECT:GuardianDrone
+"Guardian Drone"
+END
+
+OBJECT:BlackLotus
+"Black Lotus"
+END
+
+OBJECT:Hanger
+"Hangar"
+END
+
+OBJECT:HarvardsOffice
+"Trash Bin"
+END
+
+OBJECT:Hedge
+"Hedge"
+END
+
+OBJECT:HighwaySign
+"Highway Sign"
+END
+
+OBJECT:Hijacker
+"Hijacker"
+END
+
+OBJECT:AngryMobNexus
+"<<ANGRY M0B>>"
+END
+
+OBJECT:Hotel
+"Hotel"
+END
+
+OBJECT:Humvee
+"Humvee"
+END
+
+OBJECT:POWTruck
+"POW Truck"
+END
+
+OBJECT:IndustrialBuilding
+"Industrial Building"
+END
+
+OBJECT:InfernoCannon
+"Inferno Cannon"
+END
+
+OBJECT:JapaneseLantern
+"Japanese Lantern"
+END
+
+OBJECT:JunkCar
+"Junk Car"
+END
+
+OBJECT:Limo
+"Limo"
+END
+
+OBJECT:Lumber
+"Lumber"
+END
+
+OBJECT:MIG
+"MiG"
+END
+
+OBJECT:MailBox
+"MailBox"
+END
+
+OBJECT:ManHoleCover
+"ManHole Cover"
+END
+
+OBJECT:MapleTree
+"Tree"
+END
+
+OBJECT:MarketVendor
+"Market Vendor"
+END
+
+OBJECT:Medic
+"Ambulance"
+END
+
+OBJECT:MegaMall
+"Mega Mall"
+END
+
+OBJECT:Missile
+"Missile"
+END
+
+OBJECT:MissileTeam
+"Missile Defender"
+END
+
+OBJECT:Moat
+"Moat"
+END
+
+OBJECT:MogadishuHighrise
+"Highrise"
+END
+
+OBJECT:NewsStand
+"News Stand"
+END
+
+OBJECT:NightClub
+"Night Club"
+END
+
+OBJECT:NotAMosque
+"Dome"
+END
+
+OBJECT:NuclearMissile
+"Nuclear Missile"
+END
+
+OBJECT:NukeLauncher
+"Nuke Cannon"
+END
+
+OBJECT:ParticleCannon
+"Particle Cannon"
+END
+
+OBJECT:OakTree
+"Tree"
+END
+
+OBJECT:Office
+"Office"
+END
+
+OBJECT:OilDepot
+"Oil Depot"
+END
+
+OBJECT:OilRefinery
+"Oil Refinery"
+END
+
+OBJECT:OilTank
+"Oil Tank"
+END
+
+OBJECT:OldWoodenTelephonePole
+"Telephone Pole"
+END
+
+OBJECT:Outpost
+"Outpost"
+END
+
+OBJECT:Overlord
+"Overlord"
+END
+
+OBJECT:Palace
+"Palace"
+END
+
+OBJECT:PalmTree
+"Tree"
+END
+
+OBJECT:ParkBench
+"Park Bench"
+END
+
+OBJECT:ParkGazebo
+"Park Gazebo"
+END
+
+OBJECT:ParkPavillion
+"Park Pavilion"
+END
+
+OBJECT:ParkingGarage
+"Parking Garage"
+END
+
+OBJECT:ParkingMeter
+"Parking Meter"
+END
+
+OBJECT:Pathfinder
+"Pathfinder"
+END
+
+OBJECT:PatriotBattery
+"Patriot Missile System"
+END
+
+OBJECT:GattlingCannon
+"Gattling Cannon"
+END
+
+OBJECT:PatriotMissile
+"Patriot Missile System"
+END
+
+OBJECT:PhoneBooth
+"Phone Booth"
+END
+
+OBJECT:PineTree
+"Tree"
+END
+
+OBJECT:PoliceCar
+"Police Car"
+END
+
+OBJECT:Prison
+"Prison"
+END
+
+OBJECT:PropagandaBlimp
+"Prop. Blimp"
+END
+
+OBJECT:PropagandaCenter
+"Propaganda Center"
+END
+
+OBJECT:Pub
+"Watering Hole"
+END
+
+OBJECT:QuadCannon
+"Quad Cannon"
+END
+
+OBJECT:QuonsetHut
+"Quonset Hut"
+END
+
+OBJECT:RailTie
+"Rail Tie"
+END
+
+OBJECT:Ranger
+"Ranger"
+END
+
+OBJECT:Raptor
+"Raptor"
+END
+
+OBJECT:RaptorPilot
+"Pilot"
+END
+
+OBJECT:Restaurant
+"Restaurant"
+END
+
+OBJECT:RetailStore
+"Retail Store"
+END
+
+OBJECT:RiverHouse
+"River House"
+END
+
+OBJECT:RoadCone
+"Road Cone"
+END
+
+OBJECT:RocketBuggy
+"Rocket Buggy"
+END
+
+OBJECT:RadarVan
+"Radar Van"
+END
+
+OBJECT:RocketBuggyDebris
+"Rocket Buggy Debris"
+END
+
+OBJECT:RocketBuggyMissile
+"Rocket Buggy Missile"
+END
+
+OBJECT:TomahawkMissile
+"Tomahawk Missile"
+END
+
+OBJECT:SCUDMissile
+"SCUD Missile"
+END
+
+OBJECT:RangerTeamMissile
+"Ranger Team Missile"
+END
+
+OBJECT:Rocks
+"Rocks"
+END
+
+OBJECT:RopeCoil
+"Rope Coil"
+END
+
+OBJECT:Rubble
+"Rubble"
+END
+
+OBJECT:ColonelBurton
+"Colonel Burton"
+END
+
+OBJECT:SUV
+"SUV"
+END
+
+OBJECT:Schoolhouse
+"Schoolhouse"
+END
+
+OBJECT:Scorpion
+"Scorpion"
+END
+
+OBJECT:Marauder
+"Marauder Tank"
+END
+
+OBJECT:ScoutDrone
+"Scout Drone"
+END
+
+OBJECT:SpyDrone
+"Spy Drone"
+END
+
+OBJECT:ScrapCar
+"Scrap Car"
+END
+
+OBJECT:ScudLauncher
+"SCUD Launcher"
+END
+
+OBJECT:ScudStorm
+"SCUD Storm"
+END
+
+OBJECT:SecretLab
+"Secret Lab"
+END
+
+OBJECT:SecretPolice
+"Secret Police"
+END
+
+OBJECT:SecurityFence
+"Security Fence"
+END
+
+OBJECT:Hacker
+"Hacker"
+END
+
+OBJECT:Officer
+"Officer"
+END
+
+OBJECT:Agent
+"Agent"
+END
+
+OBJECT:Sedan
+"Sedan"
+END
+
+OBJECT:SeismicTank
+"Seismic Tank"
+END
+
+OBJECT:Shack
+"Shack"
+END
+
+OBJECT:ShippingContainer
+"Shipping Container"
+END
+
+OBJECT:ShippingCrate
+"Shipping Crate"
+END
+
+OBJECT:SignalLights
+"Signal Lights"
+END
+
+OBJECT:Slide
+"Slide"
+END
+
+OBJECT:SovietBuilding
+"Old Office Building"
+END
+
+OBJECT:SovietGovtBuildingSmall
+"Old Govt. Building"
+END
+
+OBJECT:SovietRadioBuilding
+"Old Radio Building"
+END
+
+OBJECT:SpeakerTower
+"Speaker Tower"
+END
+
+OBJECT:SportCar
+"Sports Car"
+END
+
+OBJECT:Sprinkler
+"Sprinkler"
+END
+
+OBJECT:SpruceTree
+"Tree"
+END
+
+OBJECT:StanTallTower
+"Tall Tower"
+END
+
+OBJECT:Starlifter
+"Starlifter2"
+END
+
+OBJECT:StatueAngel
+"Angel Statue"
+END
+
+OBJECT:StatueLenin
+"Statue"
+END
+
+OBJECT:StatueRoman
+"Roman Statue"
+END
+
+OBJECT:StealthFighter
+"Stealth Fighter"
+END
+
+OBJECT:StingerSite
+"Stinger Site"
+END
+
+OBJECT:StoneArch
+"Stone Arch"
+END
+
+OBJECT:StoneWall
+"Stone Wall"
+END
+
+OBJECT:PicketFence
+"Picket Fence"
+END
+
+OBJECT:StopLight
+"Stop Light"
+END
+
+OBJECT:StreetLamp
+"Street Lamp"
+END
+
+OBJECT:StreetLight
+"Street Light"
+END
+
+OBJECT:StreetSign
+"Street Sign"
+END
+
+OBJECT:SupplyTruck
+"Supply Truck"
+END
+
+OBJECT:SupplyWarehouse
+"Supply Dock"
+END
+
+OBJECT:Swing
+"Swing"
+END
+
+OBJECT:TVStation
+"TV Station"
+END
+
+OBJECT:TankTrap
+"Tank Trap"
+END
+
+OBJECT:TankerTruck
+"Tanker Truck"
+END
+
+OBJECT:TaxiCab
+"Taxi Cab"
+END
+
+OBJECT:Technical
+"Technical"
+END
+
+OBJECT:Tent
+"Tent"
+END
+
+OBJECT:Terrorist
+"Terrorist"
+END
+
+OBJECT:Tire
+"Tire"
+END
+
+OBJECT:TireObstacle
+"Tire Obstacle"
+END
+
+OBJECT:Tollbooth
+"Toll booth"
+END
+
+OBJECT:Tomahawk
+"Tomahawk"
+END
+
+OBJECT:TownHouse
+"Townhouse"
+END
+
+OBJECT:ToxinTruck
+"Toxin Tractor"
+END
+
+OBJECT:TrashCan
+"Trash Can"
+END
+
+OBJECT:TrashDumpster
+"Trash Bin"
+END
+
+OBJECT:TrashPaper
+"Trash Paper"
+END
+
+OBJECT:TrashPile
+"Trash Pile"
+END
+
+OBJECT:TreeStump
+"Tree Stump"
+END
+
+OBJECT:TroopCrawler
+"Troop Crawler"
+END
+
+OBJECT:TunnelDefender
+"RPG Trooper"
+END
+
+OBJECT:TunnelNetwork
+"Tunnel Network"
+END
+
+OBJECT:Cave
+"Cave"
+END
+
+OBJECT:GLAHole
+"GLA Hole"
+END
+
+OBJECT:GLARock
+"GLA Rock"
+END
+
+OBJECT:UNHumvee
+"UN Humvee"
+END
+
+OBJECT:UNSoldier
+"UN Soldier"
+END
+
+OBJECT:VendingMachine
+"Vending Machine"
+END
+
+OBJECT:Wall
+"Wall"
+END
+
+OBJECT:ConcreteWall
+"Concrete Wall"
+END
+
+OBJECT:WatchTower
+"Watch Tower"
+END
+
+OBJECT:WaterPlant
+"Water Plant"
+END
+
+OBJECT:WindMill
+"Wind Mill"
+END
+
+OBJECT:WoodBeams
+"Wood Beams"
+END
+
+OBJECT:WoodTower
+"Wood Tower"
+END
+
+OBJECT:WoodWall
+"Wood Wall"
+END
+
+OBJECT:WoodenBarrels
+"Wooden Barrels"
+END
+
+OBJECT:Worker
+"Worker"
+END
+
+OBJECT:Birch
+"Tree"
+END
+
+OBJECT:Building
+"Building"
+END
+
+OBJECT:Cathedral
+"Cathedral"
+END
+
+OBJECT:FarmHouse
+"Farm House"
+END
+
+OBJECT:Fir
+"Tree"
+END
+
+OBJECT:Garage
+"Garage"
+END
+
+OBJECT:OscarTheGrouch
+"Junk Dealer"
+END
+
+OBJECT:Pilot
+"Pilot"
+END
+
+OBJECT:Pump
+"Pump"
+END
+
+OBJECT:Shop
+"Shop"
+END
+
+OBJECT:StingerMissile
+"Stinger Missile"
+END
+
+OBJECT:StingerSoldier
+"Stinger Soldier"
+END
+
+OBJECT:StorageTank
+"Storage Tank"
+END
+
+OBJECT:Well
+"Well"
+END
+
+OBJECT:WineVat
+"Vat"
+END
+
+OBJECT:GenericMale
+"Civilian"
+END
+
+OBJECT:GenericFemale
+"Civilian"
+END
+
+OBJECT:MogadishuFemaleCivilian
+"Civilian"
+END
+
+OBJECT:MogadishuMaleCivilian
+"Civilian"
+END
+
+OBJECT:Crane
+"Crane"
+END
+
+OBJECT:OceanCenter
+"Convention Center"
+END
+
+OBJECT:SoccerStadium
+"Soccer Stadium"
+END
+
+OBJECT:Ambulance
+"Ambulance"
+END
+
+OBJECT:AsianCar
+"Car"
+END
+
+OBJECT:Backhoe
+"Backhoe"
+END
+
+OBJECT:LargeForklift
+"Large Forklift"
+END
+
+OBJECT:SmallForklift
+"Forklift"
+END
+
+OBJECT:CropDuster
+"Crop Duster"
+END
+
+OBJECT:Cessna
+"Plane"
+END
+
+OBJECT:ChickenTruck
+"Chicken Truck"
+END
+
+OBJECT:Combine
+"Combine"
+END
+
+OBJECT:Eurovan
+"Van"
+END
+
+OBJECT:EuroPoliceVan
+"Police Van"
+END
+
+OBJECT:Firetruck
+"Fire Truck"
+END
+
+OBJECT:FarmerTruck
+"Farmer Truck"
+END
+
+OBJECT:AsianFishingBoat
+"Fishing Boat"
+END
+
+OBJECT:TourBus
+"Tour Bus"
+END
+
+OBJECT:FishingTrowler
+"Fishing Trawler"
+END
+
+OBJECT:WorkTruck
+"Work Truck"
+END
+
+OBJECT:TugBoat
+"Tug Boat"
+END
+
+OBJECT:BioHazardTech
+"Bio-Hazard Technician"
+END
+
+OBJECT:MilitiaTank
+"Militia Tank"
+END
+
+Network:PlayerDisconnected
+"%s has been disconnected"
+END
+
+Network:PlayerLeftGame
+"%s has left the game"
+END
+
+Network:Vote
+"Vote"
+END
+
+Network:QuitGame
+"QUIT GAME"
+END
+
+MAP:AlpineAssault
+"Alpine Assault"
+END
+
+MAP:AustrianAmbush
+"Market Garden"
+END
+
+MAP:Badlands
+"Desert Fury"
+END
+
+MAP:BridgeBusters
+"Iron Dragon"
+END
+
+MAP:KashmarKlash
+"Wasteland Warlords"
+END
+
+MAP:Oasis
+"Golden Oasis"
+END
+
+MAP:ScorchedEarth
+"Scorched Earth"
+END
+
+MAP:SleepyHollow
+"Heartland Shield"
+END
+
+MAP:SmalltownUSA
+"Homeland Alliance"
+END
+
+MAP:TampicoTrauma
+"Silent River"
+END
+
+MAP:WoodcrestCircle
+"Final Crusader"
+END
+
+MAP:XinjiangBang
+"Winter Wolf"
+END
+
+Audio:Speakers0
+"2 Speakers"
+END
+
+Audio:Speakers1
+"Headphones"
+END
+
+Audio:Speakers2
+"Surround Sound"
+END
+
+Audio:Speakers3
+"4 Speaker"
+END
+
+Audio:Speakers4
+"5.1 Surround"
+END
+
+Audio:Speakers5
+"7.1 Surround"
+END
+
+MAP:CHI01ObjectiveText
+"MISSION OBJECTIVE  \n Destroy the Nuclear Warhead Storage Facility"
+END
+
+MAP:CHI02Open
+"Hong Kong, China  \n Hong Kong Crisis"
+END
+
+SCRIPT:CHI02AudioHolder01
+"<Red Guard speaking>  \n 'General, we're all that's left of the assault force! We need to build a Command Center and get the radar up to receive new orders'"
+END
+
+SCRIPT:CHI02AudioHolder02
+"<Red Guard speaking>  \n 'General, if we don't get our radar up we can't receive intelligence on the enemy's position. We need that radar'"
+END
+
+SCRIPT:CHI02AudioHolder03
+"<'EVA' speaking>  \n 'General, you're alive!?! We thought we lost you when the bridge went down. Well, you're not out of danger yet, so let's get started'"
+END
+
+SCRIPT:CHI02AudioHolder04
+"<'EVA' speaking>  \n 'First, you're going to need to finish your base. The barracks, reactor, and supply center are all essential to your survival, so finish constructing them immediately. I'll contact you again once your base is complete'"
+END
+
+SCRIPT:CHI02AudioHolder05
+"<'EVA' speaking>  \n 'Excellent, your base is complete, except for a War Factory. We need to get you one now. There should be a surplus base--with a War Factory--here'"
+END
+
+SCRIPT:CHI02AudioHolder06
+"<'EVA' speaking>  \n 'I don't know what condition the base is in, but it should allow you to build armored units to help your fight. Get there as soon as possible, General.'"
+END
+
+SCRIPT:CHI02AudioHolder07
+"<'EVA' speaking>  \n 'Now we know the GLA's reason for coming to Hong Kong: They're targeting key buildings around the city. Our main objective is to destroy all of the GLA's forces, but if we can also keep them from destroying those buildings, our leaders would be most grateful.'"
+END
+
+SCRIPT:CHI02AudioHolder08
+"<'EVA' speaking>  \n 'If you can keep your radar operating, I can track the Terrorists for you and give you their possible targets.'"
+END
+
+SCRIPT:CHI02AudioHolder09
+"<'EVA' speaking>  \n 'General, a Terrorist is leaving the Convention Center, and he's strapped with enough explosives to bring down a building! I'll mark the Terrorist in red on your radar. I'll mark his possible targets in yellow. Stop him before he reaches one of those targets!'"
+END
+
+SCRIPT:CHI02AudioHolder10
+"<'EVA' speaking>  \n 'Another Terrorist has left the Convention Center! I'll mark his location in red. His possible targets are marked in yellow. Stop him, General.'"
+END
+
+SCRIPT:CHI02AudioHolder11
+"<'EVA' speaking>  \n 'General, this building is a Terrorist target--we must protect it!'"
+END
+
+SCRIPT:CHI02AudioHolder12
+"<'EVA' speaking>  \n 'General, the Terrorists have taken over the Convention Center! You're going to have to destroy the Convention Center and the attached parking structures to stop the Terrorist threat.'"
+END
+
+SCRIPT:CHI02AudioHolder13
+"<'EVA' speaking>  \n 'Excellent, you've reached the surplus base. Hmm, it's not much to look at, but it will allow you to build tanks, and more War Factories, if you need.'"
+END
+
+SCRIPT:CHI02AudioHolder14
+"<'EVA' speaking>  \n 'The Terrorist threat is finished. Good work, General.'"
+END
+
+SCRIPT:CHI02AudioHolder15
+"<'EVA' speaking>  \n 'General, I've detected GLA armored units on the move. They didn't come from the Convention Center, so the GLA must have another base somewhere in Hong Kong. Find that base and destroy it!'"
+END
+
+SCRIPT:CHI02AudioHolder16
+"<'EVA' speaking>  \n 'General, the GLA have brought their Toxin Tractors with them. You'll know them by the green ooze they spray. Keep your infantry units away from them and use your tanks to deal with this new threat.'"
+END
+
+SCRIPT:CHI02AudioHolder17
+"<'EVA' speaking>  \n 'Good work, General, you've destroyed the Toxin base. Now they shouldn't be able to build any more Toxin Tractors.'"
+END
+
+SCRIPT:CHI02AudioHolder18
+"<'EVA' speaking>  \n 'Wait, General, there is a large force up ahead. I'll call for an EMP strike to clear the area, standby.'"
+END
+
+SCRIPT:CHI02AudioHolder19
+"<'EVA' speaking>  \n 'That should give you a clear path to their base. Let's finish this, General.'"
+END
+
+SCRIPT:CHI02AudioHolder20
+"<AutoFerry Capt. speaking>  \n 'Finally, the military is here! Those Terrorists are ruining my business! If you put your forces aboard I'll take you out to the Convention Center. You can sneak in the backdoor and catch them by surprise. Jut hit the Transport button when you're ready.'"
+END
+
+SCRIPT:CHI02Box01
+"Use the DOZER to build the COMMAND CENTER  \n Once the COMMAND CENTER is complete,  \n select it and begin the RADAR upgrade  \n Once the upgrade is finished, a radar screen will appear  \n in the lower-left-hand corner of the Command Interface"
+END
+
+SCRIPT:CHI02Box02
+"NEW UNIT: DRAGON TANK  \n The DRAGON TANK breathes fire that can quickly dispatch enemy infantry,  \n even if they are garrisoned inside a building or structure"
+END
+
+MAP:CHI02Obj01
+"MISSION OBJECTIVE:  \n Destroy the Convention Center  \n and its attached parking structures  \n to stop the Terrorist threat"
+END
+
+MAP:CHI02Obj02
+"MISSION OBJECTIVE:  \n Destroy the GLA base"
+END
+
+MAP:CHI02SecondaryObj01
+"Secondary Objective:  \n Stop GLA Terrorists from destroying  \n targeted buildings in downtown Hong Kong"
+END
+
+MAP:CHI02SecondaryObj02
+"Secondary Objective:  \n Destroy the Toxin Tractor production facility"
+END
+
+MAP:CHI03Open
+"Three Gorges Dam...Hubei Province, China  \n A Flood of Violence"
+END
+
+MAP:CHI03Obj1
+"MISSION OBJECTIVE:  \n Destroy the Dam"
+END
+
+MAP:CHI03Obj2
+"MISSION OBJECTIVE:  \n Destroy the GLA base"
+END
+
+MAP:CHI03Obj3
+"MISSION OBJECTIVE:  \n Defeat all remaining GLA forces"
+END
+
+MAP:CHI03AudioHolder01
+"<Red Guard speaking> 'General, the water level has dropped! GLA forces are crossing the river!'"
+END
+
+MAP:CHI06Open
+"Bishkek, Aldastan Subcapital  \n Dead in their Tracks"
+END
+
+MAP:CHI06Obj1
+"MISSION OBJECTIVE:  \n Get Black Lotus to the middle of the train bridge"
+END
+
+MAP:CHI07Open
+"Dushanbe, Aldastan Capital City  \n Nuclear Winter"
+END
+
+MAP:Demo58Open
+"Kazakhstan DMZ  \n Operation: Blue Eagle"
+END
+
+MAP:Demo58End1
+"Battle Control Off-Line..."
+END
+
+MAP:Demo58End2
+"COMMAND AND CONQUER GENERALS  \n COMING: CHRISTMAS 2002"
+END
+
+MAP:Demo48Open
+"Mazar Free Fire Zone  \n Operation: White Knight"
+END
+
+MAP:GLA02MapName
+"Pillage the Village"
+END
+
+MAP:GLA02Open
+"Villages Outside Almaty, Kazakhstan  \n Aid Supplies Drop Zone"
+END
+
+MAP:GLA02ObjectiveText01
+"MISSION OBJECTIVE  \n Collect $40,000 in stolen supplies"
+END
+
+MAP:GLA021stThirdObjective
+"First Goal:  \n Collect $20,000 by taking the UN Convoys' crates"
+END
+
+MAP:GLA022ndThirdObjective
+"Second Goal:  \n Collect $30,000 by taking the crates dropped by the US planes"
+END
+
+MAP:GLA023rdThirdObjective
+"Final Goal: Collect $40,000 in supplies by raiding the US base"
+END
+
+MAP:GLA02CivBuildingHint
+"Villagers have supplies stored in their homes  \n Destroy their homes and steal the supplies hidden there"
+END
+
+MAP:GLA02CivKillHint
+"The villagers are taking our supplies. STOP THEM"
+END
+
+MAP:GLA02QuadsArrival
+"Reinforcements have arrived:  \n Use Quad Cannons to bring down enemy aircraft"
+END
+
+MAP:GLA02CrateReminder
+"Collect the crates to reach your goal"
+END
+
+MAP:GLA02MonkeyReminder
+"You will not reach our goal if you spend all your money"
+END
+
+MAP:GLA06MapName
+"Appropriate Poisons"
+END
+
+MAP:GLA06Open
+"Western Shore of the Aral Sea, Kazakhstan  \n Toxic Waste Containment and Disposal Facilities"
+END
+
+MAP:GLA06MissionObjective
+"MISSION OBJECTIVE:  \n Capture 4 Bunkers and Wipe out all American defenders"
+END
+
+MAP:GLA06BunkerWarning
+"WARNING:  \n The Bunkers are fragile and will explode violently when destroyed"
+END
+
+MAP:GLA06BunkerDestroyed
+"WARNING:  \n The fool Americans are trying to stop us by destroying the bunkers"
+END
+
+MAP:GLA06BunkerRetaken
+"The Americans have retaken our bunker. Take it back now"
+END
+
+MAP:GLA06BunkerObjective
+"You must own 4 bunkers to complete your mission"
+END
+
+MAP:GLA06KillEnemies
+"You own the required number of bunkers  \n Now wipe out the Americans to secure your victory"
+END
+
+MAP:GLA06ScoutsInBase
+"American scouts have found us  \n Be prepared to fight the Americans"
+END
+
+MAP:GLA06Only8Bunkers
+"You must be more careful with the bunkers  \n You must own 4 to complete your mission"
+END
+
+MAP:GLA06Only6Bunkers
+"Only 6 Bunkers remain  \n If 3 more are destroyed your mission will fail"
+END
+
+MAP:GLA06Only4Bunkers
+"WARNING:  \n If another bunker is destroyed your mission will fail"
+END
+
+MAP:GLA07MapName
+"Trojan Horse"
+END
+
+MAP:GLA07Open
+"Somewhere Near Lenger, Kazakhstan  \n Splinter Cell-Controlled Region"
+END
+
+SCRIPT:GLA07ChnTmr
+"Chinese Forces Arrive In:"
+END
+
+MAP:GLA07ChineseArrival
+"WARNING: Chinese forces have entered the area"
+END
+
+MAP:GLA07MissionObjective
+"MISSION OBJECTIVE  \n Eliminate all traitors"
+END
+
+MAP:GLA07ConvoyHint01
+"Sneak the stolen trucks into the traitors' base  \n Once inside detonate the trucks to destroy the traitors"
+END
+
+MAP:GLA07ConvoyHint02
+"WARNING:  \n If your forces are seen with the stolen trucks the traitors  \n will know they are yours"
+END
+
+MAP:GLA07ConvoyHint03
+"WARNING: This area is off limits to the stolen trucks  \n If the traitors discover them here they will be attacked"
+END
+
+MAP:GLA07ConvoyHint04
+"Order the trucks to detonate near the traitors' buildings  \n for maximum effectiveness"
+END
+
+MAP:GLA07BaseKIACleanUp
+"The traitor base is destroyed  \n Wipe out their remaining forces to complete your victory"
+END
+
+MAP:GLA07ConvoyDetected
+"ALERT:  \n The traitors know we control the convoy  \n The convoy will now be attacked by the traitors"
+END
+
+MAP:GLA03Open
+"Zhambul, Kazakhstan  \n Chinese-Controlled Civilian Population Center"
+END
+
+MAP:USA01Open
+"Mazar Free Fire Zone  \n Operation: Silent Dawn"
+END
+
+SCRIPT:TrainingMove
+"Left click on units to select them. Selected units can be given commands. With a unit selected you can left click on the ground to give them a move command. Left click on enemy soldiers to order your selected unit to attack"
+END
+
+SCRIPT:TrainingCommand
+"You have liberated a USA Command Center. Here you can use many of your special abilities. To choose technologies and special weapons click on the flashing General button"
+END
+
+SCRIPT:TrainingExplor
+"The Fog of War around your units can be pushed back by moving into new and unexplored areas. The Fog shows you where you have explored and where you have not. Explore new areas to find enemy forces and resources to expand your army"
+END
+
+SCRIPT:TrainingBarracks
+"You have liberated a USA Barracks. Buildings like this allow you to train new units. The Barracks trains soldiers. Left click on your new Barracks to see what soldiers you can train. Left click on a unit in the Barracks to spend the supplies to create that unit"
+END
+
+SCRIPT:TrainingPilots
+"You have freed several Pilots. USA pilots are often veterans of many battles and they can enter your vehicles to provide their skills and experience to the crew of the vehicle. Vehicles with golden chevrons near them have experienced crews and are more effective in combat"
+END
+
+SCRIPT:TrainingSupply
+"You have liberated a USA Supply Center. Supply Centers collect supplies, providing you with the resources to build new buildings and units. Each Supply Center automatically generates a single Chinook helicopter that will gather supplies for you"
+END
+
+SCRIPT:TrainingDozer
+"You have liberated a USA Construction Dozer. Left click on your new Construction Dozer to see what buildings it can create. Select the War Factory and choose a location for it to be built. Once done creating the War Factory, the Dozer will be available for other construction projects"
+END
+
+SCRIPT:TrainingUnits
+"Your new War Factory can be used to build vehicles like Crusader Tanks. Left click on a Crusader Tank to order it to be built. You can left click multiple times to order multiple tanks to be constructed"
+END
+
+SCRIPT:TrainingPower
+"You have liberated a USA Cold Fusion Reactor. Reactors are used by American and Chinese forces to power their base. Your power bar indicates how much power your base has. If your base runs low on power base defenses may go off-line and your radar will go out"
+END
+
+SCRIPT:TrainingAbilities
+"Some units have special abilities. Select a unit to see what special powers it has. Left click on the power to activate it. In the case of the USA Crusader Tank, each tank can build a single Battle Drone. Battle Drones are small robotic helpers that automatically engage enemies and repair their Crusader Tank in case it is damaged by enemy fire"
+END
+
+SCRIPT:TrainingObjective
+"You have liberated an entire USA base and are now ready to carry the fight to the enemy. Each mission has mission objectives that you must follow in order to win the mission and to progress in your war against your enemies. Follow the mission objective to win the mission"
+END
+
+SCRIPT:TrainingUrban
+"Civilian buildings can be occupied by soldiers. Order your soldiers to enter civilian buildings to get a defensive bonus. Civilian buildings occupied in this way are powerful strong-points for your troops and can be used to defend important routes into and out of your base"
+END
+
+SCRIPT:TrainingTech
+"Civilian Objective Buildings can be captured by your Rangers. Holding these buildings will give you advantages against your enemies. Capture the Oil Derricks by selecting a Ranger, left clicking the capture button and then left clicking on the Oil Derrick itself. Oil Derricks provide you with additional resources as they pump oil"
+END
+
+SCRIPT:TrainingCrate
+"Crates contain bonus items for your soldiers that will increase their abilities. Additional ammunition, armor and other items can be found in crates. Order your soldiers or vehicles to move onto a crate to open it and collect the contents"
+END
+
+SCRIPT:TrainingMissionObjective
+"MISSION OBJECTIVE  \n Destroy GLA Bio-Weapons Factory"
+END
+
+SCRIPT:TrainingOpeningObjective
+"MISSION OBJECTIVE  \n Liberate the USA Base"
+END
+
+MAP:USA01Opening
+"Iraqi War Zone  \n Operation: Final Justice"
+END
+
+MAP:USA01BahdadText
+"Siege of Baghdad  \n Day 3"
+END
+
+MAP:USA01ObjectiveText
+"MISSION OBJECTIVE  \n Destroy the SCUD Storm"
+END
+
+MAP:USA02Open
+"Al Hanad, Yemen  \n Operation: Treasure Hunt"
+END
+
+MAP:USA02Objective1Text
+"MISSION OBJECTIVE  \n Rescue Captured Pilots"
+END
+
+MAP:USA02Objective2Text
+"MISSION OBJECTIVE  \n Return the final Pilot to Base for debriefing"
+END
+
+MAP:USA03Objective1Text
+"MISSION OBJECTIVE  \n Ensure the escape of 100 U.S. forces"
+END
+
+SCRIPT:USA03RescueCounter
+"Escaped U.S. Forces:"
+END
+
+MAP:USA04Open
+"Kazakhstan Coast, 1400 Hours  \n Operation: Stormbringer"
+END
+
+SCRIPT:USA04BomberTimer
+"Bombers Arriving In:"
+END
+
+MAP:USA06Objective1Text
+"MISSION OBJECTIVE:  \n Prevent the GLA from constructing their river base"
+END
+
+MAP:USA06Objective2Text
+"MISSION OBJECTIVE:  \n Destroy the GLA's Main Base"
+END
+
+SCRIPT:GLA03CivCounter
+"Traitors Killed:"
+END
+
+SCRIPT:GLA03Objective01
+"MISSION OBJECTIVES:  \n Claim the Command Center to the East to begin production  \n Kill 300 traitors"
+END
+
+SCRIPT:GLA03Objective02
+"MISSION OBJECTIVE:  \n Use Toxin Tractors to kill 300 traitors"
+END
+
+SCRIPT:GLA03Objective03
+"Destroy the pharmaceutical factory in the north"
+END
+
+MAP:GLA03Objective04
+"Free the prisoners"
+END
+
+MAP:GLA03Objective05
+"Kill 300 traitors"
+END
+
+MAP:GLA03Objective06
+"Destroy the pharmaceutical factory"
+END
+
+SCRIPT:GLA04Objective01
+"MISSION OBJECTIVE:  \n Destroy civilian buildings and gather $40,000"
+END
+
+SCRIPT:GLA04Objective02
+"WARNING:  \n Spending money on units will put you farther from your goal of $40,000  \n Be sure not to overspend"
+END
+
+SCRIPT:GLA04Objective03
+"WARNING:  \n American forces are using the airport as a staging base  \n Cross the river and destroy it"
+END
+
+SCRIPT:GLA04Objective04
+"WARNING:  \n American aircraft dispatched to eliminate heavy vehicles  \n Advise using Angry Mobs and Technicals only"
+END
+
+SCRIPT:GLA05Objective01
+"MISSION OBJECTIVE:  \n Destroy the American airbase"
+END
+
+SCRIPT:GLA05Objective02
+"MISSION OBJECTIVE:  \n Destroy the American airbase to the West"
+END
+
+MAP:GLA01Open
+"Shymkent DMZ  \n Operation: Black Rain"
+END
+
+MAP:GLA01ObjectiveText
+"MISSION OBJECTIVE: Destroy the Dam"
+END
+
+MAP:USA07Open
+"Southeastern Kazakhstan  \n Operation: Desperate Union"
+END
+
+MAP:USA07Objective1
+"MISSION OBJECTIVE:  \n Destroy the GLA to the northeast"
+END
+
+MAP:USA07General
+"General's Arrival"
+END
+
+MAP:USA07Objective2
+"MISSION OBJECTIVE:  \n Destroy the Chinese Command Center  \n and the Nuclear Missile Silo"
+END
+
+MAP:GLA08Temp
+"GLA Mission 8 - Southern Kazakhstan  \n Baikonur Cosmodrome"
+END
+
+MAP:CHI08Temp
+"China Mission 8 - Last China Mission  \n Status: Incomplete"
+END
+
+MAP:CHI07Temp
+"China Mission 7 - Nuke-O-Rama  \n Status: Incomplete"
+END
+
+MAP:CHI05Temp
+"China Mission 5 - Firebomb GLA  \n Status: Incomplete"
+END
+
+MAP:USA08Temp
+"USA Mission 8 - Devastate GLA  \n Status: Incomplete"
+END
+
+MAP:USA06Temp
+"USA Mission 6 - E3 Revamp  \n Status: Incomplete"
+END
+
+MAP:USA05Temp
+"USA Mission 5 - River Raid  \n Status: Incomplete"
+END
+
+CONTROLBAR:TooltipDaisyCutter
+"Strong vs. Buildings  \n  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:TooltipFireParticleUplinkCannon
+"Strong vs. Buildings  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipParaDrop
+"Drops Rangers by plane  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipClusterMines
+"Drops mines by plane  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipEMPPulse
+"Strong vs. Vehicles  \n  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:TooltipA10Strike
+"Strong vs. Buildings  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipFireNukeMissile
+"Strong vs. Everything  \n  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:TooltipFireSCUDStorm
+"Strong vs. Everything  \n  \n Countdown Timer: 5:00"
+END
+
+CONTROLBAR:TooltipFireArtilleryBarrage
+"Strong vs. Buildings, Large groups of units  \n  \n Countdown Timer: 5:00"
+END
+
+CONTROLBAR:TooltipFireSuperWeaponCashHack
+"Steal money from enemy supply centers  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipFireSpySatScan
+"Reveal target area. Spot hidden units  \n  \n Countdown Timer: 1:00"
+END
+
+CONTROLBAR:TooltipFireSpyDrone
+"Create spy drone over target  \n  \n Countdown Timer: 1:30"
+END
+
+CONTROLBAR:TooltipFireRadarVanScan
+"Reveal target area. Spot hidden enemies  \n  \n Countdown Timer: 0:30"
+END
+
+CONTROLBAR:TooltipFireRadioJam
+"Cut enemy communication  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipFireEmergencyRepair
+"Emergency Repair  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipFireRebelAmbush
+"Creates rebels  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipFireAnthraxBomb
+"Strong vs. Infantry  \n  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:TooltipCIAIntelligence
+"Spy on enemy forces  \n  \n Countdown Timer: 5:00"
+END
+
+CONTROLBAR:TooltipDemoTrapProxy
+"Explode when enemy gets near"
+END
+
+CONTROLBAR:TooltipDemoTrapManual
+"Explode on your command"
+END
+
+CONTROLBAR:TooltipDemoTrapDetonate
+"Explode demo trap"
+END
+
+CONTROLBAR:TooltipMissileDefenderLaser
+"Laser-lock improves missile rate of fire"
+END
+
+CONTROLBAR:TooltipBattlePlansBombardment
+"Deploy cannon  \n All units: 20% Firepower Bonus"
+END
+
+CONTROLBAR:TooltipBattlePlansHoldTheLine
+"Deploy walls  \n All units: 10% Armor Bonus"
+END
+
+CONTROLBAR:TooltipBattlePlansSearchAndDestroy
+"Deploy scanners  \n All units: 20% Weapon Range Bonus"
+END
+
+CONTROLBAR:TooltipSetRallyPoint
+"Set the rally point for this building"
+END
+
+CONTROLBAR:TooltipSell
+"Sell the building for 50% of its value"
+END
+
+CONTROLBAR:TooltipNukeReactorOverCharge
+"Damage the reactor to create 50% more power"
+END
+
+CONTROLBAR:TooltipCancelUpgrade
+"Cancel this upgrade"
+END
+
+CONTROLBAR:TooltipUSAUpgradeAdvancedTraining
+"Units gain veterancy at twice the usual speed"
+END
+
+CONTROLBAR:TooltipUSAUpgradeDroneARmor
+"All drones get improved armor"
+END
+
+CONTROLBAR:TooltipUSAUpgradeAdvancedControlRods
+"Reactor provides 100% more power"
+END
+
+CONTROLBAR:TooltipUSAUpgradeFlashBangGrenades
+"Rangers Flash-Bang civilian buildings to clear enemy soldiers"
+END
+
+CONTROLBAR:TooltipUSAUpgradeCompositeArmor
+"Tanks get +25% armor"
+END
+
+CONTROLBAR:TooltipUSAUpgradeCruiseMissile
+"Tomahawks can be given a flight-path"
+END
+
+CONTROLBAR:TooltipUSAUpgradeTOW
+"Arm Humvees with a missile. Can fire at ground or air targets"
+END
+
+CONTROLBAR:USAUpgradeRocketPods
+"Comanches fire rocket barrage"
+END
+
+CONTROLBAR:TooltipUSAUpgradeLaserMissiles
+"Raptor and Stealth Fighter missiles do +25% more damage"
+END
+
+CONTROLBAR:TooltipChinaUpgradeMines
+"Creates mines around the building"
+END
+
+CONTROLBAR:TooltipUpgradeChinaOverlordGattlingCannon
+"Build a Gattling Cannon on this Overlord"
+END
+
+CONTROLBAR:TooltipUpgradeChinaOverlordPropagandaTower
+"Build a Propaganda Tower on this Overlord"
+END
+
+CONTROLBAR:TooltipUpgradeChinaOverlordBattleBunker
+"Build a Bunker on this Overlord. Bunker can be occupied by your soldiers"
+END
+
+CONTROLBAR:TooltipChinaUpgradeRadar
+"Build a radar for this Command Center"
+END
+
+CONTROLBAR:TooltipChinaUpgradeNationalism
+"+25% to Horde bonus for Red Guard, Tank Hunter and Battlemaster"
+END
+
+CONTROLBAR:TooltipChinaUpgradeBlackNapalm
+"+25% damage to all flame weapons"
+END
+
+CONTROLBAR:TooltipChinaUpgradeChainGuns
+"+25% damage to all gattling weapons"
+END
+
+CONTROLBAR:TooltipUpgradeChinaSubliminal
+"+25% to Speaker Tower bonuses"
+END
+
+CONTROLBAR:TooltipUpgradeChinaUraniumShells
+"+25% shot damage on Battlemaster and Overlord"
+END
+
+CONTROLBAR:TooltipUpgradeChinaNuclearTanks
+"Improves Overlord and Battlemaster speed"
+END
+
+CONTROLBAR:TooltipUpgradeChinaStunBullets
+"Red Guard may try to capture enemy soldiers"
+END
+
+CONTROLBAR:TooltipDisguiseAsVehicle
+"Disguise the Bomb Truck as the targeted vehicle"
+END
+
+CONTROLBAR:TooltipGLAUpgradeBioBomb
+"Bomb Truck becomes a biowar weapon"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeHEBomb
+"100% more damage for this Bomb Truck"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeRadarVanScan
+"Radar Van can scan the map to search for enemy forces"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeScorpionRocket
+"Scorpion gains a rocket attack"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeAPRockets
+"+25% damage bonus on all Rocket attacks"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeToxinShells
+"Scorpion and Marauder shells carry a small amount of Anthrax"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeAnthraxBeta
+"+25% damage bonus to all toxin units"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeAPBullets
+"+25% damage bonus to Rebel, Technical, Quad Cannon and Jarmen Kell"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeJunkRepair
+"All vehicles auto-repair"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeCamouflage
+"Rebels are hidden from enemy sight when not shooting"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeTranqDarts
+"Rebels may try to capture enemy soldiers"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeArmTheMob
+"Arm all Angry Mobs with AK-47s"
+END
+
+CONTROLBAR:ToolTipStructureExit
+"Order this unit to exit"
+END
+
+CONTROLBAR:ToolTipTransportExit
+"Order this unit to exit"
+END
+
+CONTROLBAR:ToolTipEvacuate
+"Order all units to exit"
+END
+
+CONTROLBAR:ToolTipRailedTransport
+"Go"
+END
+
+CONTROLBAR:ToolTipUSACombatDrop
+"Order Rangers to rappel down on enemy target. Use on garrisoned buildings to kill all enemy soldiers inside"
+END
+
+CONTROLBAR:ToolTipGuard
+"Order unit to move to guard a specific location and pursue targets if necessary"
+END
+
+CONTROLBAR:ToolTipGuardWithoutPursuit
+"Order unit to move to guard a specific location, but not to pursue targets out of the area"
+END
+
+CONTROLBAR:ToolTipGuardFlyingUnitsOnly
+"Order unit to move to attack airborne units that come near a specified location"
+END
+
+CONTROLBAR:ToolTipAttackMove
+"Order unit to move to the target area and stop to engage enemies on the way"
+END
+
+CONTROLBAR:ToolTipCommandStop
+"Order unit to stop whatever it is doing"
+END
+
+CONTROLBAR:ToolTipWayPoints
+"Click on the ground to set waypoints"
+END
+
+CONTROLBAR:ToolTipUSARangerCaptureBuilding
+"Capture targeted enemy building"
+END
+
+CONTROLBAR:ToolTipUSAFire20mmCannon
+"Fire 20mm Cannon at the target"
+END
+
+CONTROLBAR:ToolTipUSAFireAntiTankMissiles
+"Fire antitank missiles at the target"
+END
+
+CONTROLBAR:ToolTipUSAFireRocketPods
+"Fire a barrage of rockets at the target area"
+END
+
+CONTROLBAR:ToolTipGLAFireScorpionRocket
+"Fire a single heavy rocket at the target"
+END
+
+CONTROLBAR:ToolTipGLASCUDHEWarhead
+"Load the SCUD missile with explosives"
+END
+
+CONTROLBAR:ToolTipGLASCUDAnthraxWarhead
+"Load the SCUD missile with Anthrax"
+END
+
+CONTROLBAR:ToolTipGLAFireToxinTractorSlime
+"Spray the area with toxins"
+END
+
+CONTROLBAR:ToolTipGLARebelCaptureBuilding
+"Capture targeted enemy building"
+END
+
+CONTROLBAR:ToolTipGLATerroristMakeCarBomb
+"Enter civilian car and fill it with explosives"
+END
+
+CONTROLBAR:ToolTipGLAFireFireBomb
+"Use fire bombs on target"
+END
+
+CONTROLBAR:ToolTipGLAHijackerHijack
+"Hijack target enemy vehicle"
+END
+
+CONTROLBAR:ToolTipGLAFireJarmenKellVehicleSnipe
+"Kill vehicle crew"
+END
+
+CONTROLBAR:ToolTipChinaFireMIG
+"Fire"
+END
+
+CONTROLBAR:ToolTipChinaRedGuardCaptureBuilding
+"Capture targeted enemy building"
+END
+
+CONTROLBAR:ToolTipChinaRedGuardFireStunBullets
+"Capture target enemy soldier"
+END
+
+CONTROLBAR:ToolTipChinaRedGuardFireBayonet
+"Use Bayonet on targeted enemy soldier"
+END
+
+CONTROLBAR:ToolTipChinaFireBlackLotusCaptureHack
+"Capture enemy building"
+END
+
+CONTROLBAR:ToolTipChinaFireBlackLotusVehicleHack
+"Disable enemy vehicle"
+END
+
+CONTROLBAR:ToolTipChinaFireBlackLotusCashHack
+"Steal cash from targeted enemy Supply Center"
+END
+
+CONTROLBAR:ToolTipChinaFireHackerInternetHack
+"Hack into the Internet to steal money"
+END
+
+CONTROLBAR:ToolTipChinaHackerBuildingHack
+"Disable enemy building with a powerful computer virus"
+END
+
+CONTROLBAR:ToolTipChinaDragonTankFire
+"Fire"
+END
+
+CONTROLBAR:TooltipFireWall
+"Lay down an arc of fire on targeted area"
+END
+
+CONTROLBAR:ToolTipPickUpPrisoner
+"Pick up enemy prisoner to return him to your base"
+END
+
+CONTROLBAR:ToolTipReturnToPrison
+"Return to prisoner holding facility"
+END
+
+CONTROLBAR:ToolTipChinaFireTankHunterTNTAttack
+"Place a TNT explosive charge"
+END
+
+CONTROLBAR:ToolTipUSAFireBurtonKnifeAttack
+"Use knife on targeted enemy soldier to make a silent attack"
+END
+
+CONTROLBAR:ToolTipUSAFireBurtonTimedDemo
+"Place a timed demolition charge"
+END
+
+CONTROLBAR:ToolTipUSABurtonPlaceRemoteCharge
+"Place a remote-controlled demolition charge you can detonate at any time"
+END
+
+CONTROLBAR:ToolTipUSABurtonDetonateCharges
+"Detonate all remote charges"
+END
+
+CONTROLBAR:ToolTipCancelConstruction
+"Cancel construction"
+END
+
+CONTROLBAR:ToolTipUSABuildCommandCenter
+"Commands special weapons. Creates Construction Dozers. Provides radar"
+END
+
+CONTROLBAR:ToolTipUSABuildPowerPlant
+"Provides power for USA bases  \n  \n Power Supplied: 5"
+END
+
+CONTROLBAR:ToolTipUSABuildBarracks
+"Trains USA soldiers for use in battle"
+END
+
+CONTROLBAR:ToolTipUSABuildSupplyCenter
+"Drop-off point for USA Chinook supply gatherers  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:ToolTipUSABuildWall
+"USA fence system. Laser-sensors alert to enemy troops moving through fence. Fence blocks enemy vehicle movement"
+END
+
+CONTROLBAR:ToolTipUSABuildWarFactory
+"Builds all USA ground vehicles  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:ToolTipUSABuildPatriotBattery
+"Ground and air defense. Can relay position of enemy to nearby Patriots  \n  \n Power Required: 3"
+END
+
+CONTROLBAR:ToolTipUSABuildAirField
+"Builds USA aircraft  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:ToolTipUSABuildParticleCannon
+"Fires a particle beam anywhere on the map  \n  \n Power Required: 10"
+END
+
+CONTROLBAR:ToolTipUSABuildStrategyCenter
+"All USA forces can use a single battle plan  \n  \n Bombardment  \n Search and Destroy  \n Hold the Line  \n  \n Power Required: 2"
+END
+
+CONTROLBAR:ToolTipUSABuildDetentionCamp
+"Grants ability to spy on enemies"
+END
+
+CONTROLBAR:ToolTipUSABuildSupplyDropZone
+"Calls in a paradrop of supplies every 2 minutes  \n  \n Power Required: 4"
+END
+
+CONTROLBAR:ToolTipGLABuildCommandCenter
+"Commands special weapons. Trains Workers"
+END
+
+CONTROLBAR:ToolTipGLABUildDemoTrap
+"Stealthy explosive device"
+END
+
+CONTROLBAR:ToolTipGLABuildBarracks
+"Trains GLA soldiers"
+END
+
+CONTROLBAR:ToolTipGLABuildSupplyStash
+"Collects supplies"
+END
+
+CONTROLBAR:ToolTipGLABuildArmsDealer
+"Builds vehicles"
+END
+
+CONTROLBAR:ToolTipChinaBuildCommandCenter
+"Commands special weapons. Creates Construction Dozers"
+END
+
+CONTROLBAR:ToolTipChinaBuildPowerPlant
+"Chinese power plant. Can be overloaded to provide +50% power  \n  \n Power Supplied: 10"
+END
+
+CONTROLBAR:ToolTipChinaBuildBarracks
+"Trains Chinese soldiers"
+END
+
+CONTROLBAR:ToolTipChinaBuildSupplyCenter
+"Drop-off point for China supply gatherers  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:ToolTipChinaBuildWarFactory
+"Builds Chinese vehicles  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:ToolTipChinaBuildBunker
+"Can hold 5 Chinese soldiers"
+END
+
+CONTROLBAR:ToolTipChinaBuildPropagandaCenter
+"Builds important Chinese technologies  \n  \n Power Required: 2"
+END
+
+CONTROLBAR:ToolTipChinaBuildAirField
+"Builds Chinese aircraft  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:ToolTipChinaBuildGattlingCannon
+"Powerful anti-air base defense  \n  \n Power Required: 3"
+END
+
+CONTROLBAR:ToolTipChinaBuildNuclearMissileLauncher
+"Launches a nuclear missile. Builds important Chinese upgrades  \n  \n Power Required: 10"
+END
+
+CONTROLBAR:ToolTipChinaBuildSpeakerTower
+"Heals your forces and increases firing speed  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:ToolTipGLABuildTunnelNetwork
+"Base defense and underground tunnel. Units can enter the Tunnel Network and exit at any other Tunnel Network"
+END
+
+CONTROLBAR:ToolTipGLABuildPalace
+"Holds important GLA technologies. Can be garrisoned by GLA troops"
+END
+
+CONTROLBAR:ToolTipGLABuildBlackMarket
+"Holds important GLA technologies. Provides free supplies to the GLA player"
+END
+
+CONTROLBAR:ToolTipGLABuildStingerSite
+"Anti-air and anti-tank base defense"
+END
+
+CONTROLBAR:ToolTipGLABuildScudStorm
+"Launches a volley of SCUD missiles  \n  \n Countdown Timer: 5:00"
+END
+
+CONTROLBAR:ToolTipGLABuildPrison
+"Used to hold captured enemy soldiers"
+END
+
+CONTROLBAR:ToolTipUSABuildRanger
+"Strong vs. infantry  \n Weak vs. light vehicles"
+END
+
+CONTROLBAR:ToolTipUSABuildDozer
+"Builds all USA structures and repairs buildings"
+END
+
+CONTROLBAR:ToolTipGLABuildWorker
+"Builds all GLA structures. Repairs buildings and collects supplies"
+END
+
+CONTROLBAR:ToolTipChinaBuildDozer
+"Builds all Chinese structures and repairs buildings"
+END
+
+CONTROLBAR:ToolTipGLABuildScorpion
+"Strong vs. light vehicles  \n Weak vs. rocket soldiers, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildRocketBuggy
+"Strong vs. buildings  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildRadarVan
+"Provides Radar. Can spot hidden enemy units"
+END
+
+CONTROLBAR:ToolTipChinaBuildOverlord
+"Strong vs. vehicles, buildings  \n Weak vs. rocket-armed infantry, aircraft"
+END
+
+CONTROLBAR:ToolTipChinaBuildGattlingTank
+"Strong vs. infantry, aircraft  \n Weak vs. tanks"
+END
+
+CONTROLBAR:ToolTipGLABuildRebel
+"Strong vs. infantry  \n Weak vs. tanks, light vehicles"
+END
+
+CONTROLBAR:ToolTipChinaBuildRedguard
+"Gains Horde bonus when in groups of 5 or more  \n  \nStrong vs. infantry  \n Weak vs. vehicles"
+END
+
+CONTROLBAR:ToolTipChinaBuildHacker
+"Can disable enemy buildings with a computer virus or can hack into the internet to steal money  \n  \n Strong vs. buildings  \n Weak vs. infantry, vehicles"
+END
+
+CONTROLBAR:ToolTipUSABUildChinook
+"Transport helicopter. Collects supplies. Works with Rangers to perform Combat Drop attack"
+END
+
+CONTROLBAR:ToolTipChinaBuildSupplyTruck
+"Gathers supplies"
+END
+
+CONTROLBAR:ToolTipUSABuildPaladin
+"Uses a laser to destroy missiles and enemy infantry  \n  \n Strong vs. tanks, buildings, and rockets  \n Weak vs. aircraft"
+END
+
+CONTROLBAR:ToolTipUSABuildRaptor
+"Can engage ground or air targets  \n  \n Strong vs. aircraft, tanks, light vehicles  \n Weak vs. missile-armed infantry, anti-air defenses"
+END
+
+CONTROLBAR:ToolTipUSABuildAurora
+"Super-sonic attack makes Aurora immune to enemy fire. After super-sonic attack, Aurora speed is reduced to 50%  \n  \n Strong vs. buildings  \n Weak vs. fighters, anti-air units"
+END
+
+CONTROLBAR:ToolTipUSABuildStealthFighter
+"Stealthed while moving  \n  \n Strong vs. enemy base defenses  \n Weak vs. enemy fighters"
+END
+
+CONTROLBAR:ToolTipUSABuildComanche
+"Fires missiles and cannon. Re-arms in the air  \n  \n Strong vs. tanks, light vehicles, infantry  \n Weak vs. missile-armed infantry, anti-air defenses"
+END
+
+CONTROLBAR:ToolTipUSABuildMissileDefender
+"Use special laser-guided attack to rapid-fire missiles  \n  \n Strong vs. tanks, aircraft  \n Weak vs. infantry"
+END
+
+CONTROLBAR:ToolTipUSABuildPathFinder
+"Camouflaged while not moving or shooting. Spots hidden enemies  \n  \n Strong vs. infantry  \n Weak vs. light vehicles, scouts"
+END
+
+CONTROLBAR:ToolTipUSABuildColonelBurton
+"Camouflaged. Reveals himself when he shoots or plants a bomb  \n  \n Build Limit: 1  \n Strong vs. Infantry  \n Weak vs. Scouts"
+END
+
+CONTROLBAR:ToolTipUSABuildTomahawk
+"Strong vs. base defenses  \n Weak vs. tanks, aircraft, light vehicles"
+END
+
+CONTROLBAR:ToolTipUSABuildHumvee
+"Transport. Infantry inside can use fire-ports to engage the enemy  \n  \n Strong vs. infantry  \n Weak vs. tanks"
+END
+
+CONTROLBAR:ToolTipUSABuildMedic
+"Heals vehicles and soldiers. Cleans up radiation and toxins"
+END
+
+CONTROLBAR:ToolTipUSABuildScoutDrone
+"Extends sight range and reveals hidden enemies"
+END
+
+CONTROLBAR:ToolTipUSABuildBattleDrone
+"Fires a small machine gun and repairs its parent vehicle  \n  \n Strong vs. infantry  \n Weak vs. missile armed infantry"
+END
+
+CONTROLBAR:ToolTipChinaBuildMIG
+"Creates a fire-storm in large groups  \n  \n Strong vs. tanks, light vehicles  \n Weak vs. missile armed infantry, anti-air defenses"
+END
+
+CONTROLBAR:ToolTipChinaBuildBlackLotus
+"Captures enemy buildings, steals cash from enemy supply centers and disables enemy vehicles. Camouflaged unless using an ability  \n  \n Strong vs. buildings, vehicles  \n Weak vs. scout units"
+END
+
+CONTROLBAR:ToolTipChinaBuildTankHunter
+"Special TNT attack  \n Gains Horde bonus when in groups of 5 or more  \n  \n Strong vs. tanks  \n Weak vs. infantry"
+END
+
+CONTROLBAR:ToolTipChinaBuildInfernoCannon
+"Creates a fire-storm in large groups  \n  \n Strong vs. base defenses, infantry  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipChinaBuildNukeLauncher
+"Strong vs. buildings, infantry  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipChinaBuildTroopCrawler
+"Transport. Comes with 8 Red Guard. Detects stealth units  \n  \n Strong vs. infantry, buildings  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipChinaBuildDragonTank
+"Can burn soldiers out of buildings. Can create a wall of flame  \n  \n Strong vs. infantry, buildings  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildTerrorist
+"Suicide soldier  \n  \n Strong vs. tanks, buildings  \n Weak vs. infantry, light vehicles"
+END
+
+CONTROLBAR:ToolTipGLABuildRPGTrooper
+"Strong vs. tanks  \n Weak vs. infantry"
+END
+
+CONTROLBAR:ToolTipGLABuildAngryMob
+"Strong vs. infantry, vehicles  \n Weak vs. flame, toxins, flash-bang grenades"
+END
+
+CONTROLBAR:ToolTipGLABuildHijacker
+"Can capture any enemy vehicle. Camouflaged  \n  \n Strong vs. tanks, vehicles  \n Weak vs. infantry, scouts"
+END
+
+CONTROLBAR:ToolTipGLABuildJarmenKell
+"Is camouflaged. Can hide inside civilian buildings to snipe at enemy soldiers. Can kill the crew of enemy vehicles making them vulnerable to capture  \n  \n Strong vs. infantry, vehicles  \n Weak vs. Scouts"
+END
+
+CONTROLBAR:ToolTipGLABuildToxinTruck
+"Clears buildings of enemy soldiers. Contaminates terrain  \n Can upgrade weapon with scavenged parts from enemy kills  \n Strong vs. infantry  \n Weak vs. tanks, aircraft, base defenses"
+END
+
+CONTROLBAR:ToolTipChinaBuildBattlemaster
+"Gains Horde bonus when in groups of 5 or more  \n  \n Strong vs. tanks, buildings  \n Weak vs. infantry, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildMarauder
+"Can upgrade weapon with scavenged parts from enemy kills  \n  \n Strong vs. buildings, light vehicles  \n Weak vs. rocket soldiers, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildTechnical
+"Can upgrade weapon with scavenged parts from enemy kills  \n  \n Strong vs. infantry  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildQuadCannon
+"Can upgrade weapon with scavenged parts from enemy kills  \n  \n Strong vs. infantry, aircraft  \n Weak vs. tanks"
+END
+
+CONTROLBAR:ToolTipGLABuildBombTruck
+"Can disguise to look like any vehicle, friend or foe  \n  \n Strong vs. infantry, buildings  \n Weak vs. Scouts"
+END
+
+CONTROLBAR:ToolTipGLABuildSCUDLauncher
+"Can be equipped with either an explosive or biological warhead  \n  \n Strong vs. buildings, infantry  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipUSABuildCrusader
+"Strong vs. vehicles, buildings  \n Weak vs. aircraft, missile armed infantry"
+END
+
+CONTROLBAR:ToolTipUSASciencePaladin
+"Paladins can shoot down enemy missiles with an advanced defensive laser system  \n  \n Build at: War Factory"
+END
+
+CONTROLBAR:ToolTipUSASciencePathFinder
+"Pathfinders are elite camouflaged snipers  \n  \n Build at: Barracks"
+END
+
+CONTROLBAR:ToolTipUSAScienceStealthFighter
+"Stealthed while moving  \n  \n Build at: Air Field"
+END
+
+CONTROLBAR:ToolTipUSAScienceSpyDrone
+"Spy Drones are camouflaged against enemy sight and radar and reveal enemy positions  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipUSAScienceParaDrop
+"Drop Rangers from the air  \n  \n Rank 1: 5 Rangers  \n Rank 2: 10 Rangers  \n Rank 3: 20 Rangers  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipUSAScienceA10Strike
+"A10 Thunderbolts destroy buildings, vehicles, and infantry  \n  \n Rank 1: 1 A10 Thunderbolt  \n Rank 2: 2 A10 Thunderbolts  \n Rank 3: 3 A10 Thunderbolts  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipUSAScienceDaisyCutter
+"Fuel Air Bombs destroy buildings and enemy troop concentrations  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceNukeCannon
+"Nuke Cannons lob small tactical nukes great distances  \n  \n Build at: War Factory  \n Requires: Propaganda Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceRedGuardTraining
+"All Red Guard will be built as veterans"
+END
+
+CONTROLBAR:ToolTipChinaScienceClusterMines
+"Cluster Mines are deployed by air  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceARtilleryTraining
+"Nuke Cannons and Inferno Cannons are built as veterans"
+END
+
+CONTROLBAR:ToolTipChinaScienceArtilleryBarrage
+"Call off-map artillery to strike your target  \n  \n Rank 1: 12 Shells  \n Rank 2: 24 Shells  \n Rank 3: 36 Shells  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceEMPPulse
+"Allows you to call in a heavy bomber to drop an EMP Pulse bomb. EMP Pulse disables enemy vehicles and buildings  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipGLAScienceHijacker
+"Hijackers are camouflaged and can steal enemy vehicles  \n  \n Build at: Barracks"
+END
+
+CONTROLBAR:ToolTipGLAScienceSCUDLauncher
+"Fires a long-range rocket that can be equipped with explosives or deadly anthrax  \n  \n Build at: Arms Dealer"
+END
+
+CONTROLBAR:ToolTipGLaScienceMarauderTank
+"Marauder tanks can scavenge enemy kills to upgrade their main gun  \n  \n Build at: Arms Dealer"
+END
+
+CONTROLBAR:ToolTipGLAScienceTechnicalTraining
+"All Technicals will be created as veterans"
+END
+
+CONTROLBAR:ToolTipGLAScienceRebelAmbush
+"Allows you to create a surprise ambush of Rebels anywhere  \n  \n Rank 1: 4 Rebels  \n Rank 2: 8 Rebels  \n Rank 3: 16 Rebels  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipGLAScienceCashBounty
+"Earn a cash bounty for every enemy unit or building you kill  \n  \n Rank 1: 5% enemy value  \n Rank 2: 10% enemy value  \n Rank 3: 20% enemy value"
+END
+
+CONTROLBAR:ToolTipGLAScienceAnthraxBomb
+"Anthrax is deadly against enemy troop concentrations  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipUSABuildSecurityFence
+"Build security fence that prevents vehicles from passing and alerts of any enemy infantry that pass through"
+END
+
+CONTROLBAR:ToolTipChinaBuildConcreteWall
+"Build concrete wall that prevents any ground unit from passing through"
+END
+
+CONTROLBAR:ToolTipGLABuildBurningBarricade
+"Build burning barricade the burns units that try to pass over it"
+END
+
+GUI:QuitToDesktop
+"QUIT TO DESKTOP"
+END
+
+GUI:QuitToDesktopConf
+"Are you sure you want to quit back to the Desktop?"
+END
+
+GUI:NewSaveGame
+"***** NEW GAME *****"
+END
+
+GUI:TimeAM
+"am"
+END
+
+GUI:TimePM
+"pm"
+END
+
+GUI:OverwriteSaveConfirmation
+"Overwrite existing file?"
+END
+
+GUI:LoadGameConfirmation
+"Current game data will be lost. Load saved game?"
+END
+
+GUI:Rank1Required
+"RANK REQUIRED - 1 Star General"
+END
+
+GUI:Rank3Required
+"RANK REQUIRED - 3 Star General"
+END
+
+GUI:Rank8Required
+"RANK REQUIRED - 5 Star General"
+END
+
+GUI:Experience
+"Experience"
+END
+
+GUI:RemainingSkillPoints
+"Points"
+END
+
+TOOLTIP:ExperienceToLevel
+"Experience to next level"
+END
+
+GUI:SaveAndLoad
+"SAVE/LOAD"
+END
+
+GUI:SaveTime
+"Time"
+END
+
+GUI:SaveDate
+"Date"
+END
+
+SCIENCE:Rank1
+"1 Star General"
+END
+
+SCIENCE:Rank2
+"2 Star General"
+END
+
+SCIENCE:Rank3
+"3 Star General"
+END
+
+SCIENCE:Rank4
+"4 Star General"
+END
+
+SCIENCE:Rank5
+"5 Star General"
+END
+
+SCIENCE:Rank6
+"Major General"
+END
+
+SCIENCE:Rank7
+"Lt. General"
+END
+
+SCIENCE:Rank8
+"General"
+END
+
+CONTROLBAR:StructureExit
+"Exit Structure"
+END
+
+CONTROLBAR:UpgradeChinaAircraftArmor
+"MiG &Armor"
+END
+
+CONTROLBAR:RangerMachineGun
+"&Machine Gun"
+END
+
+CONTROLBAR:RedguardMachineGun
+"&Machine Gun"
+END
+
+CONTROLBAR:RebelMachineGun
+"&Machine Gun"
+END
+
+CONTROLBAR:FlashBangGrenadeMode
+"&Flash-Bang Grenade"
+END
+
+CONTROLBAR:TranqDartsMode
+"&Tranq Darts Mode"
+END
+
+CONTROLBAR:StunBulletsMode
+"Take &Prisoner Mode"
+END
+
+UPGRADE:AircraftArmor
+"Aircraft Armor"
+END
+
+MAP:USA03Open
+"Northern Kazakhstan. U.S. Forces in Full Retreat  \n Operation: Guardian Angel"
+END
+
+CONTROLBAR:TooltipChinaUpgradeAircraftArmor
+"+25% MiG health"
+END
+
+CONTROLBAR:ToolTipSwitchToRangerMachineGun
+"Switches to machine gun mode for all purpose attacking"
+END
+
+CONTROLBAR:ToolTipSwitchToRedguardMachineGun
+"Switches to machine gun mode for all purpose attacking"
+END
+
+CONTROLBAR:ToolTipSwitchToRebelMachineGun
+"Switches to machine gun mode for all purpose attacking"
+END
+
+CONTROLBAR:ToolTipSwitchToUSAFlashBang
+"Use Flash-Bang grenades"
+END
+
+CONTROLBAR:ToolTipSwitchToChinaStunBullets
+"Switches to firing stun bullets mode to capture enemy soldiers in the open"
+END
+
+CONTROLBAR:ToolTipSwitchToGLATranqDarts
+"Switches to tranq-dart weapon to capture enemy soldiers in the open"
+END
+
+GUI:ProductionQueueFull
+"The unit's production queue is full"
+END
+
+GUI:ParkingPlacesFull
+"All parking places are occupied"
+END
+
+GUI:UnitMaxedOut
+"You already have the maximum for this unit"
+END
+
+CONTROLBAR:FireTomahawkAtPosition
+"&Tomahawk Bombardment"
+END
+
+CONTROLBAR:ToolTipFireTomahawkAtPosition
+"Fire tomahawks at a location"
+END
+
+GUI:SurrenderConfirmation
+"Are you sure you want to Surrender?"
+END
+
+GUI:GameOver
+"Game Over"
+END
+
+TOOLTIP:RefreshNat
+"Click after changing firewall setup or ISP"
+END
+
+GUI:Surrender
+"SURRENDER"
+END
+
+GUI:SuperweaponEmergencyRepair
+"Emergency Repair"
+END
+
+CONTROLBAR:FireNukeCannonAtPosition
+"Nuke &Bombardment"
+END
+
+CONTROLBAR:FireInfernoCannonAtPosition
+"Inferno &Bombardment"
+END
+
+CONTROLBAR:FireScudExplosiveAtPosition
+"Explosive &Bombardment"
+END
+
+CONTROLBAR:FireScudAnthraxAtPosition
+"Anthrax B&ombardment"
+END
+
+MAP:USA04Objective1Text
+"MISSION OBJECTIVE:  \n Clear the beach of GLA forces"
+END
+
+MAP:USA04Objective2Text
+"MISSION OBJECTIVE:  \n Destroy the Stinger Sites"
+END
+
+MAP:USA04Objective3Text
+"MISSION OBJECTIVE:  \n Destroy the GLA Base"
+END
+
+CONTROLBAR:ToolTipFireNukeCannonAtPosition
+"Bombard a location with nuke cannon shells"
+END
+
+CONTROLBAR:ToolTipFireInfernoCannonAtPosition
+"Bombard a location with inferno cannon shells"
+END
+
+CONTROLBAR:ToolTipFireScudExplosiveAtPosition
+"Bombard a location with explosive warheads"
+END
+
+CONTROLBAR:ToolTipFireScudAnthraxAtPosition
+"Bombard specified location with anthrax warheads"
+END
+
+TOOLTIP:Brightness
+"Adjust the brightness of the game"
+END
+
+TOOLTIP:ScrollSpeed
+"Adjust map scroll speed"
+END
+
+TOOLTIP:SendDelay
+"For Firewall Users Only. (Please Consult the Manual)"
+END
+
+GUI:GSFailedToHost
+"Could not host the game"
+END
+
+Buddy:SelectBuddyToChat
+"Select Buddy to chat"
+END
+
+GUI:CannotConnectToServservTitle
+"CANNOT CONNECT"
+END
+
+GUI:CannotConnectToServserv
+"Unable to establish a connection with Command and Conquer Generals Zero Hour servers. Please check your internet connection"
+END
+
+MESSAGE:BattlePlanBombardmentInitiated
+"Bombardment strategy has been initiated"
+END
+
+MESSAGE:BattlePlanHoldTheLineInitiated
+"Hold the Line strategy has been initiated"
+END
+
+MESSAGE:BattlePlanSearchAndDestroyInitiated
+"Search and Destroy strategy has been initiated"
+END
+
+OBJECT:TechOilRefinery
+"Oil Refinery -- Capture to reduce the cost of vehicles"
+END
+
+OBJECT:SupplyDock
+"Supply Dock"
+END
+
+GUI:InGameDiplomacy
+"Diplomacy"
+END
+
+GUI:MapPreview
+"Map Preview"
+END
+
+GUI:Error
+"Error"
+END
+
+Buddy:Disconnected
+"You have been disconnected  \n from the buddy list"
+END
+
+GUI:SandboxMode
+"Entering sandbox mode..."
+END
+
+GUI:BookmarkXSet
+"Bookmark #%d set"
+END
+
+SCIENCE:EmergencyRepair1
+"Emergency Repair 1"
+END
+
+SCIENCE:EmergencyRepair2
+"Emergency Repair 2"
+END
+
+SCIENCE:EmergencyRepair3
+"Emergency Repair 3"
+END
+
+MAP:CHI05Open
+"Balykchy, Kyrgyzstan  \n Scorched Earth"
+END
+
+CONTROLBAR:ToolTipScienceEmergencyRepair
+"Repairs vehicles in an area  \n  \n Rank 1: Light Repair  \n Rank 2: Medium Repair  \n Rank 3: Serious Repair  \n  \n Deploy from: Command Center"
+END
+
+GUI:MinSpecFailedTitle
+"WARNING"
+END
+
+GUI:MinSpecFailedMessage
+"Your system does not meet the minimum hardware requirements. You may experience slower than normal frame rates in your multiplayer games"
+END
+
+TOOLTIP:AlreadyUpgradedDefault
+"This upgrade has already been purchased"
+END
+
+TOOLTIP:HasConflictingUpgradeDefault
+"Conflicting upgrade cannot be purchased"
+END
+
+GUI:NoGameSelected
+"Select a game to join first"
+END
+
+GUI:CloseExpScreen
+"Done"
+END
+
+TOOLTIP:CloseExpScreen
+"Return to Game"
+END
+
+GUI:GPNoCommunicator
+"The Communicator is not available in the Multiplayer Playtest"
+END
+
+GUI:GSKickedGameStarted
+"The game has started"
+END
+
+GUI:GSKickedGameFull
+"The game is full"
+END
+
+Network:PacketRouterTimeout
+"Packet Router Timeout"
+END
+
+GUI:EstablishingConnectionPaths
+"ESTABLISHING CONNECTION PATHS"
+END
+
+UPGRADE:RadarVanScan
+"Radar Van Scan"
+END
+
+MAP:CHI04Open
+"Tanggula Mountains, China  \n Broken Alliances"
+END
+
+MAP:GLA04Open
+"Astana City  \n Chinese-Occupied Capital of Kazakhstan"
+END
+
+MAP:USA07NewObjective2
+"NEW MISSION OBJECTIVE:  \n Destroy the Chinese Command Center  \n and the Nuclear Missile Silo"
+END
+
+MAP:USA07GotObjective1
+"OBJECTIVE COMPLETED:  \n Destroy the GLA to the northeast"
+END
+
+MAP:USA07GotObjective2
+"OBJECTIVE COMPLETED:  \n Destroy the Chinese Command Center  \n and the Nuclear Missile Silo"
+END
+
+GUI:Defaults
+"DEFAULTS"
+END
+
+TOOLTIP:OptionsAccept
+"Accept the changes made and exit the Options Menu"
+END
+
+TOOLTIP:OptionsCancel
+"Exit the Options Menu without making your changes"
+END
+
+TOOLTIP:OptionsDefaults
+"Reset the options to the default settings"
+END
+
+MESSAGE:StealthDiscovered
+"Enemy stealth unit discovered"
+END
+
+MESSAGE:StealthNeutralized
+"Stealth ability neutralized"
+END
+
+TOOLTIP:SortBuddies
+"Sort Buddies to the top of the game list"
+END
+
+CONTROLBAR:GeneralsExperienceMenu
+"Generals Experience Menu"
+END
+
+CONTROLBAR:GeneralsExperienceMenuDescription
+"Show the experience menu where you can spend experience points gained in battle for various General's Powers"
+END
+
+CONTROLBAR:UpDown
+"Show/Hide Toggle"
+END
+
+CONTROLBAR:UpDownDescription
+"Toggles whether the control bar is shown or hidden"
+END
+
+CONTROLBAR:DisarmMinesAtPosition
+"C&lear Mines"
+END
+
+CONTROLBAR:ToolTipDisarmMinesAtPosition
+"Clear mines and small explosives in the given area"
+END
+
+TOOLTIP:ScienceCostUnavailable
+"Cost: Unavailable"
+END
+
+GUI:OnlineIPAddresses
+"Online IP:"
+END
+
+GUI:GSDisconReason16
+"A profile with that nickname already exists"
+END
+
+GUI:GSDisconReason17
+"That password is incorrect. Please try again"
+END
+
+GUI:GSDisconReason18
+"A profile with that nickname already exists"
+END
+
+GUI:GSDisconReason19
+"Server error - cannot create account"
+END
+
+Buddy:MessageDisconnected
+"You have been disconnected  \n from the buddy list"
+END
+
+GUI:PlayerHasBeenDefeated
+"%ls has been Defeated"
+END
+
+CONTROLBAR:UpgradeAmericaRangerCaptureBuilding
+"&Capture Building"
+END
+
+CONTROLBAR:UpgradeChinaRedguardCaptureBuilding
+"&Capture Building"
+END
+
+CONTROLBAR:UpgradeGLARebelCaptureBuilding
+"&Capture Building"
+END
+
+CONTROLBAR:DetonateBombTruck
+"Detonate &Now!"
+END
+
+UPGRADE:RangerCaptureBuilding
+"Capture Building"
+END
+
+UPGRADE:RedguardCaptureBuilding
+"Capture Building"
+END
+
+UPGRADE:RebelCaptureBuilding
+"Capture Building"
+END
+
+CONTROLBAR:TooltipDetonateBombTruck
+"Orders the Bomb Truck to immediately detonate at his current location"
+END
+
+CONTROLBAR:ToolTipUSAUpgradeRangerCaptureBuilding
+"Enables Rangers to capture enemy and tech buildings"
+END
+
+CONTROLBAR:ToolTipChinaUpgradeRedGuardCaptureBuilding
+"Enables Red Guards to capture enemy and tech buildings"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeRebelCaptureBuilding
+"Enables Rebels to capture enemy and tech buildings"
+END
+
+GUI:Loading
+"LOADING"
+END
+
+TOOLTIP:EmoteButton
+"Emote"
+END
+
+CONTROLBAR:Power
+"Power"
+END
+
+CONTROLBAR:PowerDescription
+"Current Power: %d  \n Required Power: %d"
+END
+
+CONTROLBAR:Money
+"Money"
+END
+
+CONTROLBAR:MoneyDescription
+"This is the amount of money you have"
+END
+
+MAP:TourneyArena
+"Tournament Desert"
+END
+
+UPGRADE:AmericaDroneARmor
+"Drone Armor"
+END
+
+UPGRADE:APRockets
+"Armor Piercing Rockets"
+END
+
+ThingTemplate:EuropeanTowerBridge01
+"Bridge"
+END
+
+ThingTemplate:BridgeTowerConcreteRight02
+"Bridge"
+END
+
+Team:0
+"None"
+END
+
+Team:1
+"1"
+END
+
+Team:2
+"2"
+END
+
+Team:3
+"3"
+END
+
+Team:4
+"4"
+END
+
+Team:AI
+"CPU"
+END
+
+GUI:RestartConfirmation
+"Are you sure you want to restart?"
+END
+
+GUI:ErrorStartingGame
+"ERROR STARTING GAME"
+END
+
+GUI:TooManyPlayers
+"This map only supports %d players"
+END
+
+GUI:SandboxWarning
+"Clicking Start again will start a sandbox game"
+END
+
+GUI:CantFindMap
+"Cannot find the map. Is it corrupted?"
+END
+
+GUI:EnterSaveDesc
+"Enter game description"
+END
+
+GUI:MissionSave
+"Mission Start - %s %d"
+END
+
+GUI:SaveReplay
+"SAVE REPLAY"
+END
+
+GUI:OverwriteReplayTitle
+"OVERWRITE REPLAY"
+END
+
+GUI:OverwriteReplay
+"Overwrite Replay?"
+END
+
+GUI:ConfirmDelete
+"Are you sure you want to delete this game?"
+END
+
+GUI:DeleteGame
+"DELETE"
+END
+
+GUI:GameSaveComplete
+"*** Game Saved ***"
+END
+
+CAMPAIGN:USA
+"USA"
+END
+
+CAMPAIGN:GLA
+"GLA"
+END
+
+CAMPAIGN:China
+"China"
+END
+
+GUI:Easy
+"Easy"
+END
+
+GUI:Hard
+"Hard"
+END
+
+GUI:SelectDifficulty
+"SELECT DIFFICULTY"
+END
+
+GUI:NumPlayersOnline
+"Total players online: %d"
+END
+
+GUI:AllowableMaps
+"Allowable Maps"
+END
+
+GUI:QuickMatchTitle
+"QuickMatch"
+END
+
+LOAD:TRAINING_1
+"- GLA controls a Chemical Weapons Plant"
+END
+
+LOAD:TRAINING_2
+"- Destroy the Chemical Weapons Plant"
+END
+
+LOAD:TRAINING_3
+"- Eliminate the threat"
+END
+
+LOAD:USA01_1
+"- GLA has SCUD Storm"
+END
+
+LOAD:USA01_2
+"- They are based in Baghdad"
+END
+
+LOAD:USA01_3
+"- Eliminate this threat"
+END
+
+LOAD:USA02_1
+"- GLA leaders tracked to Yemen"
+END
+
+LOAD:USA02_2
+"- Comanches are searching for criminals"
+END
+
+LOAD:USA02_3
+"- Save the captured pilots"
+END
+
+LOAD:USA03_1
+"- USA forces are in full retreat"
+END
+
+LOAD:USA03_2
+"- GLA is in close pursuit"
+END
+
+LOAD:USA03_3
+"- Provide cover for retreating forces"
+END
+
+LOAD:USA04_1
+"- GLA training camp has been discovered"
+END
+
+LOAD:USA04_2
+"- Eliminate this threat"
+END
+
+LOAD:USA06_1
+"- Peace conference in Kabara City"
+END
+
+LOAD:USA06_2
+"- GLA cannot be trusted"
+END
+
+LOAD:USA06_3
+"- Be on alert"
+END
+
+LOAD:USA07_1
+"- A rogue Chinese General has joined with the GLA"
+END
+
+LOAD:USA07_2
+"- Enemy is relying on Tunnel Networks"
+END
+
+LOAD:USA07_3
+"- Attack must be launched immediately"
+END
+
+LOAD:USA08_1
+"- US forces have surrounded the GLA capital"
+END
+
+LOAD:USA08_2
+"- GLA has biological weapons"
+END
+
+LOAD:USA08_3
+"- Chinese have pledged their support to US"
+END
+
+LOAD:USA08_4
+"- GLA must be eliminated"
+END
+
+LOAD:China01_1
+"- China's might is on parade"
+END
+
+LOAD:China01_2
+"- Protect China's military display"
+END
+
+LOAD:China01_3
+"- Eliminate any threat in Beijing area"
+END
+
+LOAD:China02_1
+"- GLA cell has been discovered in Hong Kong"
+END
+
+LOAD:China02_2
+"- Terrorists are using convention center as base"
+END
+
+LOAD:China02_3
+"- Cell must be eradicated"
+END
+
+LOAD:China03_1
+"- GLA has infested the Three Gorges Dam area"
+END
+
+LOAD:China03_2
+"- Enemy reinforcements now threaten our forces"
+END
+
+LOAD:China03_3
+"- Drown the GLA with Chinese forces"
+END
+
+LOAD:China04_1
+"- GLA has constructed a Bio-Toxin factory"
+END
+
+LOAD:China04_2
+"- Locate factory with help of operative Black Lotus"
+END
+
+LOAD:China04_3
+"- Air strike will aid in its destruction"
+END
+
+LOAD:China05_1
+"- GLA has taken over Balykchy"
+END
+
+LOAD:China05_2
+"- US forces will provide air support"
+END
+
+LOAD:China05_3
+"- Call in Carpet Bombs and destroy the GLA"
+END
+
+LOAD:China06_1
+"- GLA has commandeered one of China's Railroads"
+END
+
+LOAD:China06_2
+"- GLA is gathering in Bishkek, Aldastan"
+END
+
+LOAD:China06_3
+"- Use Black Lotus to destroy the train bridge"
+END
+
+LOAD:China07_1
+"- GLA Asian terrorist cell identified in Tajikistan"
+END
+
+LOAD:China07_2
+"- Authorized to utilize your nuclear arsenal"
+END
+
+LOAD:GLA01_1
+"- Many brothers have been lost"
+END
+
+LOAD:GLA01_2
+"- China's defenses are spread thin"
+END
+
+LOAD:GLA01_3
+"- Destroy Chinese forces"
+END
+
+LOAD:GLA02_1
+"- U.N. supplies en route to Almaty region"
+END
+
+LOAD:GLA02_2
+"- Intercept these deliveries for our cause"
+END
+
+LOAD:GLA02_3
+"- Collect supplies to infuse the GLA with funds"
+END
+
+LOAD:GLA03_1
+"- Oppressors have corrupted the people of Zhambul"
+END
+
+LOAD:GLA03_2
+"- Their only true freedom lies in death"
+END
+
+LOAD:GLA03_3
+"- Use Toxin Tractors to eliminate them"
+END
+
+LOAD:GLA04_1
+"- We have found new allies in Astana"
+END
+
+LOAD:GLA04_2
+"- We can use them to harass the enemy"
+END
+
+LOAD:GLA04_3
+"- While Astana burns, loot the city for supplies"
+END
+
+LOAD:GLA05_1
+"- The arrogance of the USA cannot go unanswered"
+END
+
+LOAD:GLA05_2
+"- Keep region from their imperialist grasp"
+END
+
+LOAD:GLA05_3
+"- Destroy their 'superior' air force"
+END
+
+LOAD:GLA06_1
+"- Reports from the Aral Sea are not good"
+END
+
+LOAD:GLA06_2
+"- US forces have control of our toxin storage facility"
+END
+
+LOAD:GLA06_3
+"- Retake the storage bunkers"
+END
+
+LOAD:GLA07_1
+"- GLA defectors have joined with China"
+END
+
+LOAD:GLA07_2
+"- Assault the convoys and sever their supply lines"
+END
+
+LOAD:GLA07_3
+"- Eliminate the traitors and their Chinese allies"
+END
+
+LOAD:GLA08_1
+"- Take control of the Cosmodrome"
+END
+
+LOAD:GLA08_2
+"- The missiles there will deliver deadly toxin to our enemies"
+END
+
+LOAD:GLA08_3
+"- Our destiny is at hand"
+END
+
+TOOLTIP:DownloadProgress
+"Download Progress"
+END
+
+TOOLTIP:BattleHonorBlitz10
+"Blitz Honor  \n Beat opponent(s) in 10 minutes or less to earn this medal"
+END
+
+TOOLTIP:BattleHonorBlitz5
+"Blitz Honor  \n Beat opponent(s) in 5 minutes or less to earn this medal"
+END
+
+TOOLTIP:BattleHonorLoyaltyUSADisabled
+"USA Loyalty Honor  \n Play 20+ games in a row as USA to earn this medal"
+END
+
+TOOLTIP:BattleHonorLoyaltyChinaDisabled
+"China Loyalty Honor  \n Play 20+ games in a row as China to earn this medal"
+END
+
+TOOLTIP:BattleHonorLoyaltyGLADisabled
+"GLA Loyalty Honor  \n Play 20+ games in a row as the GLA to earn this medal"
+END
+
+TOOLTIP:BattleHonorBattleTankDisabled
+"Battle Tank Honor  \n Build 50+ tanks against computer opponent(s) to earn this medal"
+END
+
+TOOLTIP:BattleHonorAirWingDisabled
+"Air Wing Honor  \n Build 20+ aircraft against computer opponent(s) to earn this medal"
+END
+
+TOOLTIP:BattleHonorEnduranceDisabled
+"Endurance Honor  \n Beat every map to earn a Bronze, Silver, or Gold medal"
+END
+
+TOOLTIP:BattleHonorCampaignUSADisabled
+"USA Campaign Honor  \n Complete the USA Campaign to earn this honor  \n Beat the campaign on Hard difficulty to achieve the highest honor"
+END
+
+TOOLTIP:BattleHonorCampaignChinaDisabled
+"China Campaign Honor  \n Complete the China Campaign to earn this honor  \n Beat the campaign on Hard difficulty to achieve the highest honor"
+END
+
+TOOLTIP:BattleHonorCampaignGLADisabled
+"GLA Campaign Honor  \n Complete the GLA Campaign to earn this honor  \n Beat the campaign on Hard difficulty to achieve the highest honor"
+END
+
+TOOLTIP:BattleHonorChallengeDisabled
+"Challenge Honor  \n Defeat 1-7 Hard computer opponents to earn this medal"
+END
+
+GUI:BuildingsKilledStat
+"Buildings Killed"
+END
+
+GUI:BuildingsBuiltStat
+"Buildings Built"
+END
+
+GUI:BuildingsLostStat
+"Buildings Lost"
+END
+
+GUI:QMWinStreak
+"QuickMatch win streak"
+END
+
+GUI:LastLadder
+"Last Ladder"
+END
+
+GUI:LobbyJoined
+"You have joined %ls"
+END
+
+GUI:GSNoLoginInfoAll
+"Please enter your email, nickname, and password. Then, click on Login or Create Account"
+END
+
+GUI:GSNoLoginInfoEmailNickname
+"Please enter your email and nickname. Then, click on Login or Create Account"
+END
+
+GUI:GSNoLoginInfoEmailPassword
+"Please enter your email and password. Then, click on Login or Create Account"
+END
+
+GUI:Any
+"Any"
+END
+
+GUI:GSNoLoginInfoNicknamePassword
+"Please enter your nickname and password. Then, click on Login or Create Account"
+END
+
+GUI:GSNoLoginInfoEmail
+"Please enter your email. Then, click on Login or Create Account"
+END
+
+GUI:GSNoLoginInfoNickname
+"Please enter your nickname. Then, click on Login or Create Account"
+END
+
+GUI:GSNoLoginInfoPassword
+"Please enter your password. Then, click on Login or Create Account"
+END
+
+Buddy:MultipleOnlineNotification
+"You have buddies online"
+END
+
+GUI:ResetHonors
+"Reset Honors"
+END
+
+Chat:Observers
+"Observers View"
+END
+
+TOOLTIP:buddies
+"Sort game list by Buddies"
+END
+
+TOOLTIP:AddToBuddies
+"Add a player to your list of Buddies"
+END
+
+TOOLTIP:StagingPlayerInfo
+" \n Region: %ls  \n Ping: %d ms  \n %d wins/%d losses  \n %d disconnects  \n Favorite army: %ls"
+END
+
+GUI:CantBuildTooCloseToSupplies
+"You cannot build there because it is too close to a source of supplies"
+END
+
+OBJECT:Frosty
+"Snowman"
+END
+
+OBJECT:Prop
+"."
+END
+
+OBJECT:BigGate
+"Gate"
+END
+
+OBJECT:TownHall
+"Town Hall"
+END
+
+OBJECT:RailroadBridge
+"Railroad Bridge"
+END
+
+OBJECT:TheLoo
+"Out House"
+END
+
+OBJECT:TrainCar
+"Train Car"
+END
+
+OBJECT:SandBagWall
+"Sandbag Wall"
+END
+
+OBJECT:Structure
+"Civilian Building"
+END
+
+OBJECT:Airport
+"Civilian Airport"
+END
+
+OBJECT:Highrise
+"Highrise"
+END
+
+OBJECT:BridgeTower
+"Bridge Tower"
+END
+
+OBJECT:Field
+"Pitch"
+END
+
+OBJECT:SoccerStadiumGoal
+"Goal"
+END
+
+OBJECT:BigLightpost
+"Light Post"
+END
+
+MAP:BigRivers
+"Mountain Fox"
+END
+
+MAP:CHI01Open
+"Chinese Military Parade, Beijing  \n The Dragon Awakes"
+END
+
+MAP:CHI03Obj1Done
+"MISSION OBJECTIVE Complete"
+END
+
+MAP:CHI07Obj1
+"MISSION OBJECTIVE:  \n Establish a base and locate resources"
+END
+
+MAP:CHI07Obj2
+"MISSION OBJECTIVE:  \n Defeat the GLA"
+END
+
+MAP:GLA02OpenAlt2
+"Villages Outside Almaty, Kazakhstan  \n Seize the foreign supplies for our cause"
+END
+
+MAP:GLA02OpenAlt1
+"Villages Outside Almaty, Kazakhstan  \n Operation: Pillage the Village"
+END
+
+MAP:GLA06OpenAlt2
+"Western Shore of the Aral Sea, Kazakhstan  \n Steal the poisons of the West to use against them"
+END
+
+MAP:GLA06OpenAlt1
+"Western Shore of the Aral Sea, Kazakhstan  \n Operation: Appropriate Poisons"
+END
+
+MAP:GLA07OpenAlt2
+"Somewhere Near Lenger, Kazakhstan  \n Show the world what happens to traitors"
+END
+
+MAP:GLA07OpenAlt
+"Somewhere Near Lenger, Kazakhstan  \n Operation: Trojan Horse"
+END
+
+MAP:GLA03Open02
+"Chinese-Occupied Zhambul, Kazakhstan  \n Operation: Righteous Fire"
+END
+
+MAP:GLA03Directive
+"Informant Report:  \n Destroy the pharmaceutical factory to obtain an Anthrax Bomb"
+END
+
+MAP:USA02Hint1Text
+"Use pilots to grant added veterancy to your vehicles"
+END
+
+MAP:USA02Hint2Text
+"Use the Ranger's Flash-Bang upgrade to clear out garrisoned structures"
+END
+
+MAP:USA03Hint1Text
+"Build Patriot Missile Systems to defend your base"
+END
+
+MAP:USA04Hint1Text
+"Use Tomahawk Missile Launchers to clear out GLA strong-points"
+END
+
+MAP:NVIDIATEXT
+"Command & Conquer Generals  \n Coming February 2003"
+END
+
+MAP:USA06ObjHint2
+"HINT:  \n Capture this facility"
+END
+
+MAP:USA06ObjHint1
+"HINT:  \n There are important civilian buildings here"
+END
+
+MAP:GLA03Objective07
+"Objective Complete:  \n 300 traitors eliminated"
+END
+
+MAP:GLA03Objective08
+"Objective Complete:  \n Pharmaceutical factory destroyed"
+END
+
+MAP:GLA05Open
+"Adana, Turkey  \n Incirlik Air Base"
+END
+
+SCRIPT:GLA05Directive03
+"WARNING:  \n American air forces inbound  \n Build Stinger Sites to defend your base"
+END
+
+SCRIPT:GLA05Directive04
+"Secondary Objective:  \n Destroy the Chinese spy outpost"
+END
+
+SCRIPT:GLA05Directive05
+"WARNING:  \n American air forces inbound  \n Use Stinger Sites and Quad Cannons to shoot down enemy aircraft"
+END
+
+MAP:GLA08Open
+"Baikonur Cosmodrome, Southern Kazakhstan  \n Soviet-Era Rocket Launch Facility"
+END
+
+MAP:GLA08Open02
+"Southern Kazakhstan  \n Baikonur Cosmodrome"
+END
+
+SCRIPT:GLA08Objective01
+"MISSION OBJECTIVES:  \n Capture the ground control building  \n Capture the rocket launch gantry"
+END
+
+SCRIPT:GLA08Objective02
+"MISSION OBJECTIVE:  \n Capture the ground control building"
+END
+
+SCRIPT:GLA08Objective03
+"MISSION OBJECTIVE:  \n Capture the rocket launch gantry"
+END
+
+SCRIPT:GLA08Directive04
+"WARNING:  \n Enemy superweapon incoming"
+END
+
+MAP:USA07hint1
+"HINT:  \n Utilize this Supply Dock"
+END
+
+MAP:CHI05ObjInit
+"MISSION OBJECTIVE:  \n Destroy the 3 GLA camps  \n and the main GLA base"
+END
+
+MAP:CHI05Obj4
+"There are 4 targets remaining"
+END
+
+MAP:CHI05Obj3
+"There are 3 targets remaining"
+END
+
+MAP:CHI05Obj2
+"There are 2 targets remaining"
+END
+
+MAP:CHI05Obj1
+"There is only 1 target remaining"
+END
+
+MAP:CHI05Objhint1
+"HINT:  \n Utilize this Supply Dock"
+END
+
+MAP:CHI05Objhint2
+"HINT:  \n Capture these facilities"
+END
+
+MAP:CHI05ObjCBReady
+"HINT:  \n Carpet Bombers are now available"
+END
+
+MAP:USA08MapName
+"Last Call"
+END
+
+MAP:USA08Open
+"GLA Capital City, Aldastan  \n Operation: Last Call"
+END
+
+MAP:USA08OpenAlt
+"Akmola, Kazakhstan  \n Operation: Last Call"
+END
+
+MAP:USA08Objective01
+"MISSION OBJECTIVE:  \n Destroy all GLA forces and structures"
+END
+
+MAP:USA08WallGarWarning
+"WARNING:  \n The GLA has garrisoned the wall  \n Rangers must use Flash-bangs to kill garrisoned GLA troops"
+END
+
+MAP:USA08ChinaHint
+"Capture the Chinese buildings  \n Build combined US and China forces to wipe out the GLA"
+END
+
+MAP:USA08SCUDStormWarn
+"WARNING:  \n The GLA has constructed a SCUD Storm"
+END
+
+MAP:USA08MineWarn
+"WARNING:  \n GLA demo traps detected"
+END
+
+MAP:USA08GLABaseKIA
+"The GLA bases are destroyed  \n Eliminate the remaining GLA forces to win the war"
+END
+
+CONTROLBAR:TooltipCarpetBomb
+"Carpet Bomb target area  \n  \n Countdown Timer: 2:30"
+END
+
+CONTROLBAR:TooltipCrateDrop
+"Drop supply crates"
+END
+
+CONTROLBAR:TooltipDetonateNuke
+"Explode hidden nuclear device"
+END
+
+MAP:GLA01Objective
+"MISSION OBJECTIVE  \n Destroy the Dam"
+END
+
+MAP:GLA01Objective2
+"MISSION OBJECTIVE  \n Destroy the Chinese base"
+END
+
+MAP:TrainingGenerals
+"Left click on the generals button in the lower right corner of your screen to choose a new ability for your General. As you are promoted your General will gain access to new abilities. Some abilities will allow you to create new special units, while others will give you special powers that are used from your Command Center"
+END
+
+MAP:TrainingSalvage
+"You have created a pile of salvage. Whenever GLA vehicles destroy enemy vehicles salvage is left behind. GLA vehicles can pick up salvage by moving over it. Salvage may be worth money or experience. Technicals, Quad Cannons and Marauders can upgrade their weapons with salvage"
+END
+
+MAP:TrainingUpgrade
+"Upgrades are bought at different structures in your base. They improve your units. Left click on the Barracks and then left click on Capture Building icon to upgrade your Rangers to be able to capture enemy buildings"
+END
+
+GUI:SaveAndContinue
+"CONTINUE"
+END
+
+TOOLTIP:PlayerSetting
+"Choose to match with a 1 vs. 1 or Team Game"
+END
+
+TOOLTIP:Ping
+"Choose your tolerance for your opponent's connection speed"
+END
+
+TOOLTIP:Disconnect
+"Choose your tolerance for total opponent disconnects"
+END
+
+TOOLTIP:Ladder
+"Choose the ladder on which you'd like to play"
+END
+
+TOOLTIP:QuickMatchStatus
+"QuickMatch will attempt to match you based on skill level, PC spec, etc"
+END
+
+TOOLTIP:OnlineIP
+"IP Address used to connect to C&C Generals Zero Hour Online"
+END
+
+TOOLTIP:LanIP
+"IP Address used to connect with players in network games"
+END
+
+TOOLTIP:GamesBeingformed
+"Your connection speed to this game's players"
+END
+
+TOOLTIP:EmoteText
+"Left click to enter text"
+END
+
+CONTROLBAR:ToolTipChinaScienceCashHack
+"Steal money from enemy supply centers. You cannot steal more money than the enemy has  \n  \n Rank 1: $1000  \n Rank 2: $2000  \n Rank 3: $4000  \n  \n Deploy from: Command Center"
+END
+
+GUI:TRAINING
+"TRAINING"
+END
+
+GUI:CHINA_Caps
+"CHINA"
+END
+
+TOOLTIP:SupplyDock
+"Supplies"
+END
+
+TOOLTIP:TechBuilding
+"Tech Building"
+END
+
+TOOLTIP:Mission1
+"."
+END
+
+TOOLTIP:Mission2_8
+"Campaign One"
+END
+
+TOOLTIP:Mission9_16
+"Campaign Two"
+END
+
+TOOLTIP:Mission17_23
+"Campaign Three"
+END
+
+TOOLTIP:ButtonClear
+"Clear out the player name text box"
+END
+
+GUI:Objectives:
+"Summary:"
+END
+
+GUI:WinStreak
+"Win Streak"
+END
+
+GUI:LossStreak
+"Loss Streak"
+END
+
+GUI:PlayerNoMapWillTransfer
+"%ls does not have the map %ls. It will be transferred at game start"
+END
+
+GUI:LocalPlayerNoMapWillTransfer
+"You do not have the map %ls. It will be transferred to you at game start"
+END
+
+GUI:CouldNotTransferMap
+"Unable to transfer the map. The game cannot start"
+END
+
+GUI:Status
+"Status"
+END
+
+MapTransfer:CurrentFile
+"Current file: %ls"
+END
+
+MapTransfer:Timeout
+"Abort in %d:%2.2d"
+END
+
+MapTransfer:Preparing
+"Preparing..."
+END
+
+MapTransfer:Sending
+"Sending..."
+END
+
+MapTransfer:Recieving
+"Receiving..."
+END
+
+MapTransfer:Done
+"Done"
+END
+
+ThingTemplate:SalvageCrate
+"Salvage Crate"
+END
+
+ThingTemplate:IndustrialBridgeTower01
+"Bridge"
+END
+
+ThingTemplate:Crypt01
+"Crypt"
+END
+
+ThingTemplate:AsianAartmentSingle01
+"Apartment"
+END
+
+CONTROLBAR:RadioJam
+"Radio Jam"
+END
+
+MAP:USA01OBJOpen
+"MISSION OBJECTIVE  \n Destroy all enemy forces"
+END
+
+MAP:TrainingWarFactory
+"MISSION OBJECTIVE  \n Use your DOZER to build a WAR FACTORY"
+END
+
+TOOLTIP:MapNoSuccess
+"Beat this map against an Easy opponent!"
+END
+
+TOOLTIP:MapEasySuccess
+"Beat this map against a Medium opponent!"
+END
+
+TOOLTIP:MapMediumSuccess
+"Beat this map against a Hard opponent!"
+END
+
+TOOLTIP:MapHardSuccess
+"Beat this map against the maximum number of Hard opponents!"
+END
+
+Buddy:CantTalkToIngameBuddy
+"You cannot send messages to buddies in your game if you are observing"
+END
+
+MAP:Bavarian
+"Final Crusade"
+END
+
+MAP:CLake
+"Tournament Lake"
+END
+
+MAP:SBlast
+"Sand Serpent"
+END
+
+MAP:SleepingGiant
+"Dark Mountain"
+END
+
+MAP:SwissMP
+"Lone Eagle"
+END
+
+MAP:KandaharHighlands
+"Twilight Flame"
+END
+
+MAP:BoraBora
+"Tournament Island"
+END
+
+MAP:PrecipicePass
+"Fortress Avalanche"
+END
+
+MAP:TTourney
+"Tournament Tundra"
+END
+
+MAP:Gwall
+"Fallen Empire"
+END
+
+GUI:HTTPProxy
+"HTTP Proxy:"
+END
+
+GUI:WinPercent
+"%d%%"
+END
+
+TOOLTIP:PlayerCreatedName
+"Name of the player that created the game"
+END
+
+TOOLTIP:HTTPProxy
+"Set an HTTP Proxy to use for C&C Generals Zero Hour Online"
+END
+
+CONTROLBAR:BriefingHistory
+"Mission Briefings"
+END
+
+CONTROLBAR:BriefingHistoryDescription
+"Click to see mission briefings"
+END
+
+MAP:CHI04Objective1Text
+"MISSION OBJECTIVE  \n Destroy the GLA's Stinger Sites"
+END
+
+MAP:CHI04Objective2Text
+"MISSION OBJECTIVE  \n Use Black Lotus to capture the Chinese War Factory"
+END
+
+MAP:CHI04Objective3Text
+"MISSION OBJECTIVE  \n Destroy Stinger Sites around the Chemical Factory"
+END
+
+MAP:CHI04Hint1Text
+"HINT: Use Black Lotus to disable enemy vehicles"
+END
+
+MAP:CHI04Hint2Text
+"HINT: Use Hackers to generate additional income"
+END
+
+MAP:CHI04Hint3Text
+"HINT: Use Black Lotus to hack into the enemy's supply center to siphon off additional resources"
+END
+
+GUI:GotoMainMenu
+"MAIN MENU"
+END
+
+TOOLTIP:BattleHonorFairPlay
+"Fair Play Honor  \n Disconnect from Online games less than 10% of the time (with at least 10 games played) to earn this medal"
+END
+
+TOOLTIP:BattleHonorApocalypse
+"Apocalypse Honor  \n Player has built the Particle Cannon, Nuclear Missile, and SCUD Storm in a solo or multiplayer online game"
+END
+
+TOOLTIP:BattleHonorFairPlayDisabled
+"Fair Play Honor  \n Disconnect from Online games less than 10% of the time (with at least 10 games played) to earn this medal"
+END
+
+TOOLTIP:BattleHonorApocalypseDisabled
+"Apocalypse Medal  \n Build the Particle Cannon, Nuclear Missile, and SCUD Storm to earn this medal"
+END
+
+TOOLTIP:BattleHonorPreorder
+"Officers Club Honor  \n Player is a founding member of the Generals community"
+END
+
+TOOLTIP:BattleHonorPreorderDisabled
+"Officers Club Medal  \n Player did not preorder Generals"
+END
+
+GUI:Credits
+"CREDITS"
+END
+
+ERROR:D3DFailurePrompt
+"DirectX Error"
+END
+
+ERROR:D3DFailureMessage
+"Please make sure you have DirectX 8.1 or higher installed. Also verify that your video card meets the minimum requirements"
+END
+
+GUI:AudioHardware
+"Hardware Accelerated Audio"
+END
+
+GUI:AudioSurround
+"Surround Sound"
+END
+
+TOOLTIP:CheckAudioHardware
+"Check this box to enable hardware acceleration for Audio"
+END
+
+TOOLTIP:AudioSurround
+"Check this box if you have surround sound speakers"
+END
+
+CAMPAIGN:TRAINING
+"Training"
+END
+
+GUI:WinPercentLabel
+"Win Percent"
+END
+
+GUI:BestWinStreak
+"Best Win Streak"
+END
+
+Buddy:MatchingNotification
+"%hs is QuickMatching"
+END
+
+Buddy:StagingNotification
+"%hs is setting up a game"
+END
+
+Buddy:LoadingNotification
+"%hs is starting a game"
+END
+
+Buddy:PlayingNotification
+"%hs is playing a game"
+END
+
+CONTROLBAR:GeneralsPromotion
+"General's Promotion"
+END
+
+CONTROLBAR:GeneralsExp
+"Generals Experience"
+END
+
+CONTROLBAR:GeneralsExpDescription
+"This meter shows how close you are to reaching your next General level"
+END
+
+TOOLTIP:TooltipNukeReactorOverChargeIsOn
+"Overcharge is currently ON"
+END
+
+TOOLTIP:TooltipNukeReactorOverChargeIsOff
+"Overcharge is currently OFF"
+END
+
+GUI:ESRB_Top
+"ESRB Notice:"
+END
+
+GUI:ESRB_Bottom
+"Game Experience May  \n Change During Online Play"
+END
+
+GUI:ReplaySaved
+"Replay Saved"
+END
+
+OBJECT:Monument
+"Monument"
+END
+
+TOOLTIP:TooltipNotEnoughMoneyToBuild
+"Insufficient funds"
+END
+
+TOOLTIP:TooltipCannotPurchaseBecauseQueueFull
+"Build queue full"
+END
+
+TOOLTIP:TooltipCannotBuildUnitBecauseParkingFull
+"Airfield full"
+END
+
+TOOLTIP:TooltipCannotBuildUnitBecauseMaximumNumber
+"Unit already exists"
+END
+
+GUI:SocketError
+"Failed trying to communicate with the network, check your connection"
+END
+
+GUI:NetworkError
+"NETWORK ERROR"
+END
+
+GUI:BuddiesTab
+"Buddies"
+END
+
+TOOLTIP:BattleHonorOfficersClub
+"Officers Club Honor  \n Founding member of the Generals Community"
+END
+
+GUI:CreateFormationDescription
+"Create a formation of the selected units and they will retain it as they move"
+END
+
+GUI:ScatterDescription
+"Scatter selected object(s)"
+END
+
+OBJECT:TrainWreckBridge
+"Train Wreck Bridge"
+END
+
+MAP:BarrenBadlands
+"Barren Badlands"
+END
+
+MAP:CraterCanyon
+"Crater Canyon"
+END
+
+MAP:DustDevil
+"Dust Devil"
+END
+
+MAP:EasternEverglades
+"Eastern Everglades"
+END
+
+MAP:ForgottenForest
+"Forgotten Forest"
+END
+
+MAP:InterstateInferno
+"Interstate Inferno"
+END
+
+MAP:MountainMayhem
+"Mountain Mayhem"
+END
+
+MAP:NoMansLand
+"No Man's Land"
+END
+
+MAP:OverlandOffensive
+"Overland Offensive"
+END
+
+MAP:RockyRampage
+"Rocky Rampage"
+END
+
+MAP:SnowblindStrike
+"Snowblind Strike"
+END
+
+MAP:UrbanUnderground
+"Urban Underground"
+END
+
+MAP:VictoryValley
+"Victory Valley"
+END
+
+MAP:WastelandWarfare
+"Wasteland Warfare"
+END
+
+MAP:RogueAgent
+"Rogue Agent"
+END
+
+MAP:DesertEagle
+"Desert Eagle"
+END
+
+MAP:FlashFire
+"Flash Fire"
+END
+
+MAP:MountainGuns
+"Mountain Guns"
+END
+
+MAP:FlashEffect
+"Flash Effect"
+END
+
+MAP:LightsOut
+"Lights Out"
+END
+
+MAP:SteelTrap
+"Steel Trap"
+END
+
+MAP:ArmoredFury
+"Armored Fury"
+END
+
+MAP:InfiniteJustice
+"Cairo Commandos"
+END
+
+MAP:Whiteout
+"Whiteout"
+END
+
+MAP:FalloutEffect
+"Fallout Effect"
+END
+
+MAP:FloodedPlains
+"Flooded Plains"
+END
+
+MAP:TournamentContinent
+"Tournament Continent"
+END
+
+MAP:TournamentCity
+"Tournament City"
+END
+
+MAP:TournamentLadder01
+"Tournament Ladder 01"
+END
+
+MAP:TournamentLadder02
+"Tournament Ladder 02"
+END
+
+MAP:TournamentLadder03
+"Tournament Ladder 03"
+END
+
+MAP:TournamentLadder04
+"Tournament Ladder 04"
+END
+
+MAP:TrainingGLAHole
+"GLA buildings have deep underground areas that allow their workers to remain protected. After destroying a GLA building a hole will be left behind. Workers hidden in this hole will eventually rebuild the structure. Attack the hole to remove the GLA threat"
+END
+
+TOOLTIP:BattleHonorStreak25
+"Streak Honor  \n Player has won 25 Skirmish games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+GUI:InsertCDPrompt
+"Missing CD"
+END
+
+GUI:InsertCDMessage
+"Please insert the first game CD"
+END
+
+CONTROLBAR:OrRequirement
+"or"
+END
+
+SCRIPT:USA02RescueCounter
+"Pilots Remaining:"
+END
+
+GUI:AddCash
+"$%d"
+END
+
+GUI:LoseCash
+"-$%d"
+END
+
+RADAR:HarvesterUnderAttack
+"Resource gatherer under attack"
+END
+
+OBJECT:PharmaceuticalFactory
+"Pharmaceutical Factory"
+END
+
+GUI:CareerWins
+"Career Wins"
+END
+
+GUI:CareerLosses
+"Career Losses"
+END
+
+GUI:CurrentWinStreak
+"Current Win Streak"
+END
+
+GUI:CarrerWinPercent
+"Career Win Percentage"
+END
+
+TOOLTIP:NumberOfPlayers
+"Number of players currently in this game"
+END
+
+TOOTIP:Password
+"Password required to join game"
+END
+
+TOOLTIP:PingInfo
+"Connection speed quality to host"
+END
+
+TOOLTIP:LobbyOfficersClub
+"Officers Club: Founding member of the Generals Community"
+END
+
+GUI:Display
+"OPTIONS"
+END
+
+GUI:Audio
+"AUDIO"
+END
+
+GUI:LANLobby
+"LAN LOBBY"
+END
+
+GUI:Mute
+"Mute"
+END
+
+GUI:NeedHumanPlayers
+"You need a non-observer human player to start the game"
+END
+
+GUI:MediumDifficulty
+"Medium"
+END
+
+CONTROLBAR:ObsPlayerLabel
+"%ls (Team %ls)"
+END
+
+GUI:LowTextureDetail
+"Low Texture Detail"
+END
+
+TOOLTIP:LowTextureDetail
+"Use Low Resolution Textures"
+END
+
+GUI:QuickMatch800x600
+"Please change your video resolution to 800 x 600 to play QuickMatch"
+END
+
+OBJECT:CargoPlane
+"Cargo Plane"
+END
+
+OBJECT:HuNanProvince
+"Beijing"
+END
+
+OBJECT:HongKong
+"Hong Kong"
+END
+
+OBJECT:HubeiProvince
+"Three Gorges Dam"
+END
+
+OBJECT:Tangula
+"Tanggula Mountains"
+END
+
+OBJECT:Balykchy
+"Balykchy"
+END
+
+OBJECT:Bishkek
+"Bishkek"
+END
+
+OBJECT:Dushanbe
+"Dushanbe"
+END
+
+OBJECT:Shymkent
+"Shymkent"
+END
+
+OBJECT:Almaty
+"Almaty"
+END
+
+OBJECT:Zambul
+"Zhambul"
+END
+
+OBJECT:Astana
+"Astana"
+END
+
+OBJECT:Incirlik
+"Incirlik"
+END
+
+OBJECT:AralSea
+"Aral Sea"
+END
+
+OBJECT:Lenger
+"Lenger"
+END
+
+OBJECT:Baikonur
+"Baikonur"
+END
+
+OBJECT:Mazar
+"Mazar"
+END
+
+OBJECT:Baghdad
+"Baghdad"
+END
+
+OBJECT:AlHanad
+"Al Hanad"
+END
+
+OBJECT:NorthKazakhstan
+"Northern Kazakhstan"
+END
+
+OBJECT:KazakhstanCoast
+"Kazakhstan Coast"
+END
+
+OBJECT:KazakhstanDMZ
+"Kazakhstan DMZ"
+END
+
+OBJECT:SouthKazkahstan
+"Southeastern Kazakhstan"
+END
+
+OBJECT:Akmola
+"Akmola"
+END
+
+SCRIPT:GLA03Objective01a
+"MISSION OBJECTIVES:  \n Claim the Command Center to the East to begin production  \n Kill 200 traitors"
+END
+
+SCRIPT:GLA03Objective02a
+"MISSION OBJECTIVE:  \n Use Toxin Tractors to kill 200 traitors"
+END
+
+TOOLTIP:Campaign1
+"Campaign 3"
+END
+
+TOOLTIP:Campaign2
+"Campaign 2"
+END
+
+TOOLTIP:Campaign3
+"Campaign 1"
+END
+
+GUI:Setup
+"SETUP"
+END
+
+GUI:PlayerInfo
+"PLAYER INFO"
+END
+
+GUI:Persona
+"PERSONA"
+END
+
+GUI:TextureHigh
+"High Quality (slower)"
+END
+
+GUI:TextureMedium
+"Medium Quality"
+END
+
+GUI:TextureLow
+"Low Quality (faster)"
+END
+
+GUI:GameSpeed
+"Game Speed"
+END
+
+GUI:SlowGameSpeed
+"Slow"
+END
+
+GUI:MediumGameSpeed
+"Medium"
+END
+
+GUI:FastGameSpeed
+"Fast"
+END
+
+GUI:RestartConfirmationTitle
+"RESTART?"
+END
+
+GUI:SurrenderConfirmationTitle
+"SURRENDER?"
+END
+
+TOOLTIP:StartPositionN
+"Start Position for player %d"
+END
+
+LABEL:FORMATION
+"F"
+END
+
+GUI:IgnoreSm
+"Ignore"
+END
+
+GUI:AcceptSm
+"ACCEPT"
+END
+
+GUI:EasyCaps
+"EASY"
+END
+
+GUI:MediumDifficultyCaps
+"MEDIUM"
+END
+
+GUI:HardCaps
+"HARD"
+END
+
+TOOLTIP:AdvanceOptionsAccept
+"Accept the changes made to the Advance Display Options"
+END
+
+TOOLTIP:AdvanceOptionsCancel
+"Exit the Advance Display Options Menu without making your changes"
+END
+
+GUI:AdvanceDisplayOptions
+"ADVANCED DISPLAY OPTIONS"
+END
+
+GUI:Shadows
+"Shadows"
+END
+
+TOOLTIP:Shadows
+"Toggle showing shadows in game. Turn off for improved performance"
+END
+
+GUI:BehindBuilding
+"Behind Buildings"
+END
+
+TOOLTIP:BehindBuilding
+"Toggle showing units behind buildings. Turn off for improved performance"
+END
+
+GUI:ShowProps
+"Show Props"
+END
+
+TOOLTIP:ShowProps
+"Toggle displaying game props. Turn off for improved performance"
+END
+
+GUI:LowResSlider
+"TEXTURE RESOLUTION"
+END
+
+GUI:HighResSlower
+"High Resolution (Slower)"
+END
+
+GUI:LowResFaster
+"Low Resolution (Faster)"
+END
+
+TOOLTIP:LowResSlider
+"Higher resolution textures can slow the game down"
+END
+
+GUI:ParticleCap
+"PARTICLE CAP"
+END
+
+GUI:MoreParticlesSlower
+"Max Particles (Slower)"
+END
+
+GUI:LessParticlesFaster
+"Min Particles (Faster)"
+END
+
+TOOLTIP:ParticleCapSlider
+"More particles can slow the game down"
+END
+
+GUI:CurrentLossStreak
+"Current Loss Streak"
+END
+
+GUI:Custom
+"Custom"
+END
+
+GUI:ToggleOnOff
+"Visual Effects"
+END
+
+GUI:RestartMission
+"RESTART MISSION"
+END
+
+GUI:ExitMission
+"EXIT MISSION"
+END
+
+GUI:OlderReplayVersionTitle
+"OLDER REPLAY VERSION"
+END
+
+GUI:OlderReplayVersion
+"Loading may not display the replay properly, continue to load?"
+END
+
+GUI:Shadows2D
+"2D Shadows"
+END
+
+TOOLTIP:Shadows2D
+"Toggle showing 2D shadows in game. Turn off for improved performance"
+END
+
+GUI:Shadows3D
+"3D Shadows"
+END
+
+TOOLTIP:Shadows3D
+"Toggle showing 3D shadows in game. Turn off for improved performance"
+END
+
+GUI:CloudShadows
+"Cloud Shadows"
+END
+
+TOOLTIP:CloudShadows
+"Toggle showing cloud shadows on terrain. Turn off for improved performance"
+END
+
+GUI:GroundLighting
+"Extra Ground Lighting"
+END
+
+TOOLTIP:GroundLighting
+"Toggle showing detailed lighting on terrain. Turn off for improved performance"
+END
+
+GUI:SmoothWater
+"Smooth Water Borders"
+END
+
+TOOLTIP:SmoothWater
+"Toggle smoothing of water borders. Turn off for improved performance"
+END
+
+GUI:ExtraAnimations
+"Extra Animations"
+END
+
+TOOLTIP:ExtraAnimations
+"Toggle showing optional animations like tree sway. Turn off for improved performance"
+END
+
+GUI:NoDynamicLOD
+"Disable Dynamic Level of Detail"
+END
+
+TOOLTIP:NoDynamicLOD
+"Disable automatic detail adjustment. Turn off for improved performance"
+END
+
+GUI:UnlockMaxFPS
+"Uncapped FPS"
+END
+
+TOOLTIP:UnlockMaxFPS
+"Allows frame rates above 30. Affects game speed so only recommended for benchmarks"
+END
+
+GUI:TreeSway
+"Tree Animation"
+END
+
+TOOLTIP:TreeSway
+"Toggle tree animations. Turn off for improved performance"
+END
+
+GUI:TankTreads
+"Vehicle Tracks"
+END
+
+TOOLTIP:TankTreads
+"Toggle marks left by vehicles. Turn off for improved performance"
+END
+
+GUI:WaterWaves
+"Water Waves"
+END
+
+TOOLTIP:WaterWaves
+"Toggle wave animations on shorelines. Turn off for improved performance"
+END
+
+GUI:BuildupAnimations
+"Buildup Animations"
+END
+
+TOOLTIP:BuildupAnimations
+"Show additional animations during structure construction. Turn off for improved performance"
+END
+
+GUI:AdvancedOptionsToggleOnOff
+"Toggle On/Off - Off to improve performance"
+END
+
+GUI:PerformanceTestingMessage
+"Please wait while we test your system performance to determine optimal settings"
+END
+
+GUI:PerformanceTestingTitle
+"Testing System Performance"
+END
+
+GUI:ReducedColor
+"16-Bit Color"
+END
+
+TOOLTIP:ReducedColor
+"Improves performance but reduces visual quality"
+END
+
+GUI:SelectAMapLowerCase
+"Select Map"
+END
+
+GUI:SaveAndExit
+"SAVE AND EXIT"
+END
+
+GUI:PerSideWinPercentage
+"%d%% %ls"
+END
+
+GUI:WinnersToday
+"TODAY'S WINNERS"
+END
+
+GUI:WinnersLastWeek
+"LAST WEEK'S WINNERS"
+END
+
+MOTD:NumPlayersHeading
+"Welcome to Generals Zero Hour Online."
+END
+
+TOOLTIP:GameAcceptance
+"Game Acceptance"
+END
+
+TOOLTIP:ConnectionSpeed
+"Connection Speed"
+END
+
+CONTROLBAR:NoHotKeyArtilleryBarrage
+"Artillery Barrage"
+END
+
+CONTROLBAR:NoHotKeySpySatellite
+"Spy Satellite"
+END
+
+GUI:FetchingPlayerInfo
+"Updating..."
+END
+
+CREDITS:EALosAngelesFieldRecordingsTeam
+"EA Los Angeles Field Recordings Team"
+END
+
+CREDITS:TiburonQualityAssuranceSeniorLead
+"EA Tiburon Quality Assurance Senior Lead"
+END
+
+CREDITS:TiburonQualityAssuranceProjectLead
+"EA Tiburon Quality Assurance Project Lead"
+END
+
+CREDITS:TiburonAssociateQualityAssuranceLeads
+"EA Tiburon Associate Quality Assurance Leads"
+END
+
+CREDITS:TiburonQualityAssuranceSeniorTesters
+"EA Tiburon Quality Assurance Senior Testers"
+END
+
+CREDITS:TiburonQualityAssuranceTesters
+"EA Tiburon Quality Assurance Testers"
+END
+
+CREDITS:EAUKAdditionalQualityAssurance
+"EAUK Additional Quality Assurance"
+END
+
+CREDITS:MultiplayerTestParticipants
+"Multiplayer Test Participants"
+END
+
+CREDITS:FocusTesters
+"Focus Testers"
+END
+
+CREDITS:NorthAmericaMarketingPartners
+"North America Marketing Partners"
+END
+
+CREDITS:ManagingDirectorEurope
+"Managing Director, Europe"
+END
+
+CREDITS:EuropeanMarketingPartners
+"European Marketing Partners"
+END
+
+CREDITS:AsiaPacificPresidentandCoach
+"EA Asia Pacific, President and Coach"
+END
+
+CREDITS:AsiaPacificMarketingPartners
+"EA Asia Pacific Marketing Partners"
+END
+
+CREDITS:GamingCommunityPartners
+"Gaming Community Partners"
+END
+
+CREDITS:EADevelopmentExecutives
+"EA Development Executives"
+END
+
+CREDITS:SpecialThankstotheMaxiscrew
+"Special Thanks to the Maxis crew"
+END
+
+CREDITS:VerySpecialThanks
+"Very Special Thanks"
+END
+
+CREDITS:DevelopmentTitle
+"Command & Conquer (TM) Generals Zero Hour was developed"
+END
+
+CREDITS:EAPacificDevTeam
+"Electronic Arts Los Angeles"
+END
+
+CREDITS:ExecutiveInCharge
+"Executive in Charge of Production"
+END
+
+CREDITS:Producer
+"Producer"
+END
+
+CREDITS:LeadDesigner
+"Lead Designer"
+END
+
+CREDITS:TechnicalDirector
+"Technical Director"
+END
+
+CREDITS:ArtDirector
+"Art Director"
+END
+
+CREDITS:ArtProducer
+"Art Producer"
+END
+
+CREDITS:SeniorProducer
+"Senior Producer"
+END
+
+CREDITS:AssociateProducers
+"Associate Producer"
+END
+
+CREDITS:MultiplayerTestProducer
+"Multiplayer Test Producer"
+END
+
+CREDITS:SeniorEngineers
+"Senior Engineers"
+END
+
+CREDITS:Engineers
+"Engineers"
+END
+
+CREDITS:AdditionalEngineering
+"Additional Engineering"
+END
+
+CREDITS:Designers
+"Designers"
+END
+
+CREDITS:AdditionalDesignInspirationandSupport
+"Additional Design, Inspiration and Support"
+END
+
+CREDITS:AdditionalDesign
+"Additional Design"
+END
+
+CREDITS:ExternalMultiplayMapCreators
+"External Multiplay Map Creators"
+END
+
+CREDITS:Artists
+"Artists"
+END
+
+CREDITS:AdditionalArt
+"Additional Art"
+END
+
+CREDITS:DirectorofAudio
+"Director of Audio"
+END
+
+CREDITS:SoundDesignandVoiceDirection
+"Sound Design and Voice Direction"
+END
+
+CREDITS:Composers
+"Composers"
+END
+
+CREDITS:Composer1
+"Music Composed and Produced by"
+END
+
+CREDITS:Additionalsoundsanddialogueprocessing
+"Additional Sounds and Additional Dialogue Processing"
+END
+
+CREDITS:ScriptWriters
+"Script Writers"
+END
+
+CREDITS:SoundEffectsFieldRecordings
+"Sound Effects Field Recordings"
+END
+
+CREDITS:SoundEffectsFieldRecordings1
+"Jacques Littlefield and the Military Vehicle Technology Foundation"
+END
+
+CREDITS:SoundEffectsFieldRecordings2
+"SPEC Samuel H. Cho"
+END
+
+CREDITS:SoundEffectsFieldRecordings3
+"Staff Sergeant Scott McClane of C troop 1/18 Cav"
+END
+
+CREDITS:SoundEffectsFieldRecordings4
+"Mary Beth McFadden and Francisco Mendozo at Adam's Steel - Anaheim"
+END
+
+CREDITS:CinematicCutSceneDirector
+"Cinematic Cut Scene Director"
+END
+
+CREDITS:CinematicCutSceneArtists
+"Cinematic Cut Scene Artists"
+END
+
+CREDITS:ProductionAssistance
+"Additional Production Management"
+END
+
+CREDITS:AdditionalProductionManagement
+"Additional Production Management"
+END
+
+CREDITS:CameoProduction
+"Cameo Production"
+END
+
+CREDITS:Casting
+"Casting by Deborah German Casting"
+END
+
+CREDITS:Wardrobe
+"Wardrobe by Jodi DeMarco"
+END
+
+CREDITS:HairandMakeUp
+"Hair and Make-Up by Jodi DeMarco"
+END
+
+CREDITS:EngineeringInterns
+"Engineering Interns"
+END
+
+CREDITS:ArtIntern
+"Art Intern"
+END
+
+CREDITS:EAPacificQualityAssurance
+"EA Pacific Quality Assurance"
+END
+
+CREDITS:EAPacificOperations
+"EA Pacific Operations"
+END
+
+CREDITS:VoiceActors
+"Voice Actors"
+END
+
+CREDITS:CameoPhotos
+"Cameo and Generals' Photos"
+END
+
+CREDITS:AdditionalModels
+"Additional Models by Mythos Studios"
+END
+
+CREDITS:CinematicIntroandFinaleMovies
+"Intro Movie by Mondo Media"
+END
+
+CREDITS:MotionCapture
+"Westwood Motion Capture"
+END
+
+CREDITS:MilitarypropsThanx
+"Military props supplied by David Hsu & Specialized Distribution"
+END
+
+CREDITS:SpecialThanx1
+"Thanks & Love to Daisy & Freeman Gushee, Mom & Dad and Ike! - Harvard"
+END
+
+CREDITS:SpecialThanx2
+"Love and thanks to Laura, Ben, Jack, Sam and Sophie"
+END
+
+CREDITS:SpecialThanx3
+"Thanks to the Brown Family Support Team- Robin, Josh, Beth and Meeskite"
+END
+
+CREDITS:SpecialThanx4
+"Thanks to my son Colin Moore for letting me play the game on his machine"
+END
+
+CREDITS:SpecialThanx5
+"A big hug to my new husband Joji for his love and support -Jill"
+END
+
+CREDITS:SpecialThanx7
+"Thanks to DMP, Jenny and Elizabeth"
+END
+
+CREDITS:SpecialThanx8
+"Thanks to my Father. - Mark Lorenzen"
+END
+
+CREDITS:SpecialThanx9
+"Lots of love to Madison, Reece, Melissa, Dad, and my bros! - Randy Greenback"
+END
+
+CREDITS:SpecialThanx10
+"Thanks to Maha, Ramzi, & Brooke for their support. Props to the 415 kids-Amer"
+END
+
+CREDITS:SpecialThanx11
+"Mom&Dad, Bry,Kev,Dan&Mel,Aaron&Kelsey,Mikki,Adam,Kev,Jay,James - SCC"
+END
+
+CREDITS:SpecialThanx12
+"To Brenda and Nero for their wonderful support - Eric Kearns"
+END
+
+CREDITS:SpecialThanx13
+"Thanks Gibson, Vinge, Mieville, Bear, Hebert, LeGuin - RN Smith"
+END
+
+CREDITS:SpecialThanx14
+"Deborah, Stephen, and Alan- Thanks for putting up with me - Ian Barkley-Yeung"
+END
+
+CREDITS:SpecialThanx15
+"Thanks to Cristi for your understanding and support - John"
+END
+
+CREDITS:SpecialThanx16
+"Thanks to April Wesley Kelly & Chelsie - Scott Bowen"
+END
+
+CREDITS:SpecialThanx17
+"Thanks to friends, family, Choo Choo Bear, and the hard-working ZH team! -JB"
+END
+
+CREDITS:SpecialThanx18
+"Thanks to Junko for your love. -Robert Minsk"
+END
+
+CREDITS:SpecialThanx19
+"Thank-U Carina, Kat and Brandon for being so understanding-David Wainstain"
+END
+
+CREDITS:SpecialThanx20
+"Thanks to my family, Cheryl and Brandon Burtis for their love and support"
+END
+
+CREDITS:SpecialThanx21
+"Thanks to my friends and family, especially Jeannie. I love you all - KDS"
+END
+
+CREDITS:SpecialThanx22
+"Thanks for my wonderful husband Roman - Samm"
+END
+
+CREDITS:SpecialThanx23
+"Thanks Ari for all your love, support and understanding - Jose"
+END
+
+CREDITS:SpecialThanx24
+"To Rebecca, the only thing that matters, the only thing that lasts"
+END
+
+CREDITS:SpecialThanx25
+"Thanks to my loving wife for inspiration and support - Chris Rubyor"
+END
+
+CREDITS:SpecialThanx26
+"Thanks to my wife for giving our time to me. I love you. - Jeff Stewart"
+END
+
+CREDITS:SpecialThanx27
+"Thanks to Mom BruceLauraDasmoMikeyTedoTrevor and all my buds in The OC"
+END
+
+CREDITS:SpecialThanx28
+"I would like to thank my family and Amy Ritchie"
+END
+
+CREDITS:SpecialThanx29
+"NazBoniadiArtRasoulZohreRahimiAliLeilaTabaFamilyP,T,KMLoBobWindDrFrost"
+END
+
+CREDITS:SpecialThanx31
+"Thanks to Ben Calmer & Laura Miele"
+END
+
+CREDITS:SpecialThanx33
+"Very Special Thanks to the Command & Conquer fan community."
+END
+
+CREDITS:SpecialThanx34
+"Mad props to my sweetie Joji and my baby Sparky"
+END
+
+CREDITS:SpecialThanx35
+"Thanks to my family, Cheryl and Brandon Burtis for their love and support"
+END
+
+CREDITS:SpecialThanx36
+"I'd like to thank my wife for understanding my busyness"
+END
+
+CREDITS:SpecialThanx37
+"Bjorn Muller Thanks: Mom, Dad, family & friends"
+END
+
+CREDITS:SpecialThanx38
+"I would like to thank my family and Amy for all the support"
+END
+
+CREDITS:SpecialThanx39
+"Special thanks: Mom, Dad, Bohdi, Willie, and anyone reading this"
+END
+
+CREDITS:SpecialThanx40
+"Thanks to all friends and family for waiting to have Christmas in February"
+END
+
+CREDITS:SpecialThanx41
+"Thanks to Bing, your support has been invaluable"
+END
+
+GUI:GameSaved
+"Game Saved"
+END
+
+GUI:ErrorSavingGame
+"Error saving game '%s'"
+END
+
+GUI:ErrorLoadingGame
+"Error loading game '%s'"
+END
+
+CREDITS:InspiredByLine1
+"Command & Conquer (TM) Generals Zero Hour was inspired by the original"
+END
+
+CREDITS:InspiredByLine2
+"Command & Conquer (TM) created by Westwood Studios"
+END
+
+CREDITS:MultiplayerTestParticipantThanxMessageLine1
+"Thanks to all of the fantastic Multiplayer Test participants"
+END
+
+CREDITS:MultiplayerTestParticipantThanxMessageLine2
+"that helped us put the game through its paces. Your help has"
+END
+
+CREDITS:MultiplayerTestParticipantThanxMessageLine3
+"been invaluable and we hope you enjoyed the experience"
+END
+
+CREDITS:SpecialThanxKeyMessage1
+"A very special thanks to all of our families for allowing us to do what"
+END
+
+CREDITS:SpecialThanxKeyMessage2
+"we love: making games. We can't thank you enough for your support"
+END
+
+CREDITS:SpecialThanxKeyMessage3
+"But we'll try..."
+END
+
+CREDITS:SpecialThanx6Line1
+"Thank you to my family and friends in Chilliwack, BC, Canada! - Kris Morness"
+END
+
+CREDITS:SpecialThanx6Line2
+"& support have been invaluable. I love you dearly"
+END
+
+CREDITS:SpecialThanx30Line1
+"Thanks to Jane,George,David,Sophia,Audrey,Shannon,Johan & agavenectar"
+END
+
+CREDITS:SpecialThanx30Line2
+"for being there, even though I couldn't"
+END
+
+CREDITS:SpecialThanx32Line1
+"Thanks to Bing Gordon, your continued support has been invaluable."
+END
+
+CREDITS:SpecialThanx32Line2
+"who'll do just about anything for a dollar"
+END
+
+GUI:ControlBarBack
+"BACK"
+END
+
+GUI:MainMenuLoadGame
+"LOAD GAME"
+END
+
+GUI:MainMenuLoadReplay
+"LOAD REPLAY"
+END
+
+GUI:LastReplay
+"Last Replay"
+END
+
+GUI:ControlBarMoneyDisplay
+"$ %d"
+END
+
+GUI:Player
+"Player"
+END
+
+CREDITS:UliLachelet
+"Uli L�chelt"
+END
+
+CREDITS:JorgLindner
+"J�rg Lindner"
+END
+
+CREDITS:LOCALIZATION
+"Localization"
+END
+
+CREDITS:EALocalisationManager
+"European EA Localization Manager"
+END
+
+CREDITS:EALocalisationProjectManager
+"European EA Localization Project Manager"
+END
+
+CREDITS:EuropeanIntegrationTeam
+"European Integration Team"
+END
+
+CREDITS:IntegrationEngineerManager
+"Integration Engineer Manager"
+END
+
+CREDITS:IntegrationProgrammer
+"Integration Programmers"
+END
+
+CREDITS:AudioPostproduction
+"Audio Postproduction"
+END
+
+CREDITS:SpanishLocalizationTeam
+"Spanish Localization Team"
+END
+
+CREDITS:LocalizationManagerEAIberia
+"Localization Manager EA Iberia"
+END
+
+CREDITS:QAnLTSupervisor
+"QA & LT Supervisor"
+END
+
+CREDITS:QALead
+"QA Lead"
+END
+
+CREDITS:QATesters
+"QA Testers"
+END
+
+CREDITS:LocalizationSupervisorEAIberia
+"Localization Supervisor EA Iberia"
+END
+
+CREDITS:LocalizationCoordinator
+"Localization Coordinator"
+END
+
+CREDITS:Translations
+"Translations"
+END
+
+CREDITS:DTPSupervisor
+"DTP Supervisor"
+END
+
+CREDITS:LayoutDesign
+"Layout Design"
+END
+
+CREDITS:Documentation
+"Documentation"
+END
+
+CREDITS:JoseMaria
+"Jos� Mar�a Garc�a"
+END
+
+CREDITS:AndresGine
+"Andr�s Gin�"
+END
+
+CREDITS:JoseRamon
+"Jos� Ram�n Sagarna"
+END
+
+CREDITS:DavidSuarez
+"David Su�rez"
+END
+
+CREDITS:AlejandroGomez
+"Alejandro G�mez"
+END
+
+CREDITS:IsmaeLDuran
+"Ismael Dur�n"
+END
+
+CREDITS:JoseLuis
+"Jos� Luis Rovira"
+END
+
+CREDITS:JavierMartinez
+"Javier Mart�nez"
+END
+
+CREDITS:LuisPines
+"Luis Pin�s"
+END
+
+CREDITS:EAItalyLocalization
+"EA Localization - Italy"
+END
+
+CREDITS:LocalisationManager
+"Localization Manager"
+END
+
+CREDITS:TranslationSupervisor
+"Translation Supervisor"
+END
+
+CREDITS:LTSupervisor
+"LT Supervisor"
+END
+
+CREDITS:LocalisationCoordinator
+"Localization Coordinator"
+END
+
+CREDITS:LocalisationGermany
+"EA Localization - Germany"
+END
+
+CREDITS:RobertBock
+"Robert B�ck"
+END
+
+CREDITS:TestCoordination
+"Test Coordination"
+END
+
+CREDITS:LanguageTester
+"Localization Tester"
+END
+
+CREDITS:LocalisationFrance
+"EA Localization - France"
+END
+
+CREDITS:TestManager
+"Test Manager"
+END
+
+CREDITS:FrenchLanguageTestingCoordinator
+"Language Testing Coordinator"
+END
+
+CREDITS:StephaneTachon
+"St�phane Tachon"
+END
+
+CREDITS:LanguageTesters
+"Localization Testers"
+END
+
+CREDITS:LocalisationBrazil
+"EA Localization - Brazil"
+END
+
+CREDITS:TranslationAndTesting
+"Translation & Testing"
+END
+
+CREDITS:LocalisationPoland
+"Localization - Poland"
+END
+
+GUI:LadderNameAndSize
+"%ls (%dv%d)"
+END
+
+GUI:InvalidLadderPassword
+"Invalid ladder password"
+END
+
+GUI:EnterLadderPassword
+"Enter ladder password:"
+END
+
+GUI:InternetDisconnectionMenuHeader
+"Disconnection Menu"
+END
+
+GUI:InternetDisconnectionMenuHeaderCaps
+"DISCONNECTION MENU"
+END
+
+GUI:InternetDisconnectionMenuBody1
+"One or more players have been disconnected from the game. If you choose to vote a person out of the game then click the VOTE button next to the respective player. When the timer counts down to 0 that person will be removed from the game and the battle will continue"
+END
+
+GUI:InternetDisconnectionMenuBody2
+"It is possible that the person is attempting to reconnect so you may choose to wait until this player's timer has elapsed. When the timer counts down to 0 that person will be removed from the game and the battle will continue"
+END
+
+CREDITS:EAKoreaLocalisationTeam
+"EA Korea Team"
+END
+
+CREDITS:BusinessDevelopmentManager
+"Business Development Manager"
+END
+
+CREDITS:LocalisationProducer
+"Localization Producer"
+END
+
+CREDITS:EAKoreaMarketingTeam
+"EA Korea Marketing Team"
+END
+
+CREDITS:MarketingManager
+"Marketing Manager"
+END
+
+CREDITS:ProductManager
+"Product Manager"
+END
+
+CREDITS:PublicRelations
+"Public Relations"
+END
+
+CREDITS:ProductPromotion
+"Product Promotion"
+END
+
+CREDITS:EATaiwanLocalisationTeam
+"EA Taiwan Localization Team"
+END
+
+CREDITS:EAAsiaPacificLocalisationProjectManager
+"EA Asia Pacific Localization Project Manager"
+END
+
+CREDITS:AdditionalStoryInspiration
+"Additional Story Inspiration"
+END
+
+GUI:RandomSide
+"Random"
+END
+
+GUI:Age
+"Age"
+END
+
+GUI:Month
+"Month (MM)"
+END
+
+GUI:Day
+"Day (DD)"
+END
+
+GUI:Year
+"Year (YYYY)"
+END
+
+CREDITS:DevelopmentTitle2
+"by Electronic Arts Los Angeles"
+END
+
+CREDITS:EAPacificDevTeam2
+"Command & Conquer (TM) Generals Zero Hour"
+END
+
+GUI:MustHaveAdminRights
+"You must have administrative rights to install a patch"
+END
+
+GUI:BuddyAddReq
+"User wants to add a buddy"
+END
+
+GUI:AgeFailedTitle
+"Age Requirement Notice"
+END
+
+GUI:AgeFailed
+"You must be 13 years of age or older to play this game online"
+END
+
+GUI:AdditionalLocalizationManagement
+"Additional Localization Management"
+END
+
+GUI:GroupRoom4
+"4 vs 4"
+END
+
+GUI:GroupRoom5
+"Asia"
+END
+
+GUI:GroupRoom6
+"Europe"
+END
+
+GUI:GroupRoom7
+"North America"
+END
+
+GUI:GroupRoom8
+"United Kingdom"
+END
+
+GUI:GroupRoom9
+"Germany"
+END
+
+GUI:GroupRoom10
+"Korea"
+END
+
+GUI:GroupRoom11
+"Free For All"
+END
+
+GUI:GroupRoom12
+"No Stats"
+END
+
+GUI:GroupRoom13
+"Mod Maps"
+END
+
+GUI:ControlOptions
+"CONTROL OPTIONS"
+END
+
+GUI:ClassicMouse
+"Classic"
+END
+
+GUI:AlternateMouse
+"Alternate Mouse Setup"
+END
+
+TOOLTIP:AlternateMouse
+"Right mouse button initiates unit action on battle field (attack, move, etc.)"
+END
+
+GUI:Generals_Challenge
+"CHALLENGE"
+END
+
+GUI:Generals_Challenge_Title
+"Generals' Challenge"
+END
+
+GUI:DemoMD_USA01ButtonTitle
+"USA 01"
+END
+
+GUI:DemoMD_USA02ButtonTitle
+"USA 02"
+END
+
+GUI:DemoMD_GLA03ButtonTitle
+"GLA 03"
+END
+
+GUI:DemoMD_CampEADemoTitle
+"DEMO"
+END
+
+TOOLTIP:TooltipCannotBuildBuildingBecauseMaximumNumber
+"Building already built"
+END
+
+TOOLTIP:MapMaxBrutalSuccess
+"Congratulations! You have beaten this map against the maximum number of Hard opponents!"
+END
+
+GUI:LimitArmies
+"Limit Armies"
+END
+
+TOOLTIP:LimitArmies
+"Check to limit armies to the traditional USA, GLA, and China factions and to disallow rogue general armies"
+END
+
+GUI:UseStats
+"Record Stats"
+END
+
+TOOLTIP:UseStats
+"Select whether or not this game's statistics will be recorded at the official C&C Generals Zero Hour server"
+END
+
+TOOLTIP:UseStatsOn
+"Statistics from this game WILL be recorded at the official C&C Generals Zero Hour server"
+END
+
+TOOLTIP:UseStatsOff
+"Statistics from this game WILL NOT be recorded at the official C&C Generals Zero Hour server"
+END
+
+GUI:StartingMoney
+"Starting Cash"
+END
+
+GUI:StartingMoneyFormat
+"$%u"
+END
+
+TOOLTIP:StartingMoney
+"Adjust the starting money for all players"
+END
+
+GUI:LimitSuperweapons
+"Limit Superweapons"
+END
+
+TOOLTIP:LimitSuperweapons
+"Check to limit Particle Cannons, Scud Storms, etc. to one per player"
+END
+
+TOOLTIP:BattleHonorStreak100
+"Streak Honor  \n Player has won 100 Skirmish games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak500
+"Streak Honor  \n Player has won 500 Skirmish games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak1000
+"Streak Honor  \n Player has won 1000 Skirmish games in a row"
+END
+
+TOOLTIP:BattleHonorStreak3Online
+"Streak Honor  \n Player has won 3 Online games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak10Online
+"Streak Honor  \n Player has won 10 Online games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak25Online
+"Streak Honor  \n Player has won 25 Online games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak100Online
+"Streak Honor  \n Player has won 100 Online games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak500Online
+"Streak Honor  \n Player has won 500 Online games in a row  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreak1000Online
+"Streak Honor  \n Player has won 1000 Online games in a row"
+END
+
+TOOLTIP:BattleHonorDomination100
+"Domination Honor  \n Player has won over 100 Skirmish games  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorDomination500
+"Domination Honor  \n Player has won over 500 Skirmish games  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorDomination1000
+"Domination Honor  \n Player has won over 1,000 Skirmish games  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorDomination10000
+"Domination Honor  \n Player has won over 10,000 Skirmish games"
+END
+
+TOOLTIP:BattleHonorDomination100Online
+"Domination Honor  \n Player has won over 100 Online games  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorDomination500Online
+"Domination Honor  \n Player has won over 500 Online games  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorDomination1000Online
+"Domination Honor  \n Player has won over 1,000 Online games  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorDomination10000Online
+"Domination Honor  \n Player has won over 10,000 Online games"
+END
+
+TOOLTIP:BattleHonorCampaignChallenge
+"Challenge Campaign Honor  \n Complete the Generals Challenge campaign to earn this honor  \n Beat the campaign on Hard difficulty to earn the highest honor"
+END
+
+TOOLTIP:BattleHonorUltimate
+"Ultimate Honor  \n Beat every Skirmish map against the maximum number of Hard opponents to earn this medal"
+END
+
+TOOLTIP:BattleHonorGlobalGeneral
+"Global General Honor  \n Win at least one Online game playing as each General to earn a medal"
+END
+
+TOOLTIP:BattleHonorStreakDisabled
+"Streak Honor  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorStreakOnlineDisabled
+"Streak Honor  \n Earn a new medal for 3, 10, 25, 100, 500 & 1000 consecutive wins"
+END
+
+TOOLTIP:BattleHonorCampaignChallengeDisabled
+"Challenge Campaign Honor  \n Complete the Generals Challenge campaign to earn this honor  \n Beat the campaign on Hard difficulty to earn the highest honor"
+END
+
+TOOLTIP:BattleHonorUltimateDisabled
+"Ultimate Honor  \n Beat every Skirmish map against the maximum number of Hard opponents to earn this medal"
+END
+
+TOOLTIP:BattleHonorDominationDisabled
+"Domination Honor  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorDominationOnlineDisabled
+"Domination Honor  \n Earn a new medal for 100, 500, 1000 and 10000 lifetime wins"
+END
+
+TOOLTIP:BattleHonorGlobalGeneralDisabled
+"Global General Honor  \n Win at least one Online game playing as each General to earn this medal"
+END
+
+TOOLTIP:BattleHonorBlitzDisabled
+"Blitz Honor  \n Beat opponent(s) in 10 minutes or less to earn this medal"
+END
+
+GUI:SuperweaponSpectreGunship
+"Spectre Gunship"
+END
+
+GUI:Nuke_SuperweaponNeutronMissile
+"Nuclear Missile"
+END
+
+GUI:SuperweaponGPSScrambler
+"GPS Scrambler"
+END
+
+GUI:SupW_SuperweaponParticleUplinkCannon
+"Particle Uplink Cannon"
+END
+
+GUI:SuperweaponTankParadrop
+"Tank Drop"
+END
+
+GUI:SupW_SuperweaponTomahawkStorm
+"Tomahawk Storm"
+END
+
+GUI:SupW_SuperweaponNeutronMissile
+"ICBM"
+END
+
+INI:FactionAmericaSuperWeaponGeneral
+"USA Super Weapon General"
+END
+
+INI:FactionAmericaLaserGeneral
+"USA Laser General"
+END
+
+INI:FactionAmericaAirForceGeneral
+"USA Air Force General"
+END
+
+INI:FactionAmericaCommanderInChief
+"USA Commander In Chief"
+END
+
+INI:FactionChinaTankGeneral
+"China Tank General"
+END
+
+INI:FactionChinaInfantryGeneral
+"China Infantry General"
+END
+
+INI:FactionChinaNukeGeneral
+"China Nuke General"
+END
+
+INI:FactionChinaCommanderInChief
+"China Commander In Chief"
+END
+
+INI:FactionGLAToxinGeneral
+"GLA Toxin General"
+END
+
+INI:FactionGLADemolitionGeneral
+"GLA Demolition General"
+END
+
+INI:FactionGLAStealthGeneral
+"GLA Stealth General"
+END
+
+INI:FactionGLACommanderInChief
+"GLA Commander In Chief"
+END
+
+INI:FactionBossGeneral
+"Boss General"
+END
+
+SIDE:AmericaSuperWeaponGeneral
+"USA Super Weapon General"
+END
+
+SIDE:AmericaLaserGeneral
+"USA Laser General"
+END
+
+SIDE:AmericaAirForceGeneral
+"USA Air Force General"
+END
+
+SIDE:ChinaTankGeneral
+"China Tank General"
+END
+
+SIDE:ChinaInfantryGeneral
+"China Infantry General"
+END
+
+SIDE:ChinaNukeGeneral
+"China Nuke General"
+END
+
+SIDE:GLAToxinGeneral
+"GLA Toxin General"
+END
+
+SIDE:GLADemolitionGeneral
+"GLA Demolition General"
+END
+
+SIDE:GLAStealthGeneral
+"GLA Stealth General"
+END
+
+SIDE:Boss
+"Boss General"
+END
+
+GUI:SelectAllAircraft
+"Select All Aircraft"
+END
+
+GUI:SelectAllAircraftDescription
+"Selects all Aircraft"
+END
+
+SCIENCE:USASpectreGunship1
+"Spectre Gunship"
+END
+
+SCIENCE:USALeafletDrop
+"Leaflet Drop"
+END
+
+SCIENCE:ChinaTankHunterTraining
+"Tank Hunter Training"
+END
+
+SCIENCE:ChinaBattleMasterTraining
+"Battlemaster Training"
+END
+
+SCIENCE:ChinaOverlordTraining
+"Overlord Training"
+END
+
+SCIENCE:ChinaGattlingTankTraining
+"Gattling Tank Training"
+END
+
+SCIENCE:ChinaNukeDrop
+"Nuke Drop"
+END
+
+SCIENCE:ChinaFrenzy
+"Frenzy 1"
+END
+
+SCIENCE:ChinaFrenzy2
+"Frenzy 2"
+END
+
+SCIENCE:ChinaFrenzy3
+"Frenzy 3"
+END
+
+SCIENCE:ChinaCarpetBomb
+"Carpet Bomb"
+END
+
+SCIENCE:GPSScrambler
+"GPS Scrambler"
+END
+
+SCIENCE:GLASneakAttack
+"Sneak Attack"
+END
+
+SCIENCE:ChinaTankParadrop1
+"Tank Drop 1"
+END
+
+SCIENCE:ChinaTankParadrop2
+"Tank Drop 2"
+END
+
+SCIENCE:ChinaTankParadrop3
+"Tank Drop 3"
+END
+
+SCIENCE:ChinaInfantryParadrop1
+"Infantry Paradrop 1"
+END
+
+SCIENCE:ChinaInfantryParadrop2
+"Infantry Paradrop 2"
+END
+
+SCIENCE:ChinaInfantryParadrop3
+"Infantry Paradrop 3"
+END
+
+CONTROLBAR:NoHotKeyFrenzy
+"Frenzy"
+END
+
+CONTROLBAR:CIAIntelligenceShortcut
+"Intelligence"
+END
+
+CONTROLBAR:CommunicationsDownload
+"Communications&Download"
+END
+
+CONTROLBAR:CommunicationsDownloadShortcut
+"Communications&Download"
+END
+
+CONTROLBAR:UpgradeChinaHelixPropagandaTower
+"Propaganda &Tower"
+END
+
+CONTROLBAR:UpgradeChinaHelixBattleBunker
+"Battle &Bunker"
+END
+
+CONTROLBAR:UpgradeChinaHelixGattlingCannon
+"Gattling &Cannon"
+END
+
+CONTROLBAR:UpgradeHelixNukeBomb
+"&Nuke Bomb"
+END
+
+CONTROLBAR:ConstructAmericaFireBase
+"F&ire Base"
+END
+
+CONTROLBAR:ConstructAmericaArtilleryPlatform
+"A&rtillery Platform"
+END
+
+CONTROLBAR:ConstructAmericaTankAvenger
+"Aven&ger"
+END
+
+CONTROLBAR:ConstructAmericaTankMicrowave
+"&Microwave Tank"
+END
+
+CONTROLBAR:BunkerExit
+"Exit Bunker"
+END
+
+CONTROLBAR:FireBaseExit
+"Exit Fire Base"
+END
+
+CONTROLBAR:ConstructFakeGLACommandCenter
+"Fake &Command Center"
+END
+
+CONTROLBAR:ConstructFakeGLABarracks
+"Fake &Barracks"
+END
+
+CONTROLBAR:ConstructFakeGLASupplyStash
+"Fake S&upply Stash"
+END
+
+CONTROLBAR:ConstructFakeGLAArmsDealer
+"Fake &Arms Dealer"
+END
+
+CONTROLBAR:ConstructChinaInternetCenter
+"&Internet Center"
+END
+
+CONTROLBAR:ConstructGLAVehicleCombatBike
+"Combat C&ycle"
+END
+
+CONTROLBAR:ConstructChinaTankEmperor
+"Emperor &Overlord"
+END
+
+CONTROLBAR:ConstructGLAInfantrySaboteur
+"&Saboteur"
+END
+
+CONTROLBAR:ConstructChinaInfantryPropagandaTrooper
+"&Propaganda Trooper"
+END
+
+CONTROLBAR:ConstructChinaInfantryMiniGunner
+"M&ini-Gunner"
+END
+
+CONTROLBAR:ConstructAmericaJetKingRaptor
+"King Rap&tor"
+END
+
+CONTROLBAR:ConstructAmericaJetFuelAirAurora
+"Aurora Alpha &Bomber"
+END
+
+CONTROLBAR:ConstructAmericaJetHypersonicAurora
+"&Aurora Alpha"
+END
+
+CONTROLBAR:ConstructGLAInfantrySniper
+"&Sniper"
+END
+
+CONTROLBAR:ConstructAmericaVehicleSentryDrone
+"&Sentry Drone"
+END
+
+CONTROLBAR:ConstructAmericaVehicleHellfireDrone
+"Hell&fire Drone"
+END
+
+CONTROLBAR:ConstructAmericaVehiclePointDefenseDrone
+"&Point Defense Drone"
+END
+
+CONTROLBAR:ConstructChinaVehicleHelix
+"Heli&x"
+END
+
+CONTROLBAR:ConstructChinaInfantryNukeHunter
+"Nuke H&unter"
+END
+
+CONTROLBAR:ConstructAmericaICBMLauncher
+"&ICBM"
+END
+
+CONTROLBAR:ConstructChinaVehicleListeningOutpost
+"Li&stening Outpost"
+END
+
+CONTROLBAR:ConstructFakeGLABlackMarket
+"Fake Black &Market"
+END
+
+CONTROLBAR:ConstructAmericaTomahawkStorm
+"&Tomahawk Storm"
+END
+
+CONTROLBAR:ConstructChinaTankECM
+"&ECM"
+END
+
+CONTROLBAR:ConstructGLAVehicleBattleBus
+"Battl&e Bus"
+END
+
+CONTROLBAR:UpgradeAmericaSentryDroneGun
+"Se&ntry Drone Gun"
+END
+
+CONTROLBAR:UpgradeGLAQuadCannonSnipe
+"Quan &Cannon Sniping"
+END
+
+CONTROLBAR:UpgradeAmericaSupplyLines
+"S&upply Lines"
+END
+
+CONTROLBAR:UpgradeAmericaMOAB
+"&Mother Of All Bombs"
+END
+
+CONTROLBAR:BecomeRealGLACommandCenter
+"&Become Real Command Center"
+END
+
+CONTROLBAR:BecomeRealGLABarracks
+"&Become Real Barracks"
+END
+
+CONTROLBAR:BecomeRealGLAArmsDealer
+"&Become Real Arms Dealer"
+END
+
+CONTROLBAR:BecomeRealGLASupplyStash
+"&Become Real Supply Stash"
+END
+
+CONTROLBAR:BecomeRealGLABlackMarket
+"&Become Real Black Market"
+END
+
+CONTROLBAR:UpgradeAmericaBunkerBusters
+"B&unker Busters"
+END
+
+CONTROLBAR:UpgradeAmericaCountermeasures
+"C&ountermeasures"
+END
+
+CONTROLBAR:UpgradeAmericaChemicalSuits
+"Chem&ical Suits"
+END
+
+CONTROLBAR:UpgradeChinaSatelliteHackOne
+"&Satellite Hack I"
+END
+
+CONTROLBAR:UpgradeChinaSatelliteHackTwo
+"&Satellite Hack II"
+END
+
+CONTROLBAR:UpgradeChinaFanaticism
+"&Patriotism"
+END
+
+CONTROLBAR:UpgradeChinaWGUraniumShells
+"Weapons Grade &Uranium Shells"
+END
+
+CONTROLBAR:UpgradeChinaTankAutoLoader
+"&Autoloader"
+END
+
+CONTROLBAR:UpgradeChinaNeutronShells
+"Neutron &Shells"
+END
+
+CONTROLBAR:UpgradeChinaFusionReactors
+"&Fusion Reactors"
+END
+
+CONTROLBAR:ChinaUpgradeHelixNapalmBomb
+"Enables this Helix to drop napalm bombs"
+END
+
+CONTROLBAR:ChinaUpgradeHelixNukeBomb
+"Enables this Helix to drop nuke bombs"
+END
+
+CONTROLBAR:UpgradeHelixNapalmBomb
+"&Napalm Bomb"
+END
+
+CONTROLBAR:UpgradeGLAFortifiedStructure
+"Fortifi&ed Structure"
+END
+
+CONTROLBAR:UpgradeGLABoobyTrap
+"B&ooby Trap"
+END
+
+CONTROLBAR:DetonateFakeBuilding
+"Detonate &Now!"
+END
+
+CONTROLBAR:UpgradeGLAWorkerFakeCommandSet
+"Switch to &Fake Structures"
+END
+
+CONTROLBAR:UpgradeGLAWorkerRealCommandSet
+"Switch to &Real Structures"
+END
+
+CONTROLBAR:UpgradeGLAHighExplosiveDemoTraps
+"High Explosive &Demo Traps"
+END
+
+CONTROLBAR:UpgradeGLACamoNetting
+"Camo &Netting"
+END
+
+CONTROLBAR:UpgradeGLAAnthraxGamma
+"Anthra&x Gamma"
+END
+
+CONTROLBAR:UpgradeGLAWorkerShoes
+"Worker &Shoes"
+END
+
+CONTROLBAR:UpgradeEMPMines
+"Neutron &Mines"
+END
+
+CONTROLBAR:NukeWarhead
+"&Nuclear Shell"
+END
+
+CONTROLBAR:NeutronWarhead
+"N&eutron Shells"
+END
+
+CONTROLBAR:LeafletDrop
+"&Leaflet Drop"
+END
+
+CONTROLBAR:SuitcaseNuke
+"Suitcase &Nuke"
+END
+
+CONTROLBAR:NeutronMissileShortcut
+"Nuclear Missile"
+END
+
+CONTROLBAR:ICBM
+"&ICBM"
+END
+
+CONTROLBAR:ICBMShortcut
+"ICBM"
+END
+
+CONTROLBAR:ScudStormShortcut
+"SCUD Storm"
+END
+
+CONTROLBAR:TomahawkStorm
+"&Tomahawk Storm"
+END
+
+CONTROLBAR:TomahawkStormShortcut
+"Tomahawk Storm"
+END
+
+CONTROLBAR:SpectreGunship
+"Spectre &Gunship"
+END
+
+CONTROLBAR:SpectreGunshipFromShortcut
+"Spectre Gunship"
+END
+
+CONTROLBAR:SneakAttack
+"Sneak A&ttack"
+END
+
+CONTROLBAR:TankParadrop
+"Tank Dro&p"
+END
+
+CONTROLBAR:NukeDrop
+"N&uke Drop"
+END
+
+CONTROLBAR:Frenzy
+"Frenz&y"
+END
+
+CONTROLBAR:RadarVanScanShortcut
+"Radar Scan"
+END
+
+CONTROLBAR:SelectAircraftCarriersFromShortcut
+"Select Aircraft Carriers"
+END
+
+CONTROLBAR:SelectBattleshipsFromShortcut
+"Battleship Bombardment"
+END
+
+CONTROLBAR:BattleshipFire
+"Battleship Bombardment"
+END
+
+CONTROLBAR:AircraftCarrierFire
+"Raptor Attack from Aircraft Carrier"
+END
+
+CONTROLBAR:ECMDisableVehicle
+"&Disable Vehicle"
+END
+
+CONTROLBAR:BoobyTrapAttack
+"&Booby Trap Attack"
+END
+
+CONTROLBAR:GPSScrambler
+"&GPS Scrambler"
+END
+
+CONTROLBAR:FireParticleUplinkCannonShortcut
+"Particle Cannon"
+END
+
+UPGRADE:AmericaSentryDroneGun
+"Sentry Drone Gun"
+END
+
+UPGRADE:AmericaMOAB
+"MOAB: Mother Of All Bombs"
+END
+
+UPGRADE:AmericaBunkerBusters
+"Bunker Buster Missiles"
+END
+
+UPGRADE:SatelliteHackOne
+"Satellite Hack I"
+END
+
+UPGRADE:SatelliteHackTwo
+"Satellite Hack II"
+END
+
+UPGRADE:HelixGattlingCannon
+"Helix Gattling Cannon"
+END
+
+UPGRADE:HelixPropagandaTower
+"Helix Propaganda Tower"
+END
+
+UPGRADE:HelixBattleBunker
+"Helix Battle Bunker"
+END
+
+UPGRADE:SupplyLines
+"Supply Lines"
+END
+
+UPGRADE:PointDefenseDrone
+"Point Defense Drone"
+END
+
+UPGRADE:QuadCannonSnipe
+"Quad Cannon Sniper Rounds"
+END
+
+UPGRADE:HellfireDrone
+"Hellfire Drone"
+END
+
+UPGRADE:Fanaticism
+"Patriotism"
+END
+
+UPGRADE:EMPMine
+"Neutron Mines"
+END
+
+UPGRADE:ChinaHelixNapalmBomb
+"Napalm Bomb"
+END
+
+UPGRADE:ChinaHelixNukeBomb
+"Nuke Bomb"
+END
+
+UPGRADE:WGUraniumShells
+"Weapons Grade Uranium Shells"
+END
+
+UPGRADE:TankAutoLoader
+"Auto Loader"
+END
+
+UPGRADE:NeutronShells
+"Neutron Shells"
+END
+
+UPGRADE:BecomeRealGLACommandCenter
+"Real Command Center"
+END
+
+UPGRADE:BecomeRealGLABarracks
+"Real Barracks"
+END
+
+UPGRADE:BecomeRealGLAArmsDealer
+"Real Arms Dealer"
+END
+
+UPGRADE:BecomeRealGLASupplyStash
+"Real Supply Stash"
+END
+
+UPGRADE:BecomeRealGLABlackMarket
+"Real Black Market"
+END
+
+UPGRADE:FusionReactors
+"Fusion Reactors"
+END
+
+UPGRADE:CamoNetting
+"Camo Netting"
+END
+
+UPGRADE:FortifiedStructure
+"Fortified Structure"
+END
+
+UPGRADE:BoobyTrap
+"Booby Trap"
+END
+
+UPGRADE:AnthraxGamma
+"Anthrax Gamma"
+END
+
+UPGRADE:WorkerShoes
+"Worker Shoes"
+END
+
+UPGRADE:ChemicalSuits
+"Chemical Suits"
+END
+
+UPGRADE:AmericaCountermeasures
+"Countermeasures"
+END
+
+UPGRADE:UpgradeChinaIsotopeStability
+"&Isotope Stability"
+END
+
+CONTROLBAR:TooltipUpgradeChinaIsotopeStability
+"Prevents most collateral radiation from harming friendly units when vehicles are destroyed"
+END
+
+OBJECT:SecretResearchLab
+"Secret Research Lab"
+END
+
+OBJECT:InternetCenter
+"Internet Center"
+END
+
+OBJECT:AircraftCarrier
+"Aircraft Carrier"
+END
+
+OBJECT:TechArtilleryPlatform
+"Artillery Platform -- Capture to bombard land based enemies"
+END
+
+OBJECT:NukeHunter
+"Nuke Hunter"
+END
+
+OBJECT:TechRepairPad
+"Repair Pad -- Capture to allow vehicles to repair at this facility"
+END
+
+OBJECT:AirF_Aurora
+"Fuel-Air Aurora Bomber"
+END
+
+OBJECT:SupW_Aurora
+"Aurora Alpha Bomber"
+END
+
+OBJECT:BattleBus
+"Battle Bus"
+END
+
+OBJECT:Helix
+"Helix"
+END
+
+OBJECT:PropagandaTrooper
+"Propaganda Trooper"
+END
+
+OBJECT:HellfireDrone
+"Hellfire Drone"
+END
+
+OBJECT:Avenger
+"Avenger"
+END
+
+OBJECT:Microwave
+"Microwave Tank"
+END
+
+OBJECT:MOAB
+"Mother Of All Bombs"
+END
+
+OBJECT:NukeDrop
+"Nuke Drop"
+END
+
+OBJECT:SuitcaseNuke
+"Suitcase Nuke"
+END
+
+OBJECT:StructureEMPMine
+"Neutron Mine"
+END
+
+OBJECT:ECMTank
+"ECM Tank"
+END
+
+OBJECT:Saboteur
+"Saboteur"
+END
+
+OBJECT:TechRepairBay
+"Tech Repair Bay -- Capture to repair vehicles across battlefield"
+END
+
+OBJECT:TechReinforcementPad
+"Reinforcement Pad -- Capture to receive additional vehicles"
+END
+
+OBJECT:Sniper
+"Sniper"
+END
+
+OBJECT:FireBase
+"Fire Base"
+END
+
+OBJECT:KingRaptor
+"King Raptor"
+END
+
+OBJECT:CombatBike
+"Combat Cycle"
+END
+
+OBJECT:SentryDrone
+"Sentry Drone"
+END
+
+OBJECT:TomahawkStorm
+"Tomahawk Storm"
+END
+
+OBJECT:ListeningOutpost
+"Listening Outpost"
+END
+
+Map:LeipzigLowlands
+"Leipzig Lowlands"
+END
+
+Map:BombardmentBeach
+"Bombardment Beach"
+END
+
+Map:BearTownBeatdown
+"Bear Town Beatdown"
+END
+
+MAP:RiverSnakes
+"Winding River"
+END
+
+MAP:KillingFields
+"Killing Fields"
+END
+
+MAP:ThinIce
+"Thin Ice"
+END
+
+MAP:ElScorcho
+"El Scorcho"
+END
+
+MAP:GreenPastures
+"Green Pastures"
+END
+
+MAP:FreeFireZone
+"Free Fire Zone"
+END
+
+MAP:DestructionStation
+"Destruction Station"
+END
+
+MAP:PolarStorm
+"Polar Storm"
+END
+
+MAP:BitterWinter
+"Bitter Winter"
+END
+
+MAP:CitySweep
+"City Sweep"
+END
+
+MAP:FrozenPlains
+"Frozen Plains"
+END
+
+MAP:RoadRage
+"Road Rage"
+END
+
+HELP:SentryDrone-01
+"HINT:  \n The Sentry Drone can detect camouflaged enemy units"
+END
+
+HELP:SentryDrone-02
+"HINT:  \n Purchase the Sentry Done gun from the Strategy Center"
+END
+
+HELP:MicrowaveTank-01
+"HINT:  \n The Microwave Tank can disable structures"
+END
+
+HELP:MicrowaveTank-02
+"HINT:  \n The Microwave Tank's microwaves injure nearby infantry"
+END
+
+HELP:Avenger-01
+"HINT:  \n The Avenger laser can 'paint' enemy targets  \n Firing at painted targets inflicts more damage"
+END
+
+HELP:Avenger-02
+"HINT:  \n Avengers are support units that can also attack aircraft"
+END
+
+HELP:FireBase-01
+"HINT:  \n Man the Fire Base with Missile Defenders  \n to provide both air and ground defense"
+END
+
+HELP:SpectreGunship-01
+"HINT:  \n Select an area for the Spectre Gunship to attack,  \n then manually target enemies"
+END
+
+HELP:LeafletDrop-01
+"HINT:  \n Use the Leaflet Drop to disable enemy infantry"
+END
+
+HELP:MOAB-01
+"HINT:  \n MOABs are effective against vehicles and  \n will stun any survivors"
+END
+
+HELP:Countermeasures-01
+"HINT:  \n Upgrade to Countermeasures to help air units evade attacks"
+END
+
+HELP:HellfireDrone-01
+"HINT:  \n Upgrade your vehicles with Hellfire Drones  \n to increase effectiveness against armored forces"
+END
+
+HELP:ChemicalSuit-01
+"HINT:  \n Utilize the Chemical Suit upgrade to protect infantry  \n from deadly toxins and radiation"
+END
+
+HELP:BunkerBuster-01
+"HINT:  \n The Stealth Bomber's Bunker Buster upgrade  \n can damage garrisoned enemies"
+END
+
+HELP:BunkerBuster-02
+"HINT:  \n Bunker Busters can kill units inside of Bunkers"
+END
+
+HELP:SupplyLines-01
+"HINT:  \n The Supply Lines upgrade improves income"
+END
+
+HELP:SupplyLines-02
+"HINT:  \n Upgrade Supply Lines to increase  \n the efficiency of Chinooks"
+END
+
+HELP:ListeningOutpost-01
+"HINT:  \n Listening Outposts are stealthed and will detect  \n camouflaged units"
+END
+
+HELP:ListeningOutpost-02
+"HINT:  \n Listening Outposts have a very large sight radius"
+END
+
+HELP:Helix-01
+"HINT:  \n Upgrade a Helix with a Propaganda Tower to  \n repair and heal your nearby units"
+END
+
+HELP:Helix-02
+"HINT:  \n The Helix can be upgraded to drop napalm bombs  \n These can be dropped on targets beneath the Helix"
+END
+
+HELP:Helix-03
+"HINT:  \n You can upgrade a Helix with a Battle Bunker,  \n Propaganda Tower, or Gattling Cannon"
+END
+
+HELP:ECMTank-01
+"HINT:  \n Use the ECM Tank to disrupt enemy missile and rocket fire"
+END
+
+HELP:Frenzy-01
+"HINT:  \n Use the Frenzy Generals Power to increase the  \n firepower and armor of your units"
+END
+
+HELP:InternetCenter-01
+"HINT:  \n Place Hackers in the Internet Center  \n to increase money collection rate"
+END
+
+HELP:InternetCenter-02
+"HINT:  \n Build an Internet Center and upgrade to  \n Satellite Hack 1 and 2"
+END
+
+HELP:SatelliteHack1-01
+"HINT:  \n Satellite Hack 1 reveals all enemy Command Centers"
+END
+
+HELP:SatelliteHack2-01
+"HINT:  \n Satellite Hack 2 reveals all that enemy units can see"
+END
+
+HELP:EMPMines-01
+"HINT:  \n Mines can be upgraded to Neutron Mines, which will  \n disrupt enemy vehicles"
+END
+
+HELP:NeutronShell-01
+"HINT:  \n Neutron Shell attacks from the Nuke Cannon neutralize  \n vehicles, allowing any infantry to capture them"
+END
+
+HELP:CombatCycle-01
+"HINT:  \n Combat Cycles can jump off of cliffs"
+END
+
+HELP:CombatCycle-02
+"HINT:  \n Place a Tunnel Defender on a Combat Cycle to  \n allow it to fire rockets"
+END
+
+HELP:CombatCycle-03
+"HINT:  \n Place a Terrorist on a Combat Cycle to  \n produce a Suicide Bike"
+END
+
+HELP:CombatCycle-04
+"HINT:  \n Jarmen Kell can snipe from a Combat Cycle"
+END
+
+HELP:CombatCycle-05
+"HINT:  \n Workers can use Combat Cycles to travel quickly"
+END
+
+HELP:Saboteur-01
+"HINT:  \n The Saboteur disrupts the abilities of enemy structures"
+END
+
+HELP:Saboteur-02
+"HINT:  \n Direct the Saboteur into an enemy Command Center  \n to reset their Generals Powers timers"
+END
+
+HELP:FakeStructures-01
+"HINT:  \n Build Fake Structures to fool your enemies"
+END
+
+HELP:SneakAttack-01
+"HINT:  \n Use Sneak Attack to instantly build a Tunnel Network  \n anywhere you can see"
+END
+
+HELP:GPSScramble-01
+"HINT:  \n Use the GPS Scrambler Generals Power to  \n camouflage friendly units"
+END
+
+HELP:WorkerShoes-01
+"HINT:  \n Purchase Worker Shoes to increase the speed Workers  \n travel and collect resources"
+END
+
+HELP:CamoNetting-01
+"HINT:  \n Camo-Netting camouflages your Stinger Sites  \n and Tunnel Networks"
+END
+
+HELP:FortifiedStructures-01
+"HINT:  \n Fortified Structures are harder to destroy"
+END
+
+HELP:BoobyTrap-01
+"HINT:  \n Booby Traps will detonate when an enemy tries  \n to garrison or capture the trapped structure"
+END
+
+HELP:KingRaptor-01
+"HINT:  \n King Raptors carry extra ammo and have more armor"
+END
+
+HELP:CombatChinooks-01
+"HINT:  \n Infantry inside of a Combat Chinook can fire in flight"
+END
+
+HELP:AuroraAlpha-01
+"HINT:  \n The Aurora Alpha is equipped with a small  \n but devastating Fuel Air Bomb"
+END
+
+HELP:MicrowavePatriot-01
+"HINT:  \n The EMP Patriot's Rockets are effective  \n against both vehicles and infantry"
+END
+
+HELP:AdvancedRods-01
+"HINT:  \n Advanced Rods provide more power than normal Control Rods"
+END
+
+HELP:LaserTank-01
+"HINT:  \n Build extra Power Plants when using Laser Tanks  \n They cannot move or fire when power is low"
+END
+
+HELP:LaserDefenseTurret-01
+"HINT:  \n Laser Defense Turrets are strong but require extra power"
+END
+
+HELP:AssaultTroopTransport-01
+"HINT:  \n Units can fire out of the Assault Troop Transport"
+END
+
+HELP:AttackOutpost-01
+"HINT:  \n The Attack Outpost can hold extra infantry and  \n can detect stealthed units"
+END
+
+HELP:FortifiedBunkers-01
+"HINT:  \n The Fortified Bunkers come with Mines and  \n stronger armor and can hold extra infantry"
+END
+
+HELP:Mini-Gunner-01
+"HINT:  \n Mini-Gunners carry a personal Gattling Gun"
+END
+
+HELP:InfantryBlackLotus-01
+"HINT:  \n Your Black Lotus units have improved abilities"
+END
+
+HELP:InfantryBlackLotus-02
+"HINT:  \n You can build multiple Black Lotus units"
+END
+
+HELP:InfantryHacker-01
+"HINT:  \n The Infantry General's Hacker hack money faster"
+END
+
+HELP:ChineseParadrop-01
+"HINT:  \n The Chinese Paradrop parachutes Red Guard anywhere"
+END
+
+HELP:EmperorTank-01
+"HINT:  \n Emperor Tanks are the ultimate tank,  \n effective against both vehicles and infantry"
+END
+
+HELP:EmperorTank-02
+"HINT:  \n The Emperor Tank can be upgraded with a Gattling Cannon"
+END
+
+HELP:EmperorTank-03
+"HINT:  \n Emperor Tanks come equipped with Propaganda Towers"
+END
+
+HELP:TankDrop-01
+"HINT:  \n The Tank Drop allows you to parachute Battlemasters"
+END
+
+HELP:TacticalNuke-01
+"HINT:  \n Your Airfield can upgrade MiGs to carry Tactical Nukes"
+END
+
+HELP:IsotopeStability-01
+"HINT:  \n Isotope Stability will reduce the damage done to friendly  \n units when Nuclear Tanks are destroyed"
+END
+
+HELP:AdvancedNuclearPower-01
+"HINT:  \n Advanced Nuclear Power Plants generate more power than normal Nuclear Plans"
+END
+
+HELP:ToxinRebels-01
+"HINT:  \n Toxin Rebels shoot a stream of highly poisonous toxins"
+END
+
+HELP:ToxinRebels-02
+"HINT:  \n Toxin Rebels are resistant to toxin attacks"
+END
+
+HELP:ToxinRebels-03
+"HINT:  \n Use Toxin Rebels to quickly clear out garrisoned structures"
+END
+
+HELP:ToxinNetworks-01
+"HINT:  \n Toxin Networks fire streams of toxin from their cannons"
+END
+
+HELP:ToxinTerrorists-01
+"HINT:  \n Toxin Terrorists explode in a cloud of toxin"
+END
+
+HELP:ToxinTerrorists-02
+"HINT:  \n Use Toxin Terrorists to attack large groups of infantry"
+END
+
+HELP:AnthraxGamma-01
+"HINT:  \n Anthrax Gamma increases the damage of all toxin attacks"
+END
+
+HELP:AnthraxGamma-02
+"HINT:  \n Anthrax Gamma is even more potent than Anthrax Beta"
+END
+
+HELP:AdvancedTrap-01
+"HINT:  \n Advanced Traps are more powerful than normal Demo Traps"
+END
+
+HELP:Demolitions-01
+"HINT:  \n The Demolitions upgrade gives units the ability to detonate"
+END
+
+GENERIC:MissionObjectiveCompleted-01
+"MISSION OBJECTIVE #1:  \n Accomplished"
+END
+
+GENERIC:MissionObjectiveCompleted-02
+"MISSION OBJECTIVE #2:  \n Accomplished"
+END
+
+GENERIC:MissionObjectiveCompleted-03
+"MISSION OBJECTIVE #3:  \n Accomplished"
+END
+
+GENERIC:MissionObjectiveCompleted-04
+"MISSION OBJECTIVE #4:  \n Accomplished"
+END
+
+GENERIC:MissionObjectiveCompleted-05
+"MISSION OBJECTIVE #5:  \n Accomplished"
+END
+
+LOSE:AllUnits
+"INCOMING TRANSMISSION:  \n All of our units have been destroyed  \n We have been defeated, General. This time"
+END
+
+LOSE:AllBuildings
+"INCOMING TRANSMISSION:  \n All of our buildings have been destroyed  \n We have been defeated, General. This time"
+END
+
+LOSE:AllUnitsAndBuildings
+"INCOMING TRANSMISSION:  \n All of our units and buildings have been destroyed  \n We have been defeated, General. This time"
+END
+
+HELP:OilRefinery-01
+"HINT:  \n Capture Oil Refineries to reduce the cost of vehicles"
+END
+
+HELP:ReinforcementPad-01
+"HINT:  \n Capture Reinforcement Pads to gain tank reinforcements"
+END
+
+HELP:OilDerrick-01
+"HINT:  \n Capture Oil Derricks to gain extra money"
+END
+
+HELP:RepairBay-01
+"HINT:  \n Capture Repair Bays to repair vehicles anywhere"
+END
+
+HELP:ArtilleryPlatform-01
+"HINT:  \n Capture Artillery Platforms to control key regions"
+END
+
+MAP:MD_USA01Objective1
+"MISSION OBJECTIVE:  \n Secure the train depot and destroy surrounding GLA base"
+END
+
+MAP:MD_USA01Objective1a
+"MISSION OBJECTIVE #1:  \n Secure the train depot and destroy surrounding GLA base"
+END
+
+MAP:MD_USA01ObjectiveAccomplished
+"MISSION OBJECTIVE ACCOMPLISHED"
+END
+
+MAP:MD_USA01ObjectiveAccomplisheda
+"MISSION OBJECTIVE #1 Accomplished"
+END
+
+MAP:MD_USA01Objective2
+"INCOMING TRANSMISSION:  \n Move units into the train cars"
+END
+
+MAP:MD_USA01Objective2a
+"INCOMING TRANSMISSION:  \n Move units into the train cars"
+END
+
+MAP:MD_USA01Objective3
+"MISSION OBJECTIVE:  \n Destroy the GLA base"
+END
+
+MAP:MD_USA01Objective3a
+"MISSION OBJECTIVE #2:  \n Destroy the GLA base"
+END
+
+MAP:MD_USA01Hint1
+"HINT:  \n Infantry can enter the abandoned vehicles in the Northeast"
+END
+
+MAP:MD_USA01Hint1a
+"HINT:  \n Infantry can enter the abandoned vehicles in the Northeast"
+END
+
+MAP:MD_USA01Hint2
+"HINT:  \n Garrison infantry into radio station to call in A-10s"
+END
+
+MAP:MD_USA01Hint2a
+"HINT:  \n Garrison infantry into radio station to call in A-10s"
+END
+
+OBJECT:TrainDepot
+"Train Depot"
+END
+
+OBJECT:TrainLoading
+"Boarding Platform"
+END
+
+MAP:MD_USA01Title
+"Baikonur Cosmodrome, Southern Kazakhstan  \n 'Operation Global Security'"
+END
+
+MAP:MD_USA01CINELocation02
+"U.S. Naval Base  \n Northern Europe"
+END
+
+MAP:Intro_Breifing_01
+"U.S. Recon Base outside Baikonur  \n Southern Kazakhstan"
+END
+
+MAP:MD_USA01CINELocation01
+"Somewhere in Southern Kazakhstan  \n En route to Baikonur"
+END
+
+MAP:USAX02MissionINtro
+"Off the coast of Somalia"
+END
+
+MAP:USAX02MissionStart
+"Berbera, Somalia  \n 'Operation: Helping Hand'"
+END
+
+MAP:USAX02NavyHint
+"INCOMING TRANSMISSION:  \n Naval fleet available to soften resistance"
+END
+
+MAP:USAX02ConvoyHint
+"INCOMING TRANSMISSION:  \n Convoy will begin when 10 Supply Trucks have arrived"
+END
+
+MAP:USAX02ConvoyArrived
+"MISSION OBJECTIVE #1:  \n Accomplished"
+END
+
+MAP:USAX02objectives3a
+"MISSION OBJECTIVE #2:  \n Destroy GLA Base"
+END
+
+MAP:USAX02Objectives1
+"MISSION OBJECTIVE #1:  \n Protect incoming Supply Trucks and secure Supply Warehouse"
+END
+
+MAP:USAX02Objectives2
+"MISSION OBJECTIVE:  \n Defend the docks  \n Protect the incoming supply trucks  \n Secure the warehouse"
+END
+
+MAP:USAX02Objectives3
+"MISSION OBJECTIVE:  \n Find and Destroy the GLA structures in the mountains"
+END
+
+MAP:USAX02Ships
+"Available Support:  \n Aircraft Carrier, CVN-88 Daedalus  \n Battleship Escort Group, Dreadnought"
+END
+
+MAP:USAX02Truck1Arrived
+"Supply Truck 1 of 10 has arrived"
+END
+
+MAP:USAX02Truck2Arrived
+"Supply Truck 2 of 10 has arrived"
+END
+
+MAP:USAX02Truck3Arrived
+"Supply Truck 3 of 10 has arrived"
+END
+
+MAP:USAX02Truck4Arrived
+"Supply Truck 4 of 10 has arrived"
+END
+
+MAP:USAX02Truck5Arrived
+"Supply Truck 5 of 10 has arrived"
+END
+
+MAP:USAX02Truck6Arrived
+"Supply Truck 6 of 10 has arrived"
+END
+
+MAP:USAX02Truck7Arrived
+"Supply Truck 7 of 10 has arrived"
+END
+
+MAP:USAX02Truck8Arrived
+"Supply Truck 8 of 10 has arrived"
+END
+
+MAP:USAX02Truck9Arrived
+"Supply Truck 9 of 10 has arrived"
+END
+
+MAP:USAX02Truck10Arrived
+"Supply Truck 10 has arrived  \n The convoy is preparing to depart for the warehouse"
+END
+
+MAP:USAX02ConvoyToWarehouse
+"Escort the convoy to the warehouse"
+END
+
+MAP:USAX02Dozer
+"A dozer has arrived at the docks  \n Commence base construction"
+END
+
+MAP:USAX02Dozerb
+"A Dozer has arrived"
+END
+
+MAP:USAX02Dozer2
+"A new dozer has arrived at the docks"
+END
+
+MAP:USA03xMapName
+"Last Call"
+END
+
+MAP:USA03xOpen
+"Mount Elbrus, Georgia  \n 'Operation: Snow Fall'"
+END
+
+MAP:USA03xOpenAlt
+"Mount Elbrus, Russia  \n 'Operation: Snow Fall'"
+END
+
+MAP:USA03xObjective02
+"MISSION OBJECTIVE #1:  \n Destroy the GLA POW camp and rescue the POWs  \n Col. Burton must survive"
+END
+
+MAP:USA03xObjective03
+"MISSION OBJECTIVE #2:  \n Move Col. Burton to the rally point"
+END
+
+MAP:USA03xObjectiveCompleted
+"MISSION OBJECTIVE #1:  \n Accomplished"
+END
+
+MAP:USA03xTownHallHint
+"INCOMING TRANSMISSION:  \n Search the village for MIA soldiers"
+END
+
+MAP:USA03xToxinNetworksWarning
+"WARNING:  \n Watch out for Toxin Networks and Stinger Sites"
+END
+
+MAP:USA03xPOWCamp02Hint
+"HINT:  \n Eliminate the GLA structures guarding this camp  \n to liberate the prisoners held here"
+END
+
+MAP:USA03xBurtonWarning
+"WARNING:  \n Colonel Burton is severely wounded  \n He must survive this mission"
+END
+
+MAP:USA03xChemWarning02
+"WARNING:  \n These defenses have been modified to fire chemicals  \n They will kill any infantry that get too close"
+END
+
+MAP:USA03xLoseReason01
+"INCOMING TRANSMISSION:  \n Colonel Burton has been killed  \n You have been defeated, General. This time"
+END
+
+MAP:MD-USA04_LOCALE
+"Amisbad Oil Fields, Iran  \n 'Operation: Black Gold'"
+END
+
+MAP:MD-USA04_Start02
+"INCOMING TRANSMISSION:  \n Reinforcements have arrived"
+END
+
+MAP:MD-USA04_Objective01
+"MISSION OBJECTIVE:  \n Destroy the GLA base"
+END
+
+MAP:MD-USA04_Objective02_Reminder
+"INCOMING TRANSMISSION:  \n Destroy the Radio Station to the Northeast to stop Bomb Trucks"
+END
+
+MAP:MD-USA04_Hint01
+"MISSION OBJECTIVE:  \n Destroy the GLA base"
+END
+
+MAP:MD-USA04_Hint04
+"HINT:  \n Find the 3 CIA operatives to solicit their help"
+END
+
+MAP:MD-USA04_Hint05
+"INCOMING TRANSMISSION:  \n Secure the oil fields to the West to gain money"
+END
+
+MAP:MD-USA04_Hint06
+"HINT:  \n Pathfinders can reveal camouflaged units and demo traps"
+END
+
+MAP:MD-USA04_Hint07
+"HINT:  \n Dozers can remove Booby Traps"
+END
+
+MAP:MD-USA04_Reonforcements
+"INCOMING TRANSMISSION:  \n Reinforcements have arrived"
+END
+
+MAP:MD_USA06Open
+"Al Habad, Syria  \n 'Operation: Eagle's Strike'"
+END
+
+MAP:MD-USA06Objective01
+"MISSION OBJECTIVE:  \n Capture the 4 Toxin Missile Silos before they launch"
+END
+
+MAP:MD-USA06Objective02
+"INCOMING TRANSMISSION:  \n Rebel GLA forces have joined you"
+END
+
+MAP:MD-USA06Objective03
+"INCOMING TRANSMISSION:  \n Capture the 4 Toxin Missile Silos before they can launch"
+END
+
+MAP:MD-USA06Objective04
+"Missile Silo 3 of 4 captured"
+END
+
+MAP:MD-USA06Objective05
+"Missile Silo 4 of 4 captured"
+END
+
+MAP:MD-USA06Objective06
+"Missile Silo 1 of 4 captured"
+END
+
+MAP:MD-USA06Objective07
+"Missile Silo 2 of 4 captured"
+END
+
+MAP:MD-USA06Objective14
+"HINT:  \n Intel puts some of the Missiles in this region  \n Take care not to release the toxin"
+END
+
+MAP:MD-USA06Objective15
+"WARNING:  \n Dr. Thrax is utilizing more potent toxins. Protect our infantry"
+END
+
+MAP:MD-USA06Objective16
+"INCOMING TRANSMISSION:  \n Our base is under attack sir  \n They built a tunnel network without us knowing it"
+END
+
+MAP:MD-USA06CivilianMessage01
+"INCOMING TRANSMISSION:  \n GLA Rebels to the East may aid our effort"
+END
+
+MAP:MD-USA06Hint01
+"HINT:  \n More supplies are located to the Southwest"
+END
+
+MAP:MD-USA06Hint02
+"WARNING:  \n They are using the Sneak Attack Tunnel to attack our base"
+END
+
+MAP:MD-USA06Hint03
+"HINT:  \n GLA Generals Powers are available at the GLA Command Center"
+END
+
+MAP:MD-USA06Warning01
+"WARNING:  \n Missile Launch countdown has begun"
+END
+
+MAP:MD-USA06Warning02
+"WARNING:  \n Launch in 5 minutes"
+END
+
+MAP:MD-USA06Warning03
+"WARNING:  \n Launch in 4 minutes"
+END
+
+MAP:MD-USA06Warning04
+"WARNING:  \n Launch in 3 minutes"
+END
+
+MAP:MD-USA06Warning05
+"WARNING:  \n Launch in 2 minutes"
+END
+
+MAP:MD-USA06Warning06
+"WARNING:  \n Launch in 1 minute"
+END
+
+MAP:MD-USA06Warning07
+"WARNING:  \n Launch in 30 seconds"
+END
+
+MAP:MD-USA06Warning08
+"WARNING:  \n Launch in 10 seconds"
+END
+
+MAP:MD-USA06Warning09
+"WARNING:  \n 5... 4... 3... 2... 1... Launch detected"
+END
+
+MAP:MD-USA06Failure01
+"WARNING:  \n Impact detected. You have failed, General"
+END
+
+MAP:MD-USA06Imperative01
+"WARNING:  \n Do not destroy this structure. Capture it with Rangers"
+END
+
+SCRIPT:MD-USA06MissileTimer
+"Toxin Missile Launch In:"
+END
+
+MAP:MD-USA06Warning10
+"WARNING:  \n Launch in 10 minutes"
+END
+
+MAP:MD-USA06Warning11
+"WARNING:  \n Launch in 15 minutes"
+END
+
+MAP:MD-USA06Intro1
+"Earth Orbit:  \n USA Spy Satellite Codename:Powers"
+END
+
+MAP:MD-USA06Intro2
+"Data Uplink:  \n Dr. Thrax's Toxin Facilities"
+END
+
+MAP:MD-USA06Warning15
+"INCOMING TRANSMISSION:  \n General, the GLA base to the East has  \n decided to rebel against the Toxin General and  \n his mass use of toxins"
+END
+
+MAP:MD-USA06Warning16
+"INCOMING TRANSMISSION:  \n They wish to aid us in our attack against  \n the General by giving us use of their base"
+END
+
+MAP:MD_GLA01Objective6
+"HINT: Use Combat Cycles to enter the USA base from another direction"
+END
+
+MAP:MD_GLA01Message01
+"WARNING: USA Fire Base detected"
+END
+
+MAP:MD_GLA01Message02
+"WARNING: Sentry Drones discovered"
+END
+
+MAP:MD_GLA01Message03
+"HINT:  \n Upgrade GLA units by moving them onto salvage crates"
+END
+
+OBJECT:GLALeader
+"GLA Leader"
+END
+
+MAP:Intro_Title
+"Al Safir, Syria  \n 'The Exodus'"
+END
+
+MAP:Intro_Title2
+"Halib, Sudan  \n 'The Great Escape'"
+END
+
+MAP:Intro_Loc
+"Outside the city..."
+END
+
+MAP:Intro_MO_1
+"MISSION OBJECTIVE #1:  \n Find the abandoned GLA base"
+END
+
+MAP:Intro_MO_2
+"MISSION OBJECTIVE #2:  \n Transport our leader safely to the airstrip"
+END
+
+MAP:Intro_MO_2b
+"INCOMING TRANSMISSION:  \n Bring the GLA leader to the airstrip in the Northwest"
+END
+
+MAP:Intro_MO_1a
+"MISSION OBJECTIVE:  \n Escort GLA leader to airstrip  \n GLA leader must survive"
+END
+
+MAP:Intro_MO_2a
+"INCOMING TRANSMISSION:  \n An abandoned GLA base is in this region. Reclaim it"
+END
+
+MDGLA02:TITLE
+"Somewhere near Cairo, Egypt  \n 'Hidden Agenda'"
+END
+
+MDGLA02:Hint1
+"WARNING:  \n Prince Kassad's forces are camouflaged"
+END
+
+MDGLA02:Hint2
+"HINT:  \n Radar Vans, Tunnel Networks, and  \n Stinger Sites reveal camouflaged units"
+END
+
+MDGLA02:Hint3
+"HINT:  \n More Supplies located in the Southwest"
+END
+
+MDGLA02:OBJ1
+" \n MISSION OBJECTIVE #1:  \n Capture the Command Center in the city"
+END
+
+MDGLA02:OBJ2
+" \n MISSION OBJECTIVE #2:  \n Capture the Command Center across the river"
+END
+
+MDGLA02:Expansion_2
+"INCOMING TRANSMISSION:  \n Potential expansion location discovered"
+END
+
+MDGLA02:Oil_Well
+"HINT:  \n Capture oil wells to maintain steady income"
+END
+
+MDGLA02:Bridge
+"HINT:  \n GPS Scramble will make it easier to cross this bridge"
+END
+
+MDGLA02:Damage_warn
+"INCOMING TRANSMISSION:  \n Protect the Command Center"
+END
+
+MDGLA02:Capture_CC_scram
+"HINT:  \n Capture the Command Center to gain GPS scramble ability"
+END
+
+MDGLA02:Scram_captured
+"INCOMING TRANSMISSION:  \n GPS Scramble ability obtained  \n Use it on your troops to cloak them"
+END
+
+MDGLA02:Capture_CC_sneak
+"HINT:  \n Capture this Command Center to gain Sneak Attack ability"
+END
+
+MDGLA02:Sneak_captured
+"INCOMING TRANSMISSION:  \n Sneak Attack ability obtained  \n Use it to create a Tunnel Network anywhere you can see"
+END
+
+MDGLA02:Final
+"MISSION OBJECTIVE #3:  \n Destroy or capture Kassad's main Command Center"
+END
+
+MDGLA03:Title-01
+"USA Mediterranean Fleet, Matala, Crete  \n 'On the Waterfront'"
+END
+
+MDGLA03:InfoMissionObjective01
+"MISSION OBJECTIVE #1:  \n Capture the USA Particle Cannon to the East"
+END
+
+MDGLA03:Info-MissionObjectiveAccomplished-01
+"MISSION OBJECTIVE #1:  \n Accomplished"
+END
+
+MDGLA03:Info-MissionObjective-02
+"MISSION OBJECTIVE #2:  \n Capture the USA Power Plants"
+END
+
+MDGLA03:Info-MissionObjectiveAccomplished-02
+"MISSION OBJECTIVE #2:  \n Accomplished"
+END
+
+MDGLA03:Info-MissionObjective-03
+"MISSION OBJECTIVE #3:  \n Locate the Aircraft Carrier in the Southeast"
+END
+
+MDGLA03:Info-GotParticleCannon-01
+"HINT:  \n Now we must secure some Power Plants  \n We can use the Tunnel Network to reach the next island"
+END
+
+MDGLA03:Info-SneakAttack-01
+"INCOMING TRANSMISSION:  \n Use Sneak Attack to create Tunnel Networks on nearby islands"
+END
+
+MDGLA03:Info-GotPowerPlants-01
+"INCOMING TRANSMISSION:  \n The Particle Cannon is now online  \n We must defend it and our Power Plants"
+END
+
+MDGLA03:Info-Goodies-01
+"HINT:  \n Explore islands to find salvage crates and vehicles"
+END
+
+MDGLA03:Lose-NoUnitsOrStructures-01
+"INCOMING TRANSMISSION:  \n All of your units and buildings have been destroyed  \n You have been defeated, General. This time"
+END
+
+MDGLA03:Lose-ParticleCannonDestroyed-01
+"INCOMING TRANSMISSION:  \n Without the Particle Cannon, you cannot destroy the Carrier  \n You have been defeated, General. This time"
+END
+
+MDGLA03:Lose-PowerPlantsDestroyed-01
+"INCOMING TRANSMISSION:  \n All of the power plants have been destroyed  \n You have been defeated, General. This time"
+END
+
+MDGLA03:Help-UseParticleCannon-01
+"WARNING:  \n This area looks well defended  \n The Particle Cannon might help us penetrate"
+END
+
+MDGLA03:Help-A10Warning-01
+"WARNING:  \n A10s are en route against us"
+END
+
+MDGLA03:Help-LeaveISLAND-01
+"HINT:  \n We can use Sneak Attack or our Tunnel Networks  \n to reach a nearby island"
+END
+
+MDGLA03:Help-LeaveISLAND-02
+"HINT:  \n If we can scout out an area on a nearby island,  \n we can use our Sneak Attack there"
+END
+
+MDGLA03:Info-DisabledSupplyDropZones-01
+"INCOMING TRANSMISSION:  \n We have disabled the enemy's Supply Drop Zones  \n They will soon be unable to build new units"
+END
+
+MDGLA03:Help-FoundSupplyPlanes-01
+"INCOMING TRANSMISSION:  \n Destroy the USA Supply Drop Zones to cripple their production"
+END
+
+MDGLA03:Help-FewPowerPlants-02
+"WARNING:  \n Almost all of the Power Plants have been destroyed  \n Be careful to secure one to fire the Particle Cannon"
+END
+
+MDGLA03:Help-AttackingParticleCannon-01
+"INCOMING TRANSMISSION:  \n We need this Particle Cannon to destroy the carrier  \n Do not let it be destroyed"
+END
+
+MDGLA03:Help-FindParticleCannon-01
+"HINT:  \n Capture the Particle Cannon"
+END
+
+MDGLA03:Help-LostIsland-01
+"HINT:  \n They destroyed our Tunnel Network  \n Use the Sneak Attack to return to that island"
+END
+
+MDGLA03:Help-ArmsDealer-01
+"INCOMING TRANSMISSION:  \n Liberate the Arms Dealer on the West side of this island"
+END
+
+MDGLA03:Help-JarmenKell-01
+"HINT:  \n Jarmen Kell's snipe ability can neutralize enemy  \n vehicles, allowing our infantry to capture them"
+END
+
+MAP:MD_GLA03_CINELocation01
+"USS Reagan"
+END
+
+MAP:MD_GLA04Objective1
+"MISSION OBJECTIVE:  \n Team 1: Take the ferry to the beach"
+END
+
+MAP:MD_GLA04Objective2
+"MISSION OBJECTIVE:  \n Team 2: Obtain a Radar Van"
+END
+
+MAP:MD_GLA04Objective3
+"MISSION OBJECTIVE:  \n Team 2: Garrison the Valve Station"
+END
+
+MAP:MD_GLA04Objective4
+"MISSION OBJECTIVE:  \n Team 1: Destroy the Airfield"
+END
+
+MAP:MD_GLA04Objective5
+"MISSION OBJECTIVE:  \n Team 2: Destroy the Power Plants"
+END
+
+MAP:MD_GLA04Objective6
+"MISSION OBJECTIVE:  \n Capture the Toxin Facility"
+END
+
+MAP:MD_GLA04Objective7
+"MISSION OBJECTIVE:  \n Transport the Toxins to the Airport"
+END
+
+SCRIPT:MD_GLA04Toxin_Counter
+"Toxins Remaining:"
+END
+
+MAP:MD_GLA04Title
+"Western USA Coastal Toxic Facility  \n 'Jarmen Kell and the Forty Thieves'"
+END
+
+MD_GLA05-MilitaryBriefing:String_2
+"MISSION OBJECTIVE:  \n Destroy US European Central Command in the Northeast"
+END
+
+MD_GLA05-MilitaryBriefing:String_3
+"INCOMING TRANSMISSION:  \n Rescue the POWs and bring them back here  \n The Terror Cell will awaken to assist you against the US"
+END
+
+MD_GLA05-MilitaryBriefing:String_4
+"HINT:  \n Move the POWs to their village  \n in the North and they will assist us"
+END
+
+MD_GLA05-MilitaryBriefing:String_5
+"INCOMING TRANSMISSION:  \n Remove the American threat to  \n free the POWs from their captors"
+END
+
+MD_GLA05-MilitaryBriefing:String_6
+"INCOMING TRANSMISSION:  \n We are ready to return to our village in the North"
+END
+
+MD_GLA05-MilitaryBriefing:String_7
+"INCOMING TRANSMISSION:  \n You have rescued the POWs and returned them home  \n The Terror Cell will activate and begin to assault the US"
+END
+
+MD_GLA05-MilitaryBriefing:String_8
+"HINT:  \n Capture the remaining US structures  \n and build a second base here"
+END
+
+MD_GLA05-MilitaryBriefing:String_9
+"WARNING:  \n Time is running out. Rescue the POWs"
+END
+
+MD_GLA05-MilitaryBriefing:String_10
+"WARNING:  \n We must eliminate the enemy's Southern  \n support base before they become too powerful"
+END
+
+MD_GLA05-MilitaryBriefing:String_11
+"INCOMING TRANSMISSION:  \n The Terror Cell has been eliminated  \n Do not let their deaths go unpunished"
+END
+
+MD_GLA05-MilitaryBriefing:String_12
+"INCOMING TRANSMISSION:  \n We have beaten the enemy. Victory is ours"
+END
+
+MD_GLA05-MilitaryBriefing:String_13
+"INCOMING TRANSMISSION:  \n The enemy is holding our brothers captive  \n Free them and they will assist us against the US"
+END
+
+MD_GLA05-MilitaryBriefing:String_14
+"INCOMING TRANSMISSION:  \n Intel has reported that the POWs will be moved soon  \n Infiltrate the US base to rescue them"
+END
+
+MD_GLA05-MilitaryBriefing:String_15
+"HINT:  \n Upgrade the China Command Center with Radar"
+END
+
+MD_GLA05-MilitaryBriefing:String_16
+"INCOMING TRANSMISSION:  \n Protect the GLA Terror Cell from US attacks  \n and secure the area"
+END
+
+MD_GLA05-MilitaryBriefing:String_17
+"HINT:  \n Build a GLA Command Center to use your Generals Powers"
+END
+
+MD_GLA05-MilitaryBriefing:String_18
+"INCOMING TRANSMISSION:  \n Our base is under attack"
+END
+
+MD_GLA05-MilitaryBriefing:String_19
+"WARNING:  \n The POWs are being attacked. Defend them"
+END
+
+MD_GLA05-MilitaryBriefing:String_20
+"INCOMING TRANSMISSION:  \n The POWs have all been killed  \n The Terror Cell joins us to avenge their deaths"
+END
+
+MD_GLA05-MilitaryBriefing:String_21
+"INCOMING TRANSMISSION:  \n The enemy has spread out to secure more resources  \n Remove them and use the resources for ourselves"
+END
+
+MD_GLA05-MilitaryBriefing:String_22
+"HINT:  \n Their base is massive  \n Perhaps Sneak Attacks will help us infiltrate it"
+END
+
+MD_GLA05-MilitaryBriefing:String_23
+"INCOMING TRANSMISSION:  \n With the small base neutralized, we can focus on  \n the US European Central Command base"
+END
+
+MD_GLA05-MilitaryBriefing:String_24
+" \n We have a plan...  \n We shall move in and capture the Chinese Base  \n and use it to drive the USA out of Europe"
+END
+
+MD_GLA05-MilitaryBriefing:String_25
+"The U.S. European Central Command base must fall"
+END
+
+MD_GLA05-MilitaryBriefing:String_26
+"INCOMING TRANSMISSION:  \n We are being attacked from the East  \n Eliminate the southern US Support base"
+END
+
+MD_GLA05-MilitaryBriefing:String_27
+"INCOMING TRANSMISSION:  \n The Terror Cell is being attacked by the US  \n Assist them in repulsing our foes"
+END
+
+MD_GLA05-MilitaryBriefing:String_28
+"INCOMING TRANSMISSION:  \n Rescue the POWs from the US support base before  \n they are transferred to a new location"
+END
+
+MD_GLA05-MilitaryBriefing:String_29
+"MISSION OBJECTIVE:  \n Destroy US European Central Command in the Northeast"
+END
+
+MD_GLA05-MilitaryBriefing:String_30
+"US Central Command, Stuttgart-Vaihingen, Germany  \n 'Sneak Attack'"
+END
+
+MD_GLA05-MilitaryBriefing:String_31
+"US Central Command, Stuttgart-Vaihingen, Germany  \n 'Sneak Attack'"
+END
+
+MD_GLA05-MilitaryBriefing:String_32
+"HINT: Remove the Americans from the area  \n then secure the supplies"
+END
+
+MD_GLA05-MilitaryBriefing:String_33
+"HINT:  \n Finish off the Central Command Base"
+END
+
+MD_GLA05-MilitaryBriefing:String_34
+"HINT:  \n Capture Oil Derricks and secure additional supplies  \n Capture Artillery Platforms to control key areas"
+END
+
+MD_GLA05-MilitaryBriefing:String_35
+"HINT:  \n Upgrade the Cash Bounty  \n Generals Power to increase income"
+END
+
+MD_GLA05-MilitaryBriefing:String_36
+"HINT:  \n Use the Sneak Attack ability to  \n launch an attack against the US base"
+END
+
+MD_GLA05-MilitaryBriefing:String_37
+"INCOMING TRANSMISSION:  \n The POWs have been moved away  \n Despite our failure, the Terror Cell pledges their support"
+END
+
+MD_GLA05-MilitaryBriefing:String_38
+"US Central Command, Stuttgart-Vaihingen, Germany  \n 'Sneak Attack'"
+END
+
+SCRIPT:POWCOUNTDOWN
+"POWs Transfer In:"
+END
+
+MAP:CHI01xMapName
+"The Dragon Unleashed"
+END
+
+MAP:CHI01xOpen
+"Stuttgart-Vaihingen, Germany  \n 'The Dragon Unleashed'"
+END
+
+MAP:CHI01xOpenAlt
+"Remains of USA Command Base, Germany  \n The Dragon Unleashed"
+END
+
+MAP:CHI01xObjective01
+"MISSION OBJECTIVE:  \n Eliminate all GLA forces in this region"
+END
+
+MAP:CHI01xObjective01Alt
+"MISSION OBJECTIVE:  \n Eliminate all GLA structures in this region"
+END
+
+MAP:CHI01xTechBldgHint
+"HINT:  \n The Red Guard can be used to capture buildings"
+END
+
+MAP:CHI01xOilDerrickHint
+"HINT:  \n Capture Oil Derricks to gain extra money"
+END
+
+MAP:CHI01xOilRefineryHint
+"HINT:  \n Capture the Oil Refineries to reduce cost of vehicles"
+END
+
+MAP:CHI01xGarrisonHint
+"HINT:  \n Garrisoning Red Guard and Tank Hunters inside buildings  \n increases their firepower and range"
+END
+
+MAP:CHI01xGarrisonClrHint01
+"HINT:  \n The Toxin Tractor will kill garrisoned infantry instantly  \n Do not let it approach your garrisoned structures"
+END
+
+MAP:CHI01xGarrisonClrHint02
+"HINT:  \n The Dragon Tank will kill infantry in garrisoned buildings"
+END
+
+MAP:CHI01xPerimeterWarn01
+"WARNING:  \n GLA forces are attacking our base"
+END
+
+MAP:CHI01xPerimeterWarn02
+"WARNING:  \n The enemy is preparing to attack our base"
+END
+
+MAP:CHI02xMapName
+"Defending the Fire"
+END
+
+MAP:CHI02xOpen
+"Weapons Production Facility, China  \n 'Defending the Fire'"
+END
+
+SCRIPT:CHI02xReinforcementTimer
+"Reinforcements Arrive In:"
+END
+
+MAP:CHI02xObjective01
+"MISSION OBJECTIVE #1:  \n Defend the Reactor and Storage Bunkers  \n They must not be captured or destroyed"
+END
+
+MAP:CHI02xObjective02
+"MISSION OBJECTIVE #2:  \n Destroy all GLA forces in the region"
+END
+
+MAP:CHI02xObjective02Alt
+"MISSION OBJECTIVE #2:  \n Destroy all GLA structures in the region"
+END
+
+MAP:CHI02xReactorKIAWarn
+"INCOMING TRANSMISSION:  \n Protect the Nuclear Reactor"
+END
+
+MAP:CHI02xReactorCaptureWarn
+"WARNING:  \n Do not let the enemy capture  \n the Nuclear Reactor and both bunkers"
+END
+
+MAP:CHI02xBunkerKIAWarn
+"INCOMING TRANSMISSION:  \n Protect the Storage Bunkers"
+END
+
+MAP:CHI02xBadPlayerReactorWarn
+"INCOMING TRANSMISSION:  \n We need this Nuclear Reactor  \n Do not let it be destroyed"
+END
+
+MAP:CHI02xBadPlayerBunkerWarn
+"INCOMING TRANSMISSION:  \n We need these Storage Bunkers  \n Do not let them be destroyed"
+END
+
+MAP:CHI02xSpyPostHint01
+"HINT:  \n Capture the spy post to call in Carpet Bombers"
+END
+
+MAP:CHI02xPerimeterWarn
+"WARNING:  \n Enemy forces are preparing to attack"
+END
+
+MAP:CHI02xPerimeterEasyWarn
+"WARNING:  \n Enemy forces are preparing to attack"
+END
+
+MAP:CHI02xNeutronHint01
+"HINT:  \n Use the Neutron Shell ability of Nuke Cannons to kill  \n infantry and neutralize enemy vehicles"
+END
+
+MAP:CHI02xNeutronHint02
+"HINT:  \n Your infantry can enter and control any neutralized vehicle"
+END
+
+MAP:CHI02xEMPMineHint01
+"HINT:  \n Upgrade our buildings with Neutron Mines to disable vehicles  \n Then Neutron Shells can neutralize them"
+END
+
+MAP:CHI02xCarpetBombReminder
+"INCOMING TRANSMISSION:  \n Carpet Bombers are ready"
+END
+
+MAP:CHI02xInfo1
+"INCOMING TRANSMISSION:  \n Reinforcements will arrive in 10 minutes"
+END
+
+MAP:CHI02xInfo2
+"INCOMING TRANSMISSION:  \n Reinforcements will arrive in 5 minutes"
+END
+
+SCRIPT:CHI02timer
+"Reinforcements Arrive In:"
+END
+
+MAP:MD_CHI03-Event-AngryMob-01
+"INCOMING TRANSMISSION:  \n The people rise up to serve us"
+END
+
+MAP:MD_CHI03-Help-IOLow-01
+"INCOMING TRANSMISSION:  \n Our International Opinion is becoming low  \n Destroy more GLA statues"
+END
+
+MAP:MD_CHI03-Help-IOVeryLow-01
+"INCOMING TRANSMISSION:  \n Our International Opinion is very low  \n Destroy GLA statues found throughout the city"
+END
+
+MAP:MD_CHI03-Help-IOExtremelyLow-01
+"HINT:  \n Our International Opinion is critically low  \n Destroy another GLA statue or all is lost"
+END
+
+SCRIPT:MD_CHI03InternationalOpinion
+"International Opinion:"
+END
+
+MAP:MD_CHI04Open
+"Halberstadt, Germany  \n 'Burning Skies'"
+END
+
+MAP:MD_CHI04MissionState0
+"MISSION OBJECTIVE:  \n Eliminate all waves of retreating GLA forces"
+END
+
+MAP:MD_CHI04MissionState1
+"INCOMING TRANSMISSION:  \n Wave 1 has been defeated"
+END
+
+MAP:MD_CHI04MissionState2
+"INCOMING TRANSMISSION:  \n Wave 2 has been defeated"
+END
+
+MAP:MD_CHI04MissionState3
+"INCOMING TRANSMISSION:  \n Wave 3 has been defeated"
+END
+
+MAP:MD_CHI04MissionState4
+"INCOMING TRANSMISSION:  \n Wave 4 has been defeated"
+END
+
+MAP:MD_CHI04MissionState5
+"INCOMING TRANSMISSION:  \n Wave 5 has been defeated"
+END
+
+MAP:MD_CHI04MissionState6
+"INCOMING TRANSMISSION:  \n Wave 6 has been defeated"
+END
+
+MAP:MD_CHI04MissionInfo1
+"INCOMING TRANSMISSION:  \n Wave 1 has entered the region  \n Their path is shown on the radar"
+END
+
+MAP:MD_CHI04MissionInfo2
+"INCOMING TRANSMISSION:  \n Wave 2 has entered the region  \n Their path is shown on the radar"
+END
+
+MAP:MD_CHI04MissionInfo3
+"INCOMING TRANSMISSION:  \n Wave 3 has entered the region  \n Their path is shown on the radar"
+END
+
+MAP:MD_CHI04MissionInfo4
+"INCOMING TRANSMISSION:  \n Wave 4 has entered the region  \n Their path is shown on the radar"
+END
+
+MAP:MD_CHI04MissionInfo5
+"INCOMING TRANSMISSION:  \n Wave 5 has entered the region  \n Their path is shown on the radar"
+END
+
+MAP:MD_CHI04MissionInfo6
+"INCOMING TRANSMISSION:  \n Our Intel has been jammed. New waves are arriving  \n from 2 directions, but their location is unknown"
+END
+
+MAP:MD_CHI04MissionFinaleText
+"INCOMING TRANSMISSION:  \n Our forces have arrived from the South  \n Your mission is complete"
+END
+
+MAP:MD_CHI04MissionLoseText
+"INCOMING TRANSMISSION:  \n The GLA forces have escaped to the North  \n You have been defeated, General. This time"
+END
+
+MAP:MD-CHI05_LOCALE
+"Near Hamburg, Germany  \n 'The Dragon's Destiny'"
+END
+
+MAP:MD-CHI05_USBaseDestroyedFirst
+"MISSION OBJECTIVE:  \n Destroy the GLA base to achieve victory"
+END
+
+MAP:MD-CHI05_GLABaseDestroyedFirst
+"MISSION OBJECTIVE:  \n Destroy the USA base to achieve victory"
+END
+
+MAP:MD-CHI05_PartCannon_Detected
+"WARNING:  \n Particle Cannon detected"
+END
+
+MAP:MD-CHI05_Hint01
+"HINT:  \n We should concentrate our attack on the USA base  \n We must eliminate their Particle Cannons"
+END
+
+MAP:MD-CHI05_Hint02
+"INCOMING TRANSMISSION:  \n Destroy the USA Command Center to end their air support"
+END
+
+MAP:MD-CHI05_Hint05
+"INCOMING TRANSMISSION:  \n Kill the enemy's Hijackers to protect our vehicles"
+END
+
+MAP:MD-CHI05_Hint08
+"INCOMING TRANSMISSION:  \n Jarmen Kell may be hiding in this village"
+END
+
+MAP:MD-CHI05_Hint10
+"INCOMING TRANSMISSION:  \n Prevent the Battle Buses from reaching our base"
+END
+
+MAP:MD-CHI05_Hint13
+"INCOMING TRANSMISSION:  \n The USA base is without power. Strike quickly"
+END
+
+MAP:MD-CHI05_Hint15
+"INCOMING TRANSMISSION:  \n Use Listening Outposts to stop  \n Jarmen Kell from sniping our vehicles"
+END
+
+MAP:MD-CHI05_Hint16
+"INCOMING TRANSMISSION:  \n Use infantry to recapture our neutralized vehicles"
+END
+
+MAP:MD-CHI05_InternetCenter02
+"HINT:  \n Garrison the Internet Center with Hackers for extra income"
+END
+
+MAP:ChemGeneral
+"Dr. Thrax"
+END
+
+GC_CHINABOSS:Loc
+"Somewhere near the China / Tibet border  \n 'The Tiger's Lair'"
+END
+
+GC_CHINABOSS:Hint
+"INCOMING TRANSMISSION:  \n Destroying enemy weapon bunkers will reset the timers on all superweapons"
+END
+
+GC_CHINABOSS:Reset
+" \n Superweapon timers reset"
+END
+
+GC_CHINABOSS:Strike
+" \n Superweapon Strike Imminent"
+END
+
+GC_CHINABOSS:Resources
+"HINT:  \n Resources here are limited. You will have to find more supplies quickly"
+END
+
+CONTROLBAR:TooltipMOAB
+"Strong vs. Buildings  \n Will shock units in the blast radius  \n  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:TooltipLeafletDrop
+"Strong vs. Infantry  \n  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:TooltipTankParaDrop
+"Drops Battlemasters by plane  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipNukeDrop
+"Drops a tactical nuclear warhead by plane  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipSuitcaseNuke
+"Hacker has a nuclear weapon in his suitcase  \n"
+END
+
+CONTROLBAR:TooltipSpectreGunship
+"Strong vs. Vehicles  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipFireICBM
+"Strong vs. Buildings, infantry  \n  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:TooltipFireTomahawkStorm
+"Strong vs. Buildings, Vehicles  \n  \n Countdown Timer: 5:00"
+END
+
+CONTROLBAR:TooltipFrenzy
+"Causes your units to do more damage for a limited amount time  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipFireGPSScrambler
+"GPS Scramber  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:TooltipCommunicationsDownload
+"Download location information on all enemy forces"
+END
+
+CONTROLBAR:TooltipUSAUpgradeSentryDroneGun
+"Sentry Drones gain a machine gun"
+END
+
+CONTROLBAR:TooltipGLAUpgradeQuadCannonSnipe
+"Quad Cannons gain the ability to kill infantry in a single shot"
+END
+
+CONTROLBAR:TooltipUSAUpgradeSupplyLines
+"Resources gathering mechanisms bring in an additional 10%"
+END
+
+CONTROLBAR:TooltipUSAUpgradeMOAB
+"Fuel Air Bomb is upgraded to the Mother Of All Bombs"
+END
+
+CONTROLBAR:TooltipBecomeRealBuilding
+"Upgrade this fake building to a fully functional version"
+END
+
+CONTROLBAR:TooltipUSAUpgradeChemicalSuits
+"Infantry will become more resistant to toxin and radiation damage"
+END
+
+CONTROLBAR:TooltipUSAUpgradeBunkerBusters
+"Stealth Fighter missiles damage garrisoned troops"
+END
+
+CONTROLBAR:TooltipUSAUpgradeCountermeasures
+"All aircraft capable of evading 50% of missiles fired at them"
+END
+
+CONTROLBAR:TooltipUpgradeChinaHelixGattlingCannon
+"Build a Gattling Cannon on this Helix"
+END
+
+CONTROLBAR:TooltipUpgradeChinaHelixPropagandaTower
+"Build a Propaganda Tower on this Helix"
+END
+
+CONTROLBAR:TooltipUpgradeChinaHelixBattleBunker
+"Build a Bunker on this Helix. Bunkers can be occupied by troops. Troops can fire out of bunkers"
+END
+
+CONTROLBAR:TooltipChinaUpgradeSatelliteHackOne
+"Enable the Satellite Hack ability to reveal the command centers of opponents"
+END
+
+CONTROLBAR:TooltipChinaUpgradeSatelliteHackTwo
+"Enable the Satellite Hack ability to intermittently reveal territory of all opponents"
+END
+
+CONTROLBAR:TooltipChinaUpgradeFanaticism
+"Additional +25% to Horde bonus"
+END
+
+CONTROLBAR:TooltipUpgradeChinaWGUraniumShells
+"+25% shot damage on Battlemaster and Overlord"
+END
+
+CONTROLBAR:TooltipUpgradeChinaTankAutoLoader
+"Battlemaster receives an increased rate of fire"
+END
+
+CONTROLBAR:TooltipUpgradeChinaNeutronShells
+"Upgrades Nuke Cannon to fire Neutron Shells  \n Neutron Shells will kill infantry in vehicles"
+END
+
+CONTROLBAR:ToolTipUpgradeChinaEMPMines
+"Mines release an Neutron blast when triggered"
+END
+
+CONTROLBAR:TooltipUpgradeChinaFusionReactors
+"Improves Emperor and Battlemaster speed"
+END
+
+CONTROLBAR:TooltipDetonateFakebuilding
+"Orders the fake building to immediately detonate"
+END
+
+CONTROLBAR:ToolTipUpgradeGLAWorkerFakeCommandSet
+"Switch command bar to build fake buildings"
+END
+
+CONTROLBAR:ToolTipUpgradeGLAWorkerRealCommandSet
+"Switch command bar to build real buildings"
+END
+
+CONTROLBAR:Demo_ToolTipGLAUpgradeHEBomb
+"100% more damage for all Demo Traps"
+END
+
+CONTROLBAR:ToolTipGLACamoNetting
+"This structure gains camouflage"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeFortifiedStructure
+"Buildings gain additional armor protection from attacks"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeBoobyTrap
+"Rebels can place booby traps on buildings and neutral units"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeWorkerShoes
+"Gives Workers the new shoes they've been asking for, increasing their movement"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeAnthraxGamma
+"+50% damage bonus to all toxin units"
+END
+
+CONTROLBAR:ToolTipSaboteur
+"Disables buildings. Resets superweapon timers"
+END
+
+CONTROLBAR:DropNapalmBomb
+"&Drop a Napalm Bomb"
+END
+
+CONTROLBAR:DropNukeBomb
+"&Drop a Nuke Bomb"
+END
+
+CONTROLBAR:ToolTipDropNukeBomb
+"Drops a tactical nuke on the target area"
+END
+
+CONTROLBAR:ToolTipDropNapalmBomb
+"Strong against most ground targets  \n Weak against flame vehicles"
+END
+
+CONTROLBAR:ToolTipChinaNukeWarhead
+"Load the Nuclear Shells"
+END
+
+CONTROLBAR:ToolTipChinaNeutronWarhead
+"Load the Neutron Shells"
+END
+
+CONTROLBAR:ToolTipFireBattleship
+"Call in bombardment from offshore Battleship"
+END
+
+CONTROLBAR:ToolTipFireAircraftCarrier
+"Launches the Aircraft Carrier's attack planes"
+END
+
+CONTROLBAR:ToolTipECMDisableVehicle
+"Disable enemy vehicle"
+END
+
+CONTROLBAR:ToolTipChinaFireRebelBoobyTrapAttack
+"Place a booby trap"
+END
+
+CONTROLBAR:ToolTipUSABuildFireBase
+"Ground defense. Garrisonable by four infantry"
+END
+
+CONTROLBAR:ToolTipUSABuildArtilleryPlatform
+"Builds a large range artillery platform for defenses  \n  \n Power Required: 4"
+END
+
+CONTROLBAR:ToolTipFakeGLABuilding
+"Fake buildings can be detonated or upgraded to real buildings"
+END
+
+CONTROLBAR:ToolTipChinaBuildInternetCenter
+"Helps hackers bring in money. Can be upgraded to spy on opponents"
+END
+
+CONTROLBAR:ToolTipAmericaICBMLauncher
+"Launches an Intercontinental Ballistic Missile  \n Power Required: 10"
+END
+
+CONTROLBAR:ToolTipAmericaBuildTomahawkStorm
+"Launches a volley of Tomahawk missiles  \n  \n Countdown Timer: 5:00"
+END
+
+CONTROLBAR:ToolTipGLABuildCombatBike
+"Fast and versatile  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildSaboteur
+"Non-combat infiltration unit. Can temporarily disable enemy buildings"
+END
+
+CONTROLBAR:ToolTipChinaBuildPropagandaTrooper
+"Produces propaganda to heal nearby units"
+END
+
+CONTROLBAR:ToolTipChinaBuildMiniGunner
+"Strong vs. infantry, air  \n Weak vs. tanks"
+END
+
+CONTROLBAR:ToolTipUSABuildAvenger
+"Uses a laser to destroy missiles and aircraft  \n  \n Strong vs. missiles, aircraft  \n Weak vs. vehicles, infantry"
+END
+
+CONTROLBAR:ToolTipUSABuildKingRaptor
+"Can engage ground or air targets. Equipped with a Point Defense Laser  \n Larger Payload. Detects Stealth  \n  \n Strong vs. aircraft, tanks, light vehicles  \n Weak vs. missile-armed infantry, anti-air defenses"
+END
+
+CONTROLBAR:ToolTipUSABuildFuelAirAurora
+"Super-sonic attack makes Aurora immune to enemy fire while dropping a small Fuel-Air Bomb. After super-sonic attack, Aurora speed is reduced to 50%  \n  \n Strong vs. buildings  \n Weak vs. fighters, anti-air units"
+END
+
+CONTROLBAR:ToolTipUSABuildHyersonicAurora
+"Hyper-sonic attack makes Aurora immune to enemy fire. After Hyper-sonic attack, Aurora speed is reduced to 50%  \n  \n Strong vs. buildings  \n Weak vs. fighters, anti-air units"
+END
+
+CONTROLBAR:ToolTipGLABuildSniper
+"Camouflaged while not moving or shooting. Spots hidden enemies  \n  \n Strong vs. infantry  \n Weak vs. light vehicles, scouts"
+END
+
+CONTROLBAR:ToolTipUSABuildMicrowave
+"Strong vs. base defenses  \n Weak vs. tanks, aircraft, light vehicles"
+END
+
+CONTROLBAR:ToolTipUSABuildSentryDrone
+"Detects stealth  \n  \nStrong vs. infantry  \n Weak vs. tanks"
+END
+
+CONTROLBAR:ToolTipUSABuildHellfireDrone
+"Fires a Hellfire Missile  \n  \n Strong vs. vehicles  \n Weak vs. infantry"
+END
+
+CONTROLBAR:ToolTipUSABuildPointDefenseDrone
+"Fires an anti-missile laser"
+END
+
+CONTROLBAR:ToolTipChinaBuildHelix
+"Heavy lift transport  \n upgrades with base defense structures and Napalm Bomb  \n  \n Strong vs. tanks, light vehicles  \n Weak vs. missile armed infantry, anti-air defenses"
+END
+
+CONTROLBAR:ToolTipChinaBuildListeningOutpost
+"Transport. Detects stealth units  \n  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:ToolTipChinaBuildECM
+"Strong vs. tanks, vehicles  \n Weak vs. infantry, aircraft"
+END
+
+CONTROLBAR:ToolTipGLABuildBattleBus
+"Can load it up with 8 infantry  \n  \n Strong vs. infantry, buildings"
+END
+
+CONTROLBAR:ToolTipUSAScienceSpectreGunship
+"Spectre Gunships circle the battlefield and pummel enemy forces with Howitzers and Gattling Cannons  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipUSAScienceLeafletDrop
+"Leaflets disable enemy troop concentrations while they consider their options  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceTankHunterTraining
+"All Tank Hunters will be built as veterans"
+END
+
+CONTROLBAR:ToolTipChinaScienceBattlemasterTraining
+"All Battlemasters will be built as elite"
+END
+
+CONTROLBAR:ToolTipChinaScienceOverlordTraining
+"All Overlords will be built as elite"
+END
+
+CONTROLBAR:ToolTipChinaScienceGattlingTankTraining
+"All Gattling Tanks will be built as elite"
+END
+
+CONTROLBAR:ToolTipChinaScienceNukeDrop
+"Tactical Nuclear Weapon is deployed by air  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceFrenzy
+"Causes your units to do more damage for a time when targeted  \n  \n Rank 1: 10 percent for 10 seconds  \n Rank 2: 20 percent for 20 seconds  \n Rank 3: 30 percent for 30 seconds  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceCarpetBomb
+"Allows you to call in a heavy bomber to carpet bomb an area  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipScienceGPSScrambler
+"Cloaks units within its area of effect  \n  \nDeploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipGLASneakAttack
+"Troops can create a tunnel anywhere on the map  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipSelectAircraftCarriers
+"Select aircraft carrier(s) in order to conveniently launch attacks"
+END
+
+CONTROLBAR:ToolTipSelectBattleships
+"Call in bombardment from offshore Battleship"
+END
+
+CONTROLBAR:ToolTipChinaScienceTankParadrop
+"Drop Battlemasters from the air  \n  \n Rank 1: 1 Battlemaster  \n Rank 2: 2 Battlemasters  \n Rank 3: 4 Battlemasters  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:ToolTipChinaScienceInfantryParadrop
+"Drop Red Guard from the air  \n  \n Rank 1: 5 Red Guard  \n Rank 2: 10 Red Guard  \n Rank 3: 15 Red Guard  \n  \n Deploy from: Command Center"
+END
+
+TOOLTIP:ChallengeButton
+"Generals' Challenge"
+END
+
+GUI:GeneralsChallenge
+"CHOOSE YOUR GENERAL"
+END
+
+GUI:Biography
+"Biography"
+END
+
+GUI:BioName
+"Name:"
+END
+
+GUI:BioDOB
+"Age:"
+END
+
+GUI:BioBirthplace
+"Stationed:"
+END
+
+GUI:BioStrategy
+"Tactics:"
+END
+
+GUI:BioRank
+"Rank:"
+END
+
+GUI:BioBranch
+"Branch:"
+END
+
+GUI:BioNameEntry_Pos0
+"General Granger"
+END
+
+GUI:BioDOBEntry_Pos0
+"62"
+END
+
+GUI:BioBirthplaceEntry_Pos0
+"Fort Belmont, Houston, Texas, USA"
+END
+
+GUI:BioStrategyEntry_Pos0
+"Air Power"
+END
+
+GUI:BioRankEntry_Pos0
+"4 Star General"
+END
+
+GUI:BioBranchEntry_Pos0
+"US Air Force"
+END
+
+GUI:BioClassNumber_Pos0
+"07121969-HB"
+END
+
+TOOLTIP:BioStrategyLong_Pos0
+"General Malcolm "Ace" Grainger prefers to utilize the maximum airpower available to defeat his enemies"
+END
+
+GUI:BioDefeatedEntry_Pos0
+"I guess It's time for me to go find a good airline job."
+END
+
+GUI:BioVictoriousEntry_Pos0
+"I win, you lose. What more is there to say?"
+END
+
+GUI:BioNameEntry_Pos1
+"Dr. Thrax"
+END
+
+GUI:BioDOBEntry_Pos1
+"Unknown"
+END
+
+GUI:BioBirthplaceEntry_Pos1
+"Unknown"
+END
+
+GUI:BioStrategyEntry_Pos1
+"Toxic weapons"
+END
+
+GUI:BioRankEntry_Pos1
+"Unknown"
+END
+
+GUI:BioBranchEntry_Pos1
+"Unknown"
+END
+
+TOOLTIP:BioStrategyLong_Pos1
+"Dr. Thrax prefers to mix deadly toxins to defeat his enemies"
+END
+
+GUI:BioClassNumber_Pos1
+"Unknown"
+END
+
+GUI:BioDefeatedEntry_Pos1
+"Perhaps I shouldn't have gotten my degree from a mail-order college."
+END
+
+GUI:BioVictoriousEntry_Pos1
+"You thought my toxins were ineffective and now look what has happened to you, General."
+END
+
+GUI:BioNameEntry_Pos2
+"General Tao"
+END
+
+GUI:BioDOBEntry_Pos2
+"50"
+END
+
+GUI:BioBirthplaceEntry_Pos2
+"Base Ox, Chengdu, China"
+END
+
+GUI:BioStrategyEntry_Pos2
+"Nuclear Weapons"
+END
+
+GUI:BioRankEntry_Pos2
+"General, Class AAA"
+END
+
+GUI:BioBranchEntry_Pos2
+"PLA"
+END
+
+TOOLTIP:BioStrategyLong_Pos2
+"General Tsing Shi Tao prefers to utilize nuclear radiation to defeat his enemies"
+END
+
+GUI:BioClassNumber_Pos2
+"Not applicable"
+END
+
+GUI:BioDefeatedEntry_Pos2
+"Another moment and I would have reduced you to dust."
+END
+
+GUI:BioVictoriousEntry_Pos2
+"You are lucky to have survived this battle intact. Challenge me again if you dare."
+END
+
+GUI:BioNameEntry_Pos3
+"General Alexander"
+END
+
+GUI:BioDOBEntry_Pos3
+"42"
+END
+
+GUI:BioBirthplaceEntry_Pos3
+"Camp Franklin, Belfast, Maine, USA"
+END
+
+GUI:BioStrategyEntry_Pos3
+"Weapons of Mass Destruction"
+END
+
+GUI:BioRankEntry_Pos3
+"4 Star General"
+END
+
+GUI:BioBranchEntry_Pos3
+"US Marines"
+END
+
+TOOLTIP:BioStrategyLong_Pos3
+"General Alexis Alexander prefers to build heavy base defenses and build superweapons to defeat her enemies"
+END
+
+GUI:BioClassNumber_Pos3
+"178923478-HBGB"
+END
+
+GUI:BioDefeatedEntry_Pos3
+"It's not fair! One more Super Weapon and I would have beaten you, General. Challenge me again, I dare you."
+END
+
+GUI:BioVictoriousEntry_Pos3
+"I told you you'd never beat my Super Weapons, General. Care to try again?"
+END
+
+GUI:BioNameEntry_Pos4
+"General Kwai"
+END
+
+GUI:BioDOBEntry_Pos4
+"51"
+END
+
+GUI:BioBirthplaceEntry_Pos4
+"Base Rat, Jinan, China"
+END
+
+GUI:BioStrategyEntry_Pos4
+"Advanced Tank Divisions"
+END
+
+GUI:BioRankEntry_Pos4
+"General, Class AAA"
+END
+
+GUI:BioBranchEntry_Pos4
+"PLA"
+END
+
+TOOLTIP:BioStrategyLong_Pos4
+"General Ta Hun Kwai prefers to construct well built tanks to defeat his enemies"
+END
+
+GUI:BioClassNumber_Pos4
+"9999-3224536-5"
+END
+
+GUI:BioDefeatedEntry_Pos4
+"You may have defeated my tanks, General, but the Tigress will crush you like an insect."
+END
+
+GUI:BioVictoriousEntry_Pos4
+"Tanks are the key to any victory... as you well know."
+END
+
+GUI:BioNameEntry_Pos5
+"General Townes"
+END
+
+GUI:BioDOBEntry_Pos5
+"TBD"
+END
+
+GUI:BioBirthplaceEntry_Pos5
+"Fort Union, Redwood Shores, California, USA"
+END
+
+GUI:BioStrategyEntry_Pos5
+"Laser Weaponry"
+END
+
+GUI:BioRankEntry_Pos5
+"4 Star General"
+END
+
+GUI:BioBranchEntry_Pos5
+"US Army"
+END
+
+TOOLTIP:BioStrategyLong_Pos5
+""Pinpoint" Townes prefers to utilize cutting edge laser technology to defeat his enemies"
+END
+
+GUI:BioClassNumber_Pos5
+"00010204-01KE0"
+END
+
+GUI:BioDefeatedEntry_Pos5
+"You defeated me, General, but I will scan your tactics and devise a superior strategy."
+END
+
+GUI:BioVictoriousEntry_Pos5
+"Your weaknesses became obvious when I scanned your tactics."
+END
+
+GUI:BioNameEntry_Pos6
+"Prince Kassad"
+END
+
+GUI:BioDOBEntry_Pos6
+"34"
+END
+
+GUI:BioBirthplaceEntry_Pos6
+"Tripoli, Libya"
+END
+
+GUI:BioStrategyEntry_Pos6
+"Ambush and Camouflage"
+END
+
+GUI:BioRankEntry_Pos6
+"Not Applicable"
+END
+
+GUI:BioBranchEntry_Pos6
+"GLA Cobra cell"
+END
+
+TOOLTIP:BioStrategyLong_Pos6
+"Prince Kassad prefers to use camouflage and covert ops to defeat his enemies"
+END
+
+GUI:BioClassNumber_Pos6
+"Not Applicable"
+END
+
+GUI:BioDefeatedEntry_Pos6
+"My men will not accept this defeat from their leader, General. You have signed my death warrant with your superior tactics..."
+END
+
+GUI:BioVictoriousEntry_Pos6
+"Accept your bitter defeat and remove yourself from my sight, General."
+END
+
+GUI:BioNameEntry_Pos7
+"General Fai"
+END
+
+GUI:BioDOBEntry_Pos7
+"57"
+END
+
+GUI:BioBirthplaceEntry_Pos7
+"Base Snake, Beijing, China"
+END
+
+GUI:BioStrategyEntry_Pos7
+"Advanced Infantry Divisions"
+END
+
+GUI:BioRankEntry_Pos7
+"General, Class AAA"
+END
+
+GUI:BioBranchEntry_Pos7
+"PLA"
+END
+
+TOOLTIP:BioStrategyLong_Pos7
+"General "Anvil" Shin Fai prefers to enlist highly trained soldiers to defeat his enemies"
+END
+
+GUI:BioClassNumber_Pos7
+"2030-200403-1"
+END
+
+GUI:BioDefeatedEntry_Pos7
+"TBD"
+END
+
+GUI:BioVictoriousEntry_Pos7
+"TBD"
+END
+
+GUI:BioNameEntry_Pos8
+"General Juhziz"
+END
+
+GUI:BioDOBEntry_Pos8
+"36"
+END
+
+GUI:BioBirthplaceEntry_Pos8
+"Unknown"
+END
+
+GUI:BioStrategyEntry_Pos8
+"Explosives and Bombs"
+END
+
+GUI:BioRankEntry_Pos8
+"Not Applicable"
+END
+
+GUI:BioBranchEntry_Pos8
+"GLA Scorpion Cell"
+END
+
+TOOLTIP:BioStrategyLong_Pos8
+"General Rodall "Demo" Juhziz prefers to wire up powerful explosives to defeat his enemies"
+END
+
+GUI:BioClassNumber_Pos8
+"Not Applicable"
+END
+
+GUI:BioDefeatedEntry_Pos8
+"TBD"
+END
+
+GUI:BioVictoriousEntry_Pos8
+"TBD"
+END
+
+GUI:BioNameEntry_Pos9
+"General Leang"
+END
+
+GUI:BioDOBEntry_Pos9
+"TBD"
+END
+
+GUI:BioBirthplaceEntry_Pos9
+"Base Dragon, Lanzhou, China"
+END
+
+GUI:BioStrategyEntry_Pos9
+"Unknown"
+END
+
+GUI:BioRankEntry_Pos9
+"Dragon General, Class AAAA"
+END
+
+GUI:BioBranchEntry_Pos9
+"PL- Elite Forces"
+END
+
+TOOLTIP:BioStrategyLong_Pos9
+"General "Tigress" Leiong Leang demands the use of all other technology to defeat her enemies"
+END
+
+GUI:BioClassNumber_Pos9
+"Unknown"
+END
+
+GUI:BioDefeatedEntry_Pos9
+"This has been an interesting contest. Perhaps you will challenge me again."
+END
+
+GUI:BioVictoriousEntry_Pos9
+"Improve your skills and challenge me again."
+END
+
+GUI:BioNameEntry_Pos10
+"TBD"
+END
+
+GUI:BioDOBEntry_Pos10
+"33"
+END
+
+GUI:BioBirthplaceEntry_Pos10
+"TBD"
+END
+
+GUI:BioStrategyEntry_Pos10
+"TBD"
+END
+
+GUI:BioRankEntry_Pos10
+"."
+END
+
+GUI:BioBranchEntry_Pos10
+"."
+END
+
+TOOLTIP:BioStrategyLong_Pos10
+"."
+END
+
+GUI:BioClassNumber_Pos10
+"."
+END
+
+GUI:BioDefeatedEntry_Pos10
+"TBD"
+END
+
+GUI:BioVictoriousEntry_Pos10
+"TBD"
+END
+
+GUI:BioNameEntry_Pos11
+"TBD"
+END
+
+GUI:BioDOBEntry_Pos11
+"TBD"
+END
+
+GUI:BioBirthplaceEntry_Pos11
+"TBD"
+END
+
+GUI:BioStrategyEntry_Pos11
+"TBD"
+END
+
+GUI:BioRankEntry_Pos11
+"."
+END
+
+GUI:BioBranchEntry_Pos11
+"."
+END
+
+TOOLTIP:BioStrategyLong_Pos11
+"."
+END
+
+GUI:BioClassNumber_Pos11
+"."
+END
+
+GUI:BioDefeatedEntry_Pos11
+"TBD"
+END
+
+GUI:BioVictoriousEntry_Pos11
+"TBD"
+END
+
+TOOLTIP:BioStrategyLong_GLA
+"The Global Liberation Army prefers underhanded and sneaky tactics to defeat its enemies"
+END
+
+TOOLTIP:BioStrategyLong_China
+"China uses fire and overwhelming numbers to defeat its enemies"
+END
+
+TOOLTIP:BioStrategyLong_USA
+"The USA utilizes high tech weaponry and skill to defeat its enemies"
+END
+
+TOOLTIP:BioStrategyLong_Random
+"This selection will randomly choose a faction"
+END
+
+GUI:ChallengeWinText
+"Congratulations, you've defeated %s"
+END
+
+GUI:ChallengeLossText
+"You've been defeated by %s"
+END
+
+CREDITS:DevelopmentDirector
+"Development Director"
+END
+
+CREDITS:GeneralManager
+"EALA General Manager"
+END
+
+CREDITS:LeadArtist
+"Lead Artist"
+END
+
+CREDITS:QADirector
+"QA Director"
+END
+
+CREDITS:SrTestLead
+"Sr. Test Lead"
+END
+
+CREDITS:AssistantMultiplayerTestLead
+"Assistant Multiplayer Test Lead"
+END
+
+CREDITS:TestAnalyst
+"Test Analyst"
+END
+
+CREDITS:AssistantProducer
+"Assistant Producer"
+END
+
+CREDITS:CameoPhotoshootStudio
+"Photos shot at Out West Studio"
+END
+
+CREDITS:Models
+"Models"
+END
+
+CREDITS:Actors
+"Actors"
+END
+
+CREDITS:VisualEffectsAndEditing
+"Visual Effects and Editing"
+END
+
+CREDITS:NewsReporterVideos
+"News Reporter Videos"
+END
+
+CREDITS:DirectorOfProductLocalization
+"Director of Product Localization, EALA"
+END
+
+CREDITS:LocalizationAssistance
+"Localization Assistance"
+END
+
+ACADEMY:Eva
+"Tactical Analysis"
+END
+
+ACADEMY:BuildAllStructures
+"When you're on the battlefield it's important to utilize all the tools available to you, General. Make sure you build all the structures. You must maintain a strong military force"
+END
+
+ACADEMY:BuildSupplyCenterEarlier
+"General, one of the most important functions of a strong leader is making sure that the soldiers have plenty of supplies. We suggest that you make sure to build a Supply Center or Stash whenever you begin a mission. Supplies bring you cash and cash brings you victory"
+END
+
+ACADEMY:TryBuildingRadar
+"The Fog of War surrounds us all. One helpful way to see through the pea soup is via radar. Each faction is unique in how it obtains the eye in the sky. The USA Command Center automatically comes with radar, the Chinese Command Center must be upgraded and the GLA must build a Radar Van from its Arms Dealer"
+END
+
+ACADEMY:BuildMorePeons
+"If you ask any other Generals they'll confirm a simple rule: The grunts make the army. In order to build your base you'll need to put your Dozers or Workers to work. These guys are key to your future success so don't forget them!"
+END
+
+ACADEMY:TryCapturingStructures
+"General, sometimes it's easier to take what you want rather than work for it. If you build the "Capture" upgrade from your Barracks you'll be able to steal enemy structures. There are also Tech Buildings littered around the battlefield that can enhance your army even further"
+END
+
+ACADEMY:SpendGeneralsPoints
+"With war come the spoils. Every time you destroy an enemy you'll earn your way toward more Generals Points. These can be spent by pressing the "star" button on the right side of the Command Bar. Simply open the Generals Points menu and spend your hard earned points on some new war toys"
+END
+
+ACADEMY:TryUsingSuperweapons
+"What's the use of collecting Generals points if you don't use them? If you've purchased Generals Powers by using your points an icon will pop up on the right side of the screen. Simply press it and watch the fireworks begin. The more points you spend, the more powerful the power"
+END
+
+ACADEMY:TryGarrisoningAStructure
+"Soldiers can be effective in the open, but are deadlier when garrisoned inside civilian buildings. Select your soldiers and send them into an empty structure. They'll be protected by the walls - unless a Flash Bang, Toxin Tractor or Dragon Tank comes their way"
+END
+
+ACADEMY:IdleBuildingUnits
+"General, fielding and leading a great army should be your highest goal. Make sure you're building your fighting units by clicking on a Barracks, War Factory, Airfield, etc. and then clicking a respective picture in the bottom Command Bar. It will be money well spent and will help you achieve victory"
+END
+
+ACADEMY:TryDragSelectingUnits
+"Manipulating your army is one of the trickiest things a General must learn. While you can click on each individual unit, it's usually faster to "lasso" a group of units. Simply click and drag the box around the units. They will now be in your control. If you click on another area the units will move to this spot"
+END
+
+ACADEMY:ResearchUpgrades
+"A great General can make a lot of tanks, but a greater General can make a lot of better tanks. Almost every unit has some form of upgrade. It's often best to spend your money on improving what you already have"
+END
+
+ACADEMY:RanOutOfPower
+"While the GLA has no need for power, China and the USA eat it up like popcorn. To keep a base running strong a General needs to spend money on plenty of power to supply the war machine. Make sure to build a Cold Fusion Reactor or a Nuclear Reactor for maximum output. Low power can mean a low success rate"
+END
+
+ACADEMY:BuildMoreGatherers
+"General, make sure you're building plenty of Workers, Supply Trucks or Chinooks to keep your income flowing. You can make extra gatherers by clicking on rescource gatherer's picture in the Supply Center or Stash. Don't be shy about maximizing your resource potential"
+END
+
+ACADEMY:BuildAHero
+"Jarmen Kell, Col. Burton and Black Lotus can be invaluable to your strategy. These heroes can turn the tide of a battle and are invisible to the enemy. To locate your hero on the radar, look for the cross hair icon. Though you can only build one at a time don't underestimate their importance"
+END
+
+ACADEMY:PickStrategyCenterPlan
+"The US Strategy Center is a very helpful structure. You should remember to choose the strategy that best fits your gameplan. Search & Destroy, Bombardment and Hold the Line are all excellent ways to give you the edge you need. Along with these overall strategies you can purchase many upgrades from this building"
+END
+
+ACADEMY:UseTunnelNetwork
+"When it comes to the GLA sneaking around the battlefield is their calling card. Tunnel Networks offer defense capabilities but they also allow the player to move around quickly. Simply build a few Tunnel Networks and send your units inside. Click on the structure and you can expel them from any other Tunnel Network anywhere on the map. They are key to the overall GLA strategy"
+END
+
+ACADEMY:UseControlGroups
+"Managing a large army can be a bit unruly sometimes. One way to manage lots of units easily is by creating a "control group". Simply select the group of units in question and press "Ctrl" & a number at the same time. Now anytime you press this number, the group of units will be selected. Tap the number twice quickly and the camera view will center over the group"
+END
+
+ACADEMY:UseSecondaryIncomeMethods
+"General, acquiring supplies later in a mission can be difficult. Each faction has a unique way to gain funds during long battles. China can build Hackers and an Internet Center. You can direct the Hackers to hack the internet for funds anywhere or just send them inside Internet Center to gain money even quicker. The GLA depends on the Black Market and the USA relies on the Supply Drop. If you don't plan ahead you may have shortages"
+END
+
+ACADEMY:ClearBuildings
+"Garrisoned buildings can be tough to handle - unless you know some tricks. Upgrade your USA Rangers with Flash Bangs, build GLA Toxin Tractors or Chinese Dragon Tanks to quickly clear out these strong points. The USA also can upgrade to the Bunker Buster to even clear out Tunnel Networks!"
+END
+
+ACADEMY:PickUpSalvage
+"The GLA is a sneaky bunch but they're also resourceful. Whenever the GLA units destroy another vehicle a salvage bonus is left behind. Roll over the salvaged parts to upgrade your units, gain veterancy or get some extra cash. Salvage can make a big difference in a long fight so don't leave it just lying around"
+END
+
+ACADEMY:UseGuardAbility
+"Sometimes it's important that units stay put and guard a particular area. Simply select the unit and press the "shield" button or "G" key and then select the area to be guarded. The unit will attack any enemies that enter its guard radius"
+END
+
+ACADEMY:MultipleSupplyCenters
+"Supplies are the name on the game, General. They can be gathered at Supply Docks littered around the battlefield. While one dock may be enough early on it's usually best to branch out and find a few more during a mission. You'll need to build a Supply Center or Stash close to the Supply Dock to ensure efficient collection"
+END
+
+ACADEMY:GarrionVehicle
+"Some units may enter or steal other vehicles. Stealing vehicles with Hijackers or Terrorists can allow you to sneak into enemy territory"
+END
+
+ACADEMY:UseSelectionHotkeys
+"General, hotkeys are a great way to enhance your control of your forces. "E" will select all of the same unit types on the view screen. If you tap "E" twice quickly it will select all the same type across the entire battlefield. "Q" will select all your combat units on the map. "W" will select all your air units on the map. Give them a try, they'll help you out"
+END
+
+ACADEMY:AlternateMouseInterface
+"One new addition is the "Alternate Mouse Interface" option located in the Options Menu. If you are used to commanding armies using right click as your action button then this may help you get a better handle on your army"
+END
+
+ACADEMY:DoubleClickAttackMoveGuard
+"General, we have created a new way to direct your army. Simply select your units and double click the destination area. Your units will attack-move to the spot and then guard it. You may enable this through the options menu"
+END
+
+ACADEMY:BuildBarracksSooner
+"In order to create a well balanced force you must build a Barracks earlier in the mission. Infantry can make or break your gameplan so it's best not to forget them"
+END
+
+ACADEMY:BuildWarFactorySooner
+"While infantry and airpower can be great assets nothing quite beats a good tank. Be sure to build a War Factory or Arms Dealer earlier in the mission"
+END
+
+ACADEMY:BuildTechStructureSooner
+"For the advanced weaponry there is no replacement for a Strategy Center, Propaganda Center or Palace. Don't forget to build one a bit earlier in missions to ensure success"
+END
+
+ACADEMY:NoIncome
+"General, it's vital to your success that your income flow continues throughout the mission. Too many gaps lead to losing your edge. Make sure you're keeping the supplies rolling in consistently"
+END
+
+ACADEMY:ClearMines
+"Demo Traps and mines can really be the start of a bad day. These sneaky tactics can be combated by using Dozers or Workers to clear these dangerous areas out"
+END
+
+ACADEMY:UnmannedVehicles
+"General, some units can snipe or remove enemy drivers of a vehicles. When this occurs the vehicles become neutral and can be "borrowed" from the enemy. Feel free to go for a ride at your enemy's expense"
+END
+
+ACADEMY:DisguisedUnits
+"Some units can disguise themselves as other units. There is nothing quite as satisfying as rolling a GLA Bomb Truck into an enemy base undetected and causing lots of havoc. Make sure to use this key tactic to further your battle plan"
+END
+
+ACADEMY:StealthUpgrade
+"Some structures can be upgraded to camouflage, like the GLA Tunnel Network or Stinger Sites. These will be invisible to the enemy until its too late. Surprise!"
+END
+
+ACADEMY:Firestorm
+"China has the unique ability to create a Firestorm when multiple MiGs or Inferno Cannons target a single enemy or area. Make sure to coordinate your attacks for maximum effect"
+END
+
+GUI:HeatEffects
+"Heat Effects"
+END
+
+TOOLTIP:HeatEffects
+"Toggle showing heat distortion effects. Turn off for improved performance"
+END
+
+GUI:WeatherEffects
+"Weather Effects"
+END
+
+TOOLTIP:WeatherEffects
+"Toggle showing weather effects such as snow. Turn off for improved performance"
+END
+
+DIALOGEVENT:EvaChina_AllyUnderAttackSubtitle
+"*Our ally is under attack"
+END
+
+DIALOGEVENT:EvaChina_BaseDefensesOffLineSubtitle
+"*Our base defenses are down"
+END
+
+DIALOGEVENT:EvaChina_BeaconDetectedSubtitle
+"*A beacon has been placed"
+END
+
+DIALOGEVENT:EvaChina_BlackLotusEnemySubtitle
+"*We have discovered an enemy Black Lotus"
+END
+
+DIALOGEVENT:EvaChina_BlackLotusOursSubtitle
+"*Black Lotus has been discovered"
+END
+
+DIALOGEVENT:EvaChina_BuildingBeingCapturedSubtitle
+"*Our building is being captured"
+END
+
+DIALOGEVENT:EvaChina_BuildingDisabledSubtitle
+"*A building has been disabled"
+END
+
+DIALOGEVENT:EvaChina_BuildingEnabledSubtitle
+"*A building has been reenabled"
+END
+
+DIALOGEVENT:EvaChina_BuildingStolenSubtitle
+"*The enemy has captured one of our buildings"
+END
+
+DIALOGEVENT:EvaChina_CashStolenSubtitle
+"*General, they are stealing our money"
+END
+
+DIALOGEVENT:EvaChina_ColonelBurtonEnemySubtitle
+"*We have discovered an enemy Col. Burton"
+END
+
+DIALOGEVENT:EvaChina_ColonelBurtonOursSubtitle
+"*Col. Burton has been discovered"
+END
+
+DIALOGEVENT:EvaChina_DefeatSubtitle
+"*We have been defeated"
+END
+
+DIALOGEVENT:EvaChina_DetectedNukeSubtitle
+"*Warning: a Nuclear Missile silo has been detected"
+END
+
+DIALOGEVENT:EvaChina_DetectedParticleCannonSubtitle
+"*Warning: a Particle Cannon has been detected"
+END
+
+DIALOGEVENT:EvaChina_DetectedScudStormSubtitle
+"*Warning: a Scud Storm has been detected"
+END
+
+DIALOGEVENT:EvaChina_FundsReceivedSubtitle
+"*We have received funds from our Ally"
+END
+
+DIALOGEVENT:EvaChina_FundsRequestedSubtitle
+"*You have requested funds from your Ally"
+END
+
+DIALOGEVENT:EvaChina_FundsRequestedAllySubtitle
+"*Your ally is requesting funds"
+END
+
+DIALOGEVENT:EvaChina_FundsTransferredSubtitle
+"*We have transferred funds to our Ally"
+END
+
+DIALOGEVENT:EvaChina_GeneralLevelUpSubtitle
+"*Congratulations general. You have been promoted"
+END
+
+DIALOGEVENT:EvaChina_GPSScramblerLaunchedSubtitle
+"*Warning. A GPS Scrambler has been activated"
+END
+
+DIALOGEVENT:EvaChina_IncomingAnthraxSubtitle
+"*Warning: An anthrax bomb has been launched"
+END
+
+DIALOGEVENT:EvaChina_IncomingDaisyCutterSubtitle
+"*Warning: A Daisy Cutter has been launched"
+END
+
+DIALOGEVENT:EvaChina_IncomingEmpPulseSubtitle
+"*Warning: An EMP Pulse Bomb has been launched"
+END
+
+DIALOGEVENT:EvaChina_IncomingFuelAirBombSubtitle
+"*Warning: A Fuel Air bomb has been launched"
+END
+
+DIALOGEVENT:EvaChina_InsufficientFundsSubtitle
+"*We need more funds"
+END
+
+DIALOGEVENT:EvaChina_JarmenKellEnemySubtitle
+"*We have discovered an enemy Jarmen Kell"
+END
+
+DIALOGEVENT:EvaChina_JarmenKellOursSubtitle
+"*Jarmen Kell has been discovered"
+END
+
+DIALOGEVENT:EvaChina_LaserDefenseSpeechSubtitle
+"*General, our opponent has a stronghold in the middle of the city. His laser defense system is devastating, but requires lots of power. He will be forced to divert his power to one point of defense at a time. Use this to your advantage"
+END
+
+DIALOGEVENT:EvaChina_LaunchedNukeSubtitle
+"*Warning: a Nuclear Missile has been launched"
+END
+
+DIALOGEVENT:EvaChina_LaunchedParticleCannonSubtitle
+"*Warning: Particle Cannon detected"
+END
+
+DIALOGEVENT:EvaChina_LaunchedScudStormSubtitle
+"*Warning: Scud Storm has been launched"
+END
+
+DIALOGEVENT:EvaChina_LowPowerSubtitle
+"*Our power is low"
+END
+
+DIALOGEVENT:EvaChina_NuclearMissileDetectedAllySubtitle
+"*Our ally has built a Nuclear Missile Silo"
+END
+
+DIALOGEVENT:EvaChina_NuclearMissileLaunchedAllySubtitle
+"*Our ally has launched a Nuclear Missile"
+END
+
+DIALOGEVENT:EvaChina_NuclearMissileLaunchedOursSubtitle
+"*We have launched our Nuclear Missile"
+END
+
+DIALOGEVENT:EvaChina_NuclearMissileReadySubtitle
+"*Our Nuclear Missile is ready General"
+END
+
+DIALOGEVENT:EvaChina_OpinionCivilianStructures01Subtitle
+"*General. Be careful that civilian structures are not destroyed"
+END
+
+DIALOGEVENT:EvaChina_OpinionCivilianStructures02Subtitle
+"*Destroying civilian structures will adversely affect our International Opinion!"
+END
+
+DIALOGEVENT:EvaChina_OpinionDestroyStatuesSubtitle
+"*Destroy the GLA statues to increase International Opinion, sir"
+END
+
+DIALOGEVENT:EvaChina_OpinionDestroyStructuresSubtitle
+"*Sir. Destroying enemy structures will increase International Opinion of us"
+END
+
+DIALOGEVENT:EvaChina_OpinionDestroyTroopsSubtitle
+"*Destroy more enemy troops to Increase International Opinion"
+END
+
+DIALOGEVENT:EvaChina_OpinionFallingSubtitle
+"*Our International Opinion is falling!"
+END
+
+DIALOGEVENT:EvaChina_OpinionLowSubtitle
+"*Our International Opinion is becoming low"
+END
+
+DIALOGEVENT:EvaChina_OpinionLowCriticalSubtitle
+"*Our International Opinion is critically low!"
+END
+
+DIALOGEVENT:EvaChina_OpinionLowVerySubtitle
+"*Our International Opinion is very low"
+END
+
+DIALOGEVENT:EvaChina_OpinionProtectCivilianSubtitle
+"*Protect civilian holdings from harm"
+END
+
+DIALOGEVENT:EvaChina_OpinionRisingSubtitle
+"*Our International Opinion is rising!"
+END
+
+DIALOGEVENT:EvaChina_ParticleCannonDetectedAllySubtitle
+"*Our ally has built a Particle Cannon"
+END
+
+DIALOGEVENT:EvaChina_ParticleCannonLaunchedAllySubtitle
+"*Our Ally has activated their Particle Cannon"
+END
+
+DIALOGEVENT:EvaChina_ParticleCannonLaunchedOursSubtitle
+"*Our Particle Cannon has been activated"
+END
+
+DIALOGEVENT:EvaChina_ParticleCannonReadySubtitle
+"*Our Particle Cannon is ready General"
+END
+
+DIALOGEVENT:EvaChina_ReinforcementsHaveArrivedSubtitle
+"*Reinforcements have arrived"
+END
+
+DIALOGEVENT:EvaChina_ScudStormDetectedAllySubtitle
+"*Our ally has built a Scud Storm"
+END
+
+DIALOGEVENT:EvaChina_ScudStormLaunchedAllySubtitle
+"*Our ally has launched their Scud Storm"
+END
+
+DIALOGEVENT:EvaChina_ScudStormLaunchedOursSubtitle
+"*Our Scud Storm has been launched"
+END
+
+DIALOGEVENT:EvaChina_ScudStormReadySubtitle
+"*Our Scud Storm is ready General"
+END
+
+DIALOGEVENT:EvaChina_SelectTargetSubtitle
+"*Select target"
+END
+
+DIALOGEVENT:EvaChina_SneakAttackLaunchedSubtitle
+"*Warning. A Sneak Attack has been detected"
+END
+
+DIALOGEVENT:EvaChina_UnitLostSubtitle
+"*Unit lost"
+END
+
+DIALOGEVENT:EvaChina_UpgradeCompleteSubtitle
+"*Upgrade complete"
+END
+
+DIALOGEVENT:EvaChina_UpgradeEMPminesSubtitle
+"*Neutron Mines upgrade is complete"
+END
+
+DIALOGEVENT:EvaChina_UpgradeNeutronShellSubtitle
+"*Neutron Shell upgrade is complete"
+END
+
+DIALOGEVENT:EvaChina_VehicleStolenSubtitle
+"*A vehicle has been stolen"
+END
+
+DIALOGEVENT:EvaChina_VictorySubtitle
+"*We are victorious"
+END
+
+DIALOGEVENT:EvaGLA_AllyUnderAttackSubtitle
+"*Our ally is under attack"
+END
+
+DIALOGEVENT:EvaGLA_BaseDefensesOffLineSubtitle
+"*Our base defenses are not working"
+END
+
+DIALOGEVENT:EvaGLA_BeaconDetectedSubtitle
+"*A beacon has been placed"
+END
+
+DIALOGEVENT:EvaGLA_BlackLotusEnemySubtitle
+"*We have discovered an enemy Black Lotus"
+END
+
+DIALOGEVENT:EvaGLA_BlackLotusOursSubtitle
+"*Our Jarmen Kell has been seen by the enemy"
+END
+
+DIALOGEVENT:EvaGLA_BuildingBeingCapturedSubtitle
+"*General, they are stealing our money"
+END
+
+DIALOGEVENT:EvaGLA_BuildingDisabledSubtitle
+"*A building has stopped working"
+END
+
+DIALOGEVENT:EvaGLA_BuildingEnabledSubtitle
+"*Our building is working again"
+END
+
+DIALOGEVENT:EvaGLA_BuildingStolenSubtitle
+"*They have taken control of our building"
+END
+
+DIALOGEVENT:EvaGLA_CashStolenSubtitle
+"*General, they are stealing our money"
+END
+
+DIALOGEVENT:EvaGLA_ColonelBurtonEnemySubtitle
+"*We have discovered an enemy Col. Burton"
+END
+
+DIALOGEVENT:EvaGLA_ColonelBurtonOursSubtitle
+"*Our Colonel Burton has been seen by the enemy"
+END
+
+DIALOGEVENT:EvaGLA_DefeatSubtitle
+"*We have been defeated"
+END
+
+DIALOGEVENT:EvaGLA_DetectedNukeSubtitle
+"*Be careful, we have spotted a Nuclear Missile Silo"
+END
+
+DIALOGEVENT:EvaGLA_DetectedParticleCannonSubtitle
+"*Be on guard, we have exposed an enemy Particle Cannon"
+END
+
+DIALOGEVENT:EvaGLA_DetectedScudStormSubtitle
+"*Be careful, the enemy has built a Scud Storm"
+END
+
+DIALOGEVENT:EvaGLA_EliteGuardUpgrade01Subtitle
+"*Our structures will be guarded now"
+END
+
+DIALOGEVENT:EvaGLA_EliteGuardUpgrade02Subtitle
+"*We are upgrading to Elite Guard"
+END
+
+DIALOGEVENT:EvaGLA_EliteGuardUpgrade03Subtitle
+"*The Elite Guard are protecting our buildings now"
+END
+
+DIALOGEVENT:EvaGLA_FundsReceivedSubtitle
+"*We have received funds from our Ally"
+END
+
+DIALOGEVENT:EvaGLA_FundsRequestedSubtitle
+"*You have requested funds from your Ally"
+END
+
+DIALOGEVENT:EvaGLA_FundsRequestedAllySubtitle
+"*Your ally is requesting funds"
+END
+
+DIALOGEVENT:EvaGLA_FundsTransferredSubtitle
+"*We have transferred funds to our Ally"
+END
+
+DIALOGEVENT:EvaGLA_GeneralLevelUpSubtitle
+"*Well done general. You have reached a higher rank"
+END
+
+DIALOGEVENT:EvaGLA_GPSScramblerLaunchedSubtitle
+"*General, our enemy is using their GPS Scrambler"
+END
+
+DIALOGEVENT:EvaGLA_IncomingAnthraxSubtitle
+"*Be on alert, an Anthrax Bomb may be approaching"
+END
+
+DIALOGEVENT:EvaGLA_IncomingDaisyCutterSubtitle
+"*Be on alert. A Daisy Cutter bomb may be approaching"
+END
+
+DIALOGEVENT:EvaGLA_IncomingEmpPulseSubtitle
+"*Be on alert. An EMP Pulse bomb may be approaching"
+END
+
+DIALOGEVENT:EvaGLA_IncomingFuelAirBombSubtitle
+"*Be on alert. A fuel-Air bomb may be approaching"
+END
+
+DIALOGEVENT:EvaGLA_InsufficientFundsSubtitle
+"*We will need more funds, general"
+END
+
+DIALOGEVENT:EvaGLA_JarmenKellEnemySubtitle
+"*We have discovered an enemy Jarmen Kell"
+END
+
+DIALOGEVENT:EvaGLA_JarmenKellOursSubtitle
+"*Our Black Lotus has been seen by the enemy"
+END
+
+DIALOGEVENT:EvaGLA_LaserDefenseSpeechSubtitle
+"*General, our opponent has a stronghold in the middle of the city. His laser defense system is devastating, but requires lots of power. He will be forced to divert his power to one point of defense at a time. Use this to your advantage"
+END
+
+DIALOGEVENT:EvaGLA_LaunchedNukeSubtitle
+"*General, A Nuclear Missile has been released!"
+END
+
+DIALOGEVENT:EvaGLA_LaunchedParticleCannonSubtitle
+"*General, Our enemy is using their Particle Cannon"
+END
+
+DIALOGEVENT:EvaGLA_LaunchedScudStormSubtitle
+"*General, A Scud Storm has been launched"
+END
+
+DIALOGEVENT:EvaGLA_LowPowerSubtitle
+"*Our power is low"
+END
+
+DIALOGEVENT:EvaGLA_NuclearMissileDetectedAllySubtitle
+"*Our ally has built a nuclear missile silo"
+END
+
+DIALOGEVENT:EvaGLA_NuclearMissileLaunchedAllySubtitle
+"*Our ally has launched a Nuclear Missile"
+END
+
+DIALOGEVENT:EvaGLA_NuclearMissileLaunchedOursSubtitle
+"*Launching Nuclear Missile"
+END
+
+DIALOGEVENT:EvaGLA_NuclearMissileReadySubtitle
+"*Our Nuclear missile is ready for launch"
+END
+
+DIALOGEVENT:EvaGLA_OpinionCivilianStructures01Subtitle
+"*General. Be careful that civilian structures are not destroyed"
+END
+
+DIALOGEVENT:EvaGLA_OpinionCivilianStructures02Subtitle
+"*Destroying civilian structures will adversely affect our International Opinion!"
+END
+
+DIALOGEVENT:EvaGLA_OpinionDestroyStatuesSubtitle
+"*Destroy the GLA's statues to increase our International Opinion, sir"
+END
+
+DIALOGEVENT:EvaGLA_OpinionDestroyStructuresSubtitle
+"*Sir. Destroying enemy structures will increase International Opinion of us"
+END
+
+DIALOGEVENT:EvaGLA_OpinionDestroyTroopsSubtitle
+"*Destroy more enemy troops to Increase International Opinion"
+END
+
+DIALOGEVENT:EvaGLA_OpinionFallingSubtitle
+"*Our International Opinion is falling!"
+END
+
+DIALOGEVENT:EvaGLA_OpinionLowSubtitle
+"*Our International Opinion is becoming low"
+END
+
+DIALOGEVENT:EvaGLA_OpinionLowCriticalSubtitle
+"*Our International Opinion is critically low!"
+END
+
+DIALOGEVENT:EvaGLA_OpinionLowVerySubtitle
+"*Our International Opinion is very low"
+END
+
+DIALOGEVENT:EvaGLA_OpinionProtectCivilianSubtitle
+"*Protect civilian holdings from harm"
+END
+
+DIALOGEVENT:EvaGLA_OpinionRisingSubtitle
+"*Our International Opinion is rising!"
+END
+
+DIALOGEVENT:EvaGLA_ParticleCannonDetectedAllySubtitle
+"*Our ally has built a Particle Cannon"
+END
+
+DIALOGEVENT:EvaGLA_ParticleCannonLaunchedAllySubtitle
+"*Our ally is using their Particle Cannon"
+END
+
+DIALOGEVENT:EvaGLA_ParticleCannonLaunchedOursSubtitle
+"*Releasing Particle Cannon"
+END
+
+DIALOGEVENT:EvaGLA_ParticleCannonReadySubtitle
+"*Our Particle Cannon is ready"
+END
+
+DIALOGEVENT:EvaGLA_ReinforcementsHaveArrivedSubtitle
+"*More warriors have come to our aid"
+END
+
+DIALOGEVENT:EvaGLA_ScudStormDetectedAllySubtitle
+"*Our ally has built a Scud Storm"
+END
+
+DIALOGEVENT:EvaGLA_ScudStormLaunchedAllySubtitle
+"*Our ally has launched a Scud Storm"
+END
+
+DIALOGEVENT:EvaGLA_ScudStormLaunchedOursSubtitle
+"*Launching Scud Storm"
+END
+
+DIALOGEVENT:EvaGLA_ScudStormReadySubtitle
+"*We can now use our Scud Storm"
+END
+
+DIALOGEVENT:EvaGLA_SelectTargetSubtitle
+"*Where shall we strike?"
+END
+
+DIALOGEVENT:EvaGLA_SneakAttackLaunchedSubtitle
+"*General, our enemy is using their Sneak Attack"
+END
+
+DIALOGEVENT:EvaGLA_UnitLostSubtitle
+"*A warrior has fallen"
+END
+
+DIALOGEVENT:EvaGLA_UpgradeCompleteSubtitle
+"*Upgrade complete"
+END
+
+DIALOGEVENT:EvaGLA_VehicleStolenSubtitle
+"*They have stolen a vehicle"
+END
+
+DIALOGEVENT:EvaGLA_VictorySubtitle
+"*We are victorious"
+END
+
+DIALOGEVENT:EvaUSA_AllyUnderAttackSubtitle
+"*Our ally is under attack"
+END
+
+DIALOGEVENT:EvaUSA_BaseDefensesOffLineSubtitle
+"*Base defenses off-line"
+END
+
+DIALOGEVENT:EvaUSA_BeaconDetectedSubtitle
+"*Beacon detected"
+END
+
+DIALOGEVENT:EvaUSA_BlackLotusEnemySubtitle
+"*Enemy Jarmen Kell detected"
+END
+
+DIALOGEVENT:EvaUSA_BlackLotusOursSubtitle
+"*Our Jarmen Kell has been detected"
+END
+
+DIALOGEVENT:EvaUSA_BuildingBeingCapturedSubtitle
+"*Our building is being captured"
+END
+
+DIALOGEVENT:EvaUSA_BuildingDisabledSubtitle
+"*Building Offline"
+END
+
+DIALOGEVENT:EvaUSA_BuildingEnabledSubtitle
+"*Building is back online"
+END
+
+DIALOGEVENT:EvaUSA_BuildingStolenSubtitle
+"*Building Stolen"
+END
+
+DIALOGEVENT:EvaUSA_CashStolenSubtitle
+"*General, they are stealing our money"
+END
+
+DIALOGEVENT:EvaUSA_ColonelBurtonEnemySubtitle
+"*Enemy Colonel Burton detected"
+END
+
+DIALOGEVENT:EvaUSA_ColonelBurtonOursSubtitle
+"*Our Colonel Burton has been detected"
+END
+
+DIALOGEVENT:EvaUSA_DefeatSubtitle
+"*You have been defeated"
+END
+
+DIALOGEVENT:EvaUSA_DetectedNukeSubtitle
+"*Warning: Nuclear Missile silo detected"
+END
+
+DIALOGEVENT:EvaUSA_DetectedParticleCannonSubtitle
+"*Warning: Particle Cannon detected"
+END
+
+DIALOGEVENT:EvaUSA_DetectedScudStormSubtitle
+"*Warning: Scud Storm detected"
+END
+
+DIALOGEVENT:EvaUSA_FundsReceivedSubtitle
+"*We have received funds from our Ally"
+END
+
+DIALOGEVENT:EvaUSA_FundsRequestedSubtitle
+"*You have requested funds from your Ally"
+END
+
+DIALOGEVENT:EvaUSA_FundsRequestedAllySubtitle
+"*Your ally is requesting funds"
+END
+
+DIALOGEVENT:EvaUSA_FundsTransferredSubtitle
+"*We have transferred funds to our Ally"
+END
+
+DIALOGEVENT:EvaUSA_GeneralLevelUpSubtitle
+"*Congratulations general. You have been promoted"
+END
+
+DIALOGEVENT:EvaUSA_GPSScramblerLaunchedSubtitle
+"*Warning. GPS Scrambler Detected"
+END
+
+DIALOGEVENT:EvaUSA_HeroDiscoveredEnemySubtitle
+"*An enemy hero has been discovered"
+END
+
+DIALOGEVENT:EvaUSA_HeroDiscoveredOursSubtitle
+"*One of our Heroes has been discovered"
+END
+
+DIALOGEVENT:EvaUSA_IncomingAnthraxSubtitle
+"*Anthrax Bomb detected"
+END
+
+DIALOGEVENT:EvaUSA_IncomingDaisyCutterSubtitle
+"*Daisy Cutter bomb detected"
+END
+
+DIALOGEVENT:EvaUSA_IncomingEmpPulseSubtitle
+"*EMP Pulse bomb detected"
+END
+
+DIALOGEVENT:EvaUSA_IncomingFuelAirBombSubtitle
+"*Fuel Air bomb detected"
+END
+
+DIALOGEVENT:EvaUSA_InsufficientFundsSubtitle
+"*Insufficient funds"
+END
+
+DIALOGEVENT:EvaUSA_JarmenKellEnemySubtitle
+"*Enemy Black Lotus detected"
+END
+
+DIALOGEVENT:EvaUSA_JarmenKellOursSubtitle
+"*Our Black Lotus has been detected"
+END
+
+DIALOGEVENT:EvaUSA_LaserDefenseSpeechSubtitle
+"*General, our opponent has a stronghold in the middle of the city. His laser defense system is devastating, but requires lots of power. He will be forced to divert his power to one point of defense at a time. Use this to your advantage"
+END
+
+DIALOGEVENT:EvaUSA_LaunchedNukeSubtitle
+"*Warning: Nuclear Missile launched"
+END
+
+DIALOGEVENT:EvaUSA_LaunchedParticleCannonSubtitle
+"*Warning: Particle Cannon activated"
+END
+
+DIALOGEVENT:EvaUSA_LaunchedScudStormSubtitle
+"*Warning: Scud Storm launched"
+END
+
+DIALOGEVENT:EvaUSA_LowPowerSubtitle
+"*Low power"
+END
+
+DIALOGEVENT:EvaUSA_NuclearMissileDetectedAllySubtitle
+"*Allied Nuclear Silo detected"
+END
+
+DIALOGEVENT:EvaUSA_NuclearMissileLaunchedAllySubtitle
+"*Allied Nuclear Missile launched"
+END
+
+DIALOGEVENT:EvaUSA_NuclearMissileLaunchedOursSubtitle
+"*Nuclear Missile launched"
+END
+
+DIALOGEVENT:EvaUSA_NuclearMissileReadySubtitle
+"*Nuclear Missile ready"
+END
+
+DIALOGEVENT:EvaUSA_OpinionCivilianStructures01Subtitle
+"*General. Be careful that civilian structures are not destroyed"
+END
+
+DIALOGEVENT:EvaUSA_OpinionCivilianStructures02Subtitle
+"*Destroying civilian structures will adversely affect our International Opinion!"
+END
+
+DIALOGEVENT:EvaUSA_OpinionDestroyStatuesSubtitle
+"*Destroy the GLA statues to increase International Opinion, sir"
+END
+
+DIALOGEVENT:EvaUSA_OpinionDestroyStructuresSubtitle
+"*Sir. Destroying enemy structures will increase International Opinion of us"
+END
+
+DIALOGEVENT:EvaUSA_OpinionDestroyTroopsSubtitle
+"*Destroy more enemy troops to Increase International Opinion"
+END
+
+DIALOGEVENT:EvaUSA_OpinionFallingSubtitle
+"*Our International Opinion is falling!"
+END
+
+DIALOGEVENT:EvaUSA_OpinionLowSubtitle
+"*Our International Opinion is becoming low"
+END
+
+DIALOGEVENT:EvaUSA_OpinionLowCriticalSubtitle
+"*Our International Opinion is critically low!"
+END
+
+DIALOGEVENT:EvaUSA_OpinionLowVerySubtitle
+"*Our International Opinion is very low"
+END
+
+DIALOGEVENT:EvaUSA_OpinionProtectCivilianSubtitle
+"*Protect civilian holdings from harm"
+END
+
+DIALOGEVENT:EvaUSA_OpinionRisingSubtitle
+"*Our International Opinion is rising!"
+END
+
+DIALOGEVENT:EvaUSA_ParticleCannonDetectedAllySubtitle
+"*Allied Particle Cannon detected"
+END
+
+DIALOGEVENT:EvaUSA_ParticleCannonLaunchedAllySubtitle
+"*Allied Particle Cannon activated"
+END
+
+DIALOGEVENT:EvaUSA_ParticleCannonLaunchedOursSubtitle
+"*Particle Cannon activated"
+END
+
+DIALOGEVENT:EvaUSA_ParticleCannonReadySubtitle
+"*Particle Cannon ready"
+END
+
+DIALOGEVENT:EvaUSA_ReinforcementsHaveArrivedSubtitle
+"*Reinforcements have arrived"
+END
+
+DIALOGEVENT:EvaUSA_ScudStormDetectedAllySubtitle
+"*Allied Scud Storm detected"
+END
+
+DIALOGEVENT:EvaUSA_ScudStormLaunchedAllySubtitle
+"*Allied Scud Storm launched"
+END
+
+DIALOGEVENT:EvaUSA_ScudStormLaunchedOursSubtitle
+"*Scud Storm launched"
+END
+
+DIALOGEVENT:EvaUSA_ScudStormReadySubtitle
+"*Scud Storm ready"
+END
+
+DIALOGEVENT:EvaUSA_SelectTargetSubtitle
+"*Select target"
+END
+
+DIALOGEVENT:EvaUSA_SneakAttackLaunchedSubtitle
+"*Warning. Sneak Attack detected"
+END
+
+DIALOGEVENT:EvaUSA_UnitLostSubtitle
+"*Unit lost"
+END
+
+DIALOGEVENT:EvaUSA_UpgradeCompleteSubtitle
+"*Upgrade complete"
+END
+
+DIALOGEVENT:EvaUSA_UpgradeControlRodSubtitle
+"*Control Rod upgrade complete"
+END
+
+DIALOGEVENT:EvaUSA_UpgradeControlRodAdvancedSubtitle
+"*Advanced Control Rods upgrade complete"
+END
+
+DIALOGEVENT:EvaUSA_UpgradeMoabSubtitle
+"*Moab upgrade complete"
+END
+
+DIALOGEVENT:EvaUSA_UpgradeSentryDroneSubtitle
+"*Sentry Drone upgrade complete"
+END
+
+DIALOGEVENT:EvaUSA_VehicleStolenSubtitle
+"*Vehicle Stolen"
+END
+
+DIALOGEVENT:EvaUSA_VictorySubtitle
+"*You are victorious"
+END
+
+DIALOGEVENT:MisCHI01xBrf01Subtitle
+"*General, the GLA managed to defeat the US forces in this area. We launched a devastating counter attack, but like roaches they are still alive"
+END
+
+DIALOGEVENT:MisCHI01xBrf02Subtitle
+"*Even now the GLA survivors are rebuilding"
+END
+
+DIALOGEVENT:MisCHI01xBrf03Subtitle
+"*To finally eliminate the GLA we must send in our forces and root them out of every dark corner in which they hide"
+END
+
+DIALOGEVENT:MisCHI01xBrf04Subtitle
+"*General, our new Listening Outposts are stationed in the area. They are at your disposal"
+END
+
+DIALOGEVENT:MisCHI01xBrf05Subtitle
+"*The Listening Outpost itself is unarmed, however its passengers can fire on enemies that venture too close. You will find its long sight range and stealth ability greatly enhances battlefield awareness"
+END
+
+DIALOGEVENT:MisCHI01xChat01Subtitle
+"*No GLA will slip past our garrison"
+END
+
+DIALOGEVENT:MisCHI01xChat02Subtitle
+"*Toxin Tractors! They're trying to poison us all�we need support!"
+END
+
+DIALOGEVENT:MisCHI01xChat03Subtitle
+"*Look�Oil Derricks�should we capture them?"
+END
+
+DIALOGEVENT:MisCHI01xChat04Subtitle
+"*GLA in your home? Apply a little fire�no more GLA"
+END
+
+DIALOGEVENT:MisCHI01xChat05Subtitle
+"*The GLA are rebuilding over there�stand ready to attack"
+END
+
+DIALOGEVENT:MisCHI01xChat06Subtitle
+"*We will win this day�everyone advance�"
+END
+
+DIALOGEVENT:MisCHI01xCin01aSubtitle
+"*I did not think the United States would be defeated so easily"
+END
+
+DIALOGEVENT:MisCHI01xCin01bSubtitle
+"*I do not understand why the United States has allowed this to happen"
+END
+
+DIALOGEVENT:MisCHI01xCin01cSubtitle
+"*This can not be allowed to stand. China will make things right"
+END
+
+DIALOGEVENT:MisCHI01xCin01dSubtitle
+"*The GLA's treacherous use of our resources against the Americans has caused great embarrassment to China. They must pay for their insolence"
+END
+
+DIALOGEVENT:MisCHI01xCin02Subtitle
+"*The missiles are prepared and ready for launch�final countdown started"
+END
+
+DIALOGEVENT:MisCHI01xCin03Subtitle
+"*3�2�1� Missiles are away"
+END
+
+DIALOGEVENT:MisCHI01xCin04Subtitle
+"*They believe they have won the day, but they celebrate too soon"
+END
+
+DIALOGEVENT:MisCHI01xCin05Subtitle
+"*It is pretty when used for the right reasons�"
+END
+
+DIALOGEVENT:MisCHI01xCin06Subtitle
+"*GLA survivors are running to town for cover�they must be stopped!"
+END
+
+DIALOGEVENT:MisCHI01xCin07Subtitle
+"*We are in position�bomb bay doors open�"
+END
+
+DIALOGEVENT:MisCHI01xCin08Subtitle
+"*We have spotted survivors. Ground assault will be necessary"
+END
+
+DIALOGEVENT:MisCHI01xXO01Subtitle
+"*General, our former base in the region was overrun by the GLA. You will need to construct a new base before you can engage the enemy"
+END
+
+DIALOGEVENT:MisCHI01xXO02Subtitle
+"*May I suggest that you garrison several of the nearby buildings to defend our base"
+END
+
+DIALOGEVENT:MisCHI01xXO03Subtitle
+"*General, the GLA has garrisoned several buildings throughout the town. Perhaps you could use a Dragon tank to clear out those garrisons"
+END
+
+DIALOGEVENT:MisCHI01xXO04Subtitle
+"*General, the GLA is moving Toxin Tractors towards our garrisoned buildings. If those tractors attack those buildings, everyone inside will be eliminated"
+END
+
+DIALOGEVENT:MisCHI01xXO05Subtitle
+"*The GLA are using these Oil Derricks to fund their forces. One of our Red Guard could capture those derricks. The proceeds would help defeat the GLA"
+END
+
+DIALOGEVENT:MisCHI01xXO06Subtitle
+"*General, is it wise to destroy these Oil Derricks? They would provide valuable resources for us. One of our Red Guard could capture them"
+END
+
+DIALOGEVENT:MisCHI01xXO07Subtitle
+"*You have caught them off-guard, General. One of your Red Guard could capture their buildings before they are able to respond"
+END
+
+DIALOGEVENT:MisCHI01xXO08Subtitle
+"*Now that you have re-established our base of operations, it is time to root out all remaining GLA forces in the area"
+END
+
+DIALOGEVENT:MisCHI01xXO09Subtitle
+"*Congratulations, General. You have freed the town of all GLA forces. Once you have wiped out their final base, your mission will be complete"
+END
+
+DIALOGEVENT:MisChi02Lin13Subtitle
+"*The Terrorist threat is finished. Good work, General"
+END
+
+DIALOGEVENT:MisCHI02xBrf01Subtitle
+"*General, the GLA are attempting to steal the nuclear warheads stored at this facility"
+END
+
+DIALOGEVENT:MisCHI02xBrf01aSubtitle
+"*General, the GLA are attempting to destroy our main nuclear power plant"
+END
+
+DIALOGEVENT:MisCHI02xBrf02Subtitle
+"*Our brave soldiers held off their attack but at great cost and the GLA is still out there"
+END
+
+DIALOGEVENT:MisCHI02xBrf03Subtitle
+"*You must hold off the GLA and insure that every one of our Bunkers is protected"
+END
+
+DIALOGEVENT:MisCHI02xBrf03aSubtitle
+"*You must hold off the GLA to insure that the facility is not destroyed"
+END
+
+DIALOGEVENT:MisCHI02xBrf04Subtitle
+"*We have several new technologies that should be of great benefit to your mission, General"
+END
+
+DIALOGEVENT:MisCHI02xBrf05Subtitle
+"*Our Nuclear Cannons are now upgraded to fire neutron shells. These new shells effectively eliminate soldiers and vehicle drivers. Once the radiation has cleared, one of our infantrymen can then capture the surviving vehicles"
+END
+
+DIALOGEVENT:MisCHI02xBrf06Subtitle
+"*Our buildings can now upgrade to Neutron mines. While still effective against infantry, they will also temporarily incapacitate enemy vehicles"
+END
+
+DIALOGEVENT:MisCHI02xBrf07aSubtitle
+"*General, your reinforcements will arrive in 15 minutes"
+END
+
+DIALOGEVENT:MisCHI02xBrf07bSubtitle
+"*General, your reinforcements will arrive in 10 minutes"
+END
+
+DIALOGEVENT:MisCHI02xBrf07cSubtitle
+"*General, your reinforcements will arrive in 5 minutes"
+END
+
+DIALOGEVENT:MisCHI02xBrf07dSubtitle
+"*General, your reinforcements will arrive soon"
+END
+
+DIALOGEVENT:MisCHI02xChat01Subtitle
+"*Enemy forces sighted. We will hold them back"
+END
+
+DIALOGEVENT:MisCHI02xChat02Subtitle
+"*We're taking fire on the right flank�support is needed here"
+END
+
+DIALOGEVENT:MisCHI02xChat03Subtitle
+"*They are behind us�direct all fire to the south!"
+END
+
+DIALOGEVENT:MisCHI02xChat04Subtitle
+"*GLA base in range�all teams ready to attack, General"
+END
+
+DIALOGEVENT:MisCHI02xChat05Subtitle
+"*Enemy buildings on that ridge. Give the word, General, and we will roll over them"
+END
+
+DIALOGEVENT:MisCHI02xChat06Subtitle
+"*Watch those RPG Troopers! We need help!"
+END
+
+DIALOGEVENT:MisCHI02xChat07Subtitle
+"*General, we are over the target area now and have commenced bombing"
+END
+
+DIALOGEVENT:MisCHI02xChat08Subtitle
+"*Rolling out the carpet�of bombs. Heheh"
+END
+
+DIALOGEVENT:MisCHI02xChat09Subtitle
+"*Enemy air defenses are thick here�we are taking heavy damage"
+END
+
+DIALOGEVENT:MisCHI02xChat10Subtitle
+"*Stinger sites have locked onto us�we are in trouble!"
+END
+
+DIALOGEVENT:MisCHI02xChat11Subtitle
+"*Stop that Rebel, he's trying to capture our bunker!"
+END
+
+DIALOGEVENT:MisCHI02xChat12Subtitle
+"*It isn't a Battlemaster, but it will have to do"
+END
+
+DIALOGEVENT:MisCHI02xChat13Subtitle
+"*I prefer my Gattling Tank"
+END
+
+DIALOGEVENT:MisCHI02xChat14Subtitle
+"*Another GLA wave!"
+END
+
+DIALOGEVENT:MisCHI02xChat15Subtitle
+"*We must protect our bunkers!"
+END
+
+DIALOGEVENT:MisCHI02xChat15aSubtitle
+"*We must protect the nuclear reactor!"
+END
+
+DIALOGEVENT:MisCHI02xChat16Subtitle
+"*Now we will show them how to attack a base!"
+END
+
+DIALOGEVENT:MisCHI02xChat17Subtitle
+"*Reinforcements! We are glad to see you!"
+END
+
+DIALOGEVENT:MisCHI02xChat18Subtitle
+"*We are ready for your orders, General. Where do you need us?"
+END
+
+DIALOGEVENT:MisCHI02xCin01Subtitle
+"*We must be on our guard. Reports say the GLA might attack as revenge for our entering the war"
+END
+
+DIALOGEVENT:MisCHI02xCin01aSubtitle
+"*I don't feel safe guarding this nuclear plant"
+END
+
+DIALOGEVENT:MisCHI02xCin01bSubtitle
+"*Yah. I wish I had joined up with the air force instead"
+END
+
+DIALOGEVENT:MisCHI02xCin01dSubtitle
+"*Surely after our recent victory they would not dare to attack us here"
+END
+
+DIALOGEVENT:MisCHI02xCin01cSubtitle
+"*Their food is much better. And they get to wear those fancy helmets"
+END
+
+DIALOGEVENT:MisCHI02xCin02Subtitle
+"*GLA forces! We're under attack!"
+END
+
+DIALOGEVENT:MisCHI02xCin03Subtitle
+"*They're everywhere! We're being overrun"
+END
+
+DIALOGEVENT:MisCHI02xCin04Subtitle
+"*Another wave! We need reinforcements!"
+END
+
+DIALOGEVENT:MisCHI02xCin04aSubtitle
+"*Another wave! They've got bomb trucks and terrorists! We need reinforcements!"
+END
+
+DIALOGEVENT:MisCHI02xCin04bSubtitle
+"*Another wave! They're using suicide tactics! Where are those reinforcements?!"
+END
+
+DIALOGEVENT:MisCHI02xCin05Subtitle
+"*We've lost the airfield!"
+END
+
+DIALOGEVENT:MisCHI02xCin06Subtitle
+"*They're trying to get to the storage bunkers! Protect them at all costs!"
+END
+
+DIALOGEVENT:MisCHI02xCin06aSubtitle
+"*They're trying to get to the main reactor! Protect it at all costs!"
+END
+
+DIALOGEVENT:MisCHI02xCin07Subtitle
+"*The Command Center�they got the Command Center"
+END
+
+DIALOGEVENT:MisCHI02xCin08Subtitle
+"*We held� �remaining forces report in�"
+END
+
+DIALOGEVENT:MisCHI02xCin09Subtitle
+"*Not much left. We're going to need reinforcements"
+END
+
+DIALOGEVENT:MisCHI02xCin10Subtitle
+"*The message got through, but we'll have to hold until they get here"
+END
+
+DIALOGEVENT:MisCHI02xXO01Subtitle
+"*General, our reinforcements have arrived!"
+END
+
+DIALOGEVENT:MisCHI02xXO02Subtitle
+"*General, GLA forces are attacking the bunkers"
+END
+
+DIALOGEVENT:MisCHI02xXO02aSubtitle
+"*General, GLA forces are attacking the nuclear plant!"
+END
+
+DIALOGEVENT:MisCHI02xXO03Subtitle
+"*The GLA is attempting to capture one of our bunkers"
+END
+
+DIALOGEVENT:MisCHI02xXO04Subtitle
+"*General, this bunker is badly damaged. May I suggest it be repaired before another GLA attack"
+END
+
+DIALOGEVENT:MisCHI02xXO04aSubtitle
+"*General, our nuclear plant is badly damaged. May I suggest it be repaired before another GLA attack"
+END
+
+DIALOGEVENT:MisCHI02xXO05Subtitle
+"*General, that last attack severely weakened several bunkers. If one of them is destroyed, the GLA will win this encounter"
+END
+
+DIALOGEVENT:MisCHI02xXO05aSubtitle
+"*General, that last attack severely weakened the nuclear plant. If it is destroyed, we will fail our mission!"
+END
+
+DIALOGEVENT:MisCHI02xXO06Subtitle
+"*Warning�GLA forces moving towards the bunkers"
+END
+
+DIALOGEVENT:MisCHI02xXO06aSubtitle
+"*Warning�GLA forces are moving towards the power plant!"
+END
+
+DIALOGEVENT:MisCHI02xXO07Subtitle
+"*General, I've made contact with one of our spy outposts. They are under GLA attack. If we can rescue them, I can patch into their system and we will be able to call in carpet bombers"
+END
+
+DIALOGEVENT:MisCHI02xXO08Subtitle
+"*General, if you can secure that spy outpost, it will allow you to direct carpet bombing runs on the GLA forces"
+END
+
+DIALOGEVENT:MisCHI02xXO09Subtitle
+"*General, now that our reinforcements have arrived it is time to eliminate the GLA from this area"
+END
+
+DIALOGEVENT:MisChi03RedChat12Subtitle
+"*To battle!"
+END
+
+DIALOGEVENT:MisChi03RedChat19Subtitle
+"*Bring in the tanks! Level them!"
+END
+
+DIALOGEVENT:MisCHI03xBrf01Subtitle
+"*Greetings, Commander. Now that we have thwarted the GLA's counterattack, it is time to press our advantage!"
+END
+
+DIALOGEVENT:MisCHI03xBrf02Subtitle
+"*We must liberate this town from the GLA's clutches"
+END
+
+DIALOGEVENT:MisCHI03xBrf03Subtitle
+"*There is a very heavily defended GLA base north of the river. We must destroy it, but it will not be an easy task"
+END
+
+DIALOGEVENT:MisCHI03xBrf04Subtitle
+"*Our operations have attracted much attention from the rest of the world, and we will be watched closely. The longer this battle goes on, the lower our International Opinion will fall"
+END
+
+DIALOGEVENT:MisCHI03xBrf05Subtitle
+"*Damage to civilian property must be avoided. Our operation must be precise, and swift. Destruction of GLA forces will cause International Opinion to rise, in our favor"
+END
+
+DIALOGEVENT:MisCHI03xBrf09Subtitle
+"*If our International Opinion becomes high enough, the people of the town might join our cause"
+END
+
+DIALOGEVENT:MisCHI03xBrf10Subtitle
+"*It will then be easy to annihilate the GLA's defenses"
+END
+
+DIALOGEVENT:MisCHI03xChat01Subtitle
+"*They must have a camouflaged Tunnel Network near here�"
+END
+
+DIALOGEVENT:MisCHI03xChat02Subtitle
+"*They've ambushed us!"
+END
+
+DIALOGEVENT:MisCHI03xChat03Subtitle
+"*They've ambushed our base!"
+END
+
+DIALOGEVENT:MisCHI03xChat04Subtitle
+"*We have found their secret base!"
+END
+
+DIALOGEVENT:MisCHI03xChat05Subtitle
+"*They are coming from the far side of the lake"
+END
+
+DIALOGEVENT:MisCHI03xChat06Subtitle
+"*Their troops must be hidden in the forest"
+END
+
+DIALOGEVENT:MisCHI03xChat07Subtitle
+"*I wonder what's across the river�"
+END
+
+DIALOGEVENT:MisCHI03xChat08Subtitle
+"*Their hit-and-run attacks are proving inconvenient"
+END
+
+DIALOGEVENT:MisCHI03xChat09Subtitle
+"*The buggies are back!"
+END
+
+DIALOGEVENT:MisCHI03xChat10Subtitle
+"*Sneak attack!"
+END
+
+DIALOGEVENT:MisCHI03xChat11Subtitle
+"*Crush that Inferno Cannon!"
+END
+
+DIALOGEVENT:MisCHI03xChat12Subtitle
+"*The people are too afraid to come out from their homes"
+END
+
+DIALOGEVENT:MisCHI03xChat13Subtitle
+"*We must free them from this oppression!"
+END
+
+DIALOGEVENT:MisCHI03xXO01Subtitle
+"*The people rise to support us!"
+END
+
+DIALOGEVENT:MisCHI03xXO10Subtitle
+"*General. Destroying the GLA statues will be critical to increasing our International Opinion and will boost support of our efforts amongst the population"
+END
+
+DIALOGEVENT:MisCHI03xXO11Subtitle
+"*They have dispatched a Toxic Tractor to clear our garrisonned structures!"
+END
+
+DIALOGEVENT:MisCHI03xXO12Subtitle
+"*Our Dragon Tanks will be a high priority target�guard them well"
+END
+
+DIALOGEVENT:MisCHI03xXO13Subtitle
+"*Well done, sir. The destruction of the statue has caused world opinion to rise"
+END
+
+DIALOGEVENT:MisCHI03xXO16Subtitle
+"*Do not let them destroy the buildings!"
+END
+
+DIALOGEVENT:MisCHI03xXO17Subtitle
+"*Use the Neutron Shell to clear buildings without damaging them"
+END
+
+DIALOGEVENT:MisCHI03xXO18Subtitle
+"*Beware! Their defensive structures are hidden with camo-netting"
+END
+
+DIALOGEVENT:MisCHI03xXO19Subtitle
+"*General, the GLA have the city well-defended. We need to clear them out"
+END
+
+DIALOGEVENT:MisCHI03xXO20Subtitle
+"*You're making good progress, Commander. Much of the city is now free of GLA control"
+END
+
+DIALOGEVENT:MisCHI03xXO21Subtitle
+"*Sir! The city is rising up against our foes!"
+END
+
+DIALOGEVENT:MisCHI03xXO22Subtitle
+"*General, we must clear the GLA from this area!"
+END
+
+DIALOGEVENT:MisCHI03xXO23Subtitle
+"*Our International Opinion is high. Great work!"
+END
+
+DIALOGEVENT:MisCHI04xChat01Subtitle
+"*They have almost escaped! We must stop them!"
+END
+
+DIALOGEVENT:MisCHI04xChat010Subtitle
+"*They are skirting the lake. Intercept them!"
+END
+
+DIALOGEVENT:MisCHI04xChat011Subtitle
+"*They're coming for our base!"
+END
+
+DIALOGEVENT:MisCHI04xChat012Subtitle
+"*We have stopped the first wave of GLA!"
+END
+
+DIALOGEVENT:MisCHI04xChat013Subtitle
+"*Again we have put them in their place!"
+END
+
+DIALOGEVENT:MisCHI04xChat014Subtitle
+"*No one can stand to the might of China!"
+END
+
+DIALOGEVENT:MisCHI04xChat015Subtitle
+"*Sun Tzu would be proud"
+END
+
+DIALOGEVENT:MisCHI04xChat016Subtitle
+"*Victory is ours!"
+END
+
+DIALOGEVENT:MisCHI04xChat017Subtitle
+"*None shall pass"
+END
+
+DIALOGEVENT:MisCHI04xChat018Subtitle
+"*We will banish them from the skies!"
+END
+
+DIALOGEVENT:MisCHI04xChat019Subtitle
+"*Our power is unsurpassed!"
+END
+
+DIALOGEVENT:MisCHI04xChat02Subtitle
+"*Cut them off at the village!"
+END
+
+DIALOGEVENT:MisCHI04xChat020Subtitle
+"*The Helix isn't the only powerhouse"
+END
+
+DIALOGEVENT:MisCHI04xChat03Subtitle
+"*We cannot let them get past that hill"
+END
+
+DIALOGEVENT:MisCHI04xChat04Subtitle
+"*They will surely pass by here. We should defend this area"
+END
+
+DIALOGEVENT:MisCHI04xChat05Subtitle
+"*Here is another choke point"
+END
+
+DIALOGEVENT:MisCHI04xChat06Subtitle
+"*We should secure these buildings"
+END
+
+DIALOGEVENT:MisCHI04xChat07Subtitle
+"*What are they doing?"
+END
+
+DIALOGEVENT:MisCHI04xChat08Subtitle
+"*Watch out for the toxin!"
+END
+
+DIALOGEVENT:MisCHI04xChat09Subtitle
+"*We've been ambushed!"
+END
+
+DIALOGEVENT:MisCHI04xChat15Subtitle
+"*Our forces are in position. We are ready for anything"
+END
+
+DIALOGEVENT:MisCHI04xChat16Subtitle
+"*They are stronger than we thought. We need air support. Send in the Helix now!"
+END
+
+DIALOGEVENT:MisCHI04xXO01Subtitle
+"*The GLA is sending forth another wave!"
+END
+
+DIALOGEVENT:MisCHI04xXO02Subtitle
+"*This wave is retreating towards the north"
+END
+
+DIALOGEVENT:MisCHI04xXO03Subtitle
+"*They are retreating to the northeast"
+END
+
+DIALOGEVENT:MisCHI04xXO04Subtitle
+"*This wave is retreating to the east"
+END
+
+DIALOGEVENT:MisCHI04xXO05Subtitle
+"*The European Union is extremely pleased with our performance, General. We need to stay aggressive and eliminate the GLA"
+END
+
+DIALOGEVENT:MisCHI04xXO06Subtitle
+"*This force was only a diversion!"
+END
+
+DIALOGEVENT:MisCHI04xXO07Subtitle
+"*General, they have a scud storm! We must spread out our troops to deny them a target!"
+END
+
+DIALOGEVENT:MisCHI04xXO08Subtitle
+"*Wait�they're not targeting us�"
+END
+
+DIALOGEVENT:MisCHI04xXO09Subtitle
+"*The GLA have no honor! They have decimated the village to clear a path!"
+END
+
+DIALOGEVENT:MisCHI04xXO10Subtitle
+"*We should assemble a base to secure this region"
+END
+
+DIALOGEVENT:MisCHI04xXO11Subtitle
+"*Our Helix is the Overlord of the skies. Build more to help us control the area"
+END
+
+DIALOGEVENT:MisCHI04xXO12Subtitle
+"*Sir, I recommend placing Listening Outposts at key locations"
+END
+
+DIALOGEVENT:MisCHI04xXO13Subtitle
+"*Current Intel reports that the GLA are retreating towards this location. We will make our stand here. Do not permit any GLA units to leave this area. Our new Helix Helicopter should assure your success. The appearance of our forces from the south will signal the completion of your main objective"
+END
+
+DIALOGEVENT:MisCHI04xXO14Subtitle
+"*Current Intel reports that the GLA are retreating towards this location. We will make our stand here. Do not permit any GLA units to leave this area. If too many of them escape, our mission will be a failure. Our new Helix Helicopter should assure your success. The appearance of our forces from the south will signal the completion of your main objective"
+END
+
+DIALOGEVENT:MisCHI04xXO15Subtitle
+"*A wave of GLA is approaching from the west"
+END
+
+DIALOGEVENT:MisCHI04xXO16Subtitle
+"*There is a wave of GLA approaching from the south"
+END
+
+DIALOGEVENT:MisCHI04xXO17Subtitle
+"*GLA forces have been spotted approaching from the southwest"
+END
+
+DIALOGEVENT:MisCHI04xXO18Subtitle
+"*GLA forces incoming from the southeast"
+END
+
+DIALOGEVENT:MisCHI04xXO19Subtitle
+"*A wave of GLA forces are approaching from the southwest"
+END
+
+DIALOGEVENT:MisCHI04xXO20Subtitle
+"*Another GLA wave is approaching"
+END
+
+DIALOGEVENT:MisCHI04xXO21Subtitle
+"*Excellent work, sir. Intel confirms that you have destroyed the entire wave"
+END
+
+DIALOGEVENT:MisCHI04xXO22Subtitle
+"*The enemy is about to breach our defenses"
+END
+
+DIALOGEVENT:MisCHI04xXO23Subtitle
+"*Multiple Scud Storm launches detected"
+END
+
+DIALOGEVENT:MisCHI04xXO24Subtitle
+"*Our defenses have been breached commander, we have failed the mission"
+END
+
+DIALOGEVENT:MisCHI04xXO25Subtitle
+"*Commander, our forces from the south have arrived. Out mission was a success"
+END
+
+DIALOGEVENT:MisCHI04xXO26Subtitle
+"*General, enemy forces are dangerously close to making their escape. We must deal with them quickly!"
+END
+
+DIALOGEVENT:MisCHI04xXO27Subtitle
+"*GLA forces have been detected fleeing through this location. Move into defensive positions and await enemy contact"
+END
+
+DIALOGEVENT:MisCHI04xXO28Subtitle
+"*General, Wave 1 of the enemies retreat has been detected entering the area and intel has them moving along the path shown on the your radar"
+END
+
+DIALOGEVENT:MisCHI04xXO29Subtitle
+"*General, Wave 2 of the enemies retreat has been detected entering the area and intel has them moving along the path shown on the your radar"
+END
+
+DIALOGEVENT:MisCHI04xXO30Subtitle
+"*General, Wave 3 of the enemies retreat has been detected entering the area and intel has them moving along the path shown on the your radar"
+END
+
+DIALOGEVENT:MisCHI04xXO31Subtitle
+"*General, Wave 4 of the enemies retreat has been detected entering the area and intel has them moving along the path shown on the your radar"
+END
+
+DIALOGEVENT:MisCHI04xXO32Subtitle
+"*General, Wave 5 of the enemies retreat has been detected entering the area and intel has them moving along the path shown on the your radar"
+END
+
+DIALOGEVENT:MisCHI04xXO33Subtitle
+"*Our forces have arrived from the south. You have been successful in preventing the enemy retreat. Good job General"
+END
+
+DIALOGEVENT:MisCHI04xXO34Subtitle
+"*General, the enemy forces have escaped to the North. We have failed the mission"
+END
+
+DIALOGEVENT:MisChi05OfficerC01Subtitle
+"*It's time we corrected our mistake. Kill them all!"
+END
+
+DIALOGEVENT:MisChi05OfficerC02Subtitle
+"*Let us flush these rats from their holes. Death to the cowards!"
+END
+
+DIALOGEVENT:MisCHI05xBrf01Subtitle
+"*Thanks to your remarkable efforts in Halberstadt the GLA are all but finished. US intel has located the last GLA stronghold outside of Hamburg. Unfortunately we were too late to help the Americans in this area and the GLA captured their base. Build your forces and destroy both the GLA and US bases"
+END
+
+DIALOGEVENT:MisCHI05xBrf02Subtitle
+"*The GLA have captured an old US base in the region and are building up. Your Final Objective is to Destroy both the US and GLA bases"
+END
+
+DIALOGEVENT:MisCHI05xBrf03Subtitle
+"*The GLA have increased their stealth abilities, General. They can now stealth just about anything. We'll need to stay alert"
+END
+
+DIALOGEVENT:MisCHI05xBrf04Subtitle
+"*Use your Listening Outposts to detect stealthed units"
+END
+
+DIALOGEVENT:MisCHI05xBrf05Subtitle
+"*General, I suggest you first concentrate your attack on the US base. We need to take out their Particle Cannons"
+END
+
+DIALOGEVENT:MisCHI05xChat01Subtitle
+"*It feels like we are on an Easter Egg hunt, General"
+END
+
+DIALOGEVENT:MisCHI05xCin01Subtitle
+"*Corporal! Any sign of the Chinese yet?"
+END
+
+DIALOGEVENT:MisCHI05xCin02Subtitle
+"*No sir, the last message received was at 02:00�nothing since"
+END
+
+DIALOGEVENT:MisCHI05xCin03Subtitle
+"*Well, I hope they get here soon. Our intel points to a full-scale GLA attack"
+END
+
+DIALOGEVENT:MisCHI05xCin04Subtitle
+"*Yes, sir"
+END
+
+DIALOGEVENT:MisCHI05xCin06Subtitle
+"*What the...!? Enemy contact!"
+END
+
+DIALOGEVENT:MisCHI05xCin07Subtitle
+"*Our base has been breached�.all units to your stations! Where are those Chinese we were promised!?"
+END
+
+DIALOGEVENT:MisCHI05xCin08Subtitle
+"*Fox in the hole! Fox in the hole!"
+END
+
+DIALOGEVENT:MisCHI05xCin09Subtitle
+"*Where'd they come from?!"
+END
+
+DIALOGEVENT:MisCHI05xCin10Subtitle
+"*They're capturing our buildings! We can't hold! All units, fall back! Repeat, fall back!"
+END
+
+DIALOGEVENT:MisCHI05xXO01Subtitle
+"*That's it! Power to the US base is down! Finish them quickly before they can rebuild!"
+END
+
+DIALOGEVENT:MisCHI05xXO02Subtitle
+"*Well done, General. The enemy can no longer produce US units"
+END
+
+DIALOGEVENT:MisCHI05xXO03Subtitle
+"*Well done, General. The enemy can no longer produce GLA units"
+END
+
+DIALOGEVENT:MisCHI05xXO04Subtitle
+"*Well done, General. The US base has been neutralized. Destroy the GLA base to finish this battle"
+END
+
+DIALOGEVENT:MisCHI05xXO05Subtitle
+"*Well done, General. The GLA base has been neutralized. Destroy the US base to finish this battle"
+END
+
+DIALOGEVENT:MisCHI05xXO06Subtitle
+"*We must finish what the US was not able to do. The GLA must fall and the world will be at peace"
+END
+
+DIALOGEVENT:MisCHI05xXO07Subtitle
+"*If we are able to defeat the GLA and save Europe from its clutches then there are great rewards to be had"
+END
+
+DIALOGEVENT:MisCHI05xXO08Subtitle
+"*General, you will take your place among China's finest heroes. The GLA has fallen and China is the shining beacon in a new world. Take you place of honor and bask in the glory that is China"
+END
+
+DIALOGEVENT:MisCHI05xXO09Subtitle
+"*General, the enemy has improved their stealth ability, but they do not appear to be using tanks"
+END
+
+DIALOGEVENT:MisCHI05xXO10Subtitle
+"*General, the GLA commander is lacking tanks. Perhaps we can overwhelm him with our forces"
+END
+
+DIALOGEVENT:MisCHI05xXO11Subtitle
+"*General, we are losing vehicles to Jarmen Kell. You must track him down if we are to stand a chance"
+END
+
+DIALOGEVENT:MisCHI05xXO12Subtitle
+"*General, the enemy is using HIJACKERS! We need to stop them!"
+END
+
+DIALOGEVENT:MisCHI05xXO13Subtitle
+"*General, the enemy has positioned SNIPERs in the local villages. We must clear them out"
+END
+
+DIALOGEVENT:MisCHI05xXO14Subtitle
+"*General, we are losing troops to the enemy's Quad Cannons, we need heavy armor out here"
+END
+
+DIALOGEVENT:MisCHI05xXO15Subtitle
+"*General, current intel suggests Jarmen Kell may be holed up in this small village"
+END
+
+DIALOGEVENT:MisCHI05xXO16Subtitle
+"*General, the enemy's base seems to be on the other side of this river. Perhaps we can lock him in by positioning forces near the bridges"
+END
+
+DIALOGEVENT:MisCHI05xXO17Subtitle
+"*General, we have many driverless vehicles in the field�send units to recapture them"
+END
+
+DIALOGEVENT:MisCHI05xXO18Subtitle
+"*Sir! We have detected Battle buses in sector C. We should deal with them before they can reach our base"
+END
+
+DIALOGEVENT:MisCHI05xXO19Subtitle
+"*General, the enemy has slipped units into our base! We should improve our defenses!"
+END
+
+DIALOGEVENT:MisCHI05xXO20Subtitle
+"*General, the enemy has infiltrated our base!"
+END
+
+DIALOGEVENT:MisCHI05xXO21Subtitle
+"*General! Taking out the American Command Center will put a stop to his heavy Air support"
+END
+
+DIALOGEVENT:MisCHI05xXO22Subtitle
+"*General, we need to get our INTERNET CENTER built as quickly as possible. It will help us locate enemy positions"
+END
+
+DIALOGEVENT:MisCHI05xXO23Subtitle
+"*General, the enemy has left his Flank unguarded! Now is our chance to counter attack!"
+END
+
+DIALOGEVENT:MisCHI05xXO24Subtitle
+"*General, the Americans have superior stealth detection technology. Perhaps you should capture this base instead of destroying it"
+END
+
+DIALOGEVENT:MisChi07RedGuard108Subtitle
+"*Ambush!"
+END
+
+DIALOGEVENT:MisGLA01Scorpion105Subtitle
+"*The Chinese are close"
+END
+
+DIALOGEVENT:MisGLA01Scorpion108Subtitle
+"*We have found a secret way. It's poorly guarded"
+END
+
+DIALOGEVENT:MisGLA01Scorpion109Subtitle
+"*We're under fire!"
+END
+
+DIALOGEVENT:MisGLA01xChat01Subtitle
+"*Enemy defense structures sighted, General"
+END
+
+DIALOGEVENT:MisGLA01xChat02Subtitle
+"*Enemy position spotted! We must find a way past them!"
+END
+
+DIALOGEVENT:MisGLA01xChat03Subtitle
+"*Enemy patrol! All units, open fire!"
+END
+
+DIALOGEVENT:MisGLA01xChat04Subtitle
+"*American Sentry Drones! We must destroy them quickly before they sound the alarm!"
+END
+
+DIALOGEVENT:MisGLA01xChat05Subtitle
+"*Look at them scramble! Our attack was a complete surprise!"
+END
+
+DIALOGEVENT:MisGLA01xChat06Subtitle
+"*American attackers closing in! We must hold our position, General!"
+END
+
+DIALOGEVENT:MisGLA01xChat07Subtitle
+"*Our surprise was complete! All units, concentrate on their power plants!"
+END
+
+DIALOGEVENT:MisGLA01xChat08Subtitle
+"*General! We are taking heavy losses!"
+END
+
+DIALOGEVENT:MisGLA01xCin01Subtitle
+"*Patrol to base: Target has been located and we are in pursuit"
+END
+
+DIALOGEVENT:MisGLA01xCin02Subtitle
+"*Be advised, the bombing campaign has already begun. Be careful, Patrol"
+END
+
+DIALOGEVENT:MisGLA01xCin03Subtitle
+"*Roger that, base. I'm on the right"
+END
+
+DIALOGEVENT:MisGLA01xCin04Subtitle
+"*I'll take the left"
+END
+
+DIALOGEVENT:MisGLA01xCin05Subtitle
+"*I'm taking fire!"
+END
+
+DIALOGEVENT:MisGLA01xCin06Subtitle
+"*Stay on them!"
+END
+
+DIALOGEVENT:MisGLA01xCin07Subtitle
+"*Look out!"
+END
+
+DIALOGEVENT:MisGLA01xCin08Subtitle
+"*Base! Charlie three is down! Repeat: Charlie three is down!"
+END
+
+DIALOGEVENT:MisGLA01xCin09Subtitle
+"*Continue pursuit, Charlie two! This is our best shot at him!"
+END
+
+DIALOGEVENT:MisGLA01xCin10Subtitle
+"*Escorts eliminated! I've got him!"
+END
+
+DIALOGEVENT:MisGLA01xCin11Subtitle
+"*Nooooo!"
+END
+
+DIALOGEVENT:MisGLA01xCin12Subtitle
+"*Heh heh. General, we've made our escape.and are headed for the rendevouz point. The GLA shall rise again"
+END
+
+DIALOGEVENT:MisGLA01xCin13Subtitle
+"*Affirmative. Scout team moving out"
+END
+
+DIALOGEVENT:MisGLA01xCin14Subtitle
+"*This is scout team. We detect no enemy presence. Wait�"
+END
+
+DIALOGEVENT:MisGLA01xCin15Subtitle
+"*American ambush! They have us surrounded!"
+END
+
+DIALOGEVENT:MisGLA01xCin16Subtitle
+"*Sentry Drones! These Americans are most clever. Their drones are hidden when they are still. You must proceed with caution, General"
+END
+
+DIALOGEVENT:MisGLA01xKen01Subtitle
+"*The Americans have surrounded our stronghold with military checkpoints. You must clear the way"
+END
+
+DIALOGEVENT:MisGLA01xKen02Subtitle
+"*General, you must help our true leader escape, so that the GLA can live on"
+END
+
+DIALOGEVENT:MisGLA01xKen03Subtitle
+"*Dr. Thrax may have died for the cause but he was inconsequential. If our brother escapes the US will not have seen the last of the GLA"
+END
+
+DIALOGEVENT:MisGLA01xKen04Subtitle
+"*General. The Fire Base defenses around this American position are too strong. We should avoid a direct confrontation and find another way into the base"
+END
+
+DIALOGEVENT:MisGLA01xKen05Subtitle
+"*Hold you forces back, General. We are sending in a team to scout the other side of the bridge. They will report back on enemy positions"
+END
+
+DIALOGEVENT:MisGLA01xKen06Subtitle
+"*My General. One of our Quick Strike teams has managed to elude their American pursuers, and have agreed to aid us in our mission. Their rocket pods should prove most useful against enemy armor"
+END
+
+DIALOGEVENT:MisGLA01xKen07Subtitle
+"*We have discovered one of our demolitions teams. They will help us to clear a path by destroying the outlying US support bases"
+END
+
+DIALOGEVENT:MisGLA01xKen08Subtitle
+"*General. We must secure the airfield before the transport plane arrives. The survival of the GLA depends on your success"
+END
+
+DIALOGEVENT:MisGLA01xKen09Subtitle
+"*Our Combat Cycles are very versatile. They enhance the abilities of our loyal infantry, and are able to travel over rough terrain. They are even able to survive a jump off cliffs. Use them to bypass American strong-points and attack their vulnerable sides"
+END
+
+DIALOGEVENT:MisGLA01xKen10Subtitle
+"*General! The Americans have sent a second group of pursuers to capture our leader. Protect him at all costs!"
+END
+
+DIALOGEVENT:MisGLA01xKen11Subtitle
+"*General, this hidden base can provide us with the resources we need to push past the American siege and reach the airfield"
+END
+
+DIALOGEVENT:MisGLA01xKen12Subtitle
+"*General, our leader is under attack! He must not fall to the Americans!"
+END
+
+DIALOGEVENT:MisGLA01xKen13Subtitle
+"*General, your forces are moving too far ahead of our leader. Remember that he must reach the airfield if our cause is to survive"
+END
+
+DIALOGEVENT:MisGLA01xKen14Subtitle
+"*Another American base. It must be eliminated. Be wary of their Fire Bases, sir"
+END
+
+DIALOGEVENT:MisGLA01xKen15Subtitle
+"*We are within reach of the airfield, General. Destroy the American forces and secure the area that we may fly our leader to safety"
+END
+
+DIALOGEVENT:MisGLA01xKen16Subtitle
+"*Well done, General. With you in command, we can not fail"
+END
+
+DIALOGEVENT:MisGLA01xKen17Subtitle
+"*We have reached the airfield, sir. Make sure our leader is ready and waiting at the air strip when his plane arrives"
+END
+
+DIALOGEVENT:MisGLA01xKen18Subtitle
+"*Our plane is on approach, General! Just hold your position for a little longer. Our leader must survive to board that plane!"
+END
+
+DIALOGEVENT:MisGLA01xKen19Subtitle
+"*The plane has arrived. Load our leader in so that we may fly him to safety and regroup"
+END
+
+DIALOGEVENT:MisGLA01xKen20Subtitle
+"*The plane is waiting for our leader to board. Make haste and bring him in, General. Our forces cannot hold out indefinitely against the Americans"
+END
+
+DIALOGEVENT:MisGLA01xKen21Subtitle
+"*Our operative, Jarmen Kell, has been harassing the American supply lines. He will be of great help to our mission, General"
+END
+
+DIALOGEVENT:MisGLA01xKen22Subtitle
+"*Excellent work, General. We will show the Americans that we still have the power to resist them"
+END
+
+DIALOGEVENT:MisGLA01xKen23Subtitle
+"*We have discovered an advance scout force, General. They have offered to aid us with our mission"
+END
+
+DIALOGEVENT:MisGLA01xKen24Subtitle
+"*General! Take out the American power plants to shut down their base defenses!"
+END
+
+DIALOGEVENT:MisGLA01xKen25Subtitle
+"*Our forces have been weakened, General. We must choose our battles more wisely"
+END
+
+DIALOGEVENT:MisGLA02Chatter04Subtitle
+"*We are here and ready for your command"
+END
+
+DIALOGEVENT:MisGLA02Chatter18Subtitle
+"*So much for American"
+END
+
+DIALOGEVENT:MisGLA02General07Subtitle
+"*American forces are coming. Get ready!"
+END
+
+DIALOGEVENT:MisGLA02xChat01Subtitle
+"*The enemy, they are attacking!"
+END
+
+DIALOGEVENT:MisGLA02xChat02Subtitle
+"*The resistance is too strong, there must be another way"
+END
+
+DIALOGEVENT:MisGLA02xChat03Subtitle
+"*The Prince must be stopped. The GLA must not fall to him!"
+END
+
+DIALOGEVENT:MisGLA02xChat04Subtitle
+"*Our base is under attack!"
+END
+
+DIALOGEVENT:MisGLA02xChat05Subtitle
+"*Our Palace is destroyed!"
+END
+
+DIALOGEVENT:MisGLA02xChat06Subtitle
+"*We have lost our Barracks"
+END
+
+DIALOGEVENT:MisGLA02xChat07Subtitle
+"*We must rebuild our Arms Dealer quickly"
+END
+
+DIALOGEVENT:MisGLA02xCin01Subtitle
+"*This is Recon 1 to base. I am finishing my patrol. Sector is clear"
+END
+
+DIALOGEVENT:MisGLA02xCin02Subtitle
+"*This is base. Are you certain, Recon 1? We've had reports of troop movements linked to Prince Kassad"
+END
+
+DIALOGEVENT:MisGLA02xCin03Subtitle
+"*I am most certain. I haven't seen anything but dust and shrubs for hours now. Returning to base after this"
+END
+
+DIALOGEVENT:MisGLA02xCin04Subtitle
+"*What the�?"
+END
+
+DIALOGEVENT:MisGLA02xCin05Subtitle
+"*Recon 1 to base! Enemy contact! Repeat, enemy contact!"
+END
+
+DIALOGEVENT:MisGLA02xCin06Subtitle
+"*Recon 1! What is your position?"
+END
+
+DIALOGEVENT:MisGLA02xCin07Subtitle
+"*He's preparing to fire!"
+END
+
+DIALOGEVENT:MisGLA02xCin08Subtitle
+"*Recon 1, what is your status? Recon 1! Report!"
+END
+
+DIALOGEVENT:MisGLA02xCin09Subtitle
+"*Once Prince Kassad is removed the GLA will be under our control. Then vengeance will be ours and the American infidels will burn"
+END
+
+DIALOGEVENT:MisGLA02xCin10Subtitle
+"*Prince Kassad is beginning to take control wherever he can. We must put an end to his vie for power"
+END
+
+DIALOGEVENT:MisGLA02xKen01Subtitle
+"*General, our resources are running low -- we must find a new source of supplies!"
+END
+
+DIALOGEVENT:MisGLA02xKen02Subtitle
+"*Kassad is attempting to capture nearby resources! We must not let him take what is rightfully ours!"
+END
+
+DIALOGEVENT:MisGLA02xKen03Subtitle
+"*We must reunite the GLA under one leader!"
+END
+
+DIALOGEVENT:MisGLA02xKen04Subtitle
+"*Beware! Kassad has launched a sneak attack against us!"
+END
+
+DIALOGEVENT:MisGLA02xKen05Subtitle
+"*We have much bigger plans than that rat Kassad. The world will quake as we unleash the fury of the GLA"
+END
+
+DIALOGEVENT:MisGLA02xKen06Subtitle
+"*We have acquired GPS Scramble technology! Now we can use Kassad's tricks against him!"
+END
+
+DIALOGEVENT:MisGLA02xKen07Subtitle
+"*Excellent, General! We have secured the Sneak Attack ability!"
+END
+
+DIALOGEVENT:MisGLA02xKen08Subtitle
+"*Capture the enemy Command Centers"
+END
+
+DIALOGEVENT:MisGLA02xKen09Subtitle
+"*If we can capture the enemy Command Center we can use their technology against them"
+END
+
+DIALOGEVENT:MisGLA02xKen10Subtitle
+"*General, we must capture their Command Center and use their knowledge to progress towards our goal of uniting the GLA under one flag"
+END
+
+DIALOGEVENT:MisGLA02xKen11Subtitle
+"*We are running low on resources. We must capture some oil derricks"
+END
+
+DIALOGEVENT:MisGLA02xKen12Subtitle
+"*Our enemy is attacking our Oil Supply! They must be stopped!"
+END
+
+DIALOGEVENT:MisGLA02xKen13Subtitle
+"*Use the GPS scramble to sneak past the enemy defenses!"
+END
+
+DIALOGEVENT:MisGLA02xKen14Subtitle
+"*The GPS Scramble will not work here, there are too many Stinger Sites.We will need to use a different tactic"
+END
+
+DIALOGEVENT:MisGLA02xKen15Subtitle
+"*Perhaps we can find an unguarded area to use our new Sneak Attack ability"
+END
+
+DIALOGEVENT:MisGLA02xKen16Subtitle
+"*Do not destroy the Command Center. We need to capture the structure and keep it intact"
+END
+
+DIALOGEVENT:MisGLA02xKen17Subtitle
+"*Their knowledge must be stolen. We need to use their advanced tactics to defeat them!"
+END
+
+DIALOGEVENT:MisGLA02xKen18Subtitle
+"*General, be wary of snipers -- Kassad loves to use them"
+END
+
+DIALOGEVENT:MisGLA02xKen19Subtitle
+"*This bridge is heavily defended. We will need assistance in getting across it"
+END
+
+DIALOGEVENT:MisGLA02xKen20Subtitle
+"*Capture the enemy Command Center to the North!"
+END
+
+DIALOGEVENT:MisGLA02xKen21Subtitle
+"*Capture the enemy Command Center to the West!"
+END
+
+DIALOGEVENT:MisGLA02xKen22Subtitle
+"*General, if we capture this cannon, we can use it against Kassad's forces!"
+END
+
+DIALOGEVENT:MisGLA02xKen23Subtitle
+"*If we capture the Command Center, we can use their abilities to turn the tide of this battle"
+END
+
+DIALOGEVENT:MisGLA02xKen24Subtitle
+"*Prince Kassad is no more. The GLA are once again united against our enemies!"
+END
+
+DIALOGEVENT:MisGLA02xKen25Subtitle
+"*Now that we have GPS scramble, we can move unseen past Kassad's bridge defenses!"
+END
+
+DIALOGEVENT:MisGLA02xKen26Subtitle
+"*The traitor has fortified himself on this hilltop and cut all other means of access. Sneak Attack is the only way we have to strike at his main base"
+END
+
+DIALOGEVENT:MisGLA02xKen27Subtitle
+"*General, this area is being controlled by Prince Kassad. He has turned his back on his brethren and will not aid us in our cause against the infidels"
+END
+
+DIALOGEVENT:MisGLA02xKen28Subtitle
+"*Kassad is a master of stealth, hiding his forces in plain sight. He refuses to share his knowledge with us, so we will take it from him"
+END
+
+DIALOGEVENT:MisGLA02xKen29Subtitle
+"*A GLA splinter cell commanded by Prince Kassad is controlling this area. Kassad refuses to let us use his abilities for the good of the GLA"
+END
+
+DIALOGEVENT:MisGLA02xKen30Subtitle
+"*Kassad is a master of stealth, relying on several techniques to surprise and attack his enemies"
+END
+
+DIALOGEVENT:MisGLA02xKen31Subtitle
+"*GPS scramble gives him the power to have any unit strike unseen against an enemy"
+END
+
+DIALOGEVENT:MisGLA02xKen32Subtitle
+"*Tunnel sneak attacks offer further tactical advantages�"
+END
+
+DIALOGEVENT:MisGLA02xKen33Subtitle
+"*We must have these technologies. If Kassad will not share, we will take them from him. Capture his command centers and turn his own abilities against him!"
+END
+
+DIALOGEVENT:MisGLA03Kenwar03Subtitle
+"*Free our imprisoned brothers"
+END
+
+DIALOGEVENT:MisGLA03Kenwar15Subtitle
+"*We have spotted a Prison Camp, our brothers are held inside"
+END
+
+DIALOGEVENT:MisGLA03xBrf01Subtitle
+"*Welcome, Commander!"
+END
+
+DIALOGEVENT:MisGLA03xBrf02Subtitle
+"*Kassad was too cowardly to make an attempt against the US such as this. General, you are truly a master mind"
+END
+
+DIALOGEVENT:MisGLA03xBrf03Subtitle
+"*Once the US Mediterranean naval force is shattered all of Europe will be in our grasp"
+END
+
+DIALOGEVENT:MisGLA03xBrf04Subtitle
+"*Now that we are again united, it is time to make our strength felt!"
+END
+
+DIALOGEVENT:MisGLA03xBrf05Subtitle
+"*The USA has attacked our secret base in the Mediterranean"
+END
+
+DIALOGEVENT:MisGLA03xBrf06Subtitle
+"*But before it was wiped out, we learned of the location of their Particle Cannon and naval fleet in the region"
+END
+
+DIALOGEVENT:MisGLA03xBrf07Subtitle
+"*Most of their ships are in port and helpless. We will steal their Particle Cannon and use it to take out their Aircraft Carrier!"
+END
+
+DIALOGEVENT:MisGLA03xBrf08Subtitle
+"*Look for an opportunity to reclaim and rebuild our secret base"
+END
+
+DIALOGEVENT:MisGLA03xChat01Subtitle
+"*We'll die for you!"
+END
+
+DIALOGEVENT:MisGLA03xChat02Subtitle
+"*Another one bites the dust"
+END
+
+DIALOGEVENT:MisGLA03xChat03Subtitle
+"*More victims for me"
+END
+
+DIALOGEVENT:MisGLA03xChat04Subtitle
+"*Mow them down!"
+END
+
+DIALOGEVENT:MisGLA03xChat05Subtitle
+"*They cannot escape our wrath!"
+END
+
+DIALOGEVENT:MisGLA03xChat06Subtitle
+"*We have them where we want them!"
+END
+
+DIALOGEVENT:MisGLA03xChat07Subtitle
+"*Victory will be ours!"
+END
+
+DIALOGEVENT:MisGLA03xChat08Subtitle
+"*That made a big splash!"
+END
+
+DIALOGEVENT:MisGLA03xCin01Subtitle
+"*We will avenge this cowardly attack!"
+END
+
+DIALOGEVENT:MisGLA03xCin02Subtitle
+"*Their carrier will be turned into scrap!"
+END
+
+DIALOGEVENT:MisGLA03xCin03Subtitle
+"*We have proven the might of the GLA!"
+END
+
+DIALOGEVENT:MisGLA03xKen01Subtitle
+"*Our Hijackers could take that tank easily�"
+END
+
+DIALOGEVENT:MisGLA03xKen02Subtitle
+"*That Ranger is running for help! We must not let him get away"
+END
+
+DIALOGEVENT:MisGLA03xKen03Subtitle
+"*We'll need this Particle Cannon to sink the enemy Carrier. Defend it well!"
+END
+
+DIALOGEVENT:MisGLA03xKen04Subtitle
+"*Our rebels can use their Capture Building ability to take control of the Particle Cannon"
+END
+
+DIALOGEVENT:MisGLA03xKen05Subtitle
+"*We can use our Sneak Attack to create Tunnel Networks on nearby islands"
+END
+
+DIALOGEVENT:MisGLA03xKen06Subtitle
+"*We must not let the pilot reach his Tomahawk!"
+END
+
+DIALOGEVENT:MisGLA03xKen07Subtitle
+"*They're coming after the Tomahawk!"
+END
+
+DIALOGEVENT:MisGLA03xKen08Subtitle
+"*This Barracks is now ours"
+END
+
+DIALOGEVENT:MisGLA03xKen09Subtitle
+"*We have liberated this Palace"
+END
+
+DIALOGEVENT:MisGLA03xKen10Subtitle
+"*This Arms Dealer will serve us well"
+END
+
+DIALOGEVENT:MisGLA03xKen11Subtitle
+"*We have reclaimed our Command Center!"
+END
+
+DIALOGEVENT:MisGLA03xKen12Subtitle
+"*General, do you see those enemy supply planes? If we could destroy their drop zones, we would cripple their production!"
+END
+
+DIALOGEVENT:MisGLA03xKen13Subtitle
+"*Ah, this toxic tractor will come in handy"
+END
+
+DIALOGEVENT:MisGLA03xKen14Subtitle
+"*These Quad Cannons will defend us from enemy aircraft"
+END
+
+DIALOGEVENT:MisGLA03xKen15Subtitle
+"*These Marauders will boost our firepower"
+END
+
+DIALOGEVENT:MisGLA03xKen16Subtitle
+"*Destroy these tanks and we can liberate the Barracks!"
+END
+
+DIALOGEVENT:MisGLA03xKen17Subtitle
+"*If we clear this area, we can safely occupy the Command Center"
+END
+
+DIALOGEVENT:MisGLA03xKen18Subtitle
+"*Kill those troops and the Arms Dealer will be ours!"
+END
+
+DIALOGEVENT:MisGLA03xKen19Subtitle
+"*They may be launching an attack against us! Defend our buildings!"
+END
+
+DIALOGEVENT:MisGLA03xKen20Subtitle
+"*Comanches! Rally our air defenses!"
+END
+
+DIALOGEVENT:MisGLA03xKen21Subtitle
+"*We must defend against those Comanches!"
+END
+
+DIALOGEVENT:MisGLA03xKen22Subtitle
+"*They are trying to retake the Particle Cannon!"
+END
+
+DIALOGEVENT:MisGLA03xKen23Subtitle
+"*Their aircraft have destroyed our Tunnel Network!"
+END
+
+DIALOGEVENT:MisGLA03xKen24Subtitle
+"*Those clever villains! They are targeting our Power Plants. We need power to use the Particle Cannon"
+END
+
+DIALOGEVENT:MisGLA03xKen25Subtitle
+"*Almost all of the power plants have been destroyed. We must have power to use the Particle Cannon!"
+END
+
+DIALOGEVENT:MisGLA03xKen26Subtitle
+"*If we could capture some power plants, we could use the Particle Cannon against them"
+END
+
+DIALOGEVENT:MisGLA03xKen27Subtitle
+"*Ahh.. We have found some hidden goodies"
+END
+
+DIALOGEVENT:MisGLA03xKen28Subtitle
+"*This pass is well defended. We should use the Particle Cannon to blast through"
+END
+
+DIALOGEVENT:MisGLA03xKen29Subtitle
+"*Be careful! This pass is heavily guarded!"
+END
+
+DIALOGEVENT:MisGLA03xKen30Subtitle
+"*They've dispatched infantry onto the islands!"
+END
+
+DIALOGEVENT:MisGLA03xKen31Subtitle
+"*They're choppers are bringing reinforcements!"
+END
+
+DIALOGEVENT:MisGLA03xKen32Subtitle
+"*They have launched an A10 Strike against us!"
+END
+
+DIALOGEVENT:MisGLA03xKen33Subtitle
+"*They've paradropped onto the Particle Cannon!"
+END
+
+DIALOGEVENT:MisGLA03xKen34Subtitle
+"*We have disabled their Supply Drop Zones! Their production will be crippled!"
+END
+
+DIALOGEVENT:MisGLA03xKen35Subtitle
+"*Your mission is to destroy the enemy Aircraft Carrier with the Particle Cannon. You will have to penetrate their base on the mainland to get a visual lock on the Carrier so that you can destroy it"
+END
+
+DIALOGEVENT:MisGLA03xKen36Subtitle
+"*Great work! Now we must secure some Power Plants"
+END
+
+DIALOGEVENT:MisGLA03xKen37Subtitle
+"*The Tunnel Network will bring us to the next island"
+END
+
+DIALOGEVENT:MisGLA03xKen38Subtitle
+"*The Particle Cannon is now online. We should defend it and the Power Plants"
+END
+
+DIALOGEVENT:MisGLA03xKen39Subtitle
+"*All of our units and buildings have been destroyed!"
+END
+
+DIALOGEVENT:MisGLA03xKen40Subtitle
+"*Without the Particle Cannon, it will be impossible to sink the Carrier"
+END
+
+DIALOGEVENT:MisGLA03xKen41Subtitle
+"*Now the Americans shall taste bitter defeat!"
+END
+
+DIALOGEVENT:MisGLA03xKen42Subtitle
+"*They destroyed our Tunnel Network! Use the sneak attack to reclaim the Particle Cannon!"
+END
+
+DIALOGEVENT:MisGLA03xKen43Subtitle
+"*We are closing in on the Aircraft Carrier. It is just south of here"
+END
+
+DIALOGEVENT:MisGLA03xKen44Subtitle
+"*There's the Aircraft Carrier! Destroy it using the Particle Cannon!"
+END
+
+DIALOGEVENT:MisGLA03xKen45Subtitle
+"*Jarmen Kell is here to serve us"
+END
+
+DIALOGEVENT:MisGLA03xKen46Subtitle
+"*His snipe ability can disable enemy vehicles, allowing our infantry to then capture them"
+END
+
+DIALOGEVENT:MisGLA03xKen47Subtitle
+"*These docked Battleships are harmless"
+END
+
+DIALOGEVENT:MisGLA03xKen48Subtitle
+"*The Battleship is bombarding us! Destroy it!"
+END
+
+DIALOGEVENT:MisGLA03xKen49Subtitle
+"*This must be the enemy's main base"
+END
+
+DIALOGEVENT:MisGLA03xKen50Subtitle
+"*These fake buildings will fool our foes"
+END
+
+DIALOGEVENT:MisGLA03xKen51Subtitle
+"*Build more fake structures to trick the enemy!"
+END
+
+DIALOGEVENT:MisGLA04Dispatcher06Subtitle
+"*American forces are on their way"
+END
+
+DIALOGEVENT:MisGLA04xChat01Subtitle
+"*We've got to clear out those bunkers!"
+END
+
+DIALOGEVENT:MisGLA04xChat02Subtitle
+"*Their power is down! No Patriots to deal with!"
+END
+
+DIALOGEVENT:MisGLA04xChat03Subtitle
+"*Break down the fences and rescue our brethren!"
+END
+
+DIALOGEVENT:MisGLA04xChat04Subtitle
+"*Now our brothers may be free!"
+END
+
+DIALOGEVENT:MisGLA04xChat05Subtitle
+"*An american chinook would help to transport our troops. Capture this supply depot if you can"
+END
+
+DIALOGEVENT:MisGLA04xChat06Subtitle
+"*Get some anti air over here, general! Their Comanches are tearing us to bits!"
+END
+
+DIALOGEVENT:MisGLA04xChat07Subtitle
+"*General, we must find some way to take out these bridge defenses!"
+END
+
+DIALOGEVENT:MisGLA04xChat08Subtitle
+"*General, we are using our cell phones to call in a surprise tunnel network!"
+END
+
+DIALOGEVENT:MisGLA04xChat09Subtitle
+"*We'll need these tractors if we want to clear any bunkers"
+END
+
+DIALOGEVENT:MisGLA04xChat10Subtitle
+"*This ferry is under our control now! You will take us where we want to go!"
+END
+
+DIALOGEVENT:MisGLA04xChat11Subtitle
+"*Yes, yes. I will do what you say!"
+END
+
+DIALOGEVENT:MisGLA04xChat12Subtitle
+"*Our brothers have been freed"
+END
+
+DIALOGEVENT:MisGLA04xChat13Subtitle
+"*There sure are a lot of sports utility vehicles in this strange land"
+END
+
+DIALOGEVENT:MisGLA04xChat14Subtitle
+"*We have a GLA sympathizer in this area. He and his brothers have agreed to help us"
+END
+
+DIALOGEVENT:MisGLA04xChat15Subtitle
+"*Tanks! Take off! Go, Go, Go!"
+END
+
+DIALOGEVENT:MisGLA04xCin01Subtitle
+"*This is team one. We are in position"
+END
+
+DIALOGEVENT:MisGLA04xCin02Subtitle
+"*My brethren, be careful, as we tread on enemy soil. Our main objective is to obtain chemical samples from the nearby American toxin facility"
+END
+
+DIALOGEVENT:MisGLA04xCin03Subtitle
+"*The remains of the American naval force have moved to the Mediterranean, in response to the loss of their command fleet. This has allowed us to slip in"
+END
+
+DIALOGEVENT:MisGLA04xCin04Subtitle
+"*We defeated them there, and we shall be victorious here"
+END
+
+DIALOGEVENT:MisGLA04xCin05Subtitle
+"*Brothers rejoice! Once we have the toxins from this facility, our scientists will be able to forge a weapon of mass infection"
+END
+
+DIALOGEVENT:MisGLA04xCin06Subtitle
+"*The Americans have meddled for too long. With this new weapon, we shall be able to strike fear into the hearts of our oppressors!"
+END
+
+DIALOGEVENT:MisGLA04xCin07Subtitle
+"*(Very evil laugh)"
+END
+
+DIALOGEVENT:MisGLA04xCin08Subtitle
+"*Team one, are toxins secured and on board?"
+END
+
+DIALOGEVENT:MisGLA04xCin09Subtitle
+"*We have the samples"
+END
+
+DIALOGEVENT:MisGLA04xCin10Subtitle
+"*We are ready for takeoff"
+END
+
+DIALOGEVENT:MisGLA04xCin11Subtitle
+"*Check. Package is secure"
+END
+
+DIALOGEVENT:MisGLA04xCin12Subtitle
+"*You are clear to proceed. We will defend your escape!"
+END
+
+DIALOGEVENT:MisGLA04xCin13Subtitle
+"*General the Patriots are online!"
+END
+
+DIALOGEVENT:MisGLA04xCin14Subtitle
+"*Hold them back until we clear the landing strip!"
+END
+
+DIALOGEVENT:MisGLA04xCin15Subtitle
+"*Keep them off our tail!"
+END
+
+DIALOGEVENT:MisGLA04xCin16Subtitle
+"*Get away you stupid Americans!"
+END
+
+DIALOGEVENT:MisGLA04xCin17Subtitle
+"*We'll meet again when we reach the toxin facility"
+END
+
+DIALOGEVENT:MisGLA04xCin18Subtitle
+"*The Americans think they have driven us out"
+END
+
+DIALOGEVENT:MisGLA04xCin19Subtitle
+"*We will divide and conquer"
+END
+
+DIALOGEVENT:MisGLA04xCin20Subtitle
+"*We are nothing against this air power!"
+END
+
+DIALOGEVENT:MisGLA04xCin21Subtitle
+"*You have not seen the last of us!"
+END
+
+DIALOGEVENT:MisGLA04xCin22Subtitle
+"*We will get our revenge, you filthy Americans!"
+END
+
+DIALOGEVENT:MisGLA04xCin23Subtitle
+"*Let's do our part to take down these capitalist pigs!"
+END
+
+DIALOGEVENT:MisGLA04xCin24Subtitle
+"*These Americans will pay for the lives of our brethren"
+END
+
+DIALOGEVENT:MisGLA04xCin25Subtitle
+"*Let's light up these GLA intruders! Fox 1!"
+END
+
+DIALOGEVENT:MisGLA04xCin26Subtitle
+"*GLA spotted offshore! All units to defense positions"
+END
+
+DIALOGEVENT:MisGLA04xCin27Subtitle
+"*We got GLA infiltration at coordinated 77BetaGamma! All available units move to respond!"
+END
+
+DIALOGEVENT:MisGLA04xCin28Subtitle
+"*There's more of them on the beach!"
+END
+
+DIALOGEVENT:MisGLA04xCin29Subtitle
+"*GLA infiltrators spotted on the ledge!"
+END
+
+DIALOGEVENT:MisGLA04xCin30Subtitle
+"*We've got GLA inside city limits! All units converge on coordinates 34AlphaAlpha"
+END
+
+DIALOGEVENT:MisGLA04xKen01Subtitle
+"*Good job, General! Only 15 more toxin samples to be retrieved"
+END
+
+DIALOGEVENT:MisGLA04xKen02Subtitle
+"*Good job, General! Only 10 more toxin samples to be retrieved"
+END
+
+DIALOGEVENT:MisGLA04xKen03Subtitle
+"*Good job, General! Only 5 more toxin samples to be retrieved"
+END
+
+DIALOGEVENT:MisGLA04xKen04Subtitle
+"*General, we have a plan to attack America's Central Command in Europe. But we do not yet have the power to strike at them directly. We need a new toxin weapon"
+END
+
+DIALOGEVENT:MisGLA04xKen05Subtitle
+"*Both of our forces are in place. The two groups must work together if we are to retrieve the toxins"
+END
+
+DIALOGEVENT:MisGLA04xKen06Subtitle
+"*Our hijackers can capture vehicles and they are stealthed unless they are moving"
+END
+
+DIALOGEVENT:MisGLA04xKen07Subtitle
+"*Jarmen Kell can snipe pilots from vehicles and also take out infantry at long range"
+END
+
+DIALOGEVENT:MisGLA04xKen08Subtitle
+"*Our Saboteurs can perform a number of secret operations like shutting down power plants"
+END
+
+DIALOGEVENT:MisGLA04xKen09Subtitle
+"*Our rebels are camouflaged, and can capture buildings to aid us in our cause"
+END
+
+DIALOGEVENT:MisGLA04xKen10Subtitle
+"*Good luck, General. May stealth and cunning be with you in your quest"
+END
+
+DIALOGEVENT:MisGLA04xKen11Subtitle
+"*Good morning, General"
+END
+
+DIALOGEVENT:MisGLA04xKen12Subtitle
+"*General, we must capture that ferry"
+END
+
+DIALOGEVENT:MisGLA04xKen13Subtitle
+"*General, there are mines here, but we cannot detect them! We need a Radar Van!"
+END
+
+DIALOGEVENT:MisGLA04xKen14Subtitle
+"*General, get someone into that Valve station by the river. Draining the coolant reservoir will allow our brothers to continue further"
+END
+
+DIALOGEVENT:MisGLA04xKen15Subtitle
+"*Excellent"
+END
+
+DIALOGEVENT:MisGLA04xKen16Subtitle
+"*Good work"
+END
+
+DIALOGEVENT:MisGLA04xKen17Subtitle
+"*General! Destroy that airfield before we are wiped out!"
+END
+
+DIALOGEVENT:MisGLA04xKen18Subtitle
+"*General. We must destroy their power! Then the Americans will be sitting ducks for sure!"
+END
+
+DIALOGEVENT:MisGLA04xKen19Subtitle
+"*General, we must capture that toxin facility"
+END
+
+DIALOGEVENT:MisGLA04xKen20Subtitle
+"*Excellent work, General. Now we must protect these trucks as they transport the toxins to the cargo plane"
+END
+
+DIALOGEVENT:MisGLA04xKen21Subtitle
+"*Use the trucks to begin gathering toxins from the facility"
+END
+
+DIALOGEVENT:MisGLA04xKen22Subtitle
+"*General, the Americans have sent reinforcements!"
+END
+
+DIALOGEVENT:MisGLA04xKen23Subtitle
+"*Another cell of hijackers has arrived to support our cause"
+END
+
+DIALOGEVENT:MisGLA04xKen24Subtitle
+"*Another cell of rebels has arrived to support our cause"
+END
+
+DIALOGEVENT:MisGLA04xKen25Subtitle
+"*JarmenKell has been found and he has returned to help our cause"
+END
+
+DIALOGEVENT:MisGLA04xKen26Subtitle
+"*Our brothers have broken through and provided us with reinforcements"
+END
+
+DIALOGEVENT:MisGLA04xKen27Subtitle
+"*The US will not suspect an attack on their soil after our victory in Greece"
+END
+
+DIALOGEVENT:MisGLA04xKen28Subtitle
+"*Kassad would never have had the courage to attack the US homeland"
+END
+
+DIALOGEVENT:MisGLA04xKen29Subtitle
+"*Once we've stolen the secret toxin agent from the US Bio Center, we will be unstoppable"
+END
+
+DIALOGEVENT:MisGLA05Buggy104Subtitle
+"*Beware Patriot Batteries, they are dangerous"
+END
+
+DIALOGEVENT:MisGLA05Buggy108Subtitle
+"*Go to your graves, American scum!"
+END
+
+DIALOGEVENT:MisGLA05Kenwar02bSubtitle
+"*Destroy the American airbase and they will lose much of their ability to project power in this region"
+END
+
+DIALOGEVENT:MisGLA05Kenwar05Subtitle
+"*The Americans will use their airpower to stop us"
+END
+
+DIALOGEVENT:MisGLA05Quad201Subtitle
+"*Die American!"
+END
+
+DIALOGEVENT:MisGLA05Rebel02Subtitle
+"*We are defenseless against American air attacks!"
+END
+
+DIALOGEVENT:MisGLA05Scorpion105Subtitle
+"*American cowards! Fight on the ground, like men!"
+END
+
+DIALOGEVENT:MisGLA05xChat01Subtitle
+"*This region is under the control of the United States Air Force General Granger. We can and will use force to remove you from this area. You are hereby under order to clear out immediately"
+END
+
+DIALOGEVENT:MisGLA05xCin01Subtitle
+"*Our forces are few, but we can use what we have to come out on top"
+END
+
+DIALOGEVENT:MisGLA05xCin02Subtitle
+"*Since we do not have a base in this region we must take one!"
+END
+
+DIALOGEVENT:MisGLA05xCin03Subtitle
+"*The Chinese base� We must strike now! Their Base will soon be ours!"
+END
+
+DIALOGEVENT:MisGLA05xJarmen01Subtitle
+"*If you rescue our fellow comrades from the Southern US base, our elite warriors will fight alongside you!"
+END
+
+DIALOGEVENT:MisGLA05xJarmen02Subtitle
+"*Thank you for rescuing our brothers! In return we will open up an area of the US base for you to begin your assault"
+END
+
+DIALOGEVENT:MisGLA05xJarmen03Subtitle
+"*Heh heh heh heh heh� (Sinister Laugh) That will teach them"
+END
+
+DIALOGEVENT:MisGLA05xJarmen04Subtitle
+"*Do not let our deaths go unpunished!"
+END
+
+DIALOGEVENT:MisGLA05xJarmen05Subtitle
+"*Together we have beaten the enemy! Victory is ours!"
+END
+
+DIALOGEVENT:MisGLA05xJarmen06Subtitle
+"*Thank you for your help in rescuing my soldiers. We shall repay the favor and help you to take out the U.S. Central Command Base"
+END
+
+DIALOGEVENT:MisGLA05xKen01Subtitle
+"*Once this base is destroyed the US will scurry home like cowardly dogs. All of Europe will be ours"
+END
+
+DIALOGEVENT:MisGLA05xKen02Subtitle
+"*The Americans have our brethren held hostage in their base. We must rescue them"
+END
+
+DIALOGEVENT:MisGLA05xKen03Subtitle
+"*It is in our best interest to rescue the POW's from the clutches of the Americans"
+END
+
+DIALOGEVENT:MisGLA05xKen04Subtitle
+"*Good work! Capture or eliminate this base to ensure the POW's safety"
+END
+
+DIALOGEVENT:MisGLA05xKen05Subtitle
+"*We must transport them safely back home to their base in the North. No harm must come to them"
+END
+
+DIALOGEVENT:MisGLA05xKen06Subtitle
+"*We are running low on supplies. We must spread out and capture new resources"
+END
+
+DIALOGEVENT:MisGLA05xKen07Subtitle
+"*More attacks from the air! We must build more air defenses�"
+END
+
+DIALOGEVENT:MisGLA05xKen08Subtitle
+"*Rebuild our defenses quickly, we haven't long before the next attack"
+END
+
+DIALOGEVENT:MisGLA05xKen09Subtitle
+"*The new toxin agent we �borrowed� from the US will be especially effective against their own forces"
+END
+
+DIALOGEVENT:MisGLA05xKen10Subtitle
+"*First the Mediterranean fleet, then an attack upon US soil�and now begins our European domination"
+END
+
+DIALOGEVENT:MisGLA05xKen11Subtitle
+"*We are being attacked from the east. End the attacks now, we must eliminate them so we can focus on the main base to the north"
+END
+
+DIALOGEVENT:MisGLA05xKen12Subtitle
+"*Almost there� The U.S. will pay dearly for their transgressions against our people"
+END
+
+DIALOGEVENT:MisGLA05xKen13Subtitle
+"*We are running low on funds. Scout the area for resources, we must not be stopped"
+END
+
+DIALOGEVENT:MisGLA05xKen14Subtitle
+"*With this area secure we must now build up and launch an assault on the U.S. European Central Command Base"
+END
+
+DIALOGEVENT:MisGLA05xKen15Subtitle
+"*The Americans are relying heavily on air units. Build more Stinger sites and Quad Cannons"
+END
+
+DIALOGEVENT:MisGLA05xKen16Subtitle
+"*They are targeting our defenses, we must camouflage the stinger sites"
+END
+
+DIALOGEVENT:MisGLA05xKen17Subtitle
+"*My General, we need to build a Scud Storm"
+END
+
+DIALOGEVENT:MisGLA05xKen18Subtitle
+"*The American General is using a Particle Cannon against us"
+END
+
+DIALOGEVENT:MisGLA05xKen19Subtitle
+"*We have to try a different tactic. Use a sneak attack to get units into the base"
+END
+
+DIALOGEVENT:MisGLA05xKen20Subtitle
+"*Capture the U.S. base and build it up. We can use their weapons against them"
+END
+
+DIALOGEVENT:MisGLA05xKen21Subtitle
+"*You must take out the Particle Cannon!"
+END
+
+DIALOGEVENT:MisGLA05xKen22Subtitle
+"*They are attacking from the ground now. Defend our base!"
+END
+
+DIALOGEVENT:MisGLA05xKen23Subtitle
+"*Rebuild the base quickly�We must prepare for more attacks!"
+END
+
+DIALOGEVENT:MisGLA05xKen24Subtitle
+"*Well done, General. Thanks to your superior tactics we now control all three super weapons. The Americans will never know what hit them!"
+END
+
+DIALOGEVENT:MisGLA05xKen25Subtitle
+"*Finish the Americans, General. They cannot hold for much longer"
+END
+
+DIALOGEVENT:MisGLA05xKen26Subtitle
+"*General, we can target their chemical bunkers and create havoc in their own base"
+END
+
+DIALOGEVENT:MisGLA05xKen27Subtitle
+"*Their Particle Cannon is no more"
+END
+
+DIALOGEVENT:MisGLA05xKen28Subtitle
+"*The Americans have built another Particle Cannon. They must not be allowed to use it against us"
+END
+
+DIALOGEVENT:MisGLA05xKen29Subtitle
+"*We must eliminate the enemy's Southern support base now! The longer we wait, the more their attacks grow in strength"
+END
+
+DIALOGEVENT:MisGLA05xKen30Subtitle
+"*Reports indicate that the POW's held captive in the U.S. Base will be moved soon. We must rescue them quickly!"
+END
+
+DIALOGEVENT:MisGLA05xKen31Subtitle
+"*You will need to completely clear the U.S. base area to free the POW's"
+END
+
+DIALOGEVENT:MisGLA05xKen32Subtitle
+"*Hurry, the POW's need to be rescued now!"
+END
+
+DIALOGEVENT:MisGLA05xKen33Subtitle
+"*We need to bring Radar online by upgrading it from the China Command Center"
+END
+
+DIALOGEVENT:MisGLA05xKen34Subtitle
+"*It is imperative that you build a GLA Command Center"
+END
+
+DIALOGEVENT:MisGLA05xKen35Subtitle
+"*With the small southern base gone we can focus on the U.S. European Central Command base"
+END
+
+DIALOGEVENT:MisGLA05xKen36Subtitle
+"*The U.S. Central Command Base is massive, we have to find a way in! Perhaps sneak attacks would work"
+END
+
+DIALOGEVENT:MisGLA05xKen37Subtitle
+"*We need to deliver the POW's to their village so that they will reawaken their Terror Cell"
+END
+
+DIALOGEVENT:MisGLA05xKen38Subtitle
+"*Our brothers are being attacked! We must help them!"
+END
+
+DIALOGEVENT:MisGLA05xKen39Subtitle
+"*Return the POW's to their village, follow the river North until you reach it"
+END
+
+DIALOGEVENT:MisGLA05xKen40Subtitle
+"*The POW's are safe! We must help them return to their village so that they may aid us in our fight against the US!"
+END
+
+DIALOGEVENT:MisGLA05xKen41Subtitle
+"*Take these tanks and we will use them as our own!"
+END
+
+DIALOGEVENT:MisGLA05xKen42Subtitle
+"*Secure the supplies and we will hold the perfect area from which to launch our assaults on the Americans!"
+END
+
+DIALOGEVENT:MisGLA05xKen43Subtitle
+"*The soldiers are safe and their families are full of joy! They will fight with us and we have been given more supplies as well"
+END
+
+DIALOGEVENT:MisGLA05xKen44Subtitle
+"*We have let our brothers down but they will still fight alongside us"
+END
+
+DIALOGEVENT:MisGLA05xKen45Subtitle
+"*Our brothers will fight on our side to avenge the death of the POW's!"
+END
+
+DIALOGEVENT:MisGLA05xKen46Subtitle
+"*The Americans have moved the POW's, but our brothers will still fight alongside us against our enemy!"
+END
+
+DIALOGEVENT:MisGLA05xKen47Subtitle
+"*Europe will soon be ours!"
+END
+
+DIALOGEVENT:MisGLA05xPOW01Subtitle
+"*Free us from our captors. Protect us from all US attacks and we will assist you!"
+END
+
+DIALOGEVENT:MisGLA05xPOW02Subtitle
+"*We are ready to travel home when you are"
+END
+
+DIALOGEVENT:MisGLA05xPOW03Subtitle
+"*Hurry, there is little time!"
+END
+
+DIALOGEVENT:MisGLA05xPOW04Subtitle
+"*Our time is running out!"
+END
+
+DIALOGEVENT:MisGLA05xPOW05Subtitle
+"*Please save us!"
+END
+
+DIALOGEVENT:MisGLA05xPOW06Subtitle
+"*We need your help!"
+END
+
+DIALOGEVENT:MisGLA06Chatter01Subtitle
+"*Bridge up ahead. Looks heavily defended"
+END
+
+DIALOGEVENT:MisGLA06Chatter02Subtitle
+"*We're coming up on a bridge. No Americans"
+END
+
+DIALOGEVENT:MisGLA06Chatter07Subtitle
+"*Die Americans!"
+END
+
+DIALOGEVENT:MisGLA06Cin01Subtitle
+"*Die Americans!"
+END
+
+DIALOGEVENT:MisGLA06General05Subtitle
+"*We have been discovered by the American scouts. Be ready to fight"
+END
+
+DIALOGEVENT:MisGLA06General20Subtitle
+"*You must push them back so you can take control of the bunkers"
+END
+
+DIALOGEVENT:MisGLA07Convoy13Subtitle
+"*We have found some supplies, could be useful"
+END
+
+DIALOGEVENT:MisGLA08Buggy101Subtitle
+"*To glory!"
+END
+
+DIALOGEVENT:MisGLA08Kenwar10Subtitle
+"*We will have to hit them with everything we have"
+END
+
+DIALOGEVENT:MisGLA08Kenwar39Subtitle
+"*Our forces are prepared to begin the assault"
+END
+
+DIALOGEVENT:MisUSA01Commander03Subtitle
+"*Fast movers in-bound"
+END
+
+DIALOGEVENT:MisUSA01Commander09Subtitle
+"*Echo company, bomber in-bound, you're too close, pull back!"
+END
+
+DIALOGEVENT:MisUSA01Echo108Subtitle
+"*More contacts, range 300"
+END
+
+DIALOGEVENT:MisUSA01Echo201Subtitle
+"*I'm hit!"
+END
+
+DIALOGEVENT:MisUSA01Eva02Subtitle
+"*General, capture enemy oil derricks to secure more supplies for the war effort"
+END
+
+DIALOGEVENT:MisUSA01Raptor201Subtitle
+"*Light 'em up"
+END
+
+DIALOGEVENT:MisUSA01xBrf01Subtitle
+"*Welcome back, General"
+END
+
+DIALOGEVENT:MisUSA01xBrf02Subtitle
+"*The GLA launched their missile from the Baikonur Facility early this morning. Intel reports that they are preparing a second launch"
+END
+
+DIALOGEVENT:MisUSA01xBrf03Subtitle
+"*Use of this missile will severely weaken our foothold in Europe. It is vital that we remove this threat"
+END
+
+DIALOGEVENT:MisUSA01xBrf04Subtitle
+"*Our sources indicate that the next missile is being transported to the launch facility by train. These tracks are the only way into the facility"
+END
+
+DIALOGEVENT:MisUSA01xBrf05Subtitle
+"*If we can intercept that train in time, we can use it as cover to infiltrate the base"
+END
+
+DIALOGEVENT:MisUSA01xBrf06Subtitle
+"*The first step in completing our mission is to secure and hold this Train Depot"
+END
+
+DIALOGEVENT:MisUSA01xBrf07Subtitle
+"*Good luck, General"
+END
+
+DIALOGEVENT:MisUSA01xC+A39hat11Subtitle
+"*More GLA structures to the east!"
+END
+
+DIALOGEVENT:MisUSA01xChat01Subtitle
+"*Scorpions at 9 o clock!"
+END
+
+DIALOGEVENT:MisUSA01xChat02Subtitle
+"*All aboard!"
+END
+
+DIALOGEVENT:MisUSA01xChat03Subtitle
+"*Everybody got their tickets?"
+END
+
+DIALOGEVENT:MisUSA01xChat04Subtitle
+"*Honey, I'm home! Ha ha ha"
+END
+
+DIALOGEVENT:MisUSA01xChat05Subtitle
+"*Get some infantry into these vehicles! We can use them to help defeat the GLA!"
+END
+
+DIALOGEVENT:MisUSA01xChat06Subtitle
+"*Somebody garrison that Radio Station! We need air support now!"
+END
+
+DIALOGEVENT:MisUSA01xChat07Subtitle
+"*Aim for those barrels! They're explosive!"
+END
+
+DIALOGEVENT:MisUSA01xChat08Subtitle
+"*Ok boys. Let's load 'em up, and mooove 'em out!"
+END
+
+DIALOGEVENT:MisUSA01xChat09Subtitle
+"*Stinger sites are down! Repeat Stingers down! All units converge on GLA structures! Let's tear this place up!"
+END
+
+DIALOGEVENT:MisUSA01xChat10Subtitle
+"*More GLA structures to the west!"
+END
+
+DIALOGEVENT:MisUSA01xChat12Subtitle
+"*Will do, HQ! Got 'em in my sights"
+END
+
+DIALOGEVENT:MisUSA01xChat13Subtitle
+"*Delivering payload"
+END
+
+DIALOGEVENT:MisUSA01xChat14Subtitle
+"*Love that fresh smell of MOAB in the morning"
+END
+
+DIALOGEVENT:MisUSA01xCin01Subtitle
+"*All units clear the launch area. Launch is scheduled in t-minus�"
+END
+
+DIALOGEVENT:MisUSA01xCin02Subtitle
+"*5"
+END
+
+DIALOGEVENT:MisUSA01xCin03Subtitle
+"*4"
+END
+
+DIALOGEVENT:MisUSA01xCin04Subtitle
+"*3"
+END
+
+DIALOGEVENT:MisUSA01xCin05Subtitle
+"*2"
+END
+
+DIALOGEVENT:MisUSA01xCin06Subtitle
+"*1"
+END
+
+DIALOGEVENT:MisUSA01xCin07Subtitle
+"*0"
+END
+
+DIALOGEVENT:MisUSA01xCin08Subtitle
+"*We have launch"
+END
+
+DIALOGEVENT:MisUSA01xCin09Subtitle
+"*Launch is a go"
+END
+
+DIALOGEVENT:MisUSA01xCin10Subtitle
+"*Filthy Americans. We will torch your presence here"
+END
+
+DIALOGEVENT:MisUSA01xCin11Subtitle
+"*Stupid American cowboys!"
+END
+
+DIALOGEVENT:MisUSA01xEva01Subtitle
+"*Good work, General. The depot is secured"
+END
+
+DIALOGEVENT:MisUSA01xEva02Subtitle
+"*Now we need to build an attack force large enough to destroy the GLA base"
+END
+
+DIALOGEVENT:MisUSA01xEva03Subtitle
+"*Load your best units onto the train"
+END
+
+DIALOGEVENT:MisUSA01xEva04Subtitle
+"*The train will depart when it is completely full"
+END
+
+DIALOGEVENT:MisUSA01xEva05Subtitle
+"*Good work, General the train is full"
+END
+
+DIALOGEVENT:MisUSA01xEva06Subtitle
+"*Get that Dragon Tank up there to clear out those buildings"
+END
+
+DIALOGEVENT:MisUSA01xEva07Subtitle
+"*Build more units. We don't want to fail in our surprise attack"
+END
+
+DIALOGEVENT:MisUSA01xEva08Subtitle
+"*General! Get your men out of the pit! We've got MOABS on the way that are gonna blow this place to bits"
+END
+
+DIALOGEVENT:MisUSA01xEva09Subtitle
+"*We need to finish destroying this base!"
+END
+
+DIALOGEVENT:MisUSA01xEva10Subtitle
+"*The MOABs will be here any minute!"
+END
+
+DIALOGEVENT:MisUSA01xEva11Subtitle
+"*Alpha Wing! Area is clear. You may proceed"
+END
+
+DIALOGEVENT:MisUSA01xEva12Subtitle
+"*Good work, General. It looks like the GLA threat has finally been removed. It's time to put all this behind us and get looking for those WMDs"
+END
+
+DIALOGEVENT:MisUSA02Comanche101Subtitle
+"*Thanks for getting me out, sir! Things were getting a little dicey for me"
+END
+
+DIALOGEVENT:MisUSA02Comanche204Subtitle
+"*They're swarming us, sir!"
+END
+
+DIALOGEVENT:MisUSA02xBrf01Subtitle
+"*The docks have been cleared, General. Our first task will be to hold them while the supply trucks are brought in. Until the Dozers arrive, we will have to defend this position with our troops as they filter in"
+END
+
+DIALOGEVENT:MisUSA02xBrf02Subtitle
+"*Most of our fleet survived the GLA Baikonur Attack. Our Aircraft Carrier and Battleship escorts are at your disposal to aid with this operation"
+END
+
+DIALOGEVENT:MisUSA02xChat01Subtitle
+"*Air-strike Launched"
+END
+
+DIALOGEVENT:MisUSA02xChat02Subtitle
+"*Battleship commencing bombardment"
+END
+
+DIALOGEVENT:MisUSA02xChat03Subtitle
+"*Docks are all clear. No GLA in sight"
+END
+
+DIALOGEVENT:MisUSA02xChat04Subtitle
+"*Roger that"
+END
+
+DIALOGEVENT:MisUSA02xChat05Subtitle
+"*Commencing Attack"
+END
+
+DIALOGEVENT:MisUSA02xChat06Subtitle
+"*Launching Air-strike"
+END
+
+DIALOGEVENT:MisUSA02xChat07Subtitle
+"*Guns a blazing"
+END
+
+DIALOGEVENT:MisUSA02xChat08Subtitle
+"*We'll give them some red glare alright"
+END
+
+DIALOGEVENT:MisUSA02xCin01Subtitle
+"*Carrier Command to fleet. Keep up the fire, boys. The GLA are bringing in reinforcements"
+END
+
+DIALOGEVENT:MisUSA02xCin02Subtitle
+"*Roger that, Carrier command. Maintaining suppression fire on the docks"
+END
+
+DIALOGEVENT:MisUSA02xCin03Subtitle
+"*Be careful what you hit. We just want to clear it out, not destroy it"
+END
+
+DIALOGEVENT:MisUSA02xEva01Subtitle
+"*Good work, sir! Our next objective is to provide safe passage for the supply trucks as they travel through the city. The trucks must reach the city's supply warehouse. We must also retain control of the docks. Good luck, sir"
+END
+
+DIALOGEVENT:MisUSA02xEva02Subtitle
+"*Supply Trucks are beginning to move, General. We must provide protection as they make their way to the drop off point"
+END
+
+DIALOGEVENT:MisUSA02xEva03Subtitle
+"*I'm sending you some new prototype sentry drones. The enemy can't detect them if they stay still. The drones are also capable of spotting stealthed units as well as GLA demo traps. They should prove to be very useful"
+END
+
+DIALOGEVENT:MisUSA02xEva04Subtitle
+"*Our dozer has arrived sir! Begin building up your base. The GLA are preparing a new wave of attacks against us!"
+END
+
+DIALOGEVENT:MisUSA02xEva05Subtitle
+"*Great job, sir! The people of this city have expressed their gratitude for the relief supplies. Our final objective is to drive the GLA from the area. Destroy their main base overlooking the city and the area will be secured"
+END
+
+DIALOGEVENT:MisUSA02xEva06Subtitle
+"*Reinforcements incoming, General"
+END
+
+DIALOGEVENT:MisUSA02xEva07Subtitle
+"*General, our Sentry Drones can help spot GLA Demo Traps"
+END
+
+DIALOGEVENT:MisUSA02xEva08Subtitle
+"*Sir, there are still GLA near the warehouse. We need to clear them out immediately"
+END
+
+DIALOGEVENT:MisUSA02xEva09Subtitle
+"*Supply Trucks are under attack!"
+END
+
+DIALOGEVENT:MisUSA02xEva10Subtitle
+"*Good job, all trucks are safely to the docks, now lets get them to the city"
+END
+
+DIALOGEVENT:MisUSA02xEva11Subtitle
+"*Try to minimize civilian casualties"
+END
+
+DIALOGEVENT:MisUSA02xEva12Subtitle
+"*You've discovered a GLA training camp, sir. Intelligence believes that members of this camp were partially responsible for the Baikonur Launch. We have been ordered to take it out"
+END
+
+DIALOGEVENT:MisUSA02xEva13Subtitle
+"*Secure the warehouse so the supply trucks can proceed safely"
+END
+
+DIALOGEVENT:MisUSA02xEva14Subtitle
+"*Once the warehouse is secure the supply trucks will proceed"
+END
+
+DIALOGEVENT:MisUSA02xEva15Subtitle
+"*Dozers have arrived general. You are cleared to eliminate the GLA at your discretion"
+END
+
+DIALOGEVENT:MisUSA02xEva16Subtitle
+"*Get the food to the city before the GLA can steal or destroy it"
+END
+
+DIALOGEVENT:MisUSA02xEva17Subtitle
+"*General, we've done it. The city is free from the GLA tyranny. It looks like they've got some Intel that will lead us straight to those hidden WMDs"
+END
+
+DIALOGEVENT:MisUSA02xEva18Subtitle
+"*Full naval support is available for this operation"
+END
+
+DIALOGEVENT:MisUSA02xEva19Subtitle
+"*Use the battleships and aircraft carrier at your discretion"
+END
+
+DIALOGEVENT:MisUSA02xEva20Subtitle
+"*The battleships are in range and awaiting targets, General"
+END
+
+DIALOGEVENT:MisUSA02xEva21Subtitle
+"*The CVN Daedalus is standing by with aircraft at the ready"
+END
+
+DIALOGEVENT:MisUSA02xEva22Subtitle
+"*The warehouse needs to be secured, but the safety of the docks must not be compromised"
+END
+
+DIALOGEVENT:MisUSA02xEva23Subtitle
+"*Our forces are limited in this area. You will receive reinforcements as they become available"
+END
+
+DIALOGEVENT:MisUSA02xEva24Subtitle
+"*Secure the warehouse without compromising the safety of the docks"
+END
+
+DIALOGEVENT:MisUSA02xEva25Subtitle
+"*The convoy has resupplied the warehouse"
+END
+
+DIALOGEVENT:MisUSA02xEva26Subtitle
+"*The GLA Base is the next objective, General"
+END
+
+DIALOGEVENT:MisUSA02xSupply01Subtitle
+"*As soon as that warehouse is safe, we will roll out"
+END
+
+DIALOGEVENT:MisUSA02xSupply02Subtitle
+"*Thanks for the cover fire, General! All trucks loaded and ready to move out. Just clear out that city for us, sir!"
+END
+
+DIALOGEVENT:MisUSA02xSupply03Subtitle
+"*The streets are lined with Demo Traps, sir! We'll need them swept clear!"
+END
+
+DIALOGEVENT:MisUSA02xSupply04Subtitle
+"*We've reached the warehouse, General. Thanks for the escort!"
+END
+
+DIALOGEVENT:MisUSA02xSupply05Subtitle
+"*Convoy's arrived safely, sir. Thanks for the cover"
+END
+
+DIALOGEVENT:MisUSA02xVillager01Subtitle
+"*Oh thank you"
+END
+
+DIALOGEVENT:MisUSA02xVillager02Subtitle
+"*Bless You"
+END
+
+DIALOGEVENT:MisUSA02xVillager03Subtitle
+"*I haven't eaten in so long"
+END
+
+DIALOGEVENT:MisUSA02xVillager04Subtitle
+"*Will there be any more?"
+END
+
+DIALOGEVENT:MisUSA03Comanche102Subtitle
+"*Quad Cannons are picking us apart, sir"
+END
+
+DIALOGEVENT:MisUSA03Crusader105Subtitle
+"*We need more support! They're chewing us up!"
+END
+
+DIALOGEVENT:MisUSA03Crusader108Subtitle
+"*Someone get those buggies off us!"
+END
+
+DIALOGEVENT:MisUSA03Crusader304Subtitle
+"*Enemy contacts confirmed! They're moving in fast!"
+END
+
+DIALOGEVENT:MisUSA03Crusader307Subtitle
+"*All units! Keep up the fire!"
+END
+
+DIALOGEVENT:MisUSA03xBrf01Subtitle
+"*General, Col Burton and Black Lotus are in position and ready for your orders"
+END
+
+DIALOGEVENT:MisUSA03xBrf02Subtitle
+"*Their primary objective is this secret laboratory. It's location was revealed by the documents captured during your last mission"
+END
+
+DIALOGEVENT:MisUSA03xBrf03Subtitle
+"*The GLA are working on a new weapon of mass destruction. Black Lotus must download this data so we know how far along their research has come"
+END
+
+DIALOGEVENT:MisUSA03xBrf04Subtitle
+"*Once she has completed her download, Col Burton must bring the mountainside down on the lab and bury it forever"
+END
+
+DIALOGEVENT:MisUSA03xBurton01Subtitle
+"*We're at the bridge. Lotus, take care of that Scorpion, I'll deal with the other guards"
+END
+
+DIALOGEVENT:MisUSA03xBurton02Subtitle
+"*That wasn't part of the plan, Lotus"
+END
+
+DIALOGEVENT:MisUSA03xBurton03Subtitle
+"*You'll wait for me? All right, Lotus, let's race�"
+END
+
+DIALOGEVENT:MisUSA03xBurton04Subtitle
+"*I'm on my way"
+END
+
+DIALOGEVENT:MisUSA03xBurton05Subtitle
+"*All right, I see the POW camp�looks like they have a Tunnel Network that passes under the river"
+END
+
+DIALOGEVENT:MisUSA03xBurton06Subtitle
+"*Nice work, Lotus�Tunnels down here�just take care of a couple guards and I'll have everyone freed"
+END
+
+DIALOGEVENT:MisUSA03xBurton07Subtitle
+"*Those vehicles would come in handy if the intel about the defenses around the mountains are correct. General, we ought to rescue them, too"
+END
+
+DIALOGEVENT:MisUSA03xBurton08Subtitle
+"*General, I'm in position near the second POW Camp�there's a Tunnel Network and guards out front. I could slip past them into the compound if I climbed down the cliffs on the south end of the camp"
+END
+
+DIALOGEVENT:MisUSA03xBurton09Subtitle
+"*Don't get cocky, Lotus, you haven't won this race yet"
+END
+
+DIALOGEVENT:MisUSA03xBurton10Subtitle
+"*That's the last of them�second POW Camp is secured�someone should tell Lotus to hurry up�I don't want to be kept waiting at the Lab"
+END
+
+DIALOGEVENT:MisUSA03xBurton11Subtitle
+"*That's some new toy. General, if you focus it at those Tunnel Networks and Stinger Sites guarding the mountain, I'll slip right by them"
+END
+
+DIALOGEVENT:MisUSA03xBurton12Subtitle
+"*Looks like a whole GLA base. Intel never said anything about this being here"
+END
+
+DIALOGEVENT:MisUSA03xBurton13Subtitle
+"*Doesn't look like they were expecting me�a little C4 here and there and I'll make short work of this place�just say the word, General"
+END
+
+DIALOGEVENT:MisUSA03xBurton14Subtitle
+"*I should be safe moving through the village�just need to watch out for any Radar Vans monitoring the area. Wish I had a couple Flash Bangs"
+END
+
+DIALOGEVENT:MisUSA03xBurton15Subtitle
+"*This is it! I'm moving into position above the Lab�don't keep me waiting Lotus, its cold up here"
+END
+
+DIALOGEVENT:MisUSA03xBurton16Subtitle
+"*Charges set�say when, Lotus"
+END
+
+DIALOGEVENT:MisUSA03xBurton17Subtitle
+"*Well, Lotus, you're fast�I'll give you that. I'll be there as soon as I can"
+END
+
+DIALOGEVENT:MisUSA03xBurton18Subtitle
+"*Alright�I'm at the mountain�Tell me when your download finishes, Lotus, and I'll bury that lab where no one will ever find it again"
+END
+
+DIALOGEVENT:MisUSA03xChat01Subtitle
+"*Garrison�eat Flash Bang"
+END
+
+DIALOGEVENT:MisUSA03xChat02Subtitle
+"*There they are�remember, short controlled bursts"
+END
+
+DIALOGEVENT:MisUSA03xChat03Subtitle
+"*Infantry? No problem"
+END
+
+DIALOGEVENT:MisUSA03xChat04Subtitle
+"*We're taking fire�we need some support here!"
+END
+
+DIALOGEVENT:MisUSA03xCin01Subtitle
+"*This is Spirit, I am rolling in over the target area�"
+END
+
+DIALOGEVENT:MisUSA03xCin02Subtitle
+"*Roger, Spirit, mission is go. You ready to do this?"
+END
+
+DIALOGEVENT:MisUSA03xCin03Subtitle
+"*Yes, Colonel, let us begin"
+END
+
+DIALOGEVENT:MisUSA03xCin04Subtitle
+"*This is Spirit, bomb bay doors open� �bombs are away"
+END
+
+DIALOGEVENT:MisUSA03xCin05Subtitle
+"*Spirit to Infiltrator, your LZ is clear�Good Luck"
+END
+
+DIALOGEVENT:MisUSA03xCin06Subtitle
+"*Roger, Spirit, nice shooting"
+END
+
+DIALOGEVENT:MisUSA03xCin07Subtitle
+"*On station�everybody out who's staying"
+END
+
+DIALOGEVENT:MisUSA03xCin08Subtitle
+"*Thanks for the lift boys�see you soon�"
+END
+
+DIALOGEVENT:MisUSA03xCin09Subtitle
+"*Your small Chinooks are efficient�but I prefer the strength of our Helixes..."
+END
+
+DIALOGEVENT:MisUSA03xDrvr01Subtitle
+"*We're free! Everyone to your vehicles!"
+END
+
+DIALOGEVENT:MisUSA03xDrvr02Subtitle
+"*Thanks, General. We're at your command"
+END
+
+DIALOGEVENT:MisUSA03xEva01Subtitle
+"*General, your first objective is the destruction of this bridge. Its destruction will cut off GLA reinforcements from the other side of the river"
+END
+
+DIALOGEVENT:MisUSA03xEva02Subtitle
+"*General, GLA reinforcements have been sighted crossing the bridge"
+END
+
+DIALOGEVENT:MisUSA03xEva03Subtitle
+"*Another GLA squad has entered the area, General. Perhaps we should take care of that bridge now?"
+END
+
+DIALOGEVENT:MisUSA03xEva04Subtitle
+"*General, it appears that there are several GLA Radar Vans in the area, if your forces get to close, they will be detected"
+END
+
+DIALOGEVENT:MisUSA03xEva05Subtitle
+"*Excellent job, General. Now you only need to worry about GLA forces on this side of the river"
+END
+
+DIALOGEVENT:MisUSA03xEva06Subtitle
+"*The GLA have a POW camp along the route Col Burton must take to the GLA Lab. If you free the men held there, Col Burton will have an easier time getting to the Lab"
+END
+
+DIALOGEVENT:MisUSA03xEva07Subtitle
+"*General, intel suggests you free the men at the POW camp before you send Col Burton too far away"
+END
+
+DIALOGEVENT:MisUSA03xEva08Subtitle
+"*Congratulations, General, I'm sure the families of those men will be happy to hear they've been rescued"
+END
+
+DIALOGEVENT:MisUSA03xEva09Subtitle
+"*General, the GLA's Lab is directly north of your current position. There are a number of GLA defenses still along your route�be careful"
+END
+
+DIALOGEVENT:MisUSA03xEva10Subtitle
+"*It appears that those Oil Derricks are the only source of income for the GLA base. If you can destroy them you will cripple the GLA here"
+END
+
+DIALOGEVENT:MisUSA03xEva11Subtitle
+"*General, I'm patching through Black Lotus"
+END
+
+DIALOGEVENT:MisUSA03xEva12Subtitle
+"*General, the men you just rescued are driving our newest vehicle, the Microwave Tank"
+END
+
+DIALOGEVENT:MisUSA03xEva13Subtitle
+"*This vehicle has two modes: The first generates a continuous microwave field in front of the vehicle - very lethal to all infantry. The second allows it to disrupt the functions of any targeted building"
+END
+
+DIALOGEVENT:MisUSA03xEva14Subtitle
+"*General, the GLA know we are here and appear to be on heightened alert. Be careful when moving Col Burton into position above their Secret Lab"
+END
+
+DIALOGEVENT:MisUSA03xEva15Subtitle
+"*General, the GLA have upgraded their tank shells to contain poisons. Be careful.�"
+END
+
+DIALOGEVENT:MisUSA03xEva16Subtitle
+"*I'm showing a GLA patrol in that village, General�as well as a number of enemy forces garrisoned throughout the village"
+END
+
+DIALOGEVENT:MisUSA03xEva17Subtitle
+"*Maybe Black Lotus can find out more Intel about who is behind the GLA WMD program"
+END
+
+DIALOGEVENT:MisUSA03xEva18Subtitle
+"*That was incredible General. Looks like the GLA won't be using that facility anymore�and it seems Black Lotus downloaded some vital info about the source of this lab. For now, let's regroup and see what she was able to find out. Great work"
+END
+
+DIALOGEVENT:MisUSA03xLotus01Subtitle
+"*The scorpion is disabled�I will take care of matters across the river. Wait until I am across and then destroy the bridge"
+END
+
+DIALOGEVENT:MisUSA03xLotus02Subtitle
+"*It is now. Don't worry, I'll wait for you at the lab�do hurry"
+END
+
+DIALOGEVENT:MisUSA03xLotus03Subtitle
+"*General, I am in a position to help free your forces held prisoner. Perhaps Col. Burton would like to help?"
+END
+
+DIALOGEVENT:MisUSA03xLotus04Subtitle
+"*General, could you ask Col Burton to please hurry to the POW camp�I'm tired of waiting on him"
+END
+
+DIALOGEVENT:MisUSA03xLotus05Subtitle
+"*I will draw the camp guards attention to this side of the river. That should let you and your pet robots handle the Tunnel and free your captured men"
+END
+
+DIALOGEVENT:MisUSA03xLotus06Subtitle
+"*General�my forces are moving on the final GLA positions this side of the river. Please inform Col Burton that he should hurry�I would prefer not to wait too long for him to catch up"
+END
+
+DIALOGEVENT:MisUSA03xLotus07Subtitle
+"*Please inform Col Burton that I shall be waiting for HIM at the Lab"
+END
+
+DIALOGEVENT:MisUSA03xLotus08Subtitle
+"*I'm here, Colonel�you win. The GLA put up a stronger fight than I had anticipated. Beginning download"
+END
+
+DIALOGEVENT:MisUSA03xLotus09Subtitle
+"*I have the data! Now, Colonel!"
+END
+
+DIALOGEVENT:MisUSA03xLotus10Subtitle
+"*General. I am ready and waiting at the Lab�whenever the Colonel would like to arrive and finish this mission"
+END
+
+DIALOGEVENT:MisUSA03xLotus11Subtitle
+"*It is cold out here. You are coming aren't you Burton?"
+END
+
+DIALOGEVENT:MisUSA03xLotus12Subtitle
+"*Downloading the information now"
+END
+
+DIALOGEVENT:MisUSA03xRngr01Subtitle
+"*Thanks for the rescue, Sir"
+END
+
+DIALOGEVENT:MisUSA03xRngr02Subtitle
+"*A couple of our men broke off to check out the village east of here before we were captured. They may still be over there"
+END
+
+DIALOGEVENT:MisUSA03xRngr03Subtitle
+"*Good to see you, General, we thought we were going to end up captured"
+END
+
+DIALOGEVENT:MisUSA03xRngr04Subtitle
+"*The rest of our team was captured just after we got to the village. General, we'd like to volunteer to rescue them"
+END
+
+DIALOGEVENT:MisUSA03xRngr05Subtitle
+"*General, a squad of vehicles was captured just after we were taken. The GLA are holding them in a camp just north of here"
+END
+
+DIALOGEVENT:MisUSA04Eva02Subtitle
+"*Reinforcements arrived"
+END
+
+DIALOGEVENT:MisUSA04Eva07Subtitle
+"*We need to clear out these Stinger Sites before we can bring in our bombers to clear the GLA from the area"
+END
+
+DIALOGEVENT:MisUSA04Eva08Subtitle
+"*Construction crews have arrived sir. You'll need to get our base setup before we're overrun by the GLA"
+END
+
+DIALOGEVENT:MisUSA04Eva09Subtitle
+"*Our final objective is this GLA base here, in the hills. Take it out, and the operation is complete"
+END
+
+DIALOGEVENT:MisUSA04Officer03Subtitle
+"*Terrorists detected. All units be on the alert"
+END
+
+DIALOGEVENT:MisUSA04Ranger01Subtitle
+"*Calling in GLA bunker location at grid square Beta Charlie 6-8-9er-4-4"
+END
+
+DIALOGEVENT:MisUSA04Transport01Subtitle
+"*Transport teams 1 and 2 approaching the landing zone"
+END
+
+DIALOGEVENT:MisUSA04Transport03Subtitle
+"*Transport Team 1 reporting! Mission completed! I'm pulling out!"
+END
+
+DIALOGEVENT:MisUSA04xBrf01Subtitle
+"*General, intelligence reports that the rogue forces behind this GLA splinter cell are commanded by Dr. Thrax"
+END
+
+DIALOGEVENT:MisUSA04xBrf02Subtitle
+"*Dr. Thrax is a wanted criminal�responsible for notorious terror crimes against the US military. He must be brought to justice"
+END
+
+DIALOGEVENT:MisUSA04xBrf03Subtitle
+"*Dr. Thrax was developing a brand new toxin at his secret mountain lab. Thank goodness Lotus and Burton were there to stop him"
+END
+
+DIALOGEVENT:MisUSA04xBrf04Subtitle
+"*Dr. Thrax is receiving his funding from his oil fields. We must cut off his flow of oil"
+END
+
+DIALOGEVENT:MisUSA04xBrf05Subtitle
+"*The Intel we retrieved from the Secret Lab proves the GLA have seized these oil fields to help fund the nefarious Dr. Thrax. They may destroy them, rather then let you recapture them. Beware General, the GLA have started using Booby Traps�use Dozers to remove BOOBY TRAPS safely"
+END
+
+DIALOGEVENT:MisUSA04xChat01Subtitle
+"*Sir! Toxin Tractors are eating us up! Send help!"
+END
+
+DIALOGEVENT:MisUSA04xChat02Subtitle
+"*Toxin Tractors! Pull your infantry back!"
+END
+
+DIALOGEVENT:MisUSA04xChat03Subtitle
+"*Quad Cannons spotted sir!"
+END
+
+DIALOGEVENT:MisUSA04xChat04Subtitle
+"*We're losing units to Quad Cannons, sir! Send armor!"
+END
+
+DIALOGEVENT:MisUSA04xChat05Subtitle
+"* NO! Bravo Three was killed by a Quad Cannon, Sir!"
+END
+
+DIALOGEVENT:MisUSA04xChat06Subtitle
+"*The enemy has started sending tanks, sir! Send Missile defenders!"
+END
+
+DIALOGEVENT:MisUSA04xChat07Subtitle
+"*Ha! GLA tanks are no match for us!"
+END
+
+DIALOGEVENT:MisUSA04xChat08Subtitle
+"*Sir, we're losing units to enemy Tanks!"
+END
+
+DIALOGEVENT:MisUSA04xChat09Subtitle
+"*What's the enemy doing with those radar vans?"
+END
+
+DIALOGEVENT:MisUSA04xChat10Subtitle
+"*Was that a car bomb?"
+END
+
+DIALOGEVENT:MisUSA04xChat11Subtitle
+"*Where are those car bombs coming from?"
+END
+
+DIALOGEVENT:MisUSA04xChat12Subtitle
+"*Sir, we need more defenses out here! Car Bombs are tearing us up!"
+END
+
+DIALOGEVENT:MisUSA04xChat13Subtitle
+"*Bomb trucks?! That's not fair!"
+END
+
+DIALOGEVENT:MisUSA04xChat14Subtitle
+"*Sir, we need better defenses against these Bomb Trucks!"
+END
+
+DIALOGEVENT:MisUSA04xChat15Subtitle
+"*Sir, we've engaged angry mobs! Send anti-personnel units!"
+END
+
+DIALOGEVENT:MisUSA04xChat16Subtitle
+"*Angry mobs are destroying us! Send some snipers out here!"
+END
+
+DIALOGEVENT:MisUSA04xChat17Subtitle
+"*Sir, we need to do something about these ANGRY MOBS!"
+END
+
+DIALOGEVENT:MisUSA04xChat18Subtitle
+"*Sir, we're losing units to Terrorists, can we get a sniper out here?"
+END
+
+DIALOGEVENT:MisUSA04xChat19Subtitle
+"*Sir, these Terrorists are chewing us up! Send support!"
+END
+
+DIALOGEVENT:MisUSA04xChat20Subtitle
+"*Geez! What's with all these demo traps!"
+END
+
+DIALOGEVENT:MisUSA04xChat21Subtitle
+"*Sir, this field is littered with Demo Traps! We need to clear them out!"
+END
+
+DIALOGEVENT:MisUSA04xChat22Subtitle
+"*What?! We've lost a structure to a CAR BOMBER!"
+END
+
+DIALOGEVENT:MisUSA04xChat23Subtitle
+"*Car Bombers are attacking us! The appear to be coming from the local town"
+END
+
+DIALOGEVENT:MisUSA04xChat24Subtitle
+"*Whoa! Those bomb trucks pack a punch!"
+END
+
+DIALOGEVENT:MisUSA04xChat25Subtitle
+"*Ouch! That one hurt!"
+END
+
+DIALOGEVENT:MisUSA04xChat26Subtitle
+"*Sir, build more defenses to protect against the BOMB TRUCKS!"
+END
+
+DIALOGEVENT:MisUSA04xChat27Subtitle
+"*Whoa! Those mobs are ANGRY!"
+END
+
+DIALOGEVENT:MisUSA04xChat28Subtitle
+"*Sir, we need a Pathfinder to deal with those ANGRY MOBS!"
+END
+
+DIALOGEVENT:MisUSA04xChat29Subtitle
+"*Sir, we need anti-personnel out here NOW! These angry mobs are chewing us up!"
+END
+
+DIALOGEVENT:MisUSA04xChat30Subtitle
+"*Sir, we've lost a building to a car bomb"
+END
+
+DIALOGEVENT:MisUSA04xChat31Subtitle
+"*Terrorists are destroying our buildings! Call in snipers!"
+END
+
+DIALOGEVENT:MisUSA04xChat32Subtitle
+"*Sir! Their Bomb Trucks are destroying our base!"
+END
+
+DIALOGEVENT:MisUSA04xCIA01Subtitle
+"*Good to see some friendlies! Let's rock!"
+END
+
+DIALOGEVENT:MisUSA04xCIA02Subtitle
+"*Following your lead, General"
+END
+
+DIALOGEVENT:MisUSA04xCIA03Subtitle
+"*Here I am, lead on"
+END
+
+DIALOGEVENT:MisUSA04xCin01Subtitle
+"*Satcom, this is Charlie 5. Approaching TARGET, no hostiles sighted�wait�TARGET is in sight, Satcom�over"
+END
+
+DIALOGEVENT:MisUSA04xCin02Subtitle
+"*Roger that 5�You are a go, over"
+END
+
+DIALOGEVENT:MisUSA04xCin03Subtitle
+"*Roger Satcom�payload is away�leaving hotzone! Over"
+END
+
+DIALOGEVENT:MisUSA04xCin04Subtitle
+"*Roger that 5, out. Victor 3 you are go for IMMEDIATE drop�over"
+END
+
+DIALOGEVENT:MisUSA04xCin05Subtitle
+"*Roger Satcom�approaching target area�"
+END
+
+DIALOGEVENT:MisUSA04xCin06Subtitle
+"*Lock and Load!"
+END
+
+DIALOGEVENT:MisUSA04xCin07Subtitle
+"*Jump! Jump!"
+END
+
+DIALOGEVENT:MisUSA04xCin08Subtitle
+"*Careful not to get slimed, boys�chem weapons sighted"
+END
+
+DIALOGEVENT:MisUSA04xCin09Subtitle
+"*This is no MILK RUN, boys! Keep your heads!"
+END
+
+DIALOGEVENT:MisUSA04xCin10Subtitle
+"*Stay in formation!! No Cowboys!"
+END
+
+DIALOGEVENT:MisUSA04xCin11Subtitle
+"*Goats are away. Retuning to barn. Out"
+END
+
+DIALOGEVENT:MisUSA04xCin12Subtitle
+"*Bravo team, your primary objective is the small airstrip to your South. Secure it for incoming reinforcements. Out"
+END
+
+DIALOGEVENT:MisUSA04xCin13Subtitle
+"*Roger Satcom, moving out. Listen up kids! This is a FREE FIRE ZONE! Watch for ROACHES! If it moves kill it"
+END
+
+DIALOGEVENT:MisUSA04xCin14Subtitle
+"*Airstrip secured, General�Reinforcements en route"
+END
+
+DIALOGEVENT:MisUSA04xEva01Subtitle
+"*The GLA has started using BOOBY-TRAPS on structures in this area. They will explode if you try to capture or garrison them. Use Dozers to remove them"
+END
+
+DIALOGEVENT:MisUSA04xEva02Subtitle
+"*The GLA has seized the nearby oil fields. Protect the derricks and destroy the GLA base"
+END
+
+DIALOGEVENT:MisUSA04xEva03Subtitle
+"*BE CAREFUL, General; the enemy may have set up traps in the oil field"
+END
+
+DIALOGEVENT:MisUSA04xEva04Subtitle
+"*Good news, General. Colonel Burton knows several covert operatives in this area. Lead Burton to the ops to solicit their help"
+END
+
+DIALOGEVENT:MisUSA04xEva05Subtitle
+"*Good news, General. There are several covert operatives in this area. Find them to solicit their help"
+END
+
+DIALOGEVENT:MisUSA04xEva06Subtitle
+"*Well done General, this region is now free of GLA troublemakers"
+END
+
+DIALOGEVENT:MisUSA04xEva07Subtitle
+"*Well done, General. This area has been secured"
+END
+
+DIALOGEVENT:MisUSA04xEva08Subtitle
+"*General, Your ultimate objective is to destroy the GLA base in this area. Your main source of funding will be the oil derricks. You must secure and protect them!"
+END
+
+DIALOGEVENT:MisUSA04xEva09Subtitle
+"*Well done, General. Your mission is a success"
+END
+
+DIALOGEVENT:MisUSA04xEva10Subtitle
+"*General, the local town is being poisoned by GLA propaganda and are launching attacks against us. Destroy the GLA radio station to quell the uprising"
+END
+
+DIALOGEVENT:MisUSA04xEva11Subtitle
+"*Destroy the GLA radio-station in the city to quell the uprising"
+END
+
+DIALOGEVENT:MisUSA04xEva12Subtitle
+"*Well done, General. The GLA propaganda machine has been destroyed"
+END
+
+DIALOGEVENT:MisUSA04xEva13Subtitle
+"*Destroy the GLA RADIO STATION in the city to stop the car-bomb attacks"
+END
+
+DIALOGEVENT:MisUSA04xEva14Subtitle
+"*Destroy the GLA RADIO STATION in the city to stop the bomb-truck attacks"
+END
+
+DIALOGEVENT:MisUSA04xEva15Subtitle
+"*Destroy the GLA RADIO STATION in the city to stop the suicide attacks"
+END
+
+DIALOGEVENT:MisUSA04xEva16Subtitle
+"*General, there are several ARTILLERY PLATFORMS in the area. Capture them for suppression fire"
+END
+
+DIALOGEVENT:MisUSA04xEva17Subtitle
+"*General, There is a REPAIR PAD in the area. Capture it to help heal our vehicles"
+END
+
+DIALOGEVENT:MisUSA04xEva18Subtitle
+"*Sir, please build more defenses to protect against the car bombers"
+END
+
+DIALOGEVENT:MisUSA04xEva19Subtitle
+"*Sir, the enemy has started deploying Radar Vans, they can spot our pathfinders!"
+END
+
+DIALOGEVENT:MisUSA04xEva20Subtitle
+"*Sir, the enemy's Radar Vans are sweeping for our pathfinders�be careful"
+END
+
+DIALOGEVENT:MisUSA04xEva21Subtitle
+"*Sir, we should build Patriots to counter the bomb trucks"
+END
+
+DIALOGEVENT:MisUSA04xEva22Subtitle
+"*Sir, Enemy Terrorists are proving highly effective. I suggest you send Pathfinders"
+END
+
+DIALOGEVENT:MisUSA04xEva23Subtitle
+"*Sir! We're losing units to Demo Traps, please be more careful!"
+END
+
+DIALOGEVENT:MisUSA04xEva24Subtitle
+"*General, There is an OIL REFINERY in the area. Capture it to reduce vehicle cost"
+END
+
+DIALOGEVENT:MisUSA04xEva25Subtitle
+"*Sir, the enemy has begun attacking the OIL FIELDS"
+END
+
+DIALOGEVENT:MisUSA04xEva26Subtitle
+"*WARNING: OIL derrick DESTROYED!  \n Only 1 derrick remains!"
+END
+
+DIALOGEVENT:MisUSA04xEva27Subtitle
+"*WARNING: OIL derrick DESTROYED!  \n Only 5 derricks remain"
+END
+
+DIALOGEVENT:MisUSA04xEva28Subtitle
+"*WARNING: OIL derrick DESTROYED!  \n Only 10 derricks remain"
+END
+
+DIALOGEVENT:MisUSA04xEva29Subtitle
+"*WARNING: OIL derrick DESTROYED!  \n 15 derricks remain"
+END
+
+DIALOGEVENT:MisUSA04xEva30Subtitle
+"*General, our cash reserves are running low -- capture oil derricks for needed cash"
+END
+
+DIALOGEVENT:MisUSA04xEva31Subtitle
+"*WARNING: SCUDSTORM DETECTED!"
+END
+
+DIALOGEVENT:MisUSA04xEva32Subtitle
+"*General! Colonel Burton is down!"
+END
+
+DIALOGEVENT:MisUSA04xEva33Subtitle
+"*All the oil derricks have been DESTROYED! Your mission is a failure"
+END
+
+DIALOGEVENT:MisUSA04xEva34Subtitle
+"*Your base has been destroyed! Your mission is a failure"
+END
+
+DIALOGEVENT:MisUSA04xEva35Subtitle
+"*Good luck, sir"
+END
+
+DIALOGEVENT:MisUSA05xChat01Subtitle
+"*Our base is being attacked sir. They built a tunnel network inside our base without us knowing"
+END
+
+DIALOGEVENT:MisUSA05xChat02Subtitle
+"*Those buses are loaded with hostiles sir! Watch out!"
+END
+
+DIALOGEVENT:MisUSA05xChat03Subtitle
+"*Our base is being attacked sir. They built a tunnel network inside our base without us knowing"
+END
+
+DIALOGEVENT:MisUSA05xChat04Subtitle
+"*We offer you our assistance to rid us of this Toxin Monger. His obsession will kill us all and that we cannot allow"
+END
+
+DIALOGEVENT:MisUSA05xChat05Subtitle
+"*Death to the Devil of Disease!"
+END
+
+DIALOGEVENT:MisUSA05xChat06Subtitle
+"*Help! Over here, please release me"
+END
+
+DIALOGEVENT:MisUSA05xChat07Subtitle
+"*Thank you for releasing me. Transport me to my base in the East and I can help you"
+END
+
+DIALOGEVENT:MisUSA05xCin01Subtitle
+"*Sat-Com A4 has confirmation on base location. Visuals are uploading now"
+END
+
+DIALOGEVENT:MisUSA05xCin02Subtitle
+"*Field, please verify status of Toxin Production facilities"
+END
+
+DIALOGEVENT:MisUSA05xCin03Subtitle
+"*Then we have a go upon presentation of final clearance code"
+END
+
+DIALOGEVENT:MisUSA05xCin04Subtitle
+"*Roger that, Alpha Whiskey Echo, the birds are in the air"
+END
+
+DIALOGEVENT:MisUSA05xCin05Subtitle
+"*Toxin Production Facilities confirmed sir"
+END
+
+DIALOGEVENT:MisUSA05xCin06Subtitle
+"*Clearance code is Sierra, Hotel, Oscar, Charlie Kilo"
+END
+
+DIALOGEVENT:MisUSA05xEva01Subtitle
+"*Phase one of our operation has been completed General. Our Tomahawk Missile strike was successful in destroying all of GLA's Toxin production facilities. Only their main base and Toxin Missile silo's remain to be eliminated"
+END
+
+DIALOGEVENT:MisUSA05xEva02Subtitle
+"*General, we've tracked Dr. Thrax to this remote location. He is in possession of chemical tipped missiles, and has them prepped for launch. Destroying his toxin storage tanks has slowed him down, but we must move in and secure those missiles before they can be launched"
+END
+
+DIALOGEVENT:MisUSA05xEva03Subtitle
+"*General, Dr. Thrax was able to develop small quantities of his new toxin. Make sure your forces are on high alert"
+END
+
+DIALOGEVENT:MisUSA05xEva04Subtitle
+"*General, due to the civilian presence in this location you will need to use ground forces to assault the final base and capture the 4 toxin missile sites in the area. Our successful liberation of the oil sites in Amisbad has provided us with additional resources for this operation"
+END
+
+DIALOGEVENT:MisUSA05xEva05Subtitle
+"*Dr. Thrax must be defeated so he can't inflict further terror on the world. General, you must stop him"
+END
+
+DIALOGEVENT:MisUSA05xEva06Subtitle
+"*Our Intel indicates that this is the best area to build your base. Local unrest may be in your favor. Good luck"
+END
+
+DIALOGEVENT:MisUSA05xEva07Subtitle
+"*General, the local GLA have responded to your rescue and have given us control of their base. You may now use their forces in your attack"
+END
+
+DIALOGEVENT:MisUSA05xEva08Subtitle
+"*General, your main objective is to capture the 4 Toxin Missile Silo's targeted on US major metropolitan areas before they launch"
+END
+
+DIALOGEVENT:MisUSA05xEva09Subtitle
+"*General, infrared scans of the area indicate that they are preparing to launch the Toxin Missiles"
+END
+
+DIALOGEVENT:MisUSA05xEva10Subtitle
+"*Missile launch in 5 minutes� Your final offensive should commence now"
+END
+
+DIALOGEVENT:MisUSA05xEva11Subtitle
+"*Missile launch in 4 minutes�"
+END
+
+DIALOGEVENT:MisUSA05xEva12Subtitle
+"*Missile launch in 3 minutes�"
+END
+
+DIALOGEVENT:MisUSA05xEva13Subtitle
+"*Missile launch in 2 minutes�"
+END
+
+DIALOGEVENT:MisUSA05xEva14Subtitle
+"*Missile launch in 1 minute� We must move in now!"
+END
+
+DIALOGEVENT:MisUSA05xEva15Subtitle
+"*30 seconds until missile launch� It's almost too late General!"
+END
+
+DIALOGEVENT:MisUSA05xEva16Subtitle
+"*10 seconds until missile launch�"
+END
+
+DIALOGEVENT:MisUSA05xEva17Subtitle
+"*5� 4� 3� 2� 1� (gasp) Toxin Missile Launch detected General"
+END
+
+DIALOGEVENT:MisUSA05xEva18Subtitle
+"*Toxin Missile Impact has been detected and Hot Zone is now confirmed. The casualties are incalculable General, we have failed"
+END
+
+DIALOGEVENT:MisUSA05xEva19Subtitle
+"*The first Missile Silo has been captured and the HazMat decontamination team is en-route. One to go Commander"
+END
+
+DIALOGEVENT:MisUSA05xEva20Subtitle
+"*Good job, sir. The second Missile Silo has been captured. Two to go"
+END
+
+DIALOGEVENT:MisUSA05xEva21Subtitle
+"*Good job, sir. The third Missile Silo has been captured. One to go"
+END
+
+DIALOGEVENT:MisUSA05xEva22Subtitle
+"*Great work, General. We now have control of all 4 Toxin Missile silo's. The operation is a success"
+END
+
+DIALOGEVENT:MisUSA05xEva23Subtitle
+"*Toxin breach, you have 2 minutes to guide the Bio-engineer to the hot zone to neutralize the threat"
+END
+
+DIALOGEVENT:MisUSA05xEva24Subtitle
+"*We have a green light for the operation. Launch the attack on GLA's perimeter base"
+END
+
+DIALOGEVENT:MisUSA05xEva25Subtitle
+"*Intel says that the Missile Sites we are looking for are in this region. Use caution and make sure those toxins aren't released"
+END
+
+DIALOGEVENT:MisUSA05xEva26Subtitle
+"*Infantry won't work well here, General. Our enemy is using toxins in almost every weapon that they throw at us"
+END
+
+DIALOGEVENT:MisUSA05xEva27Subtitle
+"*General, your objective is to capture this structure, not destroy it! If those toxins are released then the region will be contaminated for 100 square miles!"
+END
+
+DIALOGEVENT:MisUSA05xEva28Subtitle
+"*General, our intel indicates that if we can leak the napalm in those tanks into those nearby tunnels exits we can flood their whole system"
+END
+
+DIALOGEVENT:MisUSA05xEva29Subtitle
+"*Congratulations General. Dr. Thrax won't be poisoning the world with his creations any longer"
+END
+
+DIALOGEVENT:MisUSA05xEva30Subtitle
+"*Now that Dr. Thrax is defeated we can finally bring our boys home. Good work, General"
+END
+
+DIALOGEVENT:MisUSA05xEva31Subtitle
+"*We have a green light on Operation: Eagle's Strike. Launch the attack on Toxin Production facilities"
+END
+
+DIALOGEVENT:MisUSA05xEva32Subtitle
+"*General, your orders are to build a base to attack the Toxin General. As your forces are ready then capture the enemies 4 Toxin Missile sites before they can launch"
+END
+
+DIALOGEVENT:MisUSA05xEva33Subtitle
+"*General, the GLA base to the east has decided to Rebel against the Toxin General and his mass use of toxins. They wish to aid us in our attack against the General by giving us use of their base"
+END
+
+DIALOGEVENT:MisUSA05xEva34Subtitle
+"*General, the enemy has detected our presence in their main base and have begun launch preparations for the Toxin Missiles. The should have launch capability in approximately 30 minutes. Intel has located and revealed the 4 missile sites on your radar screen"
+END
+
+DIALOGEVENT:MisUSA05xEva35Subtitle
+"*General, Intel puts some of the Missiles in this region. Take care not to release the toxin!"
+END
+
+DIALOGEVENT:MisUSA05xThrax01Subtitle
+"*You are too late infidel, the launch is commencing to cleanse your lands in pestilence. Hahahaha�"
+END
+
+DIALOGEVENT:MisUSA05xThrax02Subtitle
+"*Your betrayal has not gone unnoticed. You will burn with the infidels you now assist. May your sons camels swell with virulence!"
+END
+
+DIALOGEVENT:MisUSA05xThrax03Subtitle
+"*My reach is long and now you will feel my wrath! Die infidel dogs, die!"
+END
+
+DIALOGEVENT:MisUSA06Crusader101Subtitle
+"*Enemy sighted!"
+END
+
+DIALOGEVENT:MisUSA06Crusader102Subtitle
+"*More GLA. Lock and load"
+END
+
+DIALOGEVENT:MisUSA06Crusader202Subtitle
+"*They're too well dug in! We need reinforcements!"
+END
+
+DIALOGEVENT:MisUSA06Crusader206Subtitle
+"*Stop those Tractors!"
+END
+
+DIALOGEVENT:MisUSA06Officer05Subtitle
+"*Concentrate your fire, men!"
+END
+
+DIALOGEVENT:MisUSA07Crusader204Subtitle
+"*We've broken through to the north! Send reinforcements"
+END
+
+DIALOGEVENT:MisUSA07Crusader205Subtitle
+"*They're everywhere!"
+END
+
+DIALOGEVENT:MisUSA07Crusader301Subtitle
+"*Be advised, car bombs in the area"
+END
+
+DIALOGEVENT:MisUSA07Crusader303Subtitle
+"*We've crossed the bridge. Sweep and clear"
+END
+
+DIALOGEVENT:MisUSA07Crusader306Subtitle
+"*Heeelp!"
+END
+
+DIALOGEVENT:MisUSA07Officer01Subtitle
+"*We've got to clear the area! Destroy everything!"
+END
+
+DIALOGEVENT:MisUSA07Officer02Subtitle
+"*Destroy everything not American. Leave nothing behind!"
+END
+
+DIALOGEVENT:MisUSA07Officer03Subtitle
+"*Copy that Delta two. Your orders are to fall back. Over"
+END
+
+DIALOGEVENT:MisUSA08Chatter06Subtitle
+"*This is Echo one rolling into hot zone. Everyone keep your eyes open"
+END
+
+DIALOGEVENT:MisUSA08Chatter10Subtitle
+"*Car Bomb! Car Bomb!"
+END
+
+DIALOGEVENT:MisUSA08Chatter12Subtitle
+"*Car bomb! Open fire!"
+END
+
+DIALOGEVENT:MisUSA08Chatter14Subtitle
+"*Alright boys�let's go!"
+END
+
+DIALOGEVENT:MisUSA08Cin03Subtitle
+"*Looks like the whole GLA is lining up for us today"
+END
+
+DIALOGEVENT:MisUSAChatter01Subtitle
+"*Get in formation, right now!"
+END
+
+DIALOGEVENT:Taunts_BossChi001Subtitle
+"*So, I see you have decided to stay and stand against me. You will regret that decision, General. Prepare to meet your end!"
+END
+
+DIALOGEVENT:Taunts_BossChi002Subtitle
+"*The tiger stands poised to strike, General"
+END
+
+DIALOGEVENT:Taunts_BossChi003Subtitle
+"*For China! Charge!"
+END
+
+DIALOGEVENT:Taunts_BossChi004Subtitle
+"*My forces are ready to engage your defenses, General"
+END
+
+DIALOGEVENT:Taunts_BossChi005Subtitle
+"*Feel the stomping feet of my iron dragon!"
+END
+
+DIALOGEVENT:Taunts_BossChi006Subtitle
+"*Your defenses are worthless against my forces"
+END
+
+DIALOGEVENT:Taunts_BossChi007Subtitle
+"*Now we meet in the field of honor, General"
+END
+
+DIALOGEVENT:Taunts_BossChi008Subtitle
+"*This we do for the good of China"
+END
+
+DIALOGEVENT:Taunts_BossChi009Subtitle
+"*It is time to test your steel, General"
+END
+
+DIALOGEVENT:Taunts_BossChi010Subtitle
+"*You have attacked me for the last time, General. This wave will break your defenses and crush your pitiful army to dust!"
+END
+
+DIALOGEVENT:Taunts_BossChi011Subtitle
+"*The might of China falls upon you"
+END
+
+DIALOGEVENT:Taunts_BossChi012Subtitle
+"*Your inferior forces will provide no challenge for my warriors"
+END
+
+DIALOGEVENT:Taunts_BossChi013Subtitle
+"*You began this fight, General. No I will finish it"
+END
+
+DIALOGEVENT:Taunts_BossChi014Subtitle
+"*Attack the fool! Take no prisoners!"
+END
+
+DIALOGEVENT:Taunts_BossChi015Subtitle
+"*Two warriors meet on the battlefield. Who is to say who will win? I do, that's who. Me. You will fall, General"
+END
+
+DIALOGEVENT:Taunts_BossChi016Subtitle
+"*A fight that cannot be won is not worth fighting. So why are you here, General?"
+END
+
+DIALOGEVENT:Taunts_BossChi017Subtitle
+"*Rage will only get you so far, General. Now, rage and a column of tanks...that will get you somewhere"
+END
+
+DIALOGEVENT:Taunts_BossChi018Subtitle
+"*You find yourself at the end of your rope, General. And only now have you discovered that the end of that rope is on fire"
+END
+
+DIALOGEVENT:Taunts_BossChi019Subtitle
+"*The dance of battle is strange and brief�and this battle with you has been strangely brief"
+END
+
+DIALOGEVENT:Taunts_BossChi020Subtitle
+"*I see you haven't thought your strategy through. Pity"
+END
+
+DIALOGEVENT:Taunts_BossChi021Subtitle
+"*That is a losing strategy, General"
+END
+
+DIALOGEVENT:Taunts_BossChi022Subtitle
+"*You are not acting for the good of you people, General"
+END
+
+DIALOGEVENT:Taunts_BossChi023Subtitle
+"*I will give you a moments pause to consider your next move"
+END
+
+DIALOGEVENT:Taunts_BossChi024Subtitle
+"*A wise man knows when to retreat. Obviously you are not such a man"
+END
+
+DIALOGEVENT:Taunts_BossChi025Subtitle
+"*In the end, all fall before me"
+END
+
+DIALOGEVENT:Taunts_BossChi026Subtitle
+"*You cannot stand against my might"
+END
+
+DIALOGEVENT:Taunts_BossChi027Subtitle
+"*China cannot be defeated by one man"
+END
+
+DIALOGEVENT:Taunts_BossChi028Subtitle
+"*We shall mediate and consider our next move"
+END
+
+DIALOGEVENT:Taunts_BossChi029Subtitle
+"*Do not commit to a tactic you cannot support"
+END
+
+DIALOGEVENT:Taunts_BossChi030Subtitle
+"*Suicide is not a tactic, General"
+END
+
+DIALOGEVENT:Taunts_BossChi031Subtitle
+"*We sweep away your buildings like bamboo before a hurricane"
+END
+
+DIALOGEVENT:Taunts_BossChi032Subtitle
+"*Your men ran from the Barracks as we knocked it to the ground"
+END
+
+DIALOGEVENT:Taunts_BossChi033Subtitle
+"*A factory cannot produce war, General--and now your War Factory produces nothing"
+END
+
+DIALOGEVENT:Taunts_BossChi034Subtitle
+"*Your Air Field has been grounded, General"
+END
+
+DIALOGEVENT:Taunts_BossChi035Subtitle
+"*Your base defenses fall before us like blades of grass"
+END
+
+DIALOGEVENT:Taunts_BossChi036Subtitle
+"*We've destroyed your Command Center, so where are you hiding now, General?"
+END
+
+DIALOGEVENT:Taunts_BossChi037Subtitle
+"*So many of your buildings have fallen that I would have expected you to surrender by now"
+END
+
+DIALOGEVENT:Taunts_BossChi038Subtitle
+"*Don't think you can destroy my Barracks without feeling my wraith, General"
+END
+
+DIALOGEVENT:Taunts_BossChi039Subtitle
+"*I'll have to rebuild that War Factory now. You would be wise to exploit my momentary weakness�it won't last"
+END
+
+DIALOGEVENT:Taunts_BossChi040Subtitle
+"*Dozers: Rebuild the Air Field before our MiGs return!"
+END
+
+DIALOGEVENT:Taunts_BossChi041Subtitle
+"*Our defenses are cracking! Repel the invaders!"
+END
+
+DIALOGEVENT:Taunts_BossChi042Subtitle
+"*That is quite enough destruction, General. Now it is my turn"
+END
+
+DIALOGEVENT:Taunts_BossChi043Subtitle
+"*You can claim my Command Center, but this battle isn't over, General"
+END
+
+DIALOGEVENT:Taunts_BossChi044Subtitle
+"*We will avenge all those MiGs you've destroyed, General"
+END
+
+DIALOGEVENT:Taunts_BossChi045Subtitle
+"*The price of this war is too high, General. Now it is time for you to pay"
+END
+
+DIALOGEVENT:Taunts_BossChi046Subtitle
+"*China's infantry is plentiful, but too many have been sacrificed. Now I will return your cruelty ten-fold"
+END
+
+DIALOGEVENT:Taunts_BossChi047Subtitle
+"*Capture all the oil you wish--you will not have time to reap the rewards"
+END
+
+DIALOGEVENT:Taunts_BossChi048Subtitle
+"*That Artillery Platform can easily be avoided, General"
+END
+
+DIALOGEVENT:Taunts_BossChi049Subtitle
+"*Seeking to increase your efficiency with that Oil Refinery, General? A solid strategy would have served you better"
+END
+
+DIALOGEVENT:Taunts_BossChi050Subtitle
+"*Something stirs at the edge of my base"
+END
+
+DIALOGEVENT:Taunts_BossChi051Subtitle
+"*I see you approaching my base, General"
+END
+
+DIALOGEVENT:Taunts_BossChi052Subtitle
+"*You will not live to regret entering my base, General"
+END
+
+DIALOGEVENT:Taunts_BossChi053Subtitle
+"*You forces may enter my base, but they will never leave again"
+END
+
+DIALOGEVENT:Taunts_BossChi054Subtitle
+"*Those resources are under my protection, General"
+END
+
+DIALOGEVENT:Taunts_BossChi055Subtitle
+"*Why do you insist on attacking from the flanks?"
+END
+
+DIALOGEVENT:Taunts_BossChi056Subtitle
+"*Interesting attack, General, but it will not succeed against me"
+END
+
+DIALOGEVENT:Taunts_BossChi057Subtitle
+"*A brave attack, General, but bravery alone will not defeat me"
+END
+
+DIALOGEVENT:Taunts_BossChi058Subtitle
+"*That is a fools tactic, General"
+END
+
+DIALOGEVENT:Taunts_BossChi059Subtitle
+"*Leave this place before you anger me"
+END
+
+DIALOGEVENT:Taunts_BossChi060Subtitle
+"*I can see what you are doing, General. I will not allow it"
+END
+
+DIALOGEVENT:Taunts_BossChi061Subtitle
+"*Run away from here, General, before I unleash the horde on you"
+END
+
+DIALOGEVENT:Taunts_BossChi062Subtitle
+"*We are approaching your base, General. What is your defense?"
+END
+
+DIALOGEVENT:Taunts_BossChi063Subtitle
+"*Are you prepared for our attack, General? We shall see"
+END
+
+DIALOGEVENT:Taunts_BossChi064Subtitle
+"*Your defenses are inadequate, General"
+END
+
+DIALOGEVENT:Taunts_BossChi065Subtitle
+"*Now we will begin leveling your base, General"
+END
+
+DIALOGEVENT:Taunts_BossChi066Subtitle
+"*Your resources will soon be mine"
+END
+
+DIALOGEVENT:Taunts_BossChi067Subtitle
+"*I claim this Oil Derrick for China"
+END
+
+DIALOGEVENT:Taunts_BossChi068Subtitle
+"*Your flanks are exposed, General. Fatal mistake"
+END
+
+DIALOGEVENT:Taunts_BossChi069Subtitle
+"*You have allowed my forces to subvert your defenses. Now we will finish you"
+END
+
+DIALOGEVENT:Taunts_BossChi070Subtitle
+"*You have allowed your power to drop, General. Pray that isn't a fatal mistake"
+END
+
+DIALOGEVENT:Taunts_BossChi071Subtitle
+"*Without power you won't be able to defend your base, General"
+END
+
+DIALOGEVENT:Taunts_BossChi072Subtitle
+"*You have exhausted your resources, General. It is time to admit defeat"
+END
+
+DIALOGEVENT:Taunts_BossChi073Subtitle
+"*You have taxed my resources, General. Now I will come and take yours"
+END
+
+DIALOGEVENT:Taunts_BossChi074Subtitle
+"*The Scud Strom is a cowardly weapon, General. I thought more of you"
+END
+
+DIALOGEVENT:Taunts_BossChi075Subtitle
+"*You are forcing me to answer with a Nuclear Silo of my own, General"
+END
+
+DIALOGEVENT:Taunts_BossChi076Subtitle
+"*That Particle Cannon is a formidable weapon, but it cannot stop China"
+END
+
+DIALOGEVENT:Taunts_BossChi077Subtitle
+"*So many defenses�I see you have proper respect for your enemy"
+END
+
+DIALOGEVENT:Taunts_BossChi078Subtitle
+"*You cannot build more tanks than China, General"
+END
+
+DIALOGEVENT:Taunts_BossChi079Subtitle
+"*We will match you planes in the air, General. Your superiority will be only in your mind"
+END
+
+DIALOGEVENT:Taunts_BossChi080Subtitle
+"*Your men are outnumbered, General. Do not try to make a greater horde than China"
+END
+
+DIALOGEVENT:Taunts_BossChi081Subtitle
+"*Your base grows large, General�ripe for a nuclear strike"
+END
+
+DIALOGEVENT:Taunts_BossChi082Subtitle
+"*Red Guard, scatter! Scud missiles inbound!"
+END
+
+DIALOGEVENT:Taunts_BossChi083Subtitle
+"*We are immune to your nuclear missiles, General"
+END
+
+DIALOGEVENT:Taunts_BossChi084Subtitle
+"*No! Your particle beam will only injure us--we will not forget this, General"
+END
+
+DIALOGEVENT:Taunts_BossChi085Subtitle
+"*Hide in those buildings, General. Perhaps a Dragon Tank will come to visit you"
+END
+
+DIALOGEVENT:Taunts_BossChi086Subtitle
+"*Colonel Burton's exploits are legendary, but he is only one man, General"
+END
+
+DIALOGEVENT:Taunts_BossChi087Subtitle
+"*I see you have corrupted one of our Black Lotus agents. Her training will not turn the battle to your favor, General"
+END
+
+DIALOGEVENT:Taunts_BossChi088Subtitle
+"*The sniper Kell enters our battle. Do not count on his stealth to save you, General"
+END
+
+DIALOGEVENT:Taunts_BossChi089Subtitle
+"*You are foolish to build an Air Field, General. Only tanks can save you from me"
+END
+
+DIALOGEVENT:Taunts_BossChi090Subtitle
+"*You are wise to build a War Factory, General"
+END
+
+DIALOGEVENT:Taunts_BossChi091Subtitle
+"*That Barracks is only the beginning of what you will need to defeat me, General"
+END
+
+DIALOGEVENT:Taunts_BossChi092Subtitle
+"*If you are going to sell your buildings, why do you bother constructing them?"
+END
+
+DIALOGEVENT:Taunts_BossChi093Subtitle
+"*You will not defeat me this easily, General"
+END
+
+DIALOGEVENT:Taunts_BossChi094Subtitle
+"*Your advantage will not hold"
+END
+
+DIALOGEVENT:Taunts_BossChi095Subtitle
+"*I will not be beaten by the likes of you, General"
+END
+
+DIALOGEVENT:Taunts_BossChi096Subtitle
+"*This is not the end, General. I will recover from this"
+END
+
+DIALOGEVENT:Taunts_BossChi097Subtitle
+"*I must acknowledge this defeat. You have shown superior tactics, General"
+END
+
+DIALOGEVENT:Taunts_BossChi098Subtitle
+"*My superior tactics are leading to your defeat, General"
+END
+
+DIALOGEVENT:Taunts_BossChi099Subtitle
+"*You are losing this battle, General. Better to accept defeat honorably than to fight on"
+END
+
+DIALOGEVENT:Taunts_BossChi100Subtitle
+"*The end is drawing near for you, General"
+END
+
+DIALOGEVENT:Taunts_BossChi101Subtitle
+"*Why do you resist the inevitable, General?"
+END
+
+DIALOGEVENT:Taunts_BossChi102Subtitle
+"*The shadow of the dragon signals the beginning of your defeat, General"
+END
+
+DIALOGEVENT:Taunts_BossChi103Subtitle
+"*It is time to accept your defeat, General"
+END
+
+DIALOGEVENT:Taunts_BossChi104Subtitle
+"*It is time for the dragon to rise again"
+END
+
+DIALOGEVENT:Taunts_BossChi105Subtitle
+"*There is no shame in accepting your weakness"
+END
+
+DIALOGEVENT:Taunts_BossChi106Subtitle
+"*You are not ready to face me. Return when your training is complete"
+END
+
+DIALOGEVENT:Taunts_BossChi107Subtitle
+"*Why do you run towards your own demise?"
+END
+
+DIALOGEVENT:Taunts_BossChi108Subtitle
+"*This has been an interesting contest. Perhaps you will challenge me again"
+END
+
+DIALOGEVENT:Taunts_BossChi109Subtitle
+"*Improve your skills and challenge me again"
+END
+
+DIALOGEVENT:Taunts_BossChi110Subtitle
+"*Welcome, General. I hope you are prepared to face me"
+END
+
+DIALOGEVENT:Taunts_BossChi111Subtitle
+"*Your victories speak well of your ability, but my generals did not have my cunning or experience"
+END
+
+DIALOGEVENT:Taunts_BossChi112Subtitle
+"*Soon you will see what it is to face the dragon"
+END
+
+DIALOGEVENT:Taunts_BossGLA001Subtitle
+"*Most enemies would have flee from the sight of my armies. Perhaps this will be worthwhile after all"
+END
+
+DIALOGEVENT:Taunts_BossGLA002Subtitle
+"*My forces descend on you like the wind, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA003Subtitle
+"*Your men are like sheep before my warriors"
+END
+
+DIALOGEVENT:Taunts_BossGLA004Subtitle
+"*Look at all the wonderful toys you have brought to me. I broke all my toys as a child, General, and now I will break yours"
+END
+
+DIALOGEVENT:Taunts_BossGLA005Subtitle
+"*Your forces fall like wheat before my sword"
+END
+
+DIALOGEVENT:Taunts_BossGLA006Subtitle
+"*You have done well against my Generals, but I have all of their power combined. What will you do against that, General?"
+END
+
+DIALOGEVENT:Taunts_BossGLA007Subtitle
+"*You will never even see my forces, General�until it is too late"
+END
+
+DIALOGEVENT:Taunts_BossGLA008Subtitle
+"*We will sweep you from our lands, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA009Subtitle
+"*Now you will see what your useless invasion has brought you, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA010Subtitle
+"*You have dared to challenge me--now you will reap the terrible reward"
+END
+
+DIALOGEVENT:Taunts_BossGLA011Subtitle
+"*How do you feel, General, as the horsemen ride to your doorstep?"
+END
+
+DIALOGEVENT:Taunts_BossGLA012Subtitle
+"*You've had your chance to retreat, now we will annihilate you"
+END
+
+DIALOGEVENT:Taunts_BossGLA013Subtitle
+"*Bear witness to the power of my will, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA014Subtitle
+"*My rage will tear your war-machine to dust"
+END
+
+DIALOGEVENT:Taunts_BossGLA015Subtitle
+"*Toxin�explosives�stealth�Any one of these you have defeated, but all three? All is lost, General. You should surrender�for the good of your men"
+END
+
+DIALOGEVENT:Taunts_BossGLA016Subtitle
+"*Your world has made you soft, General. Mine has made me strong�"
+END
+
+DIALOGEVENT:Taunts_BossGLA017Subtitle
+"*You will learn to respect my power, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA018Subtitle
+"*You will pause while I build my next attack, then the battle will resume"
+END
+
+DIALOGEVENT:Taunts_BossGLA019Subtitle
+"*Have you grown tired dying against my defenses, General?"
+END
+
+DIALOGEVENT:Taunts_BossGLA020Subtitle
+"*The battlefield is quiet, General. Are you waiting for me to finish this?"
+END
+
+DIALOGEVENT:Taunts_BossGLA021Subtitle
+"*We await your next pathetic attack with great anticipation"
+END
+
+DIALOGEVENT:Taunts_BossGLA022Subtitle
+"*Has this been the extent of your power, General? Truly pathetic"
+END
+
+DIALOGEVENT:Taunts_BossGLA023Subtitle
+"*Your attacks have been like pathetic screams amidst the howl of a raging storm"
+END
+
+DIALOGEVENT:Taunts_BossGLA024Subtitle
+"*This battle is beginning to bore me, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA025Subtitle
+"*How much longer should I let you live, General?"
+END
+
+DIALOGEVENT:Taunts_BossGLA026Subtitle
+"*General, my subject require my attention�how much longer do you intend to dance around like a clown?"
+END
+
+DIALOGEVENT:Taunts_BossGLA027Subtitle
+"*General, your tactics remind me of a child learning to play chess"
+END
+
+DIALOGEVENT:Taunts_BossGLA028Subtitle
+"*Are you done, General? Have you exhausted your pathetic resources?"
+END
+
+DIALOGEVENT:Taunts_BossGLA029Subtitle
+"*General, I was bored minutes ago--now I'm beginning to fall asleep"
+END
+
+DIALOGEVENT:Taunts_BossGLA030Subtitle
+"*How does it feel to challenge a true military genius?"
+END
+
+DIALOGEVENT:Taunts_BossGLA031Subtitle
+"*Anything you gain I will destroy"
+END
+
+DIALOGEVENT:Taunts_BossGLA032Subtitle
+"*Now your Barracks falls--soon all shall fall"
+END
+
+DIALOGEVENT:Taunts_BossGLA033Subtitle
+"*Your War Factory is lost--rebuild it and I'll destroy it again"
+END
+
+DIALOGEVENT:Taunts_BossGLA034Subtitle
+"*I have relieved you of your Air Field, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA035Subtitle
+"*Your base defenses cannot stop my forces, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA036Subtitle
+"* General, if you cannot even hold on to your Command Center, how do you hope to defeat me?"
+END
+
+DIALOGEVENT:Taunts_BossGLA037Subtitle
+"*So many of your structures have fallen, General--why not retreat the field and spare yourself any further embarrassment?"
+END
+
+DIALOGEVENT:Taunts_BossGLA038Subtitle
+"*Do not test my patience further by destroying any more of my Oil Derricks, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA039Subtitle
+"*You dare to destroy my Barracks, General?!"
+END
+
+DIALOGEVENT:Taunts_BossGLA040Subtitle
+"*General, I require an Arms Dealer to do my business. Do not destroy another one"
+END
+
+DIALOGEVENT:Taunts_BossGLA041Subtitle
+"*You think to crush my defenses, General? More will rise in their place"
+END
+
+DIALOGEVENT:Taunts_BossGLA042Subtitle
+"*That is the last building you will destroy, General. My patience has limits"
+END
+
+DIALOGEVENT:Taunts_BossGLA043Subtitle
+"*My Command Center! You have forced me to retreat underground, but this isn't over yet, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA044Subtitle
+"*You have destroyed many of my machine, General. Perhaps I underestimated you"
+END
+
+DIALOGEVENT:Taunts_BossGLA045Subtitle
+"*My men are not targets for your practice, General. Their blood is on your hands"
+END
+
+DIALOGEVENT:Taunts_BossGLA046Subtitle
+"*Release my Oil Derrick or I will burn it down"
+END
+
+DIALOGEVENT:Taunts_BossGLA047Subtitle
+"*I see you've captured that derelict Artillery Platform. Best of luck making it work"
+END
+
+DIALOGEVENT:Taunts_BossGLA048Subtitle
+"*That Oil Refinery will not turn the tide to your favor, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA049Subtitle
+"*Impudent fool! You have invaded into my home far enough"
+END
+
+DIALOGEVENT:Taunts_BossGLA050Subtitle
+"*You are like a stinging insect, General, and it is time to squash your annoying presence"
+END
+
+DIALOGEVENT:Taunts_BossGLA051Subtitle
+"*The enemy is in our presence! Destroy him! Destroy them all!"
+END
+
+DIALOGEVENT:Taunts_BossGLA052Subtitle
+"*Fool! You have crossed the line! Your forces are forfeit!"
+END
+
+DIALOGEVENT:Taunts_BossGLA053Subtitle
+"*Ah, a flanking attack�crude, but at least it is a strategy"
+END
+
+DIALOGEVENT:Taunts_BossGLA054Subtitle
+"*Attempting to attack my back-door, General?"
+END
+
+DIALOGEVENT:Taunts_BossGLA055Subtitle
+"*A frontal attack? You should have brought more forces"
+END
+
+DIALOGEVENT:Taunts_BossGLA056Subtitle
+"*I see you've found my extra supplies�and I stress, my extra supplies. Leave them now"
+END
+
+DIALOGEVENT:Taunts_BossGLA057Subtitle
+"*Approaching my base from that path will only lead you to death"
+END
+
+DIALOGEVENT:Taunts_BossGLA058Subtitle
+"*Stay out of that village, General. I protect those under my care"
+END
+
+DIALOGEVENT:Taunts_BossGLA059Subtitle
+"*Those resources are for my people, General. They are not your for the taking"
+END
+
+DIALOGEVENT:Taunts_BossGLA060Subtitle
+"*Those buildings were not placed here for your use, General. Do not disrupt my infrastructure"
+END
+
+DIALOGEVENT:Taunts_BossGLA061Subtitle
+"*It seems you appetite has overstretched your resources, General. I hope you get your power back up before we reach your base"
+END
+
+DIALOGEVENT:Taunts_BossGLA062Subtitle
+"*Our land is without power�too bad your base cannot run without its dependence"
+END
+
+DIALOGEVENT:Taunts_BossGLA063Subtitle
+"*Out of funds, General?"
+END
+
+DIALOGEVENT:Taunts_BossGLA064Subtitle
+"*General, you are taxing my resources. Your little war will cause my people to go hungry"
+END
+
+DIALOGEVENT:Taunts_BossGLA065Subtitle
+"*A Scud Storm?! You have stolen our technology! You will pay for this, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA066Subtitle
+"*Building nuclear weapons, General? I figured you would resort to such cowardice"
+END
+
+DIALOGEVENT:Taunts_BossGLA067Subtitle
+"*Particle Cannon? Your beams from space cannot reach us beneath the earth"
+END
+
+DIALOGEVENT:Taunts_BossGLA068Subtitle
+"*So many base defenses. You must truly fear my power, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA069Subtitle
+"*How many tanks do you require, General?"
+END
+
+DIALOGEVENT:Taunts_BossGLA070Subtitle
+"*You fill the air with those annoying gnats. Now we will swat them down"
+END
+
+DIALOGEVENT:Taunts_BossGLA071Subtitle
+"*Train all the men you wish, General, but the loss of life will only grow greater by the minute"
+END
+
+DIALOGEVENT:Taunts_BossGLA072Subtitle
+"*Your base has grown large, General�perhaps too large"
+END
+
+DIALOGEVENT:Taunts_BossGLA073Subtitle
+"*Launch your toxins at us, General; we have prepared for much worse"
+END
+
+DIALOGEVENT:Taunts_BossGLA074Subtitle
+"*Everyone, underground! Their nuclear missiles approach"
+END
+
+DIALOGEVENT:Taunts_BossGLA075Subtitle
+"*Yes, use your particle beam--show the world your cowardice"
+END
+
+DIALOGEVENT:Taunts_BossGLA076Subtitle
+"*Garrison the building, General--hide like rats in a wall"
+END
+
+DIALOGEVENT:Taunts_BossGLA077Subtitle
+"*Colonel Burton will not save you, General. You'll have to fight this war yourself"
+END
+
+DIALOGEVENT:Taunts_BossGLA078Subtitle
+"*Ah, the beautiful Black Lotus. Join me, Lotus, and you could like as a queen"
+END
+
+DIALOGEVENT:Taunts_BossGLA079Subtitle
+"*Jarmen Kell? He dares to stand against me?! My vengeance will be most�unpleasant"
+END
+
+DIALOGEVENT:Taunts_BossGLA080Subtitle
+"*Your Air Field will not stand against my assault, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA081Subtitle
+"*Finally built a War Factory, eh General? What took you so long?"
+END
+
+DIALOGEVENT:Taunts_BossGLA082Subtitle
+"*Your pathetic Barracks will be of no use to you, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA083Subtitle
+"*Selling off your buildings to fund your army? Hardly seems logical, does it, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA084Subtitle
+"*This is impossible! You cannot defeat me!"
+END
+
+DIALOGEVENT:Taunts_BossGLA085Subtitle
+"*You may think you have the upper-hand, but this battle will turn like the wind"
+END
+
+DIALOGEVENT:Taunts_BossGLA086Subtitle
+"*Your soldiers may outnumber mine now, but battles are won by more than numbers, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA087Subtitle
+"*I can't believe that I'm being beaten by such a weak-minded fool. The shame will mark me forever"
+END
+
+DIALOGEVENT:Taunts_BossGLA088Subtitle
+"*Defeated by a fool�the humiliation is too great to bear�please leave me to my torment"
+END
+
+DIALOGEVENT:Taunts_BossGLA089Subtitle
+"*General, I smell the stench of fear and desperation coming from you base"
+END
+
+DIALOGEVENT:Taunts_BossGLA090Subtitle
+"* I sense the time of your demise growing near, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA091Subtitle
+"*Your forces are beginning to be overrun, General. Soon they will be my prisoners"
+END
+
+DIALOGEVENT:Taunts_BossGLA092Subtitle
+"*We are kicking you like a wounded goat, General. Admit defeat to spare your agony"
+END
+
+DIALOGEVENT:Taunts_BossGLA093Subtitle
+"*You are defeated. This is what happens to all who stand against me , General"
+END
+
+DIALOGEVENT:Taunts_BossGLA094Subtitle
+"*You are a fool to challenge me, General"
+END
+
+DIALOGEVENT:Taunts_BossGLA095Subtitle
+"*All the powers of the GLA are at my disposal"
+END
+
+DIALOGEVENT:Taunts_BossGLA096Subtitle
+"*I am more dangerous than all my three Generals combined"
+END
+
+DIALOGEVENT:Taunts_BossGLA097Subtitle
+"*You have won, General. Why do you continue to torture me by examining these statistics?"
+END
+
+DIALOGEVENT:Taunts_BossGLA098Subtitle
+"*Yes, you can now see why you have lost�the numbers speak for themselves"
+END
+
+DIALOGEVENT:Taunts_BossGLA099Subtitle
+"*You have traveled far and faced many opponents to reach me General"
+END
+
+DIALOGEVENT:Taunts_BossGLA100Subtitle
+"*I commend your efforts, but they have wholly unprepared you for what you are about to face"
+END
+
+DIALOGEVENT:Taunts_BossGLA101Subtitle
+"*You have faced Dr. Thrax's toxic warriors; Kassad's stealth legions and Juhziz's demolitions, but I taught them all in the art of war"
+END
+
+DIALOGEVENT:Taunts_BossGLA102Subtitle
+"*This will be your final battle, General. May whatever gods you pray to have mercy on you�because I will not"
+END
+
+DIALOGEVENT:Taunts_BossGLA103Subtitle
+"*This will be your final battle, General. Make your peace and prepare for the end"
+END
+
+DIALOGEVENT:Taunts_BossUSA001Subtitle
+"*Well, there you are. Too late to run now, Boy"
+END
+
+DIALOGEVENT:Taunts_BossUSA002Subtitle
+"*I hope you're ready, cause we're coming for ya"
+END
+
+DIALOGEVENT:Taunts_BossUSA003Subtitle
+"*Set the table, Kid, cause we're coming for dinner"
+END
+
+DIALOGEVENT:Taunts_BossUSA004Subtitle
+"*I've got three things to teach you, Kid: How to lose; how to cry; and how to die"
+END
+
+DIALOGEVENT:Taunts_BossUSA005Subtitle
+"*We're coming to attack soon, so get out all your white flags"
+END
+
+DIALOGEVENT:Taunts_BossUSA006Subtitle
+"*Here we come, Kid�try not to wet yourself, okay?"
+END
+
+DIALOGEVENT:Taunts_BossUSA007Subtitle
+"*What part of "die" didn't you understand?"
+END
+
+DIALOGEVENT:Taunts_BossUSA008Subtitle
+"*Ooh, you're going to get it now, Kid"
+END
+
+DIALOGEVENT:Taunts_BossUSA009Subtitle
+"*You ready? Cause here comes a tactic you may have learned in school. You ready to go back to school?"
+END
+
+DIALOGEVENT:Taunts_BossUSA010Subtitle
+"*It's time for me to teach you a thing or two about the back of my hand"
+END
+
+DIALOGEVENT:Taunts_BossUSA011Subtitle
+"*You should have run when you had the chance. Now I'm going to teach you the meaning of respect"
+END
+
+DIALOGEVENT:Taunts_BossUSA012Subtitle
+"*So, about your funeral�open casket or closed?"
+END
+
+DIALOGEVENT:Taunts_BossUSA013Subtitle
+"*I'm gonna march into your base and plant my foot in your butt, <sarcastic> "General.""
+END
+
+DIALOGEVENT:Taunts_BossUSA014Subtitle
+"*Here we come, Punk--step aside or get stepped on"
+END
+
+DIALOGEVENT:Taunts_BossUSA015Subtitle
+"*You call yourself a "General"? I call you a pain in the butt, is what I call you"
+END
+
+DIALOGEVENT:Taunts_BossUSA016Subtitle
+"*This is your idea of strategy? Of tactics? "Tank blob" is the best you can come up with? Pathetic�just pathetic�"
+END
+
+DIALOGEVENT:Taunts_BossUSA017Subtitle
+"*Yeah, I've read Sun Tzu too, Sport: "Greater enemy--retreat. Smaller enemy--attack." Is that all you got for me?"
+END
+
+DIALOGEVENT:Taunts_BossUSA018Subtitle
+"*So, where's your army, Boy? Or did you just want to bare-knuckle it? Cause I'll slap you down with my bare hands if you want. You want a piece of that, Boy?"
+END
+
+DIALOGEVENT:Taunts_BossUSA019Subtitle
+"*You got me out of bed for this? I aught to take you over my knee right now"
+END
+
+DIALOGEVENT:Taunts_BossUSA020Subtitle
+"*I got more medals than you've got teeth, Boy�which won't be saying much after I get done knocking them out for you"
+END
+
+DIALOGEVENT:Taunts_BossUSA021Subtitle
+"*Are you putting all of your defenses at the front of your base? You don't think we can go around that? Well, do you?"
+END
+
+DIALOGEVENT:Taunts_BossUSA022Subtitle
+"*Boy, you think I'm playing with you? You better think again"
+END
+
+DIALOGEVENT:Taunts_BossUSA023Subtitle
+"*Better check your flanks there, Partner; I think some of my troops just snuck into your base"
+END
+
+DIALOGEVENT:Taunts_BossUSA024Subtitle
+"*Do you think this is a game? Well do you? Wait, don't answer that"
+END
+
+DIALOGEVENT:Taunts_BossUSA025Subtitle
+"*Kid, who taught you military tactics? Huh? Cause you should go slap him square in the mouth, I tell you"
+END
+
+DIALOGEVENT:Taunts_BossUSA026Subtitle
+"*I have the whole United States military behind me, Son, and I've just decided that we don't like you"
+END
+
+DIALOGEVENT:Taunts_BossUSA027Subtitle
+"*Is this tactic of yours supposed to be some kind of joke I'm not aware of?"
+END
+
+DIALOGEVENT:Taunts_BossUSA028Subtitle
+"*So, you're not a real general, are you? You're like the Surgeon General or something like that, right?"
+END
+
+DIALOGEVENT:Taunts_BossUSA029Subtitle
+"*Does your mommy know you're out by yourself?"
+END
+
+DIALOGEVENT:Taunts_BossUSA030Subtitle
+"*You can tell me.. We're just Generals here� Do your men know you're incompetent?"
+END
+
+DIALOGEVENT:Taunts_BossUSA031Subtitle
+"*Did you know you just lost a Tech Building, Sport?"
+END
+
+DIALOGEVENT:Taunts_BossUSA032Subtitle
+"*Just blew-up your Barracks, Skippy. What you gonna do about it?"
+END
+
+DIALOGEVENT:Taunts_BossUSA033Subtitle
+"*There goes your War Factory. You mad yet, Boy?"
+END
+
+DIALOGEVENT:Taunts_BossUSA034Subtitle
+"*I don't know why you bothered to build that Air Field if you aren't going to protect it"
+END
+
+DIALOGEVENT:Taunts_BossUSA035Subtitle
+"*Who put these base defenses down like this? They can't defend anything like that"
+END
+
+DIALOGEVENT:Taunts_BossUSA036Subtitle
+"*I should let you build another Command Center just so I could knock it down again"
+END
+
+DIALOGEVENT:Taunts_BossUSA037Subtitle
+"*I feel like I'm kicking over sand castles. How many of your buildings you gonna let me destroy there, Sport?"
+END
+
+DIALOGEVENT:Taunts_BossUSA038Subtitle
+"*I let you have that Tech Building, Boy. I don't need it to beat you"
+END
+
+DIALOGEVENT:Taunts_BossUSA039Subtitle
+"*Kid, that Barracks was not a military target. Do that again and this will get ugly"
+END
+
+DIALOGEVENT:Taunts_BossUSA040Subtitle
+"*You better stand down, Son--I'm not going to stand for you blowing-up my War Factories, you hear?"
+END
+
+DIALOGEVENT:Taunts_BossUSA041Subtitle
+"*Do you know how much those jets cost? I coulda fed the whole world with what you just destroyed"
+END
+
+DIALOGEVENT:Taunts_BossUSA042Subtitle
+"*Cracking my defenses, huh? Well, go on--it should be me just enough time to overrun your base"
+END
+
+DIALOGEVENT:Taunts_BossUSA043Subtitle
+"*That's enough buildings, Son. Why don't you try attacking my forces now"
+END
+
+DIALOGEVENT:Taunts_BossUSA044Subtitle
+"*My Command Center?! You think I'm just going to sit here and take that?"
+END
+
+DIALOGEVENT:Taunts_BossUSA045Subtitle
+"*You had best leave my pilots alone, Boy. Planes are one thing, but you let my pilots return safe, you hear?"
+END
+
+DIALOGEVENT:Taunts_BossUSA046Subtitle
+"*You're a sneaky little 'cuss, aren't you? But I think that's enough of my vehicles destroyed, don't you?"
+END
+
+DIALOGEVENT:Taunts_BossUSA047Subtitle
+"*Let's get armor and air support out there--our grunts are getting torn apart!"
+END
+
+DIALOGEVENT:Taunts_BossUSA048Subtitle
+"*Let that Oil Derrick go, Boy. This war ain't about the price of gas you know"
+END
+
+DIALOGEVENT:Taunts_BossUSA049Subtitle
+"*Think you know how to use that Artillery Platform, Son?"
+END
+
+DIALOGEVENT:Taunts_BossUSA050Subtitle
+"*That Oil Refinery is not a viable target, Son. And it don't belong to you, so we're coming to get it back"
+END
+
+DIALOGEVENT:Taunts_BossUSA051Subtitle
+"*Well, you managed to get to my side of the map. Didn't think you had it in ya"
+END
+
+DIALOGEVENT:Taunts_BossUSA052Subtitle
+"*You planning to attack, or you just going to stand out there all day?"
+END
+
+DIALOGEVENT:Taunts_BossUSA053Subtitle
+"*You'll get out of my base if you know what's good for you, Boy"
+END
+
+DIALOGEVENT:Taunts_BossUSA054Subtitle
+"*Enemy's in our perimeter--all forces repel the invaders"
+END
+
+DIALOGEVENT:Taunts_BossUSA055Subtitle
+"*Those ain't your supplies, Sport. Best to step-off now, before you get hurt"
+END
+
+DIALOGEVENT:Taunts_BossUSA056Subtitle
+"*A flanking attack?! Don't make me laugh, Boy"
+END
+
+DIALOGEVENT:Taunts_BossUSA057Subtitle
+"*Trying to attack from my back-door? Good luck with that"
+END
+
+DIALOGEVENT:Taunts_BossUSA058Subtitle
+"*You coming to attack me, Boy? Nice to see you have some guts"
+END
+
+DIALOGEVENT:Taunts_BossUSA059Subtitle
+"*Get away from my Tech buildings, if you know what's good for you"
+END
+
+DIALOGEVENT:Taunts_BossUSA060Subtitle
+"*My forces have your base in sight, Kid. What you gonna do now?"
+END
+
+DIALOGEVENT:Taunts_BossUSA061Subtitle
+"*Here comes the hammer, Punk, and you don't want to be the nail"
+END
+
+DIALOGEVENT:Taunts_BossUSA062Subtitle
+"*Knock-knock, we're coming in!"
+END
+
+DIALOGEVENT:Taunts_BossUSA063Subtitle
+"*Things are about to get real bad for you, Sport. Don't say I didn't warn you"
+END
+
+DIALOGEVENT:Taunts_BossUSA064Subtitle
+"*So, here's where you're hiding your resources. Mind if I take a few?"
+END
+
+DIALOGEVENT:Taunts_BossUSA065Subtitle
+"*You're flank's wide open, Sport"
+END
+
+DIALOGEVENT:Taunts_BossUSA066Subtitle
+"*Maybe we'll come in your back-door. Whadda you think about that?"
+END
+
+DIALOGEVENT:Taunts_BossUSA067Subtitle
+"*Look out, we're coming through the front-door!"
+END
+
+DIALOGEVENT:Taunts_BossUSA068Subtitle
+"*What do we have here?"
+END
+
+DIALOGEVENT:Taunts_BossUSA069Subtitle
+"*Well, look at this"
+END
+
+DIALOGEVENT:Taunts_BossUSA070Subtitle
+"*What did you plan to do without power? I can't wait to see this strategy"
+END
+
+DIALOGEVENT:Taunts_BossUSA071Subtitle
+"*You better pay you power bill or we're going to have to postpone this fight"
+END
+
+DIALOGEVENT:Taunts_BossUSA072Subtitle
+"*You're out of resources? Boy, you don't start the dance if you can't pay the bill"
+END
+
+DIALOGEVENT:Taunts_BossUSA073Subtitle
+"*Uh-oh, looks like we're going to have to do some deficit spending"
+END
+
+DIALOGEVENT:Taunts_BossUSA074Subtitle
+"*Built yourself a Scud Storm there? You can't hit the side of a barn with a scud, don't you know that?"
+END
+
+DIALOGEVENT:Taunts_BossUSA075Subtitle
+"*Bringing out your nukes, huh? If Washington hadn't tied my hands, I'd show you some nukes, I tell you"
+END
+
+DIALOGEVENT:Taunts_BossUSA076Subtitle
+"*How'd you get a Particle Cannon, Son? That's supposed to me top-secret"
+END
+
+DIALOGEVENT:Taunts_BossUSA077Subtitle
+"*So many base defenses. I can just smell the fear coming off you, Boy"
+END
+
+DIALOGEVENT:Taunts_BossUSA078Subtitle
+"*Oh, look at this�here comes the tank blob. Not gonna work against me, Son"
+END
+
+DIALOGEVENT:Taunts_BossUSA079Subtitle
+"*That's a lot of expensive planes you're putting in the air, Kid. Sure you wanna spend that money?"
+END
+
+DIALOGEVENT:Taunts_BossUSA080Subtitle
+"*Hope all those grunts know what you're getting them into"
+END
+
+DIALOGEVENT:Taunts_BossUSA081Subtitle
+"*That's a lot of buildings, Son. You know that buildings can't fight for you, right?"
+END
+
+DIALOGEVENT:Taunts_BossUSA082Subtitle
+"*Bring the scuds, Punk--I'll show you the storm"
+END
+
+DIALOGEVENT:Taunts_BossUSA083Subtitle
+"*You're going to regret nuking me, Kid. I don't take kindly to that"
+END
+
+DIALOGEVENT:Taunts_BossUSA084Subtitle
+"*Using a particle beam, eh? You better put me away with that cause you won't like my counter-attack"
+END
+
+DIALOGEVENT:Taunts_BossUSA085Subtitle
+"*You know, only a coward fights from inside buildings. You know that, right?"
+END
+
+DIALOGEVENT:Taunts_BossUSA086Subtitle
+"*Welcome, Colonel Burton. Sorry you had to get tied up in this thing. No hard feelings"
+END
+
+DIALOGEVENT:Taunts_BossUSA087Subtitle
+"*Black Lotus ain't your salvation, Boy. She ain't gonna get anywhere near my base"
+END
+
+DIALOGEVENT:Taunts_BossUSA088Subtitle
+"*Jarmen Kell's just another sniper, Punk. I've got dozens of snipers"
+END
+
+DIALOGEVENT:Taunts_BossUSA089Subtitle
+"*Yeah, build your Air Field--get some birds in the air. May be your only shot a stopping me"
+END
+
+DIALOGEVENT:Taunts_BossUSA090Subtitle
+"*Only one War Factory? It's gonna take at least half-a-dozen to stop me, Kid"
+END
+
+DIALOGEVENT:Taunts_BossUSA091Subtitle
+"*Is that Barracks a little close to the front-lines, Kid? Hard to sleep with bullets in your barracks"
+END
+
+DIALOGEVENT:Taunts_BossUSA092Subtitle
+"*Don't just sell one building, Boy--sell them all and hope that I don't come for you anyway"
+END
+
+DIALOGEVENT:Taunts_BossUSA093Subtitle
+"*Don't get cocky, Boy--this ain't over yet"
+END
+
+DIALOGEVENT:Taunts_BossUSA094Subtitle
+"*You may think you have the upper-hand, but I've got a few tricks left in me. You'll see"
+END
+
+DIALOGEVENT:Taunts_BossUSA095Subtitle
+"*I've dug myself outta worse holes than this, Punk. You ain't gonna win that easily"
+END
+
+DIALOGEVENT:Taunts_BossUSA096Subtitle
+"*You think you're beating me? You best think again"
+END
+
+DIALOGEVENT:Taunts_BossUSA097Subtitle
+"*Huh�I guess it's over. Nice work, Kid. I guess you took me down a peg or two"
+END
+
+DIALOGEVENT:Taunts_BossUSA098Subtitle
+"*Can you feel my fist starting to close around your neck, Punk?"
+END
+
+DIALOGEVENT:Taunts_BossUSA099Subtitle
+"*Don't take losing to me so hard--everyone loses to me, Kid"
+END
+
+DIALOGEVENT:Taunts_BossUSA100Subtitle
+"*Give me a sec to get some tanks together and I'll end this little skirmish"
+END
+
+DIALOGEVENT:Taunts_BossUSA101Subtitle
+"*Why don't you just give up now, <sarcastic> "General.""
+END
+
+DIALOGEVENT:Taunts_BossUSA102Subtitle
+"*Boy, I beat you like an old drum. Who gave you a command? Cause I've got some word for them"
+END
+
+DIALOGEVENT:Taunts_BossUSA103Subtitle
+"*Don't click that button unless you're serious, Boy"
+END
+
+DIALOGEVENT:Taunts_BossUSA104Subtitle
+"*You wanna tangle with me? I think you better think again, Kid"
+END
+
+DIALOGEVENT:Taunts_BossUSA105Subtitle
+"*Don't bring that attitude in here unless you can back it up, Punk"
+END
+
+DIALOGEVENT:Taunts_BossUSA106Subtitle
+"*Show me what you got"
+END
+
+DIALOGEVENT:Taunts_BossUSA107Subtitle
+"*Maybe you could make a few extra bucks polishing my boots, cause you sure ain't no general"
+END
+
+DIALOGEVENT:Taunts_BossUSA108Subtitle
+"*Good work, General. I salute you"
+END
+
+DIALOGEVENT:Taunts_BossUSA109Subtitle
+"*I ain't gonna give no speeches, so let's just get this on"
+END
+
+DIALOGEVENT:Taunts_Demo001Subtitle
+"*I have some surprises for you, General. Why don't you come out and play?"
+END
+
+DIALOGEVENT:Taunts_Demo002Subtitle
+"*Now that the field is covered with explosives, I suppose we'll attack"
+END
+
+DIALOGEVENT:Taunts_Demo003Subtitle
+"*General, I have a delivery for you�sign for it, won't you?"
+END
+
+DIALOGEVENT:Taunts_Demo004Subtitle
+"*Careful, who knows when Jarmen Kell will sneak into your base"
+END
+
+DIALOGEVENT:Taunts_Demo005Subtitle
+"*Did your building just blow up? Hmm�I wonder how that happened?"
+END
+
+DIALOGEVENT:Taunts_Demo006Subtitle
+"*All of my forces are packed with explosives, General. I wouldn't shoot at them if I were you"
+END
+
+DIALOGEVENT:Taunts_Demo007Subtitle
+"*My Terrorists have learned to disguise themselves as�oops, have I said too much?"
+END
+
+DIALOGEVENT:Taunts_Demo008Subtitle
+"*You might notice that my explosives pack a bit more punch�I hope you appreciate our attention to quality"
+END
+
+DIALOGEVENT:Taunts_Demo009Subtitle
+"*Look how quickly the Scud Launcher destroys a building now�just wait, it's amazing"
+END
+
+DIALOGEVENT:Taunts_Demo010Subtitle
+"*First, all is silence�then "boom!"�ahh�don't you just love it, General?"
+END
+
+DIALOGEVENT:Taunts_Demo011Subtitle
+"*I rarely attack, you should feel honored"
+END
+
+DIALOGEVENT:Taunts_Demo012Subtitle
+"*Here comes another attack, General"
+END
+
+DIALOGEVENT:Taunts_Demo013Subtitle
+"*My troops are coming to assault your base�make them feel welcome"
+END
+
+DIALOGEVENT:Taunts_Demo014Subtitle
+"*Please ignore my workers, General; they're just burying some�umm�garbage for me"
+END
+
+DIALOGEVENT:Taunts_Demo015Subtitle
+"*Oh, General, you must see this�it's the bomb. <childish laugh>"
+END
+
+DIALOGEVENT:Taunts_Demo016Subtitle
+"*We're going out for more explosives, General. Be right back"
+END
+
+DIALOGEVENT:Taunts_Demo017Subtitle
+"*It's quiet out there, General. You know what quiet means, right? BOOM!!!"
+END
+
+DIALOGEVENT:Taunts_Demo018Subtitle
+"*I am the master of explosives, General. You have no defense against me"
+END
+
+DIALOGEVENT:Taunts_Demo019Subtitle
+"*Your base has been targeted for demolition"
+END
+
+DIALOGEVENT:Taunts_Demo020Subtitle
+"*Do you fear my next attack, General? You should"
+END
+
+DIALOGEVENT:Taunts_Demo021Subtitle
+"*As we speak my agents are sneaking into your base and planting explosives"
+END
+
+DIALOGEVENT:Taunts_Demo022Subtitle
+"*Your building could be wired to explode right now. You'll never know until it's too late"
+END
+
+DIALOGEVENT:Taunts_Demo023Subtitle
+"*There are few units that can detect my demolitions�do you know which ones they are?"
+END
+
+DIALOGEVENT:Taunts_Demo024Subtitle
+"*Demo Traps are difficult to construct, General. To appreciate their beauty you have to see one up close"
+END
+
+DIALOGEVENT:Taunts_Demo025Subtitle
+"*How are you enjoying my tricks and traps so far?"
+END
+
+DIALOGEVENT:Taunts_Demo026Subtitle
+"*Aww�your Tech Building went boom"
+END
+
+DIALOGEVENT:Taunts_Demo027Subtitle
+"*We've destroyed your Barracks�I hope no one was in there"
+END
+
+DIALOGEVENT:Taunts_Demo028Subtitle
+"*Your War Factory has fallen, General. Build another one so we can knock it down again"
+END
+
+DIALOGEVENT:Taunts_Demo029Subtitle
+"*Air Fields are so fragile--it's hardly even fun to destroy them"
+END
+
+DIALOGEVENT:Taunts_Demo030Subtitle
+"*Your base defenses cannot take my explosives, General"
+END
+
+DIALOGEVENT:Taunts_Demo031Subtitle
+"*Ah, there's nothing quite like destroying a Command Center"
+END
+
+DIALOGEVENT:Taunts_Demo032Subtitle
+"*We've destroyed so many of your buildings, General�I appreciate you building more for our ammusement"
+END
+
+DIALOGEVENT:Taunts_Demo033Subtitle
+"*You've destroyed our Oil Derrick. Now you're getting into the spirit of things"
+END
+
+DIALOGEVENT:Taunts_Demo034Subtitle
+"*My Barracks! Many of my demolitions were in there, General. I'll make you pay for this"
+END
+
+DIALOGEVENT:Taunts_Demo035Subtitle
+"*Not my War Factory! General, this annoy habit you've developed cannot continue"
+END
+
+DIALOGEVENT:Taunts_Demo036Subtitle
+"*Not to worry, my base defenses are only an early-warning signal. Now you must walk through my true defenses"
+END
+
+DIALOGEVENT:Taunts_Demo037Subtitle
+"*Too many! You've destroy too many of my structures, General. Now the fighting gets dirty"
+END
+
+DIALOGEVENT:Taunts_Demo038Subtitle
+"*We will rebuild that Command Center, General, and you will play for this transgression"
+END
+
+DIALOGEVENT:Taunts_Demo039Subtitle
+"*General, how do you expect me to defeat you if you keep destroying my vehicles?"
+END
+
+DIALOGEVENT:Taunts_Demo040Subtitle
+"*You're cutting my men down before they can place their demolitions�that doesn't seem right, does it, General?"
+END
+
+DIALOGEVENT:Taunts_Demo041Subtitle
+"*Ah yes, capture that Oil Derrick, General. Then we'll have more to destroy"
+END
+
+DIALOGEVENT:Taunts_Demo042Subtitle
+"*General, why do you want that Artillery Platform?"
+END
+
+DIALOGEVENT:Taunts_Demo043Subtitle
+"*Good, General, capture the Oil Refinery�they blow-up so dramatically"
+END
+
+DIALOGEVENT:Taunts_Demo044Subtitle
+"*Be careful, General--your men have just enter the danger zone around my base. Even I don't remember where all the traps are set out there"
+END
+
+DIALOGEVENT:Taunts_Demo045Subtitle
+"*General, your men are coming dangerously close to my base. I'd turn back if I were you"
+END
+
+DIALOGEVENT:Taunts_Demo046Subtitle
+"*Get out of my base, General. This whole area is wired with explosives, and I'm not afraid to use them"
+END
+
+DIALOGEVENT:Taunts_Demo047Subtitle
+"*You fool! Do you know how many explosives are surrounding your men right now?"
+END
+
+DIALOGEVENT:Taunts_Demo048Subtitle
+"*Attacking from the flank, General? There might be few defenses there, but what about traps?"
+END
+
+DIALOGEVENT:Taunts_Demo049Subtitle
+"*The back of my base is particularly nasty, General. I wouldn't recommend an assault from there"
+END
+
+DIALOGEVENT:Taunts_Demo050Subtitle
+"*A frontal assault?! You are more of a fool than I thought, General"
+END
+
+DIALOGEVENT:Taunts_Demo051Subtitle
+"*There is nothing in this valley for you except death"
+END
+
+DIALOGEVENT:Taunts_Demo052Subtitle
+"*Careful, General; this looks like a good place for an ambush�oops, too late"
+END
+
+DIALOGEVENT:Taunts_Demo053Subtitle
+"*You think I didn't prepare for you coming here, General? Fool"
+END
+
+DIALOGEVENT:Taunts_Demo054Subtitle
+"*Those are my resources, General. Go find your own"
+END
+
+DIALOGEVENT:Taunts_Demo055Subtitle
+"*General, you've entered my demolitions storage facility. One false move and we all die"
+END
+
+DIALOGEVENT:Taunts_Demo056Subtitle
+"*Ah, I see we hit one of your power lines. I hope your power isn't out for too long"
+END
+
+DIALOGEVENT:Taunts_Demo057Subtitle
+"*Your dependency on electricity will be you undoing, General"
+END
+
+DIALOGEVENT:Taunts_Demo058Subtitle
+"*Your resources are exhausted, General. My forces are circling for the kill"
+END
+
+DIALOGEVENT:Taunts_Demo059Subtitle
+"*My resources are low, General. Mind if we come take some of yours?"
+END
+
+DIALOGEVENT:Taunts_Demo060Subtitle
+"*A Scud Storm�I see�Well, perhaps it is time to build one of my own"
+END
+
+DIALOGEVENT:Taunts_Demo061Subtitle
+"*I wonder how many explosives it will take to destroy that Nuclear Silo?"
+END
+
+DIALOGEVENT:Taunts_Demo062Subtitle
+"*Now why do you want to build a Particle Cannon? We were just beginning to have fun, General"
+END
+
+DIALOGEVENT:Taunts_Demo063Subtitle
+"*So many base defenses, General. How do you expect my bombers to enter your base now?"
+END
+
+DIALOGEVENT:Taunts_Demo064Subtitle
+"*Tanks�so many tanks. I'll enjoy watching your tanks hit my traps, General"
+END
+
+DIALOGEVENT:Taunts_Demo065Subtitle
+"*Stop building planes, General�you'll miss the genius of my traps"
+END
+
+DIALOGEVENT:Taunts_Demo066Subtitle
+"*With that many infantry you're sure to set-off my Demo Traps. I'd tell them to spread out when crossing the field, General�or not"
+END
+
+DIALOGEVENT:Taunts_Demo067Subtitle
+"*So many buildings� Your base is a perfect target for my explosives, General. Thank you"
+END
+
+DIALOGEVENT:Taunts_Demo068Subtitle
+"*Foolish move, General. Your Scud Storm won't stop me"
+END
+
+DIALOGEVENT:Taunts_Demo069Subtitle
+"*Nuclear missile! You will pay for this, General"
+END
+
+DIALOGEVENT:Taunts_Demo070Subtitle
+"*No! That particle beam will set off my explosives!"
+END
+
+DIALOGEVENT:Taunts_Demo071Subtitle
+"*Yes, garrison that building, General--it probably doesn't have explosives attached to it"
+END
+
+DIALOGEVENT:Taunts_Demo072Subtitle
+"*Hello, Colonel Burton. Try not to step on any traps"
+END
+
+DIALOGEVENT:Taunts_Demo073Subtitle
+"*Black Lotus�just because you can detect my traps do not think I am now vulnerable"
+END
+
+DIALOGEVENT:Taunts_Demo074Subtitle
+"*Why would you send Jarmen Kell against me, General?"
+END
+
+DIALOGEVENT:Taunts_Demo075Subtitle
+"*Do not build any more Air Fields, General�I don't like them"
+END
+
+DIALOGEVENT:Taunts_Demo076Subtitle
+"*The War Factory builds vehicles�vehicles that will set-off my Demo Traps"
+END
+
+DIALOGEVENT:Taunts_Demo077Subtitle
+"*Do you think it is wise to build a Barracks, General?"
+END
+
+DIALOGEVENT:Taunts_Demo078Subtitle
+"*Please, General, don't sell-off what I could destroy for you"
+END
+
+DIALOGEVENT:Taunts_Demo079Subtitle
+"*General, you're not playing fair. Now go step on some traps"
+END
+
+DIALOGEVENT:Taunts_Demo080Subtitle
+"*You're exceptionally lucky, General, but you can't avoid my Demo Traps forever"
+END
+
+DIALOGEVENT:Taunts_Demo081Subtitle
+"*No one has beaten my traps, General, and you won't be the first�you'll see"
+END
+
+DIALOGEVENT:Taunts_Demo082Subtitle
+"*Do you think you're beating me, General? This could change in an instant--I don't fight fair"
+END
+
+DIALOGEVENT:Taunts_Demo083Subtitle
+"*You may have defeated me, General, but Deathstrike will avenge me"
+END
+
+DIALOGEVENT:Taunts_Demo084Subtitle
+"*Ha ha! Your troops are falling to my traps, General. Soon they'll all be gone"
+END
+
+DIALOGEVENT:Taunts_Demo085Subtitle
+"*You're losing, General. My tactics elude you"
+END
+
+DIALOGEVENT:Taunts_Demo086Subtitle
+"*You'll never defeat me, General. You should leave before you get hurt"
+END
+
+DIALOGEVENT:Taunts_Demo087Subtitle
+"*I have so many explosives left�more explosives than you have forces I'm afraid"
+END
+
+DIALOGEVENT:Taunts_Demo088Subtitle
+"*You lose, General. Too bad"
+END
+
+DIALOGEVENT:Taunts_Demo089Subtitle
+"*I have just the thing. Let's go make war"
+END
+
+DIALOGEVENT:Taunts_Demo090Subtitle
+"*Demolitions expert: How can I help you?"
+END
+
+DIALOGEVENT:Taunts_Demo091Subtitle
+"*I wonder if I could wire that button to explode?"
+END
+
+DIALOGEVENT:Taunts_Demo092Subtitle
+"*Please, General--enter my battlefield�but watch where to step"
+END
+
+DIALOGEVENT:Taunts_Demo093Subtitle
+"*You were lucky this time, General. You could never beat me again"
+END
+
+DIALOGEVENT:Taunts_Demo094Subtitle
+"*You were not prepared for this kind of war. Try again, if you dare"
+END
+
+DIALOGEVENT:Taunts_Demo095Subtitle
+"*Here we see the battlefield--open�untouched by battle�a blank slate for our little..."
+END
+
+DIALOGEVENT:Taunts_Demo096Subtitle
+"*Now where did those Demo Traps come from?"
+END
+
+DIALOGEVENT:Taunts_Demo097Subtitle
+"*Perhaps I have a few cards hidden up my sleeve, but did you except any less from me, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger001Subtitle
+"*Hey, General, you ever seen a Raptor up close?"
+END
+
+DIALOGEVENT:Taunts_Grainger002Subtitle
+"*Hey, General, did you see that Stealth Fighter?"
+END
+
+DIALOGEVENT:Taunts_Grainger003Subtitle
+"*Birds' away! Let's go hunt some dozers!"
+END
+
+DIALOGEVENT:Taunts_Grainger004Subtitle
+"*I'm done playing with you, General. (Announcing to his own forces) Everyone attack!"
+END
+
+DIALOGEVENT:Taunts_Grainger005Subtitle
+"*Will you look at that�US military spending at its best"
+END
+
+DIALOGEVENT:Taunts_Grainger006Subtitle
+"*(Singing�badly)�and the rockets' red glare, the bombs bursting in air�"
+END
+
+DIALOGEVENT:Taunts_Grainger007Subtitle
+"*Here comes the rain of terror, General"
+END
+
+DIALOGEVENT:Taunts_Grainger008Subtitle
+"*How are you enjoying the Shock-and-Awe, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger009Subtitle
+"*Death from above!"
+END
+
+DIALOGEVENT:Taunts_Grainger010Subtitle
+"*It doesn't seem fair, does it, General"
+END
+
+DIALOGEVENT:Taunts_Grainger011Subtitle
+"*It's time to pull the goalies. Everyone attack!"
+END
+
+DIALOGEVENT:Taunts_Grainger012Subtitle
+"*Bombs away!"
+END
+
+DIALOGEVENT:Taunts_Grainger013Subtitle
+"*It's awfully quiet out there�you didn't leave did you, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger014Subtitle
+"*Don't worry, General, this is just the quiet before the storm"
+END
+
+DIALOGEVENT:Taunts_Grainger015Subtitle
+"*I'd take this break to rebuild your defenses, General"
+END
+
+DIALOGEVENT:Taunts_Grainger016Subtitle
+"*Shh�did you hear that? I wouldn't worry, it's probably nothing"
+END
+
+DIALOGEVENT:Taunts_Grainger017Subtitle
+"*Sorry, General, we're just taking a lunch-break-be with you in a minute"
+END
+
+DIALOGEVENT:Taunts_Grainger018Subtitle
+"*You've forced me to use tanks�I hate using tanks"
+END
+
+DIALOGEVENT:Taunts_Grainger019Subtitle
+"*Having trouble crossing the river, General? Wanna lift?"
+END
+
+DIALOGEVENT:Taunts_Grainger020Subtitle
+"*Cowards! Stop hiding and fight!"
+END
+
+DIALOGEVENT:Taunts_Grainger021Subtitle
+"*Stealth won't save you, General; we'll find you"
+END
+
+DIALOGEVENT:Taunts_Grainger022Subtitle
+"*Ouch, that must have been expensive"
+END
+
+DIALOGEVENT:Taunts_Grainger023Subtitle
+"*Huh, where are you going to train your troops now?"
+END
+
+DIALOGEVENT:Taunts_Grainger024Subtitle
+"*Having trouble keeping up those defenses, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger025Subtitle
+"*You've lost a lot of buildings, General; were you planning on using harsh language now?"
+END
+
+DIALOGEVENT:Taunts_Grainger026Subtitle
+"*Dozers, start repairing our buildings!"
+END
+
+DIALOGEVENT:Taunts_Grainger027Subtitle
+"*I'll get you for this, General"
+END
+
+DIALOGEVENT:Taunts_Grainger028Subtitle
+"*You'll regret destroying that airfield, General"
+END
+
+DIALOGEVENT:Taunts_Grainger029Subtitle
+"*Dozers, rebuild our defenses!"
+END
+
+DIALOGEVENT:Taunts_Grainger030Subtitle
+"*This is General Granger to Aircraft Carrier Olympia: Send reinforcements�repeat: send reinforcements"
+END
+
+DIALOGEVENT:Taunts_Grainger031Subtitle
+"*They're attacking the Command Center! All forces, regroup!"
+END
+
+DIALOGEVENT:Taunts_Grainger032Subtitle
+"*I don't appreciate you shooting down my planes, General"
+END
+
+DIALOGEVENT:Taunts_Grainger033Subtitle
+"*They're taking over our Oil Derricks! Rangers, get out there and take them back!"
+END
+
+DIALOGEVENT:Taunts_Grainger034Subtitle
+"*Get out of our base!"
+END
+
+DIALOGEVENT:Taunts_Grainger035Subtitle
+"*Get out of my airspace, General!"
+END
+
+DIALOGEVENT:Taunts_Grainger036Subtitle
+"*The enemy's in our perimeter! All planes return to base!"
+END
+
+DIALOGEVENT:Taunts_Grainger037Subtitle
+"*Ground forces, defend the airfields!"
+END
+
+DIALOGEVENT:Taunts_Grainger038Subtitle
+"*You're not stealing my supplies, are you, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger039Subtitle
+"*They're coming in the back-door!"
+END
+
+DIALOGEVENT:Taunts_Grainger040Subtitle
+"*Hiding in the village, huh. That's a coward's tactic, General"
+END
+
+DIALOGEVENT:Taunts_Grainger041Subtitle
+"*Stop hiding, General. Don't make me come and get you"
+END
+
+DIALOGEVENT:Taunts_Grainger042Subtitle
+"*They're at the East gate!"
+END
+
+DIALOGEVENT:Taunts_Grainger043Subtitle
+"*Defend the East side!"
+END
+
+DIALOGEVENT:Taunts_Grainger044Subtitle
+"*Enemy forces approaching the West gate!"
+END
+
+DIALOGEVENT:Taunts_Grainger045Subtitle
+"*All forces to the West gate!"
+END
+
+DIALOGEVENT:Taunts_Grainger046Subtitle
+"*Having trouble keeping your power up, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger047Subtitle
+"*Oops, your power's down - here come the bombs!"
+END
+
+DIALOGEVENT:Taunts_Grainger048Subtitle
+"*Out of resources, General? Want to borrow some?"
+END
+
+DIALOGEVENT:Taunts_Grainger049Subtitle
+"*Hey, General, how 'bout we call this one a draw?"
+END
+
+DIALOGEVENT:Taunts_Grainger050Subtitle
+"*You may have won the battle, General, but the war is far from over"
+END
+
+DIALOGEVENT:Taunts_Grainger051Subtitle
+"*So, you built a Scud Storm. Think you can defend it?"
+END
+
+DIALOGEVENT:Taunts_Grainger052Subtitle
+"*Hmm, that's a lot of anti-air, General Think it will be enough to calm the fear?"
+END
+
+DIALOGEVENT:Taunts_Grainger053Subtitle
+"*Your tanks are no match for my planes, General"
+END
+
+DIALOGEVENT:Taunts_Grainger054Subtitle
+"*Anthrax! Everyone find cover!"
+END
+
+DIALOGEVENT:Taunts_Grainger055Subtitle
+"*Garrison all the buildings you want, General-it won't help"
+END
+
+DIALOGEVENT:Taunts_Grainger056Subtitle
+"*How much more of this can you take, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger057Subtitle
+"*Ready to surrender yet?"
+END
+
+DIALOGEVENT:Taunts_Grainger058Subtitle
+"*Haven't you lost enough troops, General?"
+END
+
+DIALOGEVENT:Taunts_Grainger059Subtitle
+"*This battle is over, General-surrender or prepare to die!"
+END
+
+DIALOGEVENT:Taunts_Grainger060Subtitle
+"*Not going to surrender, huh? Too bad"
+END
+
+DIALOGEVENT:Taunts_Grainger061Subtitle
+"*Bombs away, punk"
+END
+
+DIALOGEVENT:Taunts_Grainger062Subtitle
+"*Come on, General--I'll show you the meaning of "Death from Above.""
+END
+
+DIALOGEVENT:Taunts_Grainger063Subtitle
+"*Sonic-boom, baby. Let's do this thing"
+END
+
+DIALOGEVENT:Taunts_Grainger064Subtitle
+"*I guess it's time for me to go find a good airline job"
+END
+
+DIALOGEVENT:Taunts_Grainger065Subtitle
+"*I win--you lose. What more is there to say?"
+END
+
+DIALOGEVENT:Taunts_Grainger066Subtitle
+"*Be advised: This area is under the control of Air Force General Malcolm Granger. Withdraw now or prepare to be bombed back to the stone-age"
+END
+
+DIALOGEVENT:Taunts_Grainger067Subtitle
+"*General, you're no match for me--I own the skies!"
+END
+
+DIALOGEVENT:Taunts_Grainger068Subtitle
+"*Watch the skies, General; we're going to put on an air-show"
+END
+
+DIALOGEVENT:Taunts_Grainger069Subtitle
+"*Wanna see it again?"
+END
+
+DIALOGEVENT:Taunts_Grainger070Subtitle
+"*Ready-or-not, here I come!"
+END
+
+DIALOGEVENT:Taunts_Grainger071Subtitle
+"*You don't mind if we drop-in, do ya General?"
+END
+
+DIALOGEVENT:Taunts_Grainger072Subtitle
+"*That's two of my airfields you've hit, General. I'm starting to get annoyed"
+END
+
+DIALOGEVENT:Taunts_Grainger073Subtitle
+"*Curse you, General. If you hit another airfield I'll come for you personally"
+END
+
+DIALOGEVENT:Taunts_Grainger074Subtitle
+"*That's the last airfield you destroy today. (Announcing to his own troops) Forces, target their Command Center"
+END
+
+DIALOGEVENT:Taunts_Grainger075Subtitle
+"*I can't believe you beat me, General. I salute your superior tactics"
+END
+
+DIALOGEVENT:Taunts_Grainger076Subtitle
+"*It looks like you defeated me this time, General, but we'll meet again someday and I won't be so merciful because-"
+END
+
+DIALOGEVENT:Taunts_Grainger077Subtitle
+"*I thought he'd never shut up"
+END
+
+DIALOGEVENT:Taunts_Grainger078Subtitle
+"*You don't think I'm going to let you keep that Scud Storm, do you?"
+END
+
+DIALOGEVENT:Taunts_Grainger079Subtitle
+"*Another Scud Storm? I guess it's time to take the up a notch"
+END
+
+DIALOGEVENT:Taunts_Grainger080Subtitle
+"*Pilots, watch-out for those Stinger Sites"
+END
+
+DIALOGEVENT:Taunts_Grainger081Subtitle
+"*So many Rangers-so few buildings to capture"
+END
+
+DIALOGEVENT:Taunts_Grainger082Subtitle
+"*General, do ya know how a Fuel-Air Bomb works? How 'bout a demonstration?"
+END
+
+DIALOGEVENT:Taunts_Grainger083Subtitle
+"*Welcome to the party, Colonel Burton. You're in for it now, General"
+END
+
+DIALOGEVENT:Taunts_Grainger084Subtitle
+"*Do you know how to stop an A-10, General? Me neither"
+END
+
+DIALOGEVENT:Taunts_Grainger085Subtitle
+"*Hey, wanna see our new Bunker Buster?"
+END
+
+DIALOGEVENT:Taunts_Grainger086Subtitle
+"*Artillery! You think you can attack me with artillery?"
+END
+
+DIALOGEVENT:Taunts_Grainger087Subtitle
+"*You know that Scud Launcher is never going to make it to my base, right?"
+END
+
+DIALOGEVENT:Taunts_Grainger088Subtitle
+"*Wait, that's a Bomb Truck! Everyone look out!"
+END
+
+DIALOGEVENT:Taunts_Grainger089Subtitle
+"*You've forced me to use tanks�I hate using tanks"
+END
+
+DIALOGEVENT:Taunts_Grainger090Subtitle
+"*Having trouble crossing the river, General? Wanna lift?"
+END
+
+DIALOGEVENT:Taunts_Grainger091Subtitle
+"*Cowards! Stop hiding and fight!"
+END
+
+DIALOGEVENT:Taunts_Grainger092Subtitle
+"*Stealth won't save you, General; we'll find you"
+END
+
+DIALOGEVENT:Taunts_Grainger093Subtitle
+"*Hmm, that's a lot of anti-air, General"
+END
+
+DIALOGEVENT:Taunts_Infantry001Subtitle
+"*So, this is where you're hiding, General"
+END
+
+DIALOGEVENT:Taunts_Infantry002Subtitle
+"*<sarcastic>Feeling overwhelmed General?"
+END
+
+DIALOGEVENT:Taunts_Infantry003Subtitle
+"*(Chinese infantry troops die) <angry voice> 1 billion more where that came from"
+END
+
+DIALOGEVENT:Taunts_Infantry004Subtitle
+"*(Paradrop)Like a swarm of locusts they descend from the sky to devour all those who stand against China"
+END
+
+DIALOGEVENT:Taunts_Infantry005Subtitle
+"*Ever been hacked General?"
+END
+
+DIALOGEVENT:Taunts_Infantry006Subtitle
+"*<shouting>March!"
+END
+
+DIALOGEVENT:Taunts_Infantry007Subtitle
+"*They make good shields too"
+END
+
+DIALOGEVENT:Taunts_Infantry008Subtitle
+"*Here's a tip General, Surrender!"
+END
+
+DIALOGEVENT:Taunts_Infantry009Subtitle
+"*Don't worry General, we don't take prisoners"
+END
+
+DIALOGEVENT:Taunts_Infantry010Subtitle
+"*Unleash Horde!"
+END
+
+DIALOGEVENT:Taunts_Infantry011Subtitle
+"*It's ok General, we've brought our own flag for your base"
+END
+
+DIALOGEVENT:Taunts_Infantry012Subtitle
+"*Soon all your men will see are boots marching over them"
+END
+
+DIALOGEVENT:Taunts_Infantry013Subtitle
+"*Charge!"
+END
+
+DIALOGEVENT:Taunts_Infantry014Subtitle
+"*Death to all who oppose us!"
+END
+
+DIALOGEVENT:Taunts_Infantry015Subtitle
+"*Do you know how hard it is to feed a horde, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry016Subtitle
+"*I have enough men to hold a parade. Can we have it in your base?"
+END
+
+DIALOGEVENT:Taunts_Infantry017Subtitle
+"*Are you still here, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry018Subtitle
+"*Are you just going to sit there and wait to be overrun?"
+END
+
+DIALOGEVENT:Taunts_Infantry019Subtitle
+"*Are your resources getting low, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry020Subtitle
+"*How long does it take for you to build your little tank force?"
+END
+
+DIALOGEVENT:Taunts_Infantry021Subtitle
+"*<sarcastic> What tactic will you amaze me with now, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry022Subtitle
+"*This can't be the best you can do, General"
+END
+
+DIALOGEVENT:Taunts_Infantry023Subtitle
+"*So far I'm not impressed, General"
+END
+
+DIALOGEVENT:Taunts_Infantry024Subtitle
+"*You were not prepared for this challenge, were you, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry025Subtitle
+"*I have enough men to crush you without firing a shot"
+END
+
+DIALOGEVENT:Taunts_Infantry026Subtitle
+"*We are coming for you, General"
+END
+
+DIALOGEVENT:Taunts_Infantry027Subtitle
+"*Aww�we've knocked over your little Tech Building. Boo-hoo"
+END
+
+DIALOGEVENT:Taunts_Infantry028Subtitle
+"*Now your Barracks is gone. How will you fight without men?"
+END
+
+DIALOGEVENT:Taunts_Infantry029Subtitle
+"*Without a War Factory you'll have to fight me man-to-man, General"
+END
+
+DIALOGEVENT:Taunts_Infantry030Subtitle
+"*No more planes for you. Get on the ground and fight like a man"
+END
+
+DIALOGEVENT:Taunts_Infantry031Subtitle
+"*My men are marching right through you base defenses, General"
+END
+
+DIALOGEVENT:Taunts_Infantry032Subtitle
+"*There is only empty ground where your Command Center once stood, General"
+END
+
+DIALOGEVENT:Taunts_Infantry033Subtitle
+"*I have lost many men, General, but the cost to your buildings has been worth it"
+END
+
+DIALOGEVENT:Taunts_Infantry034Subtitle
+"*Leave my Tech Buildings alone, General!"
+END
+
+DIALOGEVENT:Taunts_Infantry035Subtitle
+"*NO! Not my Barracks! We will build another, General�then you will pay"
+END
+
+DIALOGEVENT:Taunts_Infantry036Subtitle
+"*My War Factory is not essential to my victory, but do not destroy another"
+END
+
+DIALOGEVENT:Taunts_Infantry037Subtitle
+"*You have destroyed my Air Field! This is getting annoying, General"
+END
+
+DIALOGEVENT:Taunts_Infantry038Subtitle
+"*Destroy all the base defenses you want--they're only there to slow you down anyway"
+END
+
+DIALOGEVENT:Taunts_Infantry039Subtitle
+"*You have cost me many buildings, General. My men are coming to collect repayment"
+END
+
+DIALOGEVENT:Taunts_Infantry040Subtitle
+"*Nooo! They destroyed my Command Center! Go get them! Keep them away from me!"
+END
+
+DIALOGEVENT:Taunts_Infantry041Subtitle
+"*Swat all the planes you like, General--we'll make more"
+END
+
+DIALOGEVENT:Taunts_Infantry042Subtitle
+"*My vehicles are not for your target practice, General"
+END
+
+DIALOGEVENT:Taunts_Infantry043Subtitle
+"*There are many more in my army ready to sacrifice for China, General. You won't stop us"
+END
+
+DIALOGEVENT:Taunts_Infantry044Subtitle
+"*I see you've captured my Oil Derrick, General. We are coming to take back China's oil now"
+END
+
+DIALOGEVENT:Taunts_Infantry045Subtitle
+"*That old Artillery Platform is destroyed, General; you'll never get it to work"
+END
+
+DIALOGEVENT:Taunts_Infantry046Subtitle
+"*Do you think that Oil Refinery is just there for anyone to use? Return the refinery to me now"
+END
+
+DIALOGEVENT:Taunts_Infantry047Subtitle
+"*Get any closer to my base and I'll set the horde out on you"
+END
+
+DIALOGEVENT:Taunts_Infantry048Subtitle
+"*I warn you, General, get away from my base. Do you know what a hundred men can do to a tank?"
+END
+
+DIALOGEVENT:Taunts_Infantry049Subtitle
+"*They're in our base! Kill them! Get them out of here!"
+END
+
+DIALOGEVENT:Taunts_Infantry050Subtitle
+"*They're getting too close! Protect me!"
+END
+
+DIALOGEVENT:Taunts_Infantry051Subtitle
+"*General, get away from my resources--my men need those"
+END
+
+DIALOGEVENT:Taunts_Infantry052Subtitle
+"*General, do not try to flank my base"
+END
+
+DIALOGEVENT:Taunts_Infantry053Subtitle
+"*A back-door attack will not help you, General"
+END
+
+DIALOGEVENT:Taunts_Infantry054Subtitle
+"*Attacking the front of my base is foolish, General"
+END
+
+DIALOGEVENT:Taunts_Infantry055Subtitle
+"*Those are my Tech Buildings, General. Stay away"
+END
+
+DIALOGEVENT:Taunts_Infantry056Subtitle
+"*Get out of my buildings, General!"
+END
+
+DIALOGEVENT:Taunts_Infantry057Subtitle
+"*Crossing that bridge is a mistake, General"
+END
+
+DIALOGEVENT:Taunts_Infantry058Subtitle
+"*You've run out of power, General--your defenses are down and my men will invade soon"
+END
+
+DIALOGEVENT:Taunts_Infantry059Subtitle
+"*Without power you'll never stop my horde, General"
+END
+
+DIALOGEVENT:Taunts_Infantry060Subtitle
+"*You've wasted all your resources fighting my men�but I still have more men"
+END
+
+DIALOGEVENT:Taunts_Infantry061Subtitle
+"*We are out of resources! How did this happen?"
+END
+
+DIALOGEVENT:Taunts_Infantry062Subtitle
+"*Build your Scud Storm--it will only hit a few of my men�the rest will destroy you"
+END
+
+DIALOGEVENT:Taunts_Infantry063Subtitle
+"*I thought nuclear missile were not allowed! This is hardly fair, General"
+END
+
+DIALOGEVENT:Taunts_Infantry064Subtitle
+"*That Particle Cannon is useless against my horde!"
+END
+
+DIALOGEVENT:Taunts_Infantry065Subtitle
+"*Yes, you should build more base defenses--at least then you can stop the first wave of the charging horde"
+END
+
+DIALOGEVENT:Taunts_Infantry066Subtitle
+"*Coward! You know that your tanks cannot crush my men, don't you?"
+END
+
+DIALOGEVENT:Taunts_Infantry067Subtitle
+"*So many planes�no matter, my horde and bring down your planes too"
+END
+
+DIALOGEVENT:Taunts_Infantry068Subtitle
+"*You're mobilizing a horde of your own?! You will need many more men to match my strength, General"
+END
+
+DIALOGEVENT:Taunts_Infantry069Subtitle
+"*You base has grown too large, General. It is time for my men to drop in and capture a few for China"
+END
+
+DIALOGEVENT:Taunts_Infantry070Subtitle
+"*Scud Storm! Scatter!"
+END
+
+DIALOGEVENT:Taunts_Infantry071Subtitle
+"*Nuclear missile approaching! Flee! Get me out of here!"
+END
+
+DIALOGEVENT:Taunts_Infantry072Subtitle
+"*Ooh, look at the pretty light show. What do you hope to accomplish with that petty weapon, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry073Subtitle
+"*Get out of that building, General. We have ways of bringing you out by force if necessary"
+END
+
+DIALOGEVENT:Taunts_Infantry074Subtitle
+"*You've brought Colonel Burton to our little war, General. Even he will fall when faced with the horde"
+END
+
+DIALOGEVENT:Taunts_Infantry075Subtitle
+"*Black Lotus? How will she help you survive my horde, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry076Subtitle
+"*All forces beware: Jarmen Kell is hiding in the field"
+END
+
+DIALOGEVENT:Taunts_Infantry077Subtitle
+"*I see that Air Field, General. Run to the air! Fear my horde!"
+END
+
+DIALOGEVENT:Taunts_Infantry078Subtitle
+"*My men will tear your tanks apart as fast as you can make them, General"
+END
+
+DIALOGEVENT:Taunts_Infantry079Subtitle
+"*My men are trained in groups of three�how fast can you train your men?"
+END
+
+DIALOGEVENT:Taunts_Infantry080Subtitle
+"*Selling your buildings? Foolish! What will you buy with the money to stop my horde?"
+END
+
+DIALOGEVENT:Taunts_Infantry081Subtitle
+"*I have so many forces, how can you be winning this battle?"
+END
+
+DIALOGEVENT:Taunts_Infantry082Subtitle
+"*I have underestimated your tactics, General"
+END
+
+DIALOGEVENT:Taunts_Infantry083Subtitle
+"*You've caught me off guard, General, but now I am ready for you"
+END
+
+DIALOGEVENT:Taunts_Infantry084Subtitle
+"*You will not defeat my horde, General! Your current advantage will soon be lost"
+END
+
+DIALOGEVENT:Taunts_Infantry085Subtitle
+"*I do not accept this defeat, General. My men will cover my escape and we will fight another day"
+END
+
+DIALOGEVENT:Taunts_Infantry086Subtitle
+"*My men outnumber you now, General. I would be wise to surrender"
+END
+
+DIALOGEVENT:Taunts_Infantry087Subtitle
+"*This looks like the end for you, General"
+END
+
+DIALOGEVENT:Taunts_Infantry088Subtitle
+"*If you do not retreat now I will unleash the horde to scrape you from our land"
+END
+
+DIALOGEVENT:Taunts_Infantry089Subtitle
+"*Do you feel the end drawing near, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry090Subtitle
+"*Haha! I have defeated you. Now you must choose to join my horde or die"
+END
+
+DIALOGEVENT:Taunts_Infantry091Subtitle
+"*It is time to unleash the horde!"
+END
+
+DIALOGEVENT:Taunts_Infantry092Subtitle
+"*Face me and fall like the rest"
+END
+
+DIALOGEVENT:Taunts_Infantry093Subtitle
+"*My men will crush you"
+END
+
+DIALOGEVENT:Taunts_Infantry094Subtitle
+"*We will tear through you like locusts"
+END
+
+DIALOGEVENT:Taunts_Infantry095Subtitle
+"*Men? Where are my men? You wouldn't consider letting me go would you? Please don't hurt me"
+END
+
+DIALOGEVENT:Taunts_Infantry096Subtitle
+"*We have nice uniforms in the horde�it won't be so bad�you might even like it. But I doubt it"
+END
+
+DIALOGEVENT:Taunts_Infantry097Subtitle
+"*Are you ready to face my horde, General?"
+END
+
+DIALOGEVENT:Taunts_Infantry098Subtitle
+"*And think, this is just the first wave"
+END
+
+DIALOGEVENT:Taunts_Laser001Subtitle
+"*I have you in my sights now, General"
+END
+
+DIALOGEVENT:Taunts_Laser002Subtitle
+"*Precision attack commencing"
+END
+
+DIALOGEVENT:Taunts_Laser003Subtitle
+"* (player units destroyed) Interesting choice of tactics, they didn't help my last opponent either"
+END
+
+DIALOGEVENT:Taunts_Laser004Subtitle
+"*I'm about to attack, I thought you could use the warning"
+END
+
+DIALOGEVENT:Taunts_Laser005Subtitle
+"*Maybe you should re-evaluate your strategies, they obviously don't work"
+END
+
+DIALOGEVENT:Taunts_Laser006Subtitle
+"*How do you like my new toys General?"
+END
+
+DIALOGEVENT:Taunts_Laser007Subtitle
+"*Prepare yourself General, you're about to be taught a lesson in war"
+END
+
+DIALOGEVENT:Taunts_Laser008Subtitle
+"*Easy come, easy go"
+END
+
+DIALOGEVENT:Taunts_Laser009Subtitle
+"*Maybe you're not cut out for this, try painting"
+END
+
+DIALOGEVENT:Taunts_Laser010Subtitle
+"*Beautiful aren't they General"
+END
+
+DIALOGEVENT:Taunts_Laser011Subtitle
+"*My lasers will cut through your defenses like a hot knife through butter"
+END
+
+DIALOGEVENT:Taunts_Laser012Subtitle
+"*Checkmate"
+END
+
+DIALOGEVENT:Taunts_Laser013Subtitle
+"*It's a whole new age of warfare, General, and it's coming to your doorstep"
+END
+
+DIALOGEVENT:Taunts_Laser014Subtitle
+"*Target is painted--all forces begin attack run"
+END
+
+DIALOGEVENT:Taunts_Laser015Subtitle
+"*Originally all my weapons also had laser targeting, but my enemies got confused"
+END
+
+DIALOGEVENT:Taunts_Laser016Subtitle
+"*Don't look directly at the laser--you could burn-out the back of your head"
+END
+
+DIALOGEVENT:Taunts_Laser017Subtitle
+"*Charging lasers�please wait, General"
+END
+
+DIALOGEVENT:Taunts_Laser018Subtitle
+"*Lasers must be calibrated precisely for maximum effect"
+END
+
+DIALOGEVENT:Taunts_Laser019Subtitle
+"*Dozers, build more Reactors--lasers take a lot of power"
+END
+
+DIALOGEVENT:Taunts_Laser020Subtitle
+"*Can you match fifty million mega-joules of lasing power, General?"
+END
+
+DIALOGEVENT:Taunts_Laser021Subtitle
+"*Looks like a big space battle, doesn't it"
+END
+
+DIALOGEVENT:Taunts_Laser022Subtitle
+"*My lasers are going to turn your armor to vapor"
+END
+
+DIALOGEVENT:Taunts_Laser023Subtitle
+"*General, you should really try to coordinate your attacks--this has been all to easy for me"
+END
+
+DIALOGEVENT:Taunts_Laser024Subtitle
+"*Don't get distracted by the pretty lights, General"
+END
+
+DIALOGEVENT:Taunts_Laser025Subtitle
+"*Would you like me to "beam you up," General?"
+END
+
+DIALOGEVENT:Taunts_Laser026Subtitle
+"*Your weapons can't match my pinpoint accuracy, General. Why not just surrender?"
+END
+
+DIALOGEVENT:Taunts_Laser027Subtitle
+"*Why don't you build another Barracks, General? I'll enjoy destroying that one too"
+END
+
+DIALOGEVENT:Taunts_Laser028Subtitle
+"*If you can't protect your War Factory, how safe could your Command Center be?"
+END
+
+DIALOGEVENT:Taunts_Laser029Subtitle
+"*Your planes are not safe from my lasers, especially without your Air Field"
+END
+
+DIALOGEVENT:Taunts_Laser030Subtitle
+"*Your base defenses are worthless against me"
+END
+
+DIALOGEVENT:Taunts_Laser031Subtitle
+"*Ah, the Command Center--queen of this chessboard. This match is all but over now, General"
+END
+
+DIALOGEVENT:Taunts_Laser032Subtitle
+"*My lasers have destroyed so many of your buildings�how do you keep fighting?"
+END
+
+DIALOGEVENT:Taunts_Laser033Subtitle
+"*General, don't destroy my Tech Buildings, I need those"
+END
+
+DIALOGEVENT:Taunts_Laser034Subtitle
+"*Get away from my Barracks!"
+END
+
+DIALOGEVENT:Taunts_Laser035Subtitle
+"*My War Factory! Noooo!"
+END
+
+DIALOGEVENT:Taunts_Laser036Subtitle
+"*How dare you destroy my Air Field!"
+END
+
+DIALOGEVENT:Taunts_Laser037Subtitle
+"*They're destroying our defenses! All forces: defend the base!"
+END
+
+DIALOGEVENT:Taunts_Laser038Subtitle
+"*General, these losses are unacceptable. I'll repay you for destroying my buildings"
+END
+
+DIALOGEVENT:Taunts_Laser039Subtitle
+"*No! Quickly, Dozers rebuild the Command Center!"
+END
+
+DIALOGEVENT:Taunts_Laser040Subtitle
+"*General, if you bring down any more of my planes I'll use all my Super Weapons to destroy you!"
+END
+
+DIALOGEVENT:Taunts_Laser041Subtitle
+"*Leave my vehicles alone, General!"
+END
+
+DIALOGEVENT:Taunts_Laser042Subtitle
+"*You're hunting my men on purpose, aren't you, General"
+END
+
+DIALOGEVENT:Taunts_Laser043Subtitle
+"*Reap the rewards from that Oil Derrick while you can; we'll be there to take it soon"
+END
+
+DIALOGEVENT:Taunts_Laser044Subtitle
+"*That Artillery Platform is no match for my airborne lasers"
+END
+
+DIALOGEVENT:Taunts_Laser045Subtitle
+"*Did you know that that Oil Refinery will let you build vehicles faster and more efficiently? Oops, I probably shouldn't have told you that"
+END
+
+DIALOGEVENT:Taunts_Laser046Subtitle
+"*You've tripped our outer perimeter warning lasers, General. We know you're there now"
+END
+
+DIALOGEVENT:Taunts_Laser047Subtitle
+"*I see you approaching my base, General. I wouldn't advise coming any closer"
+END
+
+DIALOGEVENT:Taunts_Laser048Subtitle
+"*The enemy is in our base! All forces return and deploy lasers!"
+END
+
+DIALOGEVENT:Taunts_Laser049Subtitle
+"*Get away from my Reactors, General!"
+END
+
+DIALOGEVENT:Taunts_Laser050Subtitle
+"*General, those resources are for me--stay away from them"
+END
+
+DIALOGEVENT:Taunts_Laser051Subtitle
+"*Attacking from the flanks, eh? It will take more than tactical tricks to beat me"
+END
+
+DIALOGEVENT:Taunts_Laser052Subtitle
+"*Flanking attacks?! You are devious, General"
+END
+
+DIALOGEVENT:Taunts_Laser053Subtitle
+"*Yes, come straight through my front-door, General�if you dare"
+END
+
+DIALOGEVENT:Taunts_Laser054Subtitle
+"*Be careful, General--the back-door of my base isn't so undefended as it seems"
+END
+
+DIALOGEVENT:Taunts_Laser055Subtitle
+"*You are foolish to come here, General"
+END
+
+DIALOGEVENT:Taunts_Laser056Subtitle
+"*These resources are not enough to save your failed strategy, General"
+END
+
+DIALOGEVENT:Taunts_Laser057Subtitle
+"*No! Stay away! I need those reactors to power my lasers!"
+END
+
+DIALOGEVENT:Taunts_Laser058Subtitle
+"*Out of power?! How could you let your base run out of power?"
+END
+
+DIALOGEVENT:Taunts_Laser059Subtitle
+"*Running out of power is a fatal mistake, General"
+END
+
+DIALOGEVENT:Taunts_Laser060Subtitle
+"*You're out of resources, General. You'll never recover before we overrun you"
+END
+
+DIALOGEVENT:Taunts_Laser061Subtitle
+"*Out of resources?! This is unacceptable! Chinooks, gather faster!"
+END
+
+DIALOGEVENT:Taunts_Laser062Subtitle
+"*Sell that Scud Storm, General, or I'll destroy it for you"
+END
+
+DIALOGEVENT:Taunts_Laser063Subtitle
+"*That Nuke Silo won't stop me, General"
+END
+
+DIALOGEVENT:Taunts_Laser064Subtitle
+"*If you build a Particle Cannon and I destroy it with a Particle Beam�is that irony?"
+END
+
+DIALOGEVENT:Taunts_Laser065Subtitle
+"*That excessive amount of base defenses will only slow down my laser, General"
+END
+
+DIALOGEVENT:Taunts_Laser066Subtitle
+"*Your conventional tanks are no match for my laser based weapons platforms, General"
+END
+
+DIALOGEVENT:Taunts_Laser067Subtitle
+"*That's quite a lot of planes, General. Are you putting on an air show?"
+END
+
+DIALOGEVENT:Taunts_Laser068Subtitle
+"*Quite a few infantry you've trained there, General. I can't wait to see this crazy plan"
+END
+
+DIALOGEVENT:Taunts_Laser069Subtitle
+"*Your base is starting to look like a housing tract, General. Maybe I should play some connect-the-dots with the Particle Cannon to thin your numbers a bit"
+END
+
+DIALOGEVENT:Taunts_Laser070Subtitle
+"*I will shoot those scud missiles down, General. Then you will pay"
+END
+
+DIALOGEVENT:Taunts_Laser071Subtitle
+"*My lasers will bring that nuke down, General. The fallout will be on your hands"
+END
+
+DIALOGEVENT:Taunts_Laser072Subtitle
+"*Particle Cannon?! I wonder what would happen if we crossed the beams"
+END
+
+DIALOGEVENT:Taunts_Laser073Subtitle
+"*General, don't garrison that building; come out and play"
+END
+
+DIALOGEVENT:Taunts_Laser074Subtitle
+"*General, Colonel Burton is a bumbling fool"
+END
+
+DIALOGEVENT:Taunts_Laser075Subtitle
+"*Black Lotus is not invisible to my lasers, General"
+END
+
+DIALOGEVENT:Taunts_Laser076Subtitle
+"*I hope Jarmen Kell isn't using a laser scope on his rifle�it wouldn't work against me"
+END
+
+DIALOGEVENT:Taunts_Laser077Subtitle
+"*Building an Air Field only provides airborne targets for my lasers, General"
+END
+
+DIALOGEVENT:Taunts_Laser078Subtitle
+"*You're going to need a lot of tanks to get to me, General. Good luck"
+END
+
+DIALOGEVENT:Taunts_Laser079Subtitle
+"*Building a Barracks will only get your men hurt, General"
+END
+
+DIALOGEVENT:Taunts_Laser080Subtitle
+"*Selling off your structures eh? That the first mistake of a desperate general"
+END
+
+DIALOGEVENT:Taunts_Laser081Subtitle
+"*What?! You can't be beating me! Your lack of precision alone should ensure my victory"
+END
+
+DIALOGEVENT:Taunts_Laser082Subtitle
+"*I can't lose to you--you're a bumbling buffoon!"
+END
+
+DIALOGEVENT:Taunts_Laser083Subtitle
+"*How can you be winning? This isn't how it played out in the simulation"
+END
+
+DIALOGEVENT:Taunts_Laser084Subtitle
+"*I've calculated every variable, yet you're winning�how is this possible?"
+END
+
+DIALOGEVENT:Taunts_Laser085Subtitle
+"*No! This can't be the end! What trickery did you use to beat me?!"
+END
+
+DIALOGEVENT:Taunts_Laser086Subtitle
+"*My planning a preparation is leading me to a clear victory"
+END
+
+DIALOGEVENT:Taunts_Laser087Subtitle
+"*Precision will always defeat brute force, General"
+END
+
+DIALOGEVENT:Taunts_Laser088Subtitle
+"*This must be like a nightmare for you, General"
+END
+
+DIALOGEVENT:Taunts_Laser089Subtitle
+"*Have you decided how you are going to accept this defeat, General?"
+END
+
+DIALOGEVENT:Taunts_Laser090Subtitle
+"*You are defeated, General. But then that was never really in question, was it?"
+END
+
+DIALOGEVENT:Taunts_Laser091Subtitle
+"*Lasers charged--tracking targets now"
+END
+
+DIALOGEVENT:Taunts_Laser092Subtitle
+"*You're not in my class, General--try an easier opponent"
+END
+
+DIALOGEVENT:Taunts_Laser093Subtitle
+"*I calculate that you will lose this battle, General"
+END
+
+DIALOGEVENT:Taunts_Laser094Subtitle
+"*Lasers make superior weapons"
+END
+
+DIALOGEVENT:Taunts_Laser095Subtitle
+"*You defeated me, General, but I will scan your tactics and devise a superior strategy"
+END
+
+DIALOGEVENT:Taunts_Laser096Subtitle
+"*Your weaknesses became obvious when I scanned your tactics"
+END
+
+DIALOGEVENT:Taunts_Laser097Subtitle
+"*There you go, General--I've drawn the line in the sand"
+END
+
+DIALOGEVENT:Taunts_Laser098Subtitle
+"*Now I dare you to cross it. Come and get me, General"
+END
+
+DIALOGEVENT:Taunts_Nuke001Subtitle
+"*At least it's a dry heat, General"
+END
+
+DIALOGEVENT:Taunts_Nuke002Subtitle
+"*Soon your base will glow like the sun"
+END
+
+DIALOGEVENT:Taunts_Nuke003Subtitle
+"*How do you expect to fight this, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke004Subtitle
+"*Your weapons are no match for my power!"
+END
+
+DIALOGEVENT:Taunts_Nuke005Subtitle
+"*Melt! Everything must melt!"
+END
+
+DIALOGEVENT:Taunts_Nuke006Subtitle
+"* The glow! The wonderful glow! Can't you see it, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke007Subtitle
+"*It looks like a nuclear winter this year, General"
+END
+
+DIALOGEVENT:Taunts_Nuke008Subtitle
+"*The end is near, General"
+END
+
+DIALOGEVENT:Taunts_Nuke009Subtitle
+"*This is only the beginning, General. The beginning of the end"
+END
+
+DIALOGEVENT:Taunts_Nuke010Subtitle
+"*Don't worry, General, the warheads are on their way"
+END
+
+DIALOGEVENT:Taunts_Nuke011Subtitle
+"*Sorry for the delay, General; just gathering my forces"
+END
+
+DIALOGEVENT:Taunts_Nuke012Subtitle
+"*Is the heat getting to you, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke013Subtitle
+"*Having a meltdown, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke014Subtitle
+"*All forces, prepare for the next assault"
+END
+
+DIALOGEVENT:Taunts_Nuke015Subtitle
+"*Now where did I put those launch codes?"
+END
+
+DIALOGEVENT:Taunts_Nuke016Subtitle
+"*Are you ready for more, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke017Subtitle
+"*I think this is your half-life, General"
+END
+
+DIALOGEVENT:Taunts_Nuke018Subtitle
+"*I hope your radar isn't down, General; I'd hate for you to miss what's coming next"
+END
+
+DIALOGEVENT:Taunts_Nuke019Subtitle
+"*I know your weaknesses now, General. The next attack will be unstoppable"
+END
+
+DIALOGEVENT:Taunts_Nuke020Subtitle
+"*Soon you will know the glory of my nuclear arsenal"
+END
+
+DIALOGEVENT:Taunts_Nuke021Subtitle
+"*I'd stock up on sun-block if I were you, General"
+END
+
+DIALOGEVENT:Taunts_Nuke022Subtitle
+"*"
+END
+
+DIALOGEVENT:Taunts_Nuke023Subtitle
+"*Eventually someone must win the arms race, or what's the point of racing?"
+END
+
+DIALOGEVENT:Taunts_Nuke024Subtitle
+"*Time to put on the lead underwear"
+END
+
+DIALOGEVENT:Taunts_Nuke025Subtitle
+"*Remember: Don't look directly at the blast, General"
+END
+
+DIALOGEVENT:Taunts_Nuke026Subtitle
+"*It appears you have only trained your men to die, General"
+END
+
+DIALOGEVENT:Taunts_Nuke027Subtitle
+"*Now your War Factory is a glow crater. Wonderful"
+END
+
+DIALOGEVENT:Taunts_Nuke028Subtitle
+"*Your defenses crack like so many eggshells, General"
+END
+
+DIALOGEVENT:Taunts_Nuke029Subtitle
+"*Oh, you weren't in that Command Center, were you, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke030Subtitle
+"*Why do you destroy my barracks, General? It isn't my men you should fear"
+END
+
+DIALOGEVENT:Taunts_Nuke031Subtitle
+"*My War Factory! What have you done?! My precious tanks�gone..."
+END
+
+DIALOGEVENT:Taunts_Nuke032Subtitle
+"*Leave me alone! What have I ever done to you?"
+END
+
+DIALOGEVENT:Taunts_Nuke033Subtitle
+"*My Command Center! No!!! I won't lose command! I won't!"
+END
+
+DIALOGEVENT:Taunts_Nuke034Subtitle
+"*I can't believe you are beating me! Perhaps you would give me a moment to rebuild?"
+END
+
+DIALOGEVENT:Taunts_Nuke035Subtitle
+"*We have suffered great loses at your hands, General, but this isn't over yet"
+END
+
+DIALOGEVENT:Taunts_Nuke036Subtitle
+"*General, you can have that oil derrick, but it won't help you stop me"
+END
+
+DIALOGEVENT:Taunts_Nuke037Subtitle
+"*Get out of my base, General! I won't ask twice"
+END
+
+DIALOGEVENT:Taunts_Nuke038Subtitle
+"*How long were you planning on stay in my base, General? Should I prepare a bunk for you?"
+END
+
+DIALOGEVENT:Taunts_Nuke039Subtitle
+"*Leave my base, General, or I will be forced detonate my warheads"
+END
+
+DIALOGEVENT:Taunts_Nuke040Subtitle
+"*Do you like my village, General? Please, make yourself at home"
+END
+
+DIALOGEVENT:Taunts_Nuke041Subtitle
+"*Coming to inspect the nukes, General? You can look, but don't touch"
+END
+
+DIALOGEVENT:Taunts_Nuke042Subtitle
+"*I'd be careful, General; these nuclear depots tend to leak"
+END
+
+DIALOGEVENT:Taunts_Nuke043Subtitle
+"*Get away from my supplies, General!"
+END
+
+DIALOGEVENT:Taunts_Nuke044Subtitle
+"*General, I wouldn't capture that oil derrick if I were you--I'll only destroy it"
+END
+
+DIALOGEVENT:Taunts_Nuke045Subtitle
+"*Get away from my silos, General!"
+END
+
+DIALOGEVENT:Taunts_Nuke046Subtitle
+"*I see your power is down, General. Should I send you some nuclear energy?"
+END
+
+DIALOGEVENT:Taunts_Nuke047Subtitle
+"*Out of funds already? Don't you know war is expensive, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke048Subtitle
+"*Please, build more tanks, General; even they will melt�eventually"
+END
+
+DIALOGEVENT:Taunts_Nuke049Subtitle
+"*Keep those planes away from my silos!"
+END
+
+DIALOGEVENT:Taunts_Nuke050Subtitle
+"*So many soldiers, General. Do they have their radiation suits on?"
+END
+
+DIALOGEVENT:Taunts_Nuke051Subtitle
+"*How many nukes do you think it will take me to destroy that new weapon, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke052Subtitle
+"*How many nukes do you think it will take me to destroy that new weapon, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke053Subtitle
+"*Selling off buildings? General, if you wanted to clear that area I could have done it for you"
+END
+
+DIALOGEVENT:Taunts_Nuke054Subtitle
+"*You cannot stand against my might, General"
+END
+
+DIALOGEVENT:Taunts_Nuke055Subtitle
+"*Surrender! Or do you want the bombing will continue?"
+END
+
+DIALOGEVENT:Taunts_Nuke056Subtitle
+"*You are losing this war, General. A few more bombs and your base will fall!"
+END
+
+DIALOGEVENT:Taunts_Nuke057Subtitle
+"*Might makes right. Wouldn't you agree, General"
+END
+
+DIALOGEVENT:Taunts_Nuke058Subtitle
+"*And now for my final attack. Hold on, General, you're going to like this�wait, no you won't"
+END
+
+DIALOGEVENT:Taunts_Nuke059Subtitle
+"*None will stand against our nuclear arsenal"
+END
+
+DIALOGEVENT:Taunts_Nuke060Subtitle
+"*Challenge me and your base will glow like the sun"
+END
+
+DIALOGEVENT:Taunts_Nuke061Subtitle
+"*Soon you'll be nothing more than nuclear waste"
+END
+
+DIALOGEVENT:Taunts_Nuke062Subtitle
+"*Another moment and I would have reduced you to dust"
+END
+
+DIALOGEVENT:Taunts_Nuke063Subtitle
+"*You are lucky to have survived this battle intact. Challenge me again if you dare"
+END
+
+DIALOGEVENT:Taunts_Nuke064Subtitle
+"*Welcome to the party, General. Please excuse the mess"
+END
+
+DIALOGEVENT:Taunts_Nuke065Subtitle
+"*Now, General, I think you understand why I am known as Mao the Nuke"
+END
+
+DIALOGEVENT:Taunts_Nuke066Subtitle
+"*We've been waiting for you, General. Please accept our gifts"
+END
+
+DIALOGEVENT:Taunts_Nuke067Subtitle
+"*More gifts, General. Our generosity is limitless"
+END
+
+DIALOGEVENT:Taunts_Nuke068Subtitle
+"*Now the battle begins in earnest. Prepare yourself, General"
+END
+
+DIALOGEVENT:Taunts_Nuke069Subtitle
+"*Cold fusion is no way to create power, General"
+END
+
+DIALOGEVENT:Taunts_Nuke070Subtitle
+"*It pains me to destroy your reactors, General"
+END
+
+DIALOGEVENT:Taunts_Nuke071Subtitle
+"*You call that a "super weapon", General? It breaks like a toy"
+END
+
+DIALOGEVENT:Taunts_Nuke072Subtitle
+"*No! My warheads! My beautiful warheads! You will pay, General"
+END
+
+DIALOGEVENT:Taunts_Nuke073Subtitle
+"*That's okay, General, I have more nukes for you"
+END
+
+DIALOGEVENT:Taunts_Nuke074Subtitle
+"*Hey, do you know how much that nuke silo costs?"
+END
+
+DIALOGEVENT:Taunts_Nuke075Subtitle
+"*Okay, General, that's enough--I'm running out of nukes!"
+END
+
+DIALOGEVENT:Taunts_Nuke076Subtitle
+"*Why do you want to blow-up my nukes anyway, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke077Subtitle
+"*No! That was my last nuclear silo! Why, General..why?"
+END
+
+DIALOGEVENT:Taunts_Nuke078Subtitle
+"*(enemy lost all silo) You have destroyed all of my silos�why, General? Why?!"
+END
+
+DIALOGEVENT:Taunts_Nuke079Subtitle
+"*(enemy caps player barracks) I've captured your barracks, General. Perhaps I will sell it"
+END
+
+DIALOGEVENT:Taunts_Nuke080Subtitle
+"*(enemy caps player war factory) My men have captured your War Factory. You really should have guarded it better"
+END
+
+DIALOGEVENT:Taunts_Nuke081Subtitle
+"*(player base) Your defenses are weak, General; we have entered you base"
+END
+
+DIALOGEVENT:Taunts_Nuke082Subtitle
+"*(combat zone) My forces are in the field, General. Soon they will roll into your base"
+END
+
+DIALOGEVENT:Taunts_Nuke083Subtitle
+"*(supply dock area) Ah, we've found some supplies. Soon we will control all of the resources!"
+END
+
+DIALOGEVENT:Taunts_Nuke084Subtitle
+"*(second supply dock area) More supplies for us. How are you funding your troops, General?"
+END
+
+DIALOGEVENT:Taunts_Nuke085Subtitle
+"*(oil derrick area) Red Guard--capture that oil derrick!"
+END
+
+DIALOGEVENT:Taunts_Nuke086Subtitle
+"*It appears we have used all the supplies in the area. I hope you've made other arrangements, General"
+END
+
+DIALOGEVENT:Taunts_Nuke087Subtitle
+"*(enemy out of power) What?! I'm out of power? How can I be out of power? Someone get me more power! Now!"
+END
+
+DIALOGEVENT:Taunts_Nuke088Subtitle
+"*(ambulance) That ambulance will not save your men from the radiation"
+END
+
+DIALOGEVENT:Taunts_Nuke089Subtitle
+"*(strat center) A Strategy Center? What strategy could you possibly devise to fight me?"
+END
+
+DIALOGEVENT:Taunts_Nuke090Subtitle
+"*(black market) The Black Market won't sell you anything powerful enough to stop me, General"
+END
+
+DIALOGEVENT:Taunts_Nuke091Subtitle
+"*(propaganda center) Your propaganda will not turn anyone against my nuclear power, General"
+END
+
+DIALOGEVENT:Taunts_Nuke092Subtitle
+"*Oh, look--I have a nuke ready for you"
+END
+
+DIALOGEVENT:Taunts_Nuke093Subtitle
+"*Wow, two nukes! I am pleased"
+END
+
+DIALOGEVENT:Taunts_Nuke094Subtitle
+"*Three nukes?!? That's three times the fun!"
+END
+
+DIALOGEVENT:Taunts_Nuke095Subtitle
+"*Four nukes? Incredible!"
+END
+
+DIALOGEVENT:Taunts_Nuke096Subtitle
+"*Five nukes? Maybe you want me to send you a clean pair of shorts now?"
+END
+
+DIALOGEVENT:Taunts_Nuke097Subtitle
+"*(player sells building) General, if you sell off any more buildings I'll win by default"
+END
+
+DIALOGEVENT:Taunts_Stealth001Subtitle
+"*Look at what I've found"
+END
+
+DIALOGEVENT:Taunts_Stealth002Subtitle
+"*Here comes my next attack�try to be ready this time, General"
+END
+
+DIALOGEVENT:Taunts_Stealth003Subtitle
+"*You can't kill what you can't see"
+END
+
+DIALOGEVENT:Taunts_Stealth004Subtitle
+"*You didn't need those troops anyways"
+END
+
+DIALOGEVENT:Taunts_Stealth005Subtitle
+"*Sleeping on the job again?"
+END
+
+DIALOGEVENT:Taunts_Stealth006Subtitle
+"*hanks for the new units. They'll prove useful in destroying you"
+END
+
+DIALOGEVENT:Taunts_Stealth007Subtitle
+"*Watch this! Oh wait, you can't"
+END
+
+DIALOGEVENT:Taunts_Stealth008Subtitle
+"*Did you bring your thermal goggles?"
+END
+
+DIALOGEVENT:Taunts_Stealth009Subtitle
+"*I think it's time to acquire a new base"
+END
+
+DIALOGEVENT:Taunts_Stealth010Subtitle
+"*It was never meant to be General. Good bye!"
+END
+
+DIALOGEVENT:Taunts_Stealth011Subtitle
+"*Closing your eyes will not make the pain of defeat any easier"
+END
+
+DIALOGEVENT:Taunts_Stealth012Subtitle
+"*My stealth assassins will make short work of your forces, General"
+END
+
+DIALOGEVENT:Taunts_Stealth013Subtitle
+"*We will strike like the snake--quick and invisible"
+END
+
+DIALOGEVENT:Taunts_Stealth014Subtitle
+"*You will not stand against this attack, General"
+END
+
+DIALOGEVENT:Taunts_Stealth015Subtitle
+"*Handsome Generals always win battles"
+END
+
+DIALOGEVENT:Taunts_Stealth016Subtitle
+"*You'll never see me until it is too late , General"
+END
+
+DIALOGEVENT:Taunts_Stealth017Subtitle
+"*General, perhaps you could introduce me to Black Lotus. I'm a great admirer of her�uh, work"
+END
+
+DIALOGEVENT:Taunts_Stealth018Subtitle
+"*When it is quiet you should fear me the most"
+END
+
+DIALOGEVENT:Taunts_Stealth019Subtitle
+"*I can't wait for your next attack, General. Can we expect it today?"
+END
+
+DIALOGEVENT:Taunts_Stealth020Subtitle
+"*Don't let your senses grow dull, General--you can expect my attack any moment now"
+END
+
+DIALOGEVENT:Taunts_Stealth021Subtitle
+"*You can't defeat me, General"
+END
+
+DIALOGEVENT:Taunts_Stealth022Subtitle
+"*I will attack when you least expect it, General"
+END
+
+DIALOGEVENT:Taunts_Stealth023Subtitle
+"*My men are all over the battlefield, General...hidden from view�ready to strike"
+END
+
+DIALOGEVENT:Taunts_Stealth024Subtitle
+"*Stealth is my ally�and your enemy"
+END
+
+DIALOGEVENT:Taunts_Stealth025Subtitle
+"*You've lost your Tech Building, General. What shall you lose next?"
+END
+
+DIALOGEVENT:Taunts_Stealth026Subtitle
+"*You could not stop me from destroying you Barracks, General. What do you value if not your men?"
+END
+
+DIALOGEVENT:Taunts_Stealth027Subtitle
+"*Destroying you War Factory was child's-play. Your Command Center can't be far behind"
+END
+
+DIALOGEVENT:Taunts_Stealth028Subtitle
+"*Your planes have lost their Air Field, and you have lost your advantage, General"
+END
+
+DIALOGEVENT:Taunts_Stealth029Subtitle
+"*There is a hole in your defenses now, General. Who can say how many of my men are in your base now"
+END
+
+DIALOGEVENT:Taunts_Stealth030Subtitle
+"*Your Command Center is gone, General. My victory is all but assured"
+END
+
+DIALOGEVENT:Taunts_Stealth031Subtitle
+"*I don't relish destroying your buildings, General, but you leave me no choice"
+END
+
+DIALOGEVENT:Taunts_Stealth032Subtitle
+"*You are targeting my Tech Buildings because you have no hope of reaching my base"
+END
+
+DIALOGEVENT:Taunts_Stealth033Subtitle
+"*You have destroyed my Barracks, but we will rebuild and those men will be avenged"
+END
+
+DIALOGEVENT:Taunts_Stealth034Subtitle
+"*My Arms Dealer will not be pleased that you destroyed his depot, General"
+END
+
+DIALOGEVENT:Taunts_Stealth035Subtitle
+"*You have destroyed that base defense, General, but that just may have allowed my men time to out-flank you"
+END
+
+DIALOGEVENT:Taunts_Stealth036Subtitle
+"*You've destroyed many of my buildings, but with even one factory left I am a dangerous opponent, General"
+END
+
+DIALOGEVENT:Taunts_Stealth037Subtitle
+"*Nicely played, General; you've destroyed my Command Center. Now I will be forced to fight dirty"
+END
+
+DIALOGEVENT:Taunts_Stealth038Subtitle
+"*You're quite adept at discovering my camouflaged vehicles, General. I'll consider a new tactic"
+END
+
+DIALOGEVENT:Taunts_Stealth039Subtitle
+"*Your brutish tactics are costing me men, General. I'll reconsider my tactics now that I know you have none"
+END
+
+DIALOGEVENT:Taunts_Stealth040Subtitle
+"*Now that I've captured this Oil Derrick, my forces will grow even faster"
+END
+
+DIALOGEVENT:Taunts_Stealth041Subtitle
+"*Artillery Platforms are so brutish, but I can't let you have it, can I?"
+END
+
+DIALOGEVENT:Taunts_Stealth042Subtitle
+"*This Oil Refinery is now mine, General"
+END
+
+DIALOGEVENT:Taunts_Stealth043Subtitle
+"*General, you are coming dangerously close to my base"
+END
+
+DIALOGEVENT:Taunts_Stealth044Subtitle
+"*I see forces approaching my base, General. You don't mean to invade do you?"
+END
+
+DIALOGEVENT:Taunts_Stealth045Subtitle
+"*You are testing my patience, General. Remove you forces from my base"
+END
+
+DIALOGEVENT:Taunts_Stealth046Subtitle
+"*If you do not remove your forces from my base, I'll remove them permanently"
+END
+
+DIALOGEVENT:Taunts_Stealth047Subtitle
+"*So you're trying to enter my base from the flank. We'll put a stop to that"
+END
+
+DIALOGEVENT:Taunts_Stealth048Subtitle
+"*A back-door attack? I didn't realize you were so devious, General"
+END
+
+DIALOGEVENT:Taunts_Stealth049Subtitle
+"*A frontal assault? That will prove a fatal mistake, General"
+END
+
+DIALOGEVENT:Taunts_Stealth050Subtitle
+"*Those are my resources, General--go find your own"
+END
+
+DIALOGEVENT:Taunts_Stealth051Subtitle
+"*Why do you insist on approaching my base that way, General?"
+END
+
+DIALOGEVENT:Taunts_Stealth052Subtitle
+"*That route is not as unguarded as it seems, General"
+END
+
+DIALOGEVENT:Taunts_Stealth053Subtitle
+"*The only thing you will find here is your own destruction, General"
+END
+
+DIALOGEVENT:Taunts_Stealth054Subtitle
+"*What is your fascination with this area, General?"
+END
+
+DIALOGEVENT:Taunts_Stealth055Subtitle
+"*We are nearing your base, General. There may be cross-hairs on your head right now"
+END
+
+DIALOGEVENT:Taunts_Stealth056Subtitle
+"*Your outer defenses are weak, General. Let's hope you base is better protected"
+END
+
+DIALOGEVENT:Taunts_Stealth057Subtitle
+"*We have entered you base, General. Ignore us at your own peril"
+END
+
+DIALOGEVENT:Taunts_Stealth058Subtitle
+"*Your defenses are broken, General. How will you repel us now?"
+END
+
+DIALOGEVENT:Taunts_Stealth059Subtitle
+"*You really should be defending these resources, General, or this battle will be very short"
+END
+
+DIALOGEVENT:Taunts_Stealth060Subtitle
+"*I've found your Tech Buildings, General. What should I do with them?"
+END
+
+DIALOGEVENT:Taunts_Stealth061Subtitle
+"*I've found the back-door to your base, General"
+END
+
+DIALOGEVENT:Taunts_Stealth062Subtitle
+"*Can you defend against my flanking attack, General? Let's find out"
+END
+
+DIALOGEVENT:Taunts_Stealth063Subtitle
+"*Only a careless general would allow the power to fail"
+END
+
+DIALOGEVENT:Taunts_Stealth064Subtitle
+"*Your power is down, General. You did not plan your infrastructure properly. Let's hope it isn't a fatal mistake"
+END
+
+DIALOGEVENT:Taunts_Stealth065Subtitle
+"*General, you can't fight without resources. What will you do now?"
+END
+
+DIALOGEVENT:Taunts_Stealth066Subtitle
+"*You have robbed me of my resources, General. Now I will return the favor"
+END
+
+DIALOGEVENT:Taunts_Stealth067Subtitle
+"*So, you have built a Scud Storm. We will have to deal with this new threat"
+END
+
+DIALOGEVENT:Taunts_Stealth068Subtitle
+"*Nuclear weapons have no place in this battle, General. Why do you insist on building them?"
+END
+
+DIALOGEVENT:Taunts_Stealth069Subtitle
+"*You would strike at me from space with your cowardly Particle Cannon? I am disappointed, General"
+END
+
+DIALOGEVENT:Taunts_Stealth070Subtitle
+"*So many base defenses, General. What are you afraid of?"
+END
+
+DIALOGEVENT:Taunts_Stealth071Subtitle
+"*You're building tanks, are you. Well, a few more sniper should take care of that"
+END
+
+DIALOGEVENT:Taunts_Stealth072Subtitle
+"*More planes? Why so many, General? Afraid to come down and face me?"
+END
+
+DIALOGEVENT:Taunts_Stealth073Subtitle
+"*Let me give you some advice, General. That large group of infantry is no match for my snipers"
+END
+
+DIALOGEVENT:Taunts_Stealth074Subtitle
+"*Your base has grown so large, General. Do you think you can defend all your buildings from capture?"
+END
+
+DIALOGEVENT:Taunts_Stealth075Subtitle
+"*You've launched! You'll regret using that Scud Storm, General"
+END
+
+DIALOGEVENT:Taunts_Stealth076Subtitle
+"*Nuclear missiles! I thought you were bluffing, General"
+END
+
+DIALOGEVENT:Taunts_Stealth077Subtitle
+"*Yes, look at the cowardly particle beam. Enjoy this, General--my answer will be swift and brutal"
+END
+
+DIALOGEVENT:Taunts_Stealth078Subtitle
+"*By all means, General, garrison that building�my snipers can possibly hit them in there"
+END
+
+DIALOGEVENT:Taunts_Stealth079Subtitle
+"*Colonel Burton, General? Perhaps you should make him the general; you'll only lead him to an early grave"
+END
+
+DIALOGEVENT:Taunts_Stealth080Subtitle
+"*Ah� the beautiful Black Lotus. Perhaps after you're defeated, General, she'll agree to join me"
+END
+
+DIALOGEVENT:Taunts_Stealth081Subtitle
+"*Jarmen Kell?! All snipers beware: Jarmen Kell has entered the field"
+END
+
+DIALOGEVENT:Taunts_Stealth082Subtitle
+"*Wise choice, building an Air Field, but planes alone will not be enough to defeat me, General"
+END
+
+DIALOGEVENT:Taunts_Stealth083Subtitle
+"*My spies tell me you've finally built your War Factory, General. Are you ready to fight now?"
+END
+
+DIALOGEVENT:Taunts_Stealth084Subtitle
+"*Train all the men you wish from that Barracks, General; they are no match for my snipers"
+END
+
+DIALOGEVENT:Taunts_Stealth085Subtitle
+"*You've sold-off one of your buildings. Such tactics lead to defeat, General"
+END
+
+DIALOGEVENT:Taunts_Stealth086Subtitle
+"*How are you defeating my forces?! It's not possible!"
+END
+
+DIALOGEVENT:Taunts_Stealth087Subtitle
+"*You may have the upper-hand now, but your desperate tactics will not endure, General"
+END
+
+DIALOGEVENT:Taunts_Stealth088Subtitle
+"*My forces will rise up against your oppression and we will defeat you, General"
+END
+
+DIALOGEVENT:Taunts_Stealth089Subtitle
+"*Enjoy your advantage for now, General�you'll make a mistake soon and I'll turn the tide of this battle"
+END
+
+DIALOGEVENT:Taunts_Stealth090Subtitle
+"*So it ends�you've defeated me, General, but someday I'll have my revenge. Watch your back, General"
+END
+
+DIALOGEVENT:Taunts_Stealth091Subtitle
+"*Your forces are weakening, General. Accept defeat and I'll go easy on you"
+END
+
+DIALOGEVENT:Taunts_Stealth092Subtitle
+"*Your attacks are ineffective against me, General. Soon we'll sweep in and destroy you"
+END
+
+DIALOGEVENT:Taunts_Stealth093Subtitle
+"*I'm enjoying this little game, General, but your pathetic attacks are beginning to bore me"
+END
+
+DIALOGEVENT:Taunts_Stealth094Subtitle
+"*I thought you would provide more of a challenge, General. I guess I overestimated you"
+END
+
+DIALOGEVENT:Taunts_Stealth095Subtitle
+"*You have fallen to Kassad, like all have before you"
+END
+
+DIALOGEVENT:Taunts_Stealth096Subtitle
+"*We will strike like the snake--unseen and deadly"
+END
+
+DIALOGEVENT:Taunts_Stealth097Subtitle
+"*Now you see me--now you're dead"
+END
+
+DIALOGEVENT:Taunts_Stealth098Subtitle
+"*I am Kassad"
+END
+
+DIALOGEVENT:Taunts_Stealth099Subtitle
+"*This will not go well for you, General"
+END
+
+DIALOGEVENT:Taunts_Stealth100Subtitle
+"*My men will not accept this defeat from their leader, General. You have signed my death warrant with your superior tactics�"
+END
+
+DIALOGEVENT:Taunts_Stealth101Subtitle
+"*Accept your bitter defeat and remove yourself from my sight, General"
+END
+
+DIALOGEVENT:Taunts_Stealth102Subtitle
+"*And another who stood against me falls�"
+END
+
+DIALOGEVENT:Taunts_Stealth103Subtitle
+"*And so it will be for you, General--no warning, no mercy�"
+END
+
+DIALOGEVENT:Taunts_Stealth104Subtitle
+"*You still have time to flee with your life, General. <evil laughter trailing off to silence>"
+END
+
+DIALOGEVENT:Taunts_Tank001Subtitle
+"*I see you haven't run in fear, General. Soon you'll wish you had"
+END
+
+DIALOGEVENT:Taunts_Tank002Subtitle
+"*My forces are at your door, General"
+END
+
+DIALOGEVENT:Taunts_Tank003Subtitle
+"*The iron dragon marches through your puny defenses"
+END
+
+DIALOGEVENT:Taunts_Tank004Subtitle
+"*I fear this will end you, General"
+END
+
+DIALOGEVENT:Taunts_Tank005Subtitle
+"*Mmm�can you feel the thunderous song of approaching armor, General?"
+END
+
+DIALOGEVENT:Taunts_Tank006Subtitle
+"*Are you protecting your flanks, General? Why don't we have a look"
+END
+
+DIALOGEVENT:Taunts_Tank007Subtitle
+"*Are you impressed with the modifications to my tanks, General?"
+END
+
+DIALOGEVENT:Taunts_Tank008Subtitle
+"*Armor...crush them"
+END
+
+DIALOGEVENT:Taunts_Tank009Subtitle
+"*Soon, the field will fill with tanks�my tanks"
+END
+
+DIALOGEVENT:Taunts_Tank010Subtitle
+"*All units...attack"
+END
+
+DIALOGEVENT:Taunts_Tank011Subtitle
+"*Nice base, General�care to surrender it?"
+END
+
+DIALOGEVENT:Taunts_Tank012Subtitle
+"*This spells your doom, General"
+END
+
+DIALOGEVENT:Taunts_Tank013Subtitle
+"*We're in your base, General; your defenses were inadequate"
+END
+
+DIALOGEVENT:Taunts_Tank014Subtitle
+"*You dare attack my War Factory! All forces, remove this pest!"
+END
+
+DIALOGEVENT:Taunts_Tank015Subtitle
+"*Tanks�build more tanks�"
+END
+
+DIALOGEVENT:Taunts_Tank016Subtitle
+"*Another battalion is on its way, General, please make them feel welcome"
+END
+
+DIALOGEVENT:Taunts_Tank017Subtitle
+"*Ah, this is the part of the battle I enjoy the most�the part just before I finish off my enemy"
+END
+
+DIALOGEVENT:Taunts_Tank018Subtitle
+"*Tanks: move faster�before our opponent considers an actual attack"
+END
+
+DIALOGEVENT:Taunts_Tank019Subtitle
+"*It's quiet out there, General. There must be a lot of tanks rolling towards your base, don't you think?"
+END
+
+DIALOGEVENT:Taunts_Tank020Subtitle
+"*I'm going to take this time to construct more defenses�no, wait, I'll build more tanks instead"
+END
+
+DIALOGEVENT:Taunts_Tank021Subtitle
+"*This area was once fertile farm land. Soon your blood will make it fertile again"
+END
+
+DIALOGEVENT:Taunts_Tank022Subtitle
+"*Your tactics amuse me, General"
+END
+
+DIALOGEVENT:Taunts_Tank023Subtitle
+"*Enjoy the rest, General--soon the attacks will begin again"
+END
+
+DIALOGEVENT:Taunts_Tank024Subtitle
+"*We're awaiting your assault, General, but I'm beginning to wonder if it will ever come"
+END
+
+DIALOGEVENT:Taunts_Tank025Subtitle
+"*Our War Factories are working hard to make more tanks, just for you, General"
+END
+
+DIALOGEVENT:Taunts_Tank026Subtitle
+"*How much longer can you survive such loses, General? Perhaps it is time to consider surrender"
+END
+
+DIALOGEVENT:Taunts_Tank027Subtitle
+"*Tanks amass in our base, preparing for the final assault. Will your defenses hold this time?"
+END
+
+DIALOGEVENT:Taunts_Tank028Subtitle
+"*Soon we will remove you from our lands"
+END
+
+DIALOGEVENT:Taunts_Tank029Subtitle
+"*This will be your last chance to prove yourself, General. Soon my tanks will end your pitiful army"
+END
+
+DIALOGEVENT:Taunts_Tank030Subtitle
+"*You cannot believe your luck will hold out much longer�can you, General?"
+END
+
+DIALOGEVENT:Taunts_Tank031Subtitle
+"*You didn't want that Tech Building, did you?"
+END
+
+DIALOGEVENT:Taunts_Tank032Subtitle
+"*Your Barracks has fallen to my tanks, General"
+END
+
+DIALOGEVENT:Taunts_Tank033Subtitle
+"*There goes your factory, General. How will you match my armor now?"
+END
+
+DIALOGEVENT:Taunts_Tank034Subtitle
+"*Without your airfield you've lost your only chance against me, General"
+END
+
+DIALOGEVENT:Taunts_Tank035Subtitle
+"*Your defenses fall like toys before my armor"
+END
+
+DIALOGEVENT:Taunts_Tank036Subtitle
+"*You can't lost your Command Center and all hope to win against me, General. I await your surrender"
+END
+
+DIALOGEVENT:Taunts_Tank037Subtitle
+"*You've lost a lot of buildings, General�isn't it time to surrender?"
+END
+
+DIALOGEVENT:Taunts_Tank038Subtitle
+"*That tech building was mine, General; you will regret destroying it"
+END
+
+DIALOGEVENT:Taunts_Tank039Subtitle
+"*So, you've destroyed my Barracks--so be it. Now I will destroy yours"
+END
+
+DIALOGEVENT:Taunts_Tank040Subtitle
+"*We will rebuild that War Factory. Soon the tanks will again flow to your base like water"
+END
+
+DIALOGEVENT:Taunts_Tank041Subtitle
+"*Destroying my Airfield will not stop me, General"
+END
+
+DIALOGEVENT:Taunts_Tank042Subtitle
+"*Destroying my defenses only let's me know where you are, General"
+END
+
+DIALOGEVENT:Taunts_Tank043Subtitle
+"*General, you are destroying an unacceptable number of my buildings. This must stop"
+END
+
+DIALOGEVENT:Taunts_Tank044Subtitle
+"*You've destroyed my Command Center�I am impressed, General...few survive this long"
+END
+
+DIALOGEVENT:Taunts_Tank045Subtitle
+"*You're shooting at my planes?! Do you think this is the best tactic against me, General?"
+END
+
+DIALOGEVENT:Taunts_Tank046Subtitle
+"*Enough! Do not destroy any more of my tanks, General"
+END
+
+DIALOGEVENT:Taunts_Tank047Subtitle
+"*Stop targeting my infantry, you coward!"
+END
+
+DIALOGEVENT:Taunts_Tank048Subtitle
+"*General, I need that Oil Derrick for my tanks. Release it to me or pay"
+END
+
+DIALOGEVENT:Taunts_Tank049Subtitle
+"*That Artillery Platform is no match for my armor, General"
+END
+
+DIALOGEVENT:Taunts_Tank050Subtitle
+"*Ah, I see you captured an Oil Refinery. Perhaps I should take it from you"
+END
+
+DIALOGEVENT:Taunts_Tank051Subtitle
+"*We are approaching you base, General. Prepare yourself"
+END
+
+DIALOGEVENT:Taunts_Tank052Subtitle
+"*Ah, my tanks are almost in range of your base. This should be over soon"
+END
+
+DIALOGEVENT:Taunts_Tank053Subtitle
+"*We've breached your defenses, General. Now your factories will begin to fall"
+END
+
+DIALOGEVENT:Taunts_Tank054Subtitle
+"*Thank you for inviting us into your base, General"
+END
+
+DIALOGEVENT:Taunts_Tank055Subtitle
+"*I see your flank is exposed, General. I expected as much"
+END
+
+DIALOGEVENT:Taunts_Tank056Subtitle
+"*There are no guards at your backdoor--a fatal mistake on your part, General"
+END
+
+DIALOGEVENT:Taunts_Tank057Subtitle
+"*I see you've built a second base, General. It will soon be removed"
+END
+
+DIALOGEVENT:Taunts_Tank058Subtitle
+"*Ah, I've found your Tech Building. Now, should I destroy it or capture it?"
+END
+
+DIALOGEVENT:Taunts_Tank059Subtitle
+"*Your power is down--your forces are finished"
+END
+
+DIALOGEVENT:Taunts_Tank060Subtitle
+"*I would suggest restoring your power, General�before we turn it off permanently"
+END
+
+DIALOGEVENT:Taunts_Tank061Subtitle
+"*Your supply pile looks low�now nothing can stop us"
+END
+
+DIALOGEVENT:Taunts_Tank062Subtitle
+"*Supplies! I need more supplies!"
+END
+
+DIALOGEVENT:Taunts_Tank063Subtitle
+"*And what you plan to do with that Scud Storm, General?"
+END
+
+DIALOGEVENT:Taunts_Tank064Subtitle
+"*And now this war has gone nuclear�excellent"
+END
+
+DIALOGEVENT:Taunts_Tank065Subtitle
+"*That Particle Cannon will never live to fire on me"
+END
+
+DIALOGEVENT:Taunts_Tank066Subtitle
+"*So many base defenses, General�all so useless"
+END
+
+DIALOGEVENT:Taunts_Tank067Subtitle
+"*So, you're trying to match my tanks in the field. I question your tactics, General"
+END
+
+DIALOGEVENT:Taunts_Tank068Subtitle
+"*I see many planes, General--like gnats waiting to be swatted out of the sky"
+END
+
+DIALOGEVENT:Taunts_Tank069Subtitle
+"*You have trained too many men, General; they will all be crushed beneath my treads"
+END
+
+DIALOGEVENT:Taunts_Tank070Subtitle
+"*Your base has grown too large, General--my tanks will enjoy the target practice"
+END
+
+DIALOGEVENT:Taunts_Tank071Subtitle
+"*Your Scud Storm will harm us, but now you have made me angry, General"
+END
+
+DIALOGEVENT:Taunts_Tank072Subtitle
+"*Only a failed General would resort to nuclear missiles"
+END
+
+DIALOGEVENT:Taunts_Tank073Subtitle
+"*This particle beam will not defeat us, General"
+END
+
+DIALOGEVENT:Taunts_Tank074Subtitle
+"*Yes, garrison your buildings--you only delay the inevitable"
+END
+
+DIALOGEVENT:Taunts_Tank075Subtitle
+"*No one soldier can turn the tide, not even Colonel Burton"
+END
+
+DIALOGEVENT:Taunts_Tank076Subtitle
+"*Ah, Black Lotus, you grace us with your presence. Perhaps you would consider fighting for me"
+END
+
+DIALOGEVENT:Taunts_Tank077Subtitle
+"*All tanks beware: Jarmen Kell has entered the field"
+END
+
+DIALOGEVENT:Taunts_Tank078Subtitle
+"*An Air Field is a wise choice against me, but it won't save you from defeat, General"
+END
+
+DIALOGEVENT:Taunts_Tank079Subtitle
+"*Build your War Factories, General; they still will not produce tanks capable of stopping mine"
+END
+
+DIALOGEVENT:Taunts_Tank080Subtitle
+"*I see you've built a Barracks, General. Please, try to keep your men out from under my tanks"
+END
+
+DIALOGEVENT:Taunts_Tank081Subtitle
+"*Yes, sell all of your buildings and flee from the field, General. This battle is lost to you"
+END
+
+DIALOGEVENT:Taunts_Tank082Subtitle
+"*You are losing, General. This battle is mine"
+END
+
+DIALOGEVENT:Taunts_Tank083Subtitle
+"*All hope is gone now, General. Surrender or die"
+END
+
+DIALOGEVENT:Taunts_Tank084Subtitle
+"*General, my forces outnumber yours�it is only a matter to time now"
+END
+
+DIALOGEVENT:Taunts_Tank085Subtitle
+"*Your inferior strategy has lead you to this place, General. You can't win now"
+END
+
+DIALOGEVENT:Taunts_Tank086Subtitle
+"*My victory was assured from the beginning"
+END
+
+DIALOGEVENT:Taunts_Tank087Subtitle
+"*Your tactics have given you a momentary advantage,General, but you won't maintain it"
+END
+
+DIALOGEVENT:Taunts_Tank088Subtitle
+"*No! You will not win, General. We will build more tanks and defeat you"
+END
+
+DIALOGEVENT:Taunts_Tank089Subtitle
+"*Your cowardly tactics may have gotten you this far, but this foolishness ends now"
+END
+
+DIALOGEVENT:Taunts_Tank090Subtitle
+"*I think I've let you win long enough, General. Prepare for the end"
+END
+
+DIALOGEVENT:Taunts_Tank091Subtitle
+"*Arrrrrgh! This cannot be! How have you defeated my tanks?!"
+END
+
+DIALOGEVENT:Taunts_Tank092Subtitle
+"*Time to unleash the war machine"
+END
+
+DIALOGEVENT:Taunts_Tank093Subtitle
+"*Your tank rush is nothing compared to mine"
+END
+
+DIALOGEVENT:Taunts_Tank094Subtitle
+"*Don't challenge my tanks, General--you will lose"
+END
+
+DIALOGEVENT:Taunts_Tank095Subtitle
+"*My armor will crush your pathetic forces"
+END
+
+DIALOGEVENT:Taunts_Tank096Subtitle
+"*You may have defeated my tanks, General, but the Tigress will crush you like an insect"
+END
+
+DIALOGEVENT:Taunts_Tank097Subtitle
+"*Tanks are the key to any victory, as you well know"
+END
+
+DIALOGEVENT:Taunts_Tank098Subtitle
+"*I see you defeated my scouts, General. The next attack won't go so well for you, I think"
+END
+
+DIALOGEVENT:Taunts_Tank099Subtitle
+"*Here we come, General, I hope your defenses are up"
+END
+
+DIALOGEVENT:Taunts_Tank100Subtitle
+"*And these are just my Battlemasters, General�just wait until the Overlord join the battle"
+END
+
+DIALOGEVENT:Taunts_Tank101Subtitle
+"*I'd be careful, General, sometimes the Red Guard like to take over buildings while you're busy with my tanks"
+END
+
+DIALOGEVENT:Taunts_Toxin001Subtitle
+"*I see you!"
+END
+
+DIALOGEVENT:Taunts_Toxin002Subtitle
+"*One taste, and you'll never go back -- even if you wanted to!"
+END
+
+DIALOGEVENT:Taunts_Toxin003Subtitle
+"*Have a taste of my own medicine!"
+END
+
+DIALOGEVENT:Taunts_Toxin004Subtitle
+"*How long can you hold your breath?"
+END
+
+DIALOGEVENT:Taunts_Toxin005Subtitle
+"*Ready for another chemistry lesson?"
+END
+
+DIALOGEVENT:Taunts_Toxin006Subtitle
+"*It's not so bad. You should only feel a long and painful burning after this!"
+END
+
+DIALOGEVENT:Taunts_Toxin007Subtitle
+"*Toxin troopers, attack!"
+END
+
+DIALOGEVENT:Taunts_Toxin008Subtitle
+"*Here we come, General, like a chemical spill"
+END
+
+DIALOGEVENT:Taunts_Toxin009Subtitle
+"*It's so hard to find a doctor that makes housecalls, but Dr. Thrax does"
+END
+
+DIALOGEVENT:Taunts_Toxin010Subtitle
+"*Spill on isle one!"
+END
+
+DIALOGEVENT:Taunts_Toxin011Subtitle
+"*Like acid rain, we decend upon your base, General"
+END
+
+DIALOGEVENT:Taunts_Toxin012Subtitle
+"*Go forth, my toxic warriors! Bring our message to the masses!"
+END
+
+DIALOGEVENT:Taunts_Toxin013Subtitle
+"*Oh, you're going to like this, General. No, wait�no you won't"
+END
+
+DIALOGEVENT:Taunts_Toxin014Subtitle
+"*You've brought this on yourself, General. Now watch your men pay for your mistake"
+END
+
+DIALOGEVENT:Taunts_Toxin015Subtitle
+"*Silent� but deadly�"
+END
+
+DIALOGEVENT:Taunts_Toxin016Subtitle
+"*That's right -- sit back and relax! Give my toxins more time to work!"
+END
+
+DIALOGEVENT:Taunts_Toxin017Subtitle
+"*The suspense� it's killing you!"
+END
+
+DIALOGEVENT:Taunts_Toxin018Subtitle
+"*Time to brew another batch!"
+END
+
+DIALOGEVENT:Taunts_Toxin019Subtitle
+"*Every moment you delay, you die a little bit more!"
+END
+
+DIALOGEVENT:Taunts_Toxin020Subtitle
+"*You can tell they're just right when the flesh falls off the bone!"
+END
+
+DIALOGEVENT:Taunts_Toxin021Subtitle
+"*Anthrax� it does a body bad"
+END
+
+DIALOGEVENT:Taunts_Toxin022Subtitle
+"*Smell that? No?"
+END
+
+DIALOGEVENT:Taunts_Toxin023Subtitle
+"*And breathe in� out� and again� feel better?"
+END
+
+DIALOGEVENT:Taunts_Toxin024Subtitle
+"*Good to the last drop!"
+END
+
+DIALOGEVENT:Taunts_Toxin025Subtitle
+"*I'll give you a "breather" before our next attack"
+END
+
+DIALOGEVENT:Taunts_Toxin026Subtitle
+"*We have a clogged toxin nozzle, General�give me a second to fix it"
+END
+
+DIALOGEVENT:Taunts_Toxin027Subtitle
+"*You'll come for the toxin, but you'll stay�because you're dead!"
+END
+
+DIALOGEVENT:Taunts_Toxin028Subtitle
+"*You will regret intruding on my experiments, General"
+END
+
+DIALOGEVENT:Taunts_Toxin029Subtitle
+"*Are you going to attack me, or are you afraid of what you might find at my base, General?"
+END
+
+DIALOGEVENT:Taunts_Toxin030Subtitle
+"*Nothing can live beneath my toxic cloud, General"
+END
+
+DIALOGEVENT:Taunts_Toxin031Subtitle
+"*You didn't really need that anyway"
+END
+
+DIALOGEVENT:Taunts_Toxin032Subtitle
+"*Your troops appear intoxicated, General!"
+END
+
+DIALOGEVENT:Taunts_Toxin033Subtitle
+"*Ohh general, looks like your troops can't hold their toxin"
+END
+
+DIALOGEVENT:Taunts_Toxin034Subtitle
+"*Your Air Field is destroyed, General. Now you'll have to walk through my clouds of death"
+END
+
+DIALOGEVENT:Taunts_Toxin035Subtitle
+"*Notice how the toxins tear everything apart?"
+END
+
+DIALOGEVENT:Taunts_Toxin036Subtitle
+"*Argh! I had my wine collection in there!"
+END
+
+DIALOGEVENT:Taunts_Toxin037Subtitle
+"*My toxins and your troops certainly have chemistry!"
+END
+
+DIALOGEVENT:Taunts_Toxin038Subtitle
+"*I didn't need that anyway!"
+END
+
+DIALOGEVENT:Taunts_Toxin039Subtitle
+"*Now where will my chemical soldiers come from?"
+END
+
+DIALOGEVENT:Taunts_Toxin040Subtitle
+"*My toxin trucks will roll again!"
+END
+
+DIALOGEVENT:Taunts_Toxin041Subtitle
+"*See, people don't belong in the air"
+END
+
+DIALOGEVENT:Taunts_Toxin042Subtitle
+"*You inconvenience me, General!"
+END
+
+DIALOGEVENT:Taunts_Toxin043Subtitle
+"*Stop destroying my buildings, General, or I will make things�unpleasant for you"
+END
+
+DIALOGEVENT:Taunts_Toxin044Subtitle
+"*You've destroyed my Command Center! Ah well, I always hated my commanders anyway�now it's just you and me, General"
+END
+
+DIALOGEVENT:Taunts_Toxin045Subtitle
+"*General, if you keep destroying my vehicles, how can I bring you your medicine?"
+END
+
+DIALOGEVENT:Taunts_Toxin046Subtitle
+"*My brave warriors! How can you do this to them? What did they ever do to-- oh wait, never mind"
+END
+
+DIALOGEVENT:Taunts_Toxin047Subtitle
+"*Give that Oil Derrick back! Don't you know petroleum is a key ingredient in my toxins?!"
+END
+
+DIALOGEVENT:Taunts_Toxin048Subtitle
+"*That Artillery Platform will not stop me, General"
+END
+
+DIALOGEVENT:Taunts_Toxin049Subtitle
+"*General, I need that Refinery to purify my toxins. What could you possibly need it for?"
+END
+
+DIALOGEVENT:Taunts_Toxin050Subtitle
+"*Did I give you permission to come in?"
+END
+
+DIALOGEVENT:Taunts_Toxin051Subtitle
+"*What are you doing in here? The recipes are mine!"
+END
+
+DIALOGEVENT:Taunts_Toxin052Subtitle
+"*You are a fool to come into my base, General!"
+END
+
+DIALOGEVENT:Taunts_Toxin053Subtitle
+"*You are too close to my precious toxins, General. Now you must die"
+END
+
+DIALOGEVENT:Taunts_Toxin054Subtitle
+"*Stay away from my scud missiles! I'll give them to you when I'm ready!"
+END
+
+DIALOGEVENT:Taunts_Toxin055Subtitle
+"*I don't think you want those supplies, they aren't � ready yet"
+END
+
+DIALOGEVENT:Taunts_Toxin056Subtitle
+"*I see you're building another base. Soon it will be abandoned"
+END
+
+DIALOGEVENT:Taunts_Toxin057Subtitle
+"*Get out of my village, General. There's not much left of it, but it is mine!"
+END
+
+DIALOGEVENT:Taunts_Toxin058Subtitle
+"*Be careful as you cross that bridge, General--the water below isn't safe for swimming"
+END
+
+DIALOGEVENT:Taunts_Toxin059Subtitle
+"*Watch out, General, that bridge might not be safe�but then, what is around here?"
+END
+
+DIALOGEVENT:Taunts_Toxin060Subtitle
+"*Do you think you're being clever, sneaking in my backdoor?"
+END
+
+DIALOGEVENT:Taunts_Toxin061Subtitle
+"*So, you've made it across the river. Now the battle gets interesting"
+END
+
+DIALOGEVENT:Taunts_Toxin062Subtitle
+"*It looks like you're out of power, General. Perhaps I should attack now"
+END
+
+DIALOGEVENT:Taunts_Toxin063Subtitle
+"*You're out of power, General. It's time for me to come and play"
+END
+
+DIALOGEVENT:Taunts_Toxin064Subtitle
+"*Your resource pile has grown small,General. I don't think you have enough left to stop my next attack�excellent�"
+END
+
+DIALOGEVENT:Taunts_Toxin065Subtitle
+"*Budget?! I don't want to hear about the budget!"
+END
+
+DIALOGEVENT:Taunts_Toxin066Subtitle
+"*You dare to build a Scud Storm in my presence! You know, of course, that we are all immune to its toxins, right, General?"
+END
+
+DIALOGEVENT:Taunts_Toxin067Subtitle
+"*A Nuke Silo? I would not have expected you to use toxic radiation�perhaps we could work together sometime"
+END
+
+DIALOGEVENT:Taunts_Toxin068Subtitle
+"*So, a Particle Cannon to counter my toxins, eh? Your technology is no match for my toxins, General"
+END
+
+DIALOGEVENT:Taunts_Toxin069Subtitle
+"*So many defenses, General. ALL USELESS!!!"
+END
+
+DIALOGEVENT:Taunts_Toxin070Subtitle
+"*Metal is only a temporary barrier to my toxins!"
+END
+
+DIALOGEVENT:Taunts_Toxin071Subtitle
+"*Ah -- coward! Your pilots still need to breathe!"
+END
+
+DIALOGEVENT:Taunts_Toxin072Subtitle
+"*Do you enjoy seeing your men glow in the dark? Build more, then!"
+END
+
+DIALOGEVENT:Taunts_Toxin073Subtitle
+"*Your base has grown large, General�a perfect target for my Scud Storm�"
+END
+
+DIALOGEVENT:Taunts_Toxin074Subtitle
+"*Yes, fire your Scud Storm�visit your useless toxins upon my base"
+END
+
+DIALOGEVENT:Taunts_Toxin075Subtitle
+"*Your nuclear missile will only mutate us and make us stronger, General"
+END
+
+DIALOGEVENT:Taunts_Toxin076Subtitle
+"*You cannot hope to clear my toxins with that particle beam, General"
+END
+
+DIALOGEVENT:Taunts_Toxin077Subtitle
+"*Yes, garrison that building--I'm sure my Toxin Tractors will love that"
+END
+
+DIALOGEVENT:Taunts_Toxin078Subtitle
+"*If you bring Colonel Burton into this I'll have to release Jarmen Kell"
+END
+
+DIALOGEVENT:Taunts_Toxin079Subtitle
+"*Black Lotus? You know, of course, that the black lotus is a poisonous flower�I think that's in one of my toxins�but I digress�"
+END
+
+DIALOGEVENT:Taunts_Toxin080Subtitle
+"*I see Jarmen Kell has joined our little war. Perhaps mine would enjoy a sniper duel"
+END
+
+DIALOGEVENT:Taunts_Toxin081Subtitle
+"*Now what do you want with that Air Field, General?"
+END
+
+DIALOGEVENT:Taunts_Toxin082Subtitle
+"*So our General builds a War Factory. How predictable of you"
+END
+
+DIALOGEVENT:Taunts_Toxin083Subtitle
+"*Yeeesss, build a Barracks--send you men to me"
+END
+
+DIALOGEVENT:Taunts_Toxin084Subtitle
+"*Sell off allyour buildings, General�and send your men to me"
+END
+
+DIALOGEVENT:Taunts_Toxin085Subtitle
+"*Give up now, and I guarantee you'll breathe easy"
+END
+
+DIALOGEVENT:Taunts_Toxin086Subtitle
+"*Your troops are short of breath, General. Give up!"
+END
+
+DIALOGEVENT:Taunts_Toxin087Subtitle
+"*My second wind spells your doom, General!"
+END
+
+DIALOGEVENT:Taunts_Toxin088Subtitle
+"*Let me drown your sorrows with a nice toxin!"
+END
+
+DIALOGEVENT:Taunts_Toxin089Subtitle
+"*Toxic Fatality"
+END
+
+DIALOGEVENT:Taunts_Toxin090Subtitle
+"*You are defeated, General. Perhaps this will teach you to defy Dr. Thrax"
+END
+
+DIALOGEVENT:Taunts_Toxin091Subtitle
+"*Would you consider a peace offering? An antidote, perhaps?"
+END
+
+DIALOGEVENT:Taunts_Toxin092Subtitle
+"*Perhaps I've inhaled too many of my own toxins--You can't possibly be defeating me"
+END
+
+DIALOGEVENT:Taunts_Toxin093Subtitle
+"*Get away from me! You will not defeat me, General. Do you hear me!"
+END
+
+DIALOGEVENT:Taunts_Toxin094Subtitle
+"*What do you have against toxins? Have you seen what they put in food these days?"
+END
+
+DIALOGEVENT:Taunts_Toxin095Subtitle
+"*Even if you defeat me, my toxins will get to you -- eventually!"
+END
+
+DIALOGEVENT:Taunts_Toxin096Subtitle
+"*No! No. I am defeated. Now where is that cyanide capsule�"
+END
+
+DIALOGEVENT:Taunts_Toxin097Subtitle
+"*That button was covered with poison�you're already dead"
+END
+
+DIALOGEVENT:Taunts_Toxin098Subtitle
+"*You dare select Dr. Thrax? You should reconsider, General"
+END
+
+DIALOGEVENT:Taunts_Toxin099Subtitle
+"*You cannot defeat my toxins, General"
+END
+
+DIALOGEVENT:Taunts_Toxin100Subtitle
+"*Perhaps I shouldn't have gotten my degree from a mail-order college"
+END
+
+DIALOGEVENT:Taunts_Toxin101Subtitle
+"*You thought my toxins were ineffective and now look what has happened to you, General"
+END
+
+DIALOGEVENT:Taunts_Toxin102Subtitle
+"*Hello, General. Do not think I cannot see your spies flying over my base. Please, look all you wish, because this may be the last time you ever see my stronghold"
+END
+
+DIALOGEVENT:Taunts_Toxin103Subtitle
+"*As you can see, my defenses are impenetrable...and my toxic weapon systems will poison your troops long before they can reach me"
+END
+
+DIALOGEVENT:Taunts_Toxin104Subtitle
+"*And do not worry about hurting the civilian population, General; they have long since fled this valley of toxic death. Our little war will play-out uninterrupted�and your delicate sensibilities will not be taxed"
+END
+
+DIALOGEVENT:Taunts_Toxin105Subtitle
+"*Ah yes, and here is where you've placed your pathetic base. Now make your stand against me--Dr. Thrax--and once your forces have breathed their last breath of my toxic air, I can return to my experiments"
+END
+
+DIALOGEVENT:Taunts_Toxin106Subtitle
+"*Do you trust your senses, General? By engaging me, you have doomed yourself to a long and painful death, for I am Dr. Thrax, and my weapons strike unseen!"
+END
+
+DIALOGEVENT:Taunts_Toxin107Subtitle
+"*Breathe easy, General, for I am Dr. Thrax, and with every breath you take, you are on your way to defeat!"
+END
+
+DIALOGEVENT:Taunts_Toxin108Subtitle
+"*The first sample is free!"
+END
+
+DIALOGEVENT:Taunts_Toxin109Subtitle
+"*Would you like the green or the blue? Both are equally satisfying!"
+END
+
+DIALOGEVENT:Taunts_Toxin110Subtitle
+"*Prepare to tell your 3-eyed grandchildren of your defeat this day!"
+END
+
+DIALOGEVENT:Taunts_Toxin111Subtitle
+"*My precious chemicals! Do you know how long it takes to mix those?"
+END
+
+DIALOGEVENT:Taunts_Toxin112Subtitle
+"*More victi- ah- volunteers for my experiments!"
+END
+
+DIALOGEVENT:Taunts_Toxin113Subtitle
+"*Now I have more vehicles to ferry my toxins! So generous of you!"
+END
+
+DIALOGEVENT:Taunts_Toxin114Subtitle
+"*Oh, did I forget to tell you about those? Watch the mines, General!"
+END
+
+DIALOGEVENT:Taunts_Toxin115Subtitle
+"*Now where did I put those chemical troops?"
+END
+
+DIALOGEVENT:Taunts_Toxin117Subtitle
+"*Bah! You!"
+END
+
+DIALOGEVENT:Taunts_Toxin118Subtitle
+"*Ah yes, and here is where you've placed your pathetic base"
+END
+
+DIALOGEVENT:Taunts_Turtle001Subtitle
+"*Oh, you're still here, General. I'm impressed by your determination. Let's dance"
+END
+
+DIALOGEVENT:Taunts_Turtle002Subtitle
+"*That didn't hurt too much, did it?"
+END
+
+DIALOGEVENT:Taunts_Turtle003Subtitle
+"*The battlefield is a rough place, General"
+END
+
+DIALOGEVENT:Taunts_Turtle004Subtitle
+"*Another perfectly executed strike"
+END
+
+DIALOGEVENT:Taunts_Turtle005Subtitle
+"*It's all going according to plan"
+END
+
+DIALOGEVENT:Taunts_Turtle006Subtitle
+"*Everything seems to be going my way"
+END
+
+DIALOGEVENT:Taunts_Turtle007Subtitle
+"*How does that feel, General?"
+END
+
+DIALOGEVENT:Taunts_Turtle008Subtitle
+"*Tactical superiority is key, General. Here, let me show you"
+END
+
+DIALOGEVENT:Taunts_Turtle009Subtitle
+"*I really don't think you're going to be able to stop this next attack�do you?"
+END
+
+DIALOGEVENT:Taunts_Turtle010Subtitle
+"*Here comes another attack�oh, and almost all of my Generals Powers are ready to go�which one do you want to see first?"
+END
+
+DIALOGEVENT:Taunts_Turtle011Subtitle
+"*Is that my Superweapon ready to go? Oh no, my attacks just feel like that"
+END
+
+DIALOGEVENT:Taunts_Turtle012Subtitle
+"*All units: Attack pattern alpha! Just kidding�who would call something "alpha"?"
+END
+
+DIALOGEVENT:Taunts_Turtle013Subtitle
+"*Here comes some of my units, General. Would you mind helping them gain some veterancy?"
+END
+
+DIALOGEVENT:Taunts_Turtle014Subtitle
+"*I rarely send in the troops, but you deserve special attention, General"
+END
+
+DIALOGEVENT:Taunts_Turtle015Subtitle
+"*I warn you not to underestimate me"
+END
+
+DIALOGEVENT:Taunts_Turtle016Subtitle
+"*You may think I'm hiding, but I'm really just planning"
+END
+
+DIALOGEVENT:Taunts_Turtle017Subtitle
+"*Fools rush in, General. I take my time"
+END
+
+DIALOGEVENT:Taunts_Turtle018Subtitle
+"*You don't know what to expect from me, do you?"
+END
+
+DIALOGEVENT:Taunts_Turtle019Subtitle
+"*If you fail to plan, you plan to fail, General. Think about it"
+END
+
+DIALOGEVENT:Taunts_Turtle020Subtitle
+"*My greatest "super weapon" is my brain�wouldn't you agree, General?"
+END
+
+DIALOGEVENT:Taunts_Turtle021Subtitle
+"*Come on, General, take your best shot"
+END
+
+DIALOGEVENT:Taunts_Turtle022Subtitle
+"*We're waiting for you, General. What's keeping you?"
+END
+
+DIALOGEVENT:Taunts_Turtle023Subtitle
+"*I've been analyzing you tactics and I'm just amazed�do you even have any tactics, General?"
+END
+
+DIALOGEVENT:Taunts_Turtle024Subtitle
+"*I'd attack if I were you, General. If you wait then I'll just have one more Superweapon to fire at you"
+END
+
+DIALOGEVENT:Taunts_Turtle025Subtitle
+"*So, your over-all strategy is to bore me off the battlefield?"
+END
+
+DIALOGEVENT:Taunts_Turtle026Subtitle
+"*Are you rethinking the wisdom of attacking me, General?"
+END
+
+DIALOGEVENT:Taunts_Turtle027Subtitle
+"*I've been trying to go easy on you, General, but you're starting to annoy me"
+END
+
+DIALOGEVENT:Taunts_Turtle028Subtitle
+"*This has been fun, General, but I think it's time to end this"
+END
+
+DIALOGEVENT:Taunts_Turtle029Subtitle
+"*Maybe we should do this some other time�when you're not so distracted�at least, I hope that's what's wrong. You did say you were a "general", right?"
+END
+
+DIALOGEVENT:Taunts_Turtle030Subtitle
+"*You weren't using that, were you?"
+END
+
+DIALOGEVENT:Taunts_Turtle031Subtitle
+"*I didn't like the look of that Barracks, at all"
+END
+
+DIALOGEVENT:Taunts_Turtle032Subtitle
+"*Your vehicles are getting on my nerves"
+END
+
+DIALOGEVENT:Taunts_Turtle033Subtitle
+"*Stay out of the air, General--you'll be safer on the ground"
+END
+
+DIALOGEVENT:Taunts_Turtle034Subtitle
+"*Was that supposed to keep me out of your base, General?"
+END
+
+DIALOGEVENT:Taunts_Turtle035Subtitle
+"*Wow, you just lost your Command Center. That's not very good, is it"
+END
+
+DIALOGEVENT:Taunts_Turtle036Subtitle
+"*Your base was much too cluttered before"
+END
+
+DIALOGEVENT:Taunts_Turtle037Subtitle
+"*You have no respect for other people's property!"
+END
+
+DIALOGEVENT:Taunts_Turtle038Subtitle
+"*People, who was supposed to be guarding the Barracks!"
+END
+
+DIALOGEVENT:Taunts_Turtle039Subtitle
+"*I was using that War Factory!"
+END
+
+DIALOGEVENT:Taunts_Turtle040Subtitle
+"*Is keeping my air field too much to ask"
+END
+
+DIALOGEVENT:Taunts_Turtle041Subtitle
+"*I put that there for a reason!"
+END
+
+DIALOGEVENT:Taunts_Turtle042Subtitle
+"*I had just gotten all of those buildings where I wanted them"
+END
+
+DIALOGEVENT:Taunts_Turtle043Subtitle
+"*I don't appreciate that kind of disrespect!"
+END
+
+DIALOGEVENT:Taunts_Turtle044Subtitle
+"*I built all of those planes for a reason!"
+END
+
+DIALOGEVENT:Taunts_Turtle045Subtitle
+"*Destroy as many vehicles as you like. See if I care"
+END
+
+DIALOGEVENT:Taunts_Turtle046Subtitle
+"*How dare you hurt my soldiers!"
+END
+
+DIALOGEVENT:Taunts_Turtle047Subtitle
+"*I let you have that one"
+END
+
+DIALOGEVENT:Taunts_Turtle048Subtitle
+"*I didn't need that anyway"
+END
+
+DIALOGEVENT:Taunts_Turtle049Subtitle
+"*Capturing the Refinery? Why, General, I didn't know you were so efficiency conscious"
+END
+
+DIALOGEVENT:Taunts_Turtle050Subtitle
+"*Who invited you here?"
+END
+
+DIALOGEVENT:Taunts_Turtle051Subtitle
+"*I don't think you have the right security clearance to be here"
+END
+
+DIALOGEVENT:Taunts_Turtle052Subtitle
+"*What gives you the right to be in my base?"
+END
+
+DIALOGEVENT:Taunts_Turtle053Subtitle
+"*This is my base, get out now!"
+END
+
+DIALOGEVENT:Taunts_Turtle054Subtitle
+"*Don't expect me to be a good hostess"
+END
+
+DIALOGEVENT:Taunts_Turtle055Subtitle
+"*I don't like unexpected visitors, General"
+END
+
+DIALOGEVENT:Taunts_Turtle056Subtitle
+"*What do you think you're doing here?"
+END
+
+DIALOGEVENT:Taunts_Turtle057Subtitle
+"*Intruders!"
+END
+
+DIALOGEVENT:Taunts_Turtle058Subtitle
+"*Your presence is starting to bother me, General"
+END
+
+DIALOGEVENT:Taunts_Turtle059Subtitle
+"*Who was supposed to be guarding that area?!?"
+END
+
+DIALOGEVENT:Taunts_Turtle060Subtitle
+"*So you've managed to crack my defenses�that won't happen again"
+END
+
+DIALOGEVENT:Taunts_Turtle061Subtitle
+"*Get out of my base, General. Don't think I'm above dropping the Particle Cannon right here"
+END
+
+DIALOGEVENT:Taunts_Turtle062Subtitle
+"*It's looking a little dark in your base, General"
+END
+
+DIALOGEVENT:Taunts_Turtle063Subtitle
+"*Did someone forget to pay the electric bill?"
+END
+
+DIALOGEVENT:Taunts_Turtle064Subtitle
+"*You didn't manage your resources very wisely, did you?"
+END
+
+DIALOGEVENT:Taunts_Turtle065Subtitle
+"*You are pushing me over-budget, General"
+END
+
+DIALOGEVENT:Taunts_Turtle066Subtitle
+"*How could this have happened! I had everything planned so perfectly!"
+END
+
+DIALOGEVENT:Taunts_Turtle067Subtitle
+"*Do you think I'm scared of your little Scud Storm?"
+END
+
+DIALOGEVENT:Taunts_Turtle068Subtitle
+"*That Nuke Silo doesn't frighten me"
+END
+
+DIALOGEVENT:Taunts_Turtle069Subtitle
+"*I appreciate your choice in weaponry, but I'm the only one allowed to have a Particle Cannon on this battlefield"
+END
+
+DIALOGEVENT:Taunts_Turtle070Subtitle
+"*Is that as secure as your base can be? Is it?"
+END
+
+DIALOGEVENT:Taunts_Turtle071Subtitle
+"*That's a lot of tanks, General. Have you seen what a Particle Cannon can do to a lot of tanks?"
+END
+
+DIALOGEVENT:Taunts_Turtle072Subtitle
+"*All these planes are just air pollution to me"
+END
+
+DIALOGEVENT:Taunts_Turtle073Subtitle
+"*So many troops, General. You weren't actually planning to rush me with them were you?"
+END
+
+DIALOGEVENT:Taunts_Turtle074Subtitle
+"*That's quite a base you have going there, General. You did remember to space out your buildings to avoid weapon strikes, right?"
+END
+
+DIALOGEVENT:Taunts_Turtle075Subtitle
+"*Do you know how long it's going to take to clean that up?!?"
+END
+
+DIALOGEVENT:Taunts_Turtle076Subtitle
+"*Get that disgusting radiation out of my base!"
+END
+
+DIALOGEVENT:Taunts_Turtle077Subtitle
+"*Hey, that's my Particle Cannon! You're not authorized to use it!"
+END
+
+DIALOGEVENT:Taunts_Turtle078Subtitle
+"*Is that a tactical move, or are you just hiding?"
+END
+
+DIALOGEVENT:Taunts_Turtle079Subtitle
+"*Colonel Burton? Really? Do you think he's going to help you?"
+END
+
+DIALOGEVENT:Taunts_Turtle080Subtitle
+"*Black Lotus? I guess it's just a girl-power showdown, isn't it?"
+END
+
+DIALOGEVENT:Taunts_Turtle081Subtitle
+"*Jarmen Kell! He better stay away from my tanks!"
+END
+
+DIALOGEVENT:Taunts_Turtle082Subtitle
+"*Nice Air Field, General--just keep those planes away from my Particle Cannon"
+END
+
+DIALOGEVENT:Taunts_Turtle083Subtitle
+"*A War Factory? You're seriously going to attack me, aren't you? It's about time"
+END
+
+DIALOGEVENT:Taunts_Turtle084Subtitle
+"*Good for you - you can build a barracks"
+END
+
+DIALOGEVENT:Taunts_Turtle085Subtitle
+"*Selling your buildings? Is that part of your going out of business sale?"
+END
+
+DIALOGEVENT:Taunts_Turtle086Subtitle
+"*Why don't you just give up? I have better things I could be doing today"
+END
+
+DIALOGEVENT:Taunts_Turtle087Subtitle
+"*Why can't I ever find one that lasts more than 5 minutes"
+END
+
+DIALOGEVENT:Taunts_Turtle088Subtitle
+"*Looks like you're losing, General. Now what did I say about planning to fail?"
+END
+
+DIALOGEVENT:Taunts_Turtle089Subtitle
+"*That's quite a beating you're taking, General. Are you ready for more?"
+END
+
+DIALOGEVENT:Taunts_Turtle090Subtitle
+"*I'd like to say, "good fight," but clearly your mind wasn't in it, General"
+END
+
+DIALOGEVENT:Taunts_Turtle091Subtitle
+"*I can't believe you would beat-up on a girl like this"
+END
+
+DIALOGEVENT:Taunts_Turtle092Subtitle
+"*I need time to think. Go away, General!"
+END
+
+DIALOGEVENT:Taunts_Turtle093Subtitle
+"*Your tactics are hardly sporting, General. Play nice!"
+END
+
+DIALOGEVENT:Taunts_Turtle094Subtitle
+"*General, look over there! Someone is capturing your buildings! Didn't buy it, huh?"
+END
+
+DIALOGEVENT:Taunts_Turtle095Subtitle
+"*You know, if you were a gentleman, you'd give me five minutes to rebuild my defenses"
+END
+
+DIALOGEVENT:Taunts_Turtle096Subtitle
+"*What?! It's over? Well, it was nice dancing with you, General. Maybe next time I'll lead"
+END
+
+DIALOGEVENT:Taunts_Turtle097Subtitle
+"*My Super Weapons are ready... are you?"
+END
+
+DIALOGEVENT:Taunts_Turtle098Subtitle
+"*You'll never crack my defenses, General"
+END
+
+DIALOGEVENT:Taunts_Turtle099Subtitle
+"*Your rush tactics won't work on me"
+END
+
+DIALOGEVENT:Taunts_Turtle100Subtitle
+"*It's not fair! One more Super Weapon and I would have beaten you, General. Challenge me again, I dare you"
+END
+
+DIALOGEVENT:Taunts_Turtle101Subtitle
+"*I told you you'd never beat my Super Weapons, General. Care to try again?"
+END
+
+DIALOGEVENT:Taunts_Turtle102Subtitle
+"*Welcome, General. Are you ready to begin?"
+END
+
+DIALOGEVENT:Taunts_Turtle103Subtitle
+"*Oh, what's that sound? Now I see a light in the sky... Hmm�"
+END
+
+DIALOGEVENT:Taunts_Turtle104Subtitle
+"*Oh my!"
+END
+
+DIALOGEVENT:Taunts_Turtle106Subtitle
+"*�oh dear�I'm sorry, General, but that's just how I like to say, "hello." Well, good luck, General"
+END
+
+DIALOGEVENT:Taunts_Turtle107Subtitle
+"*Well, good luck, General"
+END
+
+DIALOGEVENT:UnitDescriptXChina001Subtitle
+"*The Americans use the Sentry Drone as an early warning enemy detection system. The drone becomes invisible when it is not moving, and we've seen some of them upgraded with machine guns. Though no match for tanks, the drone can cause problems for foot soldiers"
+END
+
+DIALOGEVENT:UnitDescriptXChina002Subtitle
+"*The American Microwave Tank is a big microwave gun that disables structures and vehicles. The radiation from the tank can also hurt infantry, so keep our men at a safe distance"
+END
+
+DIALOGEVENT:UnitDescriptXChina003Subtitle
+"*The Avenger is an American laser based anti-air vehicle able to shoot down missiles and aircraft. It also helps other US units target our planes, so they should be considered high priority targets when encountered within a battle group"
+END
+
+DIALOGEVENT:UnitDescriptXChina004Subtitle
+"*The Specter Gunship is a large jet powered aircraft with multiple weapon systems fixed to its side enabling it to circle a target area and rain death from above. Typical American engineering--using a shotgun to swat a fly"
+END
+
+DIALOGEVENT:UnitDescriptXChina005Subtitle
+"*The Chemical Suit upgrade, makes infantry more resistant to toxins and radiation"
+END
+
+DIALOGEVENT:UnitDescriptXChina006Subtitle
+"*The US Countermeasures upgrade reduces the effectiveness of enemy fire against their air units. Missiles will often miss, and bullets do less damage"
+END
+
+DIALOGEVENT:UnitDescriptXChina007Subtitle
+"*The US Hellfire Drone upgrade creates an remote air drone that defends the parent vehicle with an automated hellfire missile system"
+END
+
+DIALOGEVENT:UnitDescriptXChina008Subtitle
+"*The Bunker Buster is an upgrade to the US Stealth Fighter and the Aurora designed to penetrate garrisoned buildings"
+END
+
+DIALOGEVENT:UnitDescriptXChina009Subtitle
+"*The Supply Lines Upgrade increases the rate that the US gathers resources from supply docks, supply drops, and oil derricks"
+END
+
+DIALOGEVENT:UnitDescriptXChina010Subtitle
+"*The US Generals have seen the wisdom of propaganda. By using a Leaflet Drop they are able to temporarily disable units while they stop to read the propaganda"
+END
+
+DIALOGEVENT:UnitDescriptXChina011Subtitle
+"*The MOAB is an upgrade to the US Fuel Air Bomb that includes a �stun� ability, temporarily shutting down surviving units and structures"
+END
+
+DIALOGEVENT:UnitDescriptXChina012Subtitle
+"*The US Fire Base structure is a defensive position surrounded by sandbags and includes a howitzer and 4 firing positions"
+END
+
+DIALOGEVENT:UnitDescriptXChina013Subtitle
+"*The Napalm Bomb is an upgrade to our Helix airship, allowing it to drop a pair of bombs which create a large firestorm effect"
+END
+
+DIALOGEVENT:UnitDescriptXChina014Subtitle
+"*Our Listening Outpost is a slow, stealthed vehicle with a large sight radius, that can be garrisoned with 2 infantry as guards. Besides uncovering stealthed objects, it can be used to determine enemy destinations by clicking on units in range"
+END
+
+DIALOGEVENT:UnitDescriptXChina015Subtitle
+"*Our Helix 2 airship is a slow transport helicopter that can carry infantry or a single vehicle. Although armed with a light machine gun, it can be upgraded with the Gattling Cannon, Propaganda Tower, or Battle Bunker. It can also be upgraded to carry a large napalm bomb"
+END
+
+DIALOGEVENT:UnitDescriptXChina016Subtitle
+"*The ECM Tank disrupts electronic tracking systems, diverting enemy missile fire. It's electro-magnetic pulse can be used to disable a single enemy vehicle. It also creates a radar jamming field that disables all drones within its range"
+END
+
+DIALOGEVENT:UnitDescriptXChina017Subtitle
+"*The Neutron Shell is an upgrade to our Nuclear Cannon, allowing it to fire neutron shells. These shells kill all infantry, and vehicle pilots inside the blast radius"
+END
+
+DIALOGEVENT:UnitDescriptXChina018Subtitle
+"*The Systems Hack allows your hackers to steal a random Generals power from our enemies. Level 1 allows theft of a 1-star or 3-star power, while level 2 allows theft of a 5-star power"
+END
+
+DIALOGEVENT:UnitDescriptXChina019Subtitle
+"*Our new Carpet Bomber plane drops a series of bombs along a targeted path, decimating all enemy forces"
+END
+
+DIALOGEVENT:UnitDescriptXChina020Subtitle
+"*Our Neutron Mines are an alternative to standard explosive mines. Neutron Mines instantly disable vehicles and kill any nearby infantry"
+END
+
+DIALOGEVENT:UnitDescriptXChina021Subtitle
+"*Our hackers, once vulnerable to attack, will find safety and increased hacking ability in our new Internet Center"
+END
+
+DIALOGEVENT:UnitDescriptXChina022Subtitle
+"*The Satellite Hack I is an internet Center upgrade that allows a reveal around every opponent's Command Center"
+END
+
+DIALOGEVENT:UnitDescriptXChina023Subtitle
+"*The Satellite Hack II is an Internet Center upgrade that grants a temporarily reveals the entire map, including stealthed enemy forces"
+END
+
+DIALOGEVENT:UnitDescriptXChina024Subtitle
+"*The GLA Saboteur is a stealth infantry unit that can climb cliffs and effect enemy buildings by entering them. Entering a power plant will temporarily cut power, while entering a superweapon will reset the timer. A saboteur who enters an enemy command center will reset the timers on all enemy General's Powers"
+END
+
+DIALOGEVENT:UnitDescriptXChina025Subtitle
+"*The Combat Cycle initially comes with a GLA Rebel driver and a mounted machine gun. The Rebel can be replaced with any other GLA infantry, granting the cycle their unique powers"
+END
+
+DIALOGEVENT:UnitDescriptXChina026Subtitle
+"*The GLA Battle Bus can hold up to 8 infantry, who fire out windows. If destroyed, the heavy steel cabin remains like a bunker"
+END
+
+DIALOGEVENT:UnitDescriptXChina027Subtitle
+"*The GLA have upgraded their Workers with Shoes to squeeze even more forced labor from their peasants"
+END
+
+DIALOGEVENT:UnitDescriptXChina028Subtitle
+"*The Camo Netting is an upgrade to GLA base defense structures, making them invisible to normal detection"
+END
+
+DIALOGEVENT:UnitDescriptXChina029Subtitle
+"*The GLA have begun garrisoning Elite Guard troops equipped with RPGs in all their structures. Use caution when infiltrating any GLA bases"
+END
+
+DIALOGEVENT:UnitDescriptXChina030Subtitle
+"*The GLA Booby Trap upgrade enables the rebel to wire structures and civilian vehicles to explode when the enemy attempts to capture or garrison them. Watch for Rebels lurking around buildings in your area"
+END
+
+DIALOGEVENT:UnitDescriptXChina031Subtitle
+"*The GLA tricks have reached a new level. They are now building Fake Structures that look like their real buildings, but are only booby-trapped facades. Destroy everything from range to avoid any GLA surprises"
+END
+
+DIALOGEVENT:UnitDescriptXChina032Subtitle
+"*The GPS Scrambler targets an area of units and makes them invisible to normal detection"
+END
+
+DIALOGEVENT:UnitDescriptXChina033Subtitle
+"*The Sneak Attack power allows GLA Generals to place a defenseless tunnel network anywhere they have explored. Although slightly weaker than a normal tunnel, it is connected to the main network"
+END
+
+DIALOGEVENT:UnitDescriptXChina034Subtitle
+"*The Artillery Platform is a fixed-position cannon capable of single-handedly controlling an area from enemy assault. It should be a priority capture on any battlefield"
+END
+
+DIALOGEVENT:UnitDescriptXChina035Subtitle
+"*A Reinforcement Pad allows a free periodic armor airdrop. Free Battlemasters can turn the tide of any battle"
+END
+
+DIALOGEVENT:UnitDescriptXChina036Subtitle
+"*The Repair Bay tech building, when captured, allows battlefield repairs for any ground vehicles. Repairs for damaged armor in a forward position can make the difference between victory and defeat"
+END
+
+DIALOGEVENT:UnitDescriptXGLA001Subtitle
+"*Be careful of the American Sentry Drone, General; it can see stealthed units and often has a mounted gun"
+END
+
+DIALOGEVENT:UnitDescriptXGLA002Subtitle
+"*The US Microwave Tank has a beam that disables structures and units. It should be attacked by large groups only"
+END
+
+DIALOGEVENT:UnitDescriptXGLA003Subtitle
+"*The US Warlock Tank has a beam that disables structures and units. It should be attacked by large groups only"
+END
+
+DIALOGEVENT:UnitDescriptXGLA004Subtitle
+"*The US Avenger is a powerful laser-base anti-air vehicle�but we have no planes, so the danger from it is minimal"
+END
+
+DIALOGEVENT:UnitDescriptXGLA005Subtitle
+"*The American Specter Gunship is a large plane with big guns. Do not engage it--seek refuge underground until it leaves the area"
+END
+
+DIALOGEVENT:UnitDescriptXGLA006Subtitle
+"*With the Chemical Suit upgrade, enemy infantry become more resistant to our toxins. But that won't stop our bullets, will it?"
+END
+
+DIALOGEVENT:UnitDescriptXGLA007Subtitle
+"*The Countermeasures upgrade reduces the effect of enemy fire against US air units. Missiles will often miss, and bullets do less damage"
+END
+
+DIALOGEVENT:UnitDescriptXGLA008Subtitle
+"*The US Hellfire Drone upgrade is a little toy plane with a missile attached. Another example of American's cowardly tactics"
+END
+
+DIALOGEVENT:UnitDescriptXGLA009Subtitle
+"*The Bunker Buster Bomb is an upgrade to the US Stealth Fighter and the Aurora. They use it to try to attack our bunkers"
+END
+
+DIALOGEVENT:UnitDescriptXGLA010Subtitle
+"*The Supply Lines Upgrade increases the rate that the US gathers resources from supply docks, supply drops, and oil derricks"
+END
+
+DIALOGEVENT:UnitDescriptXGLA011Subtitle
+"*The US Leaflet Drop temporarily disables our units as they stop to read the propaganda"
+END
+
+DIALOGEVENT:UnitDescriptXGLA012Subtitle
+"*The MOAB is an upgrade to the Fuel Air Bomb that includes a �stun� ability, temporarily shutting down surviving units and structures"
+END
+
+DIALOGEVENT:UnitDescriptXGLA013Subtitle
+"*The Fire Base is the American answer to our Stinger sites...but watch out for the big cannon in the middle"
+END
+
+DIALOGEVENT:UnitDescriptXGLA014Subtitle
+"*China's Napalm Bomb is a Helix upgrade, allowing it to drop a pair of bombs which create a large firestorm"
+END
+
+DIALOGEVENT:UnitDescriptXGLA015Subtitle
+"*The Listening Outpost is a slow, stealthed vehicle the China uses to find our stealthed units. Avoid them to remain hidden"
+END
+
+DIALOGEVENT:UnitDescriptXGLA016Subtitle
+"*China's Helix 2 is a slow transport helicopter that can carry infantry or a single vehicle"
+END
+
+DIALOGEVENT:UnitDescriptXGLA017Subtitle
+"*The Chinese ECM Tank is a vehicle which disrupts electronic tracking systems, diverting enemy missile fire"
+END
+
+DIALOGEVENT:UnitDescriptXGLA018Subtitle
+"*The Neutron Shell is an upgrade to the Chinese Nuke Cannon, allowing it to fire neutron shells. These shells kill all infantry, and vehicle pilots inside the blast radius"
+END
+
+DIALOGEVENT:UnitDescriptXGLA019Subtitle
+"*China's new Systems Hack technique allows hackers to steal a random power from their enemies. Such is the downfall of depending on power to fight wars"
+END
+
+DIALOGEVENT:UnitDescriptXGLA020Subtitle
+"*The Carpet Bomber is a plane that drops a series of bombs along a targeted path, decimating the enemy"
+END
+
+DIALOGEVENT:UnitDescriptXGLA021Subtitle
+"*The Neutron Mines are an alternative to standard Chinese Mines which disable vehicles. The mines still kill infantry as well"
+END
+
+DIALOGEVENT:UnitDescriptXGLA022Subtitle
+"*The Internet Center allows China's hackers to increase their effectiveness"
+END
+
+DIALOGEVENT:UnitDescriptXGLA023Subtitle
+"*The Satellite Hack I is an internet Center upgrade that allows China to see every opponent's Command Center"
+END
+
+DIALOGEVENT:UnitDescriptXGLA024Subtitle
+"*The Satellite Hack II is a Chinese Internet Center upgrade that grants a temporary reveal of the entire map, as well as revealing stealthed objects"
+END
+
+DIALOGEVENT:UnitDescriptXGLA025Subtitle
+"*The Saboteur is a stealth unit that can climb cliffs and effect enemy buildings by entering them"
+END
+
+DIALOGEVENT:UnitDescriptXGLA026Subtitle
+"*Our new Combat Cycle has mounted machine guns and is enhanced by the abilities of any infantry riding it"
+END
+
+DIALOGEVENT:UnitDescriptXGLA027Subtitle
+"*The Battle Bus is a slow moving transport that can hold up to 8 infantry, who may fire out of the bus. If destroyed, the hull of the Battle Bus remains and functions like a bunker"
+END
+
+DIALOGEVENT:UnitDescriptXGLA028Subtitle
+"*The Worker Shoes upgrade increase speed and gathering efficiency for all our loyal workers"
+END
+
+DIALOGEVENT:UnitDescriptXGLA029Subtitle
+"*The Camo Netting is an upgrade to our base defense structures, allowing them to be stealthed"
+END
+
+DIALOGEVENT:UnitDescriptXGLA030Subtitle
+"*The Elite Guard Upgrade is a structure ability, garrisoning the structure with 4 RPG Troopers"
+END
+
+DIALOGEVENT:UnitDescriptXGLA031Subtitle
+"*The Booby Trap is an upgrade to the rebel, allowing the unit to wire structures and civilian vehicles to explode when the enemy attempts to capture or garrison them. Captured structures are automatically booby trapped"
+END
+
+DIALOGEVENT:UnitDescriptXGLA032Subtitle
+"*Fake Structures can be built for a greatly reduced cost. These buildings are initially a booby-trapped fa�ade, but can be upgraded to fully functional versions of the structure"
+END
+
+DIALOGEVENT:UnitDescriptXGLA033Subtitle
+"*Our newly acquired GPS Scrambler targets an area of units and renders them invisible to enemies"
+END
+
+DIALOGEVENT:UnitDescriptXGLA034Subtitle
+"*Our Sneak Attack allows placement of a defenseless tunnel network at any area that has been explored. Although slightly weaker than a normal tunnel, it is connected to the main network"
+END
+
+DIALOGEVENT:UnitDescriptXGLA035Subtitle
+"*The Artillery Platform fires a weapon similar to the US Strategy Center in terms of range and damage. Capture or avoid its deadly cannon"
+END
+
+DIALOGEVENT:UnitDescriptXGLA036Subtitle
+"*The Reinforcement Pad periodically delivers a group of Scorpion tanks for our cause"
+END
+
+DIALOGEVENT:UnitDescriptXGLA037Subtitle
+"*The Repair Bay is a front-line repair facility for vehicles. It repairs vehicles like an Arms Dealer"
+END
+
+DIALOGEVENT:UnitDescriptXUSA001Subtitle
+"*The Sentry Drone is a mobile unit capable of tracking enemy movements, including those that are camouflaged. The Sentry Drone itself is also capable of stealth when not moving, and may be upgraded with an anti-personnel machine gun from the strategy center"
+END
+
+DIALOGEVENT:UnitDescriptXUSA002Subtitle
+"*The Microwave Tank is armed with a Direct-Energy microwave panel that disables targeted structures and vehicles. It also emits a continuous microwave field which damages infantry"
+END
+
+DIALOGEVENT:UnitDescriptXUSA003Subtitle
+"*The Warlock tank is armed with a Direct-Energy microwave panel that disables targeted structures and vehicles. It also emits a continuous microwave field which damages infantry"
+END
+
+DIALOGEVENT:UnitDescriptXUSA004Subtitle
+"*The Avenger is a laser based anti-air vehicle able to shoot down missiles and aircraft. It can also award bonuses to units attacking it's "painted" target"
+END
+
+DIALOGEVENT:UnitDescriptXUSA005Subtitle
+"*The Specter Gunship is a large jet powered aircraft with multiple weapon systems fixed to it's wings. While it circles the target, it auto-acquires enemies. Manual targeting is allowed, and it can upgrade to deploy countermeasures"
+END
+
+DIALOGEVENT:UnitDescriptXUSA006Subtitle
+"*With the Chemical Suit upgrade, infantry become more resistant to toxins and radiation"
+END
+
+DIALOGEVENT:UnitDescriptXUSA007Subtitle
+"*The Countermeasures upgrade reduces the effect of enemy fire against US air units. Missiles will often miss, and bullets do less damage"
+END
+
+DIALOGEVENT:UnitDescriptXUSA008Subtitle
+"*The Hellfire Drone upgrade equips the parent vehicle with a drone capable of firing a single missile. The drones auto-acquire and require time to reload"
+END
+
+DIALOGEVENT:UnitDescriptXUSA009Subtitle
+"*The Bunker Buster is an upgrade to the Stealth Fighter and the Aurora. In addition to their normal effects, these upgraded missiles damage and even kill units garrisoned within structures, including the GLA Palace, Tunnel Network, and the Chinese Battle Bunker"
+END
+
+DIALOGEVENT:UnitDescriptXUSA010Subtitle
+"*The Supply Lines Upgrade increases the amount of money gathered from supply docks, supply drops, and oil derricks"
+END
+
+DIALOGEVENT:UnitDescriptXUSA011Subtitle
+"*The Leaflet Drop temporarily disables units as they stop to read the propaganda. The plane dispenses leaflets over the targeted area and the effect only lasts a short time"
+END
+
+DIALOGEVENT:UnitDescriptXUSA012Subtitle
+"*The MOAB is an upgrade to the Fuel Air Bomb that includes a �stun� ability, temporarily shutting down surviving units and structures"
+END
+
+DIALOGEVENT:UnitDescriptXUSA013Subtitle
+"*The Fire Base is surrounded by sandbags and includes a howitzer and 4 firing positions. Infantry entering the Fire Base will take firing positions behind the sandbags"
+END
+
+DIALOGEVENT:UnitDescriptXUSA014Subtitle
+"*The Napalm Bomb is a Helix upgrade, allowing it to drop a pair of bombs which create a large firestorm"
+END
+
+DIALOGEVENT:UnitDescriptXUSA015Subtitle
+"*The Listening Outpost is a slow, stealthed vehicle with a large sight radius, and can be garrisoned with 2 infantry as guards. Besides uncovering stealthed objects, it can be used to determine enemy destinations by clicking on units in range"
+END
+
+DIALOGEVENT:UnitDescriptXUSA016Subtitle
+"*The Helix 2 is a slow transport helicopter that can carry infantry or a single vehicle. Although armed with a light machine gun, it can be upgraded with the Gattling Cannon, Propaganda Tower, or Battle Bunker. It can also be upgraded to carry a large napalm bomb"
+END
+
+DIALOGEVENT:UnitDescriptXUSA017Subtitle
+"*The ECM Tank is a vehicle which disrupts electronic tracking systems, diverting enemy missile fire. It's ECM pulse can be used to disable single enemy vehicles. Finally, it creates a radar jamming field, disabling all drones within its range"
+END
+
+DIALOGEVENT:UnitDescriptXUSA018Subtitle
+"*The Neutron Shell is an upgrade to the Chinese Nuke Cannon, allowing it to fire neutron shells. These shells kill all infantry, and vehicle pilots inside the blast radius"
+END
+
+DIALOGEVENT:UnitDescriptXUSA019Subtitle
+"*The Systems Hack allows your hackers to steal a random power from your enemies. Level 1 allows theft of a tier 1 or 3 power, while level 2 allows theft of a 5-star power"
+END
+
+DIALOGEVENT:UnitDescriptXUSA020Subtitle
+"*The Carpet Bomber is a plane that drops a series of bombs along a targeted path, decimating the enemy"
+END
+
+DIALOGEVENT:UnitDescriptXUSA021Subtitle
+"*The Neutron Mines are an alternative to standard Chinese Mines which disable vehicles. The mines still kill infantry as well"
+END
+
+DIALOGEVENT:UnitDescriptXUSA022Subtitle
+"*The Internet Center allows hackers to increase their effectiveness at generating money, and allows the use of Satellite Hacks I & II"
+END
+
+DIALOGEVENT:UnitDescriptXUSA023Subtitle
+"*The Satellite Hack I is an internet Center upgrade that allows a reveal around every opponent's Command Center"
+END
+
+DIALOGEVENT:UnitDescriptXUSA024Subtitle
+"*The Satellite Hack II is an internet Center upgrade that grants a temporary reveal of the entire map, as well as revealing stealthed objects"
+END
+
+DIALOGEVENT:UnitDescriptXUSA025Subtitle
+"*The Saboteur is a stealth unit that can climb cliffs and effect enemy buildings by entering them. Entering a power plant will temporarily cut power, while entering a superweapon will reset the timer. A saboteur who enters an enemy command center will reset the timers on all enemy General's Powers"
+END
+
+DIALOGEVENT:UnitDescriptXUSA026Subtitle
+"*The Combat Cycle initially comes with a Rebel driver and a mounted machine gun. Replacing him with a RPG Trooper will allow the bike to fire missiles. A Terrorist will create a suicide bike. Jarmen Kell, Hijackers, and Saboteurs can also ride, making the bike stealthed"
+END
+
+DIALOGEVENT:UnitDescriptXUSA027Subtitle
+"*The Battle Van is a slow moving transport that can hold up to 8 infantry, who may fire out of the bus. If destroyed, the hull of the Battle Van remains and functions like a bunker. If it is destroyed, anyone inside is also killed"
+END
+
+DIALOGEVENT:UnitDescriptXUSA028Subtitle
+"*The Worker Shoes upgrade increase speed and gathering efficiency for all GLA workers"
+END
+
+DIALOGEVENT:UnitDescriptXUSA029Subtitle
+"*The Camo Netting is an upgrade to GLA base defense structures, allowing them to be stealthed"
+END
+
+DIALOGEVENT:UnitDescriptXUSA030Subtitle
+"*The Elite Guard Upgrade is an structure ability, garrisoning the structure with 4 RPG Troopers"
+END
+
+DIALOGEVENT:UnitDescriptXUSA031Subtitle
+"*The Booby Trap is an upgrade to the rebel, allowing the unit to wire structures and civilian vehicles to explode when the enemy attempts to capture or garrison them. The explosion damages everything within a small radius. Structures captured by an upgraded rebel are automatically booby trapped"
+END
+
+DIALOGEVENT:UnitDescriptXUSA032Subtitle
+"*Fake Structures can be built for a greatly reduced cost. These buildings are initially a booby-trapped fa�ade, but can be upgraded to fully functional versions of the structure"
+END
+
+DIALOGEVENT:UnitDescriptXUSA033Subtitle
+"*The GPS Scrambler targets an area of units and renders them stealthed to enemies"
+END
+
+DIALOGEVENT:UnitDescriptXUSA034Subtitle
+"*The Sneak Attack allows placement of a defenseless tunnel network at any area that has been explored. Although slightly weaker than a normal tunnel, it is connected to the main network"
+END
+
+DIALOGEVENT:UnitDescriptXUSA035Subtitle
+"*The artillery platform is armed with a large caliber howitzer. It is an excellent suppression weapon. It is also a good gathering point from which to launch an assault"
+END
+
+DIALOGEVENT:UnitDescriptXUSA036Subtitle
+"*The Reinforcement Pad Periodically reinforces the player with one of his side's main battle tank (Scorpion, Battlemaster, Crusader)"
+END
+
+DIALOGEVENT:UnitDescriptXUSA037Subtitle
+"*The Repair Bay is a repair facility for vehicles. Vehicles must �dock� with the structure in the same way that they must dock with the war factory"
+END
+
+TOOLTIP:Community
+"Win percentages for each army based on all online games played"
+END
+
+CONTROLBAR:Nuke_ToolTipChinaBuildHelix
+"Heavy lift transport  \n upgrades with base defense structures and Nuke Bomb  \n  \n Strong vs. tanks, light vehicles  \n Weak vs. missile armed infantry, anti-air defenses"
+END
+
+MAP:CHI01xListeningPostHint01
+"HINT:  \n Hidden Demo Traps will be revealed when in sight range of the Listening Post"
+END
+
+OBJECT:SupW_PatriotBattery
+"EMP Patriot System"
+END
+
+CONTROLBAR:SupW_ConstructAmericaPatriotBattery
+"E&MP Patriot System"
+END
+
+CONTROLBAR:SupW_ToolTipUSABuildPatriotBattery
+"Ground and air defense. Can relay position of enemy to nearby Patriots  \n  \n Power Required: 3"
+END
+
+MAP:USA03xBurtonSurvive
+"INCOMING TRANSMISSION:  \n Col. Burton must survive"
+END
+
+MAP:MD_GLA04_GatherHint
+"HINT:  \n Select the transport trucks and order them to gather resources from the Toxin Facility"
+END
+
+MAP:MD_GLA04_HospitalHint
+"HINT:  \n The hospital will cause your units to auto heal"
+END
+
+MAP:MD_GLA04_TractorsHint
+"HINT:  \n Toxin Tractors can kill units inside garrisoned buildings"
+END
+
+OBJECT:AssaultTroopTransport
+"Assault Troop Transport"
+END
+
+OBJECT:AssaultListeningOutpost
+"Attack Outpost"
+END
+
+UPGRADE:IsotopeStability
+"Isotope Stability"
+END
+
+CONTROLBAR:Infa_ToolTipChinaUpgradeRedGuardCaptureBuilding
+"Enables Mini-Gunners to capture enemy and tech buildings"
+END
+
+OBJECT:Lazr_PatriotBattery
+"Laser Defense Turret"
+END
+
+SCIENCE:Infa_ChinaRedGuardTraining
+"Mini-Gunner Training"
+END
+
+CONTROLBAR:Infa_ToolTipChinaScienceRedGuardTraining
+"All Mini-Gunners will be built as Elite"
+END
+
+CONTROLBAR:ToolTipChinaBuildNuclearMissileLauncherBoss
+"Launches a nuclear missile. Builds important Chinese upgrades  \n  \n Power Required: 10  \n Countdown Timer: 6:00"
+END
+
+CONTROLBAR:ToolTipUSABuildParticleCannonBoss
+"Fires a particle beam anywhere on the map  \n  \n Power Required: 10  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:ToolTipGLABuildCombatBikeTerrorist
+"Fast and versatile  \n Comes with a terrorist  \n Weak vs. aircraft"
+END
+
+CONTROLBAR:ToolTipChinaBuildSuperHacker
+"Can disable enemy buildings and vehicles with a computer virus or can hack into the internet to steal money. Camouflaged  \n  \n Strong vs. buildings  \n Weak vs. infantry, vehicles"
+END
+
+UPGRADE:Demo_SuicideBomb
+"Demolitions"
+END
+
+UPGRADE:AirF_StealthComanche
+"Stealth Comanche"
+END
+
+UPGRADE:HighExplosiveTrap
+"High-Explosive Demo Trap"
+END
+
+CAMPAIGN:CHALLENGE_0
+"Air Force General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_1
+"Toxin General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_2
+"Nuke General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_3
+"Superweapon General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_4
+"Tank General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_5
+"Laser General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_6
+"Stealth General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_7
+"Infantry General Challenge"
+END
+
+CAMPAIGN:CHALLENGE_8
+"Demolitions General Challenge"
+END
+
+OBJECT:RocketDrop
+"Rocket"
+END
+
+OBJECT:RocketBomb
+"Rocket"
+END
+
+OBJECT:PTBoat
+"PT Boat"
+END
+
+OBJECT:ShiekLimo
+"Limo"
+END
+
+OBJECT:Dock
+"Dock"
+END
+
+OBJECT:RailroadBridgeH
+"Railroad Bridge"
+END
+
+OBJECT:RepairDrone
+"Repair Drone"
+END
+
+OBJECT:CINE_Carrier
+"Aircraft Carrier"
+END
+
+OBJECT:SpectreGunship
+"Spectre Gunship"
+END
+
+SCIENCE:LaserCannon
+"Laser Cannon"
+END
+
+OBJECT:LaserCannon
+"Laser Cannon"
+END
+
+UPGRADE:TacticalNukeMig
+"Tactical Nuke MiG"
+END
+
+OBJECT:FuelAirBomb
+"Fuel Air Bomb"
+END
+
+OBJECT:CruiseMissile
+"Cruise Missile"
+END
+
+OBJECT:Ox
+"Ox"
+END
+
+CONTROLBAR:TooltipUpgradeChinaTacticalNukeMig
+"Upgrades Mig to fire a small nuke"
+END
+
+CONTROLBAR:UpgradeChinaTacticalNukeMig
+"Tactical Nuke Mi&G"
+END
+
+CONTROLBAR:Boss_ToolTipChinaBuildBarracks
+"Trains soldiers"
+END
+
+CONTROLBAR:Boss_ToolTipChinaBuildAirField
+"Builds aircraft  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:Boss_ToolTipChinaBuildBunker
+"Can hold 5 soldiers"
+END
+
+CONTROLBAR:Boss_ToolTipChinaBuildWarFactory
+"Builds vehicles  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:Boss_ToolTipChinaBuildSupplyCenter
+"Drop-off point for supply gatherers  \n  \n Power Required: 1"
+END
+
+CONTROLBAR:Infa_TooltipParaDrop
+"Drops Mini-Gunners by plane  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:Infa_ConstructChinaInfantryHacker
+"Super H&acker"
+END
+
+CONTROLBAR:Infa_ToolTipChinaBuildHacker
+"Stealthed. Can disable enemy buildings and vehicles with a computer virus or can hack into the internet to steal money  \n  \n Strong vs. buildings  \n Weak vs. infantry, vehicles"
+END
+
+CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus
+"&Super Lotus"
+END
+
+CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost
+"Attack &Outpost"
+END
+
+CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler
+"&Assault Troop Transport"
+END
+
+CONTROLBAR:Infa_ConstructChinaVehicleHelix
+"Assault Heli&x"
+END
+
+CONTROLBAR:Infa_ToolTipChinaBuildHelix
+"Heavy lift assault transport  \n upgrades with base defense structures and Napalm Bomb  \n  \n Strong vs. tanks, light vehicles  \n Weak vs. missile armed infantry, anti-air defenses"
+END
+
+OBJECT:Infa_Helix
+"Assault Helix"
+END
+
+CONTROLBAR:Infa_ToolTipChinaScienceInfantryParadrop
+"Drop Mini-Gunners from the air  \n  \n Rank 1: 5 Mini-Gunners  \n Rank 2: 10 Mini-Gunners  \n Rank 3: 15 Mini-Gunners  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:UpgradeSuicideBomb
+"&Demolitions Ability"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeSuicideBomb
+"Allows all units  \n and base defenses to use  \n Demolitions ability"
+END
+
+OBJECT:MiniGunner
+"Mini-Gunner"
+END
+
+OBJECT:AirF_Chinook
+"Combat Chinook"
+END
+
+CONTROLBAR:AirF_ConstructAmericaVehicleChinook
+"Comba&t Chinook"
+END
+
+CONTROLBAR:AirF_ToolTipUSABUildChinook
+"Assault Transport helicopter. Collects supplies. Works with Rangers to perform Combat Drop attack"
+END
+
+CONTROLBAR:SuicideAttack
+"Su&icide"
+END
+
+CONTROLBAR:ToolTipGLASuicideAttack
+"Detonate"
+END
+
+CONTROLBAR:Tank_TooltipUpgradeChinaNuclearTanks
+"+25% Emperor and Battlemaster speed"
+END
+
+CONTROLBAR:Boss_ToolTipUSABuildPowerPlant
+"Provides power for bases  \n  \n Power Supplied: 5"
+END
+
+CONTROLBAR:Nuke_ToolTipChinaBuildListeningOutpost
+"Assault Transport. Detects stealth units  \n  \n Strong vs. infantry, buildings  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:Nuke_ConstructChinaVehicleListeningOutpost
+"Assault Li&stening Outpost"
+END
+
+CONTROLBAR:Infa_ToolTipChinaBuildTroopCrawler
+"Assault Transport. Comes with 8 Mini-Gunners. Detects stealth units  \n  \n Strong vs. infantry, buildings  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:Infa_ToolTipChinaBuildListeningOutpost
+"Transport. Holds 8 infantry units. Detects stealth units  \n  \n Strong vs. infantry, buildings  \n Weak vs. tanks, aircraft"
+END
+
+CONTROLBAR:Infa_ConstructChinaBunker
+"Fortified Bun&ker"
+END
+
+CONTROLBAR:Infa_ToolTipChinaBuildBunker
+"Can hold 10 Chinese soldiers  \n Comes with minefield upgrade"
+END
+
+OBJECT:Infa_Bunker
+"Fortified Bunker"
+END
+
+CONTROLBAR:ToolTipGLAScienceSneakAttack
+"Troops can create a tunnel anywhere on the map  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:Chem_ConstructGLAInfantryRebel
+"Toxin Re&bel"
+END
+
+CONTROLBAR:Chem_ToolTipGLABuildRebel
+"Fires a stream of toxin  \n Strong vs. infantry  \n Weak vs. tanks, light vehicles"
+END
+
+OBJECT:Chem_Rebel
+"Toxin Rebel"
+END
+
+OBJECT:Chem_Terrorist
+"Toxin Terrorist"
+END
+
+CONTROLBAR:Chem_ConstructGLAInfantryTerrorist
+"&Toxin Terrorist"
+END
+
+CONTROLBAR:Chem_ToolTipGLABuildTerrorist
+"Suicide soldier explodes in a cloud of toxin"
+END
+
+CONTROLBAR:Chem_ConstructGLATunnelNetwork
+"Toxin &Network"
+END
+
+OBJECT:Chem_TunnelNetwork
+"Toxin Network"
+END
+
+CONTROLBAR:Chem_ToolTipGLABuildTunnelNetwork
+"Base defense and underground tunnel. Fires a stream of toxin. Units can enter the Tunnel Network and exit at any other Tunnel Network"
+END
+
+CONTROLBAR:UpgradeStealthComanche
+"&Stealth Upgrade"
+END
+
+CONTROLBAR:ToolTipAirFUpgradeComancheStealth
+"Comanches become stealth"
+END
+
+OBJECT:Entrance
+"Entrance"
+END
+
+CONTROLBAR:Boss_TooltipChinaUpgradeNationalism
+"+25% to Horde bonus for Tank Hunter"
+END
+
+CONTROLBAR:Lazr_ToolTipUSABuildPowerPlant
+"Provides power for USA bases  \n  \n Power Supplied: 8"
+END
+
+GUI:DoubleClickAttackMove
+"Double Click Guard"
+END
+
+TOOLTIP:DoubleClickAttackMove
+"Player units will move and then guard their destination area when action button is double clicked"
+END
+
+DIALOGEVENT:01_AllCheerSoundSubtitle
+"<Cheering>"
+END
+
+CONTROLBAR:Lazr_ToolTipUSABuildPatriotBattery
+"Ground and air defense. Can relay position of enemy to nearby Turrets  \n  \n Power Required: 5"
+END
+
+CONTROLBAR:Lazr_ConstructAmericaPatriotBattery
+"Laser Defense &Turret"
+END
+
+CONTROLBAR:Lazr_ConstructAmericaTankCrusader
+"Laser &Tank"
+END
+
+OBJECT:Lazr_Tank
+"Laser Tank"
+END
+
+CONTROLBAR:Lazr_ToolTipUSABuildCrusader
+"Strong vs. vehicles, buildings  \n Weak vs. aircraft, missile armed infantry"
+END
+
+CONTROLBAR:ToolTipChinaBuildEmperor
+"Strong vs. vehicles, buildings  \n Weak vs. rockets, aircraft"
+END
+
+CONTROLBAR:AirF_ToolTipUSAScienceSpectreGunship
+"Spectre Gunships circle the battlefield and pummel enemy forces with Howitzers and Gattling Cannons  \n  \nLevel 1: 10 seconds  \n Level 2: 15 seconds  \n Level 3: 30 seconds  \n  \n Deploy from: Command Center"
+END
+
+OBJECT:ValveStation
+"Valve Station"
+END
+
+HELP:Hijacker-01
+"HINT:  \n Move a Hijacker into an enemy vehicle to steal it"
+END
+
+MAP:MD-USA04_Hint08
+"HINT:  \n Build Fire Bases to help protect your base"
+END
+
+MAP:MD-USA04_Hint09
+"INCOMING TRANSMISSION:  \n CIA Operative found"
+END
+
+MAP:MD-USA04_Hint10
+"HINT:  \n Build defenses in the oil field to protect wells"
+END
+
+MAP:MD-USA04_Hint11
+"INCOMING TRANSMISSION:  \n The GLA Radio Station has been destroyed"
+END
+
+MAP:MD-USA06Warning17
+"WARNING:  \n Dr. Thrax has been known to use a Sneak Attack  \n Tunnel Network to surprise enemies"
+END
+
+MD_GLA05-MilitaryBriefing:String_1
+" \n The attack on the Chinese base begins now  \n Their base will soon be ours"
+END
+
+MAP:MD_CHI03-Title-01
+"Coburg, Germany  \n 'Liberation'"
+END
+
+MAP:MD_CHI03-Info-MissionObjective-01
+"MISSION OBJECTIVE:  \n Destroy the GLA statues to liberate the city  \n Our International Opinion will fall until we succeed"
+END
+
+MAP:MD_CHI03-Info-MissionObjective-02
+"INCOMING TRANSMISSION:  \n If our International Opinion reaches 0, we will be defeated"
+END
+
+MAP:MD_CHI03-Info-MissionObjective-03
+"INCOMING TRANSMISSION:  \n Destroy GLA statues to increase our International Opinion"
+END
+
+MAP:MD_CHI03-Info-MissionObjective-10
+"INCOMING TRANSMISSION:  \n We have liberated the city  \n Now exterminate the GLA base on the North side of the river"
+END
+
+MAP:MD_CHI03-Event-Built-SpeakerTower-01
+"INCOMING TRANSMISSION:  \n This Speaker Tower increases our International Opinion"
+END
+
+CONTROLBAR:Tank_TooltipUpgradeChinaUraniumShells
+"+25% shot damage on Battlemaster and Emperor"
+END
+
+CONTROLBAR:ToolTipGLAUpgradeBuggyAmmo
+"+100% Rocket Buggy ammo"
+END
+
+CONTROLBAR:Chem_ToolTipGLAUpgradeAPBullets
+"+25% damage bullet firing units"
+END
+
+GUI:BioFeatures_USA
+"MOAB  \n Countermeasures  \n Bunker Buster  \n Hellfire Drone  \n Spectre Gunship  \n Sentry Drone  \n Microwave Tank  \n Avenger  \n Fire Base"
+END
+
+GUI:BioFeatures_GLA
+"Sneak Attack  \n GPS Scrambler  \n Saboteur  \n Booby Trap  \n Camo-Netting  \n Fake Buildings  \n Fortified Buildings  \n Combat Cycles  \n Battle Bus"
+END
+
+GUI:BioFeatures_China
+"Helix  \n Listening Outpost  \n Neutron Mines  \n Frenzy  \n Internet Center  \n Carpet Bomber  \n ECM Tank  \n"
+END
+
+GUI:BioFeatures_Pos0
+"King Raptors  \n Combat Chinooks  \n Laser Point Defenses  \n Stealth Comanche upgrade  \n Cost reduction to aircraft  \n Spectre Gunship at a lower rank  \n Starts with Stealth Fighter  \n No tanks"
+END
+
+GUI:BioFeatures_Pos1
+"Toxin Rebels  \n Toxin Networks  \n Toxin Terrorists  \n Anthrax Gamma  \n Tanks start with Toxin Shells  \n Toxins begin as Anthrax Beta"
+END
+
+GUI:BioFeatures_Pos2
+"Tanks start with Uranium Shells  \n Tactical Nuke MiG  \n Isotope Stability upgrade  \n Advanced Nuclear Reactor  \n Nuke Bomber  \n Starts with Nuke Cannons"
+END
+
+GUI:BioFeatures_Pos3
+"Aurora Alpha  \n EMP Patriot System  \n Advanced Rods  \n Particle Cannons cost less  \n Vehicles cost more  \n No tanks"
+END
+
+GUI:BioFeatures_Pos4
+"Emperor Tank  \n Tank Drop  \n All tanks start as veterans  \n Tanks cost less  \n Aircraft cost more  \n No Nuke or Inferno Cannons"
+END
+
+GUI:BioFeatures_Pos5
+"Laser Tank  \n Laser Defense Turret  \n Avengers cost less  \n Advanced Cold Fusion Reactors  \n No Tomahawk Missile Launchers"
+END
+
+GUI:BioFeatures_Pos6
+"All Structures can be Camo-Netted  \n Camouflaged Rebels  \n Defenses start with Camo-Netting  \n Starts with Hijacker  \n Hijacker is always cloaked  \n Gains GPS Scrambler Sooner  \n Can GPS Scramble More Often"
+END
+
+GUI:BioFeatures_Pos7
+"Assault Troop Transport  \n Assault Helix  \n Attack Outpost  \n Fortified Bunkers  \n Mini-Gunner  \n Black Lotus hacks faster  \n Hackers hack faster  \n Mini-Gunner Paradrop  \n All Infantry start as veterans"
+END
+
+GUI:BioFeatures_Pos8
+"Advanced Demo Trap  \n Suicide Bomb upgrade  \n Terrorists do more damage  \n Starts with Booby Trap  \n Combat Cycles begin with Terrorist  \n No camouflaged units  \n Bomb Trucks cost less"
+END
+
+GUI:BioFeatures_Pos9
+"Uses the best of the best  \n All heroes  \n All superweapons  \n Diverse generals powers  \n Units drawn from all factions  \n Advanced defenses  \n"
+END
+
+GUI:BioFeatures_Pos10
+"unimplemented"
+END
+
+GUI:BioFeatures_Pos11
+"unimplemented"
+END
+
+DIALOGEVENT:Taunts_AirTrafficControl01Subtitle
+"***"
+END
+
+DIALOGEVENT:Taunts_Stealth107Subtitle
+"***"
+END
+
+DIALOGEVENT:Taunts_Stealth105Subtitle
+"***"
+END
+
+DIALOGEVENT:Taunts_Stealth106Subtitle
+"***"
+END
+
+GUI:GroupRoom14
+"Original Armies Only"
+END
+
+OBJECT:MissileSilo
+"Missile Silo"
+END
+
+OBJECT:ScudLauncherHiDef
+"Scud Launcher"
+END
+
+OBJECT:CINE_SnowyMountainParticleBones
+"."
+END
+
+OBJECT:CINE_SnowyMountainScrollingSnow
+"Snow"
+END
+
+OBJECT:CINE_SnowyMountainStatic
+"Mountain"
+END
+
+OBJECT:CINE_TreeBirds
+"Birds"
+END
+
+TOOLTIP:NoUserMaps
+"Unofficial maps are not allowed in Record Stats games"
+END
+
+GUI:FireWallPort
+"Firewall Port Override:"
+END
+
+TOOLTIP:FireWallPort
+"Open Firewall Port Number"
+END
+
+CONTROLBAR:Tank_TooltipUpgradeChinaOverlordGattlingCannon
+"Build a Gattling Cannon on this Emperor"
+END
+
+OBJECT:Tank_Overlord
+"Emperor"
+END
+
+GUI:USAAllies
+"USA Allies"
+END
+
+GUI:USAEnemies
+"USA Enemies"
+END
+
+OBJECT:BigNuclearReactor
+"Nuclear Reactor"
+END
+
+CONTROLBAR:SabotageBuilding
+"Sabotage &Building"
+END
+
+CONTROLBAR:ToolTipGLASabotageBuilding
+"Can temporarily disable enemy buildings  \n  \n Strong vs. Enemy Structures  \n Weak vs. infantry, scouts"
+END
+
+SCIENCE:Nuke_ChinaCarpetBomb
+"Nuke Bomber"
+END
+
+CONTROLBAR:Demo_ConstructGLADemoTrap
+"Advanced &Demo Trap"
+END
+
+CONTROLBAR:Nuke_ConstructChinaPowerPlant
+"Advanced Nuclear &Reactor"
+END
+
+CONTROLBAR:SupW_UpgradeAmericaAdvancedControlRods
+"Advanced &Control Rods"
+END
+
+CONTROLBAR:Nuke_CarpetBomb
+"Nu&ke Bomber"
+END
+
+OBJECT:Nuke_NuclearReactor
+"Advanced Nuclear Reactor"
+END
+
+OBJECT:Demo_DemoTrap
+"Advanced Demo Trap"
+END
+
+CONTROLBAR:Nuke_ToolTipChinaBuildPowerPlant
+"Advanced Nuclear Reactor. Can be overloaded to provide more power  \n  \n Power Supplied: 18"
+END
+
+CONTROLBAR:Nuke_ToolTipChinaScienceCarpetBomb
+"Allows you to call in a heavy bomber to carpet bomb an area with tactical nukes  \n  \n Deploy from: Command Center"
+END
+
+CONTROLBAR:Nuke_TooltipCarpetBomb
+"Nuke a target area  \n  \n Countdown Timer: 3:00"
+END
+
+GUI:FastForwardInstructions
+"Press F to toggle Fast Forward"
+END
+
+GUI:FF_ON
+"Fast Forward is on"
+END
+
+GUI:FF_OFF
+"Fast Forward is off"
+END
+
+CONTROLBAR:LeafletDropShort
+"Leaflet Drop"
+END
+
+CONTROLBAR:SneakAttackShort
+"Sneak Attack"
+END
+
+CONTROLBAR:TankParadropShort
+"Tank Drop"
+END
+
+OBJECT:Nuke_CarpetBomb
+"Nuke Bomber"
+END
+
+CONTROLBAR:Slth_ConstructGLAInfantryRebel
+"Stealth Re&bel"
+END
+
+GUI:AdjustGameSpeed
+"Adjust Game Speed"
+END
+
+GUI:SkirmishLower
+"Skirmish"
+END
+
+GUI:Refresh
+"Refresh"
+END
+
+CONTROLBAR:MOAB
+"Mother Of All &Bombs"
+END
+
+MAP:TournamentPlains
+"Tournament Plains"
+END
+
+MAP:DarkNight
+"Dark Night"
+END
+
+MAP:TournamentUrban
+"Tournament Urban"
+END
+
+MAP:TwoRoads
+"Two Roads"
+END
+
+CONTROLBAR:Chem_TooltipFireRebelAmbush
+"Creates toxin rebels  \n  \n Countdown Timer: 4:00"
+END
+
+CONTROLBAR:AirF_ToolTipUSABuildAurora
+"Super-sonic attack makes Aurora immune to enemy fire. After super-sonic attack, Aurora speed is reduced to 50%  \n  \n Strong vs. buildings  \n Weak vs. fighters, anti-air units"
+END
+
+CONTROLBAR:Chem_ToolTipGLAScienceRebelAmbush
+"Allows you to create a surprise ambush of Toxin Rebels anywhere  \n  \n Rank 1: 4 Toxin Rebels  \n Rank 2: 8 Toxin Rebels  \n Rank 3: 16 Toxin Rebels  \n  \n Deploy from: Command Center"
+END
+
+CREDITS:PackagingProjectManager
+"Packaging Project Manager"
+END
+
+CREDITS:PackagingDesign
+"Packaging Design"
+END
+
+CREDITS:DocumentationLayout
+"Documentation Layout"
+END
+
+CREDITS:DocumentationEditor
+"Documentation Editor"
+END
+
+CREDITS:Writer
+"Writer"
+END
+
+CREDITS:Studio
+"Studio"
+END
+
+CREDITS:ChineseLanguageTester
+"Chinese Language Tester"
+END
+
+CREDITS:Marketing
+"Marketing"
+END
+
+CREDITS:QuotedTraducoes
+"Quoted Tradu��es"
+END
+
+CREDITS:ClementDuval
+"Cl�ment Duval"
+END
+
+CREDITS:JoseLuisRovira
+"Jos� Luis Rovira"
+END
+
+CREDITS:ExecutiveProducer
+"Executive Producer"
+END
+
+CREDITS:TechnicalDirection
+"Technical Direction"
+END
+
+CREDITS:LeadArtists
+"Lead Artists"
+END
+
+CREDITS:QualityAssurance
+"Quality Assurance"
+END
+
+CREDITS:TestAnalysts
+"Test Analysts"
+END
+
+CREDITS:TiburonAdditionalQualityAssurance
+"Tiburon Additional Quality Assurance"
+END
+
+CREDITS:LocalizationBrazil
+"Localization Brazil"
+END
+
+CREDITS:TranslationServices
+"Translation Services"
+END
+
+CREDITS:TranslationCoordinator
+"Translation Coordinator"
+END
+
+CREDITS:LTCoordinator
+"LT Coordinator"
+END
+
+CREDITS:RecordingStudio
+"Recording Studio"
+END
+
+CREDITS:EAWorldwideDevelopmentExecutives
+"EA Worldwide Development Executives"
+END
+
+CREDITS:SpecialThanks
+"Special Thanks"
+END
+
+CREDITS:EAPacificDevTeam3
+"Development Team"
+END
+
+CREDITS:NACustomerQualityControl
+"NA Customer Quality Control"
+END
+
+CONTROLBAR:SupW_TooltipUSAUpgradeAdvancedControlRods
+"Reactor provides 300% more power"
+END
+
+CONTROLBAR:AirF_ToolTipUSABuildStealthFighter
+"Stealthed while moving  \n Equipped with a Point Defense Laser  \n  \n Strong vs. enemy base defenses  \n Weak vs. enemy fighters"
+END
+
+GUI:RetaliationTitle
+"Retaliation"
+END
+
+GUI:Retaliation
+"Toggle this button off to disable your units from retaliating against attacking enemies automatically"
+END
+
+CREDITS:LocalizationChinese
+"Localization Chinese"
+END
+
+MAP:Breakdown
+"Breakdown"
+END
+
+MAP:BulletMassacre
+"Bullet Massacre"
+END
+
+MAP:CarnageCityLimits
+"Carnage City Limits"
+END
+
+MAP:Cityscape
+"Cityscape"
+END
+
+MAP:CivilUnrest
+"Civil Unrest"
+END
+
+MAP:CottageCheese
+"Cottage Cheese"
+END
+
+MAP:DeathValley
+"Death Valley"
+END
+
+MAP:DogsOfWar
+"Dogs of War"
+END
+
+MAP:DoorToDoor
+"Door to Door"
+END
+
+MAP:FarmersFrenzy
+"Farmers Frenzy"
+END
+
+MAP:Firestorm
+"Firestorm"
+END
+
+MAP:FlakAttack
+"Flak Attack"
+END
+
+MAP:FlankTown
+"Flank Town"
+END
+
+MAP:Flashbang
+"Flash Bang"
+END
+
+MAP:FoxHunt
+"Fox Hunt"
+END
+
+MAP:GhostTown
+"Ghost Town"
+END
+
+MAP:HighRoad
+"High Road"
+END
+
+MAP:HighlandHunt
+"Highland Hunt"
+END
+
+MAP:HostileDawn
+"Hostile Dawn"
+END
+
+MAP:IslandInTheZone
+"Island in the Zone"
+END
+
+MAP:JungleRebellion
+"Jungle Rebellion"
+END
+
+MAP:LARiot
+"L.A. Riot"
+END
+
+MAP:Liberation
+"Liberation"
+END
+
+MAP:LongNight
+"Long Night"
+END
+
+MAP:ManicAggression
+"Manic Aggression"
+END
+
+MAP:Marshland
+"Marshland"
+END
+
+MAP:Mirage
+"Mirage"
+END
+
+MAP:PanicDemise
+"Panic Demise"
+END
+
+MAP:PowerPlay
+"Power Play"
+END
+
+MAP:RedRock
+"Red Rock"
+END
+
+MAP:RubbleTown
+"Rubble Town"
+END
+
+MAP:SeasideMutiny
+"Seaside Mutiny"
+END
+
+MAP:ShellShocker
+"Shell Shocker"
+END
+
+MAP:Shellshock
+"Shellshock"
+END
+
+MAP:ShockAndAwe
+"Shock and Awe"
+END
+
+MAP:Shockwave
+"Shockwave"
+END
+
+MAP:SniperDuel
+"Sniper Duel"
+END
+
+MAP:TheFrontline
+"The Frontline"
+END
+
+MAP:TournamentBeach
+"Tournament Beach"
+END
+
+MAP:TournamentCanyon
+"Tournament canyon"
+END
+
+MAP:TournamentDesolate
+"Tournament Desolate"
+END
+
+MAP:TournamentForest
+"Tournament Forest"
+END
+
+MAP:TournamentIceStorm
+"Tournament Ice Storm"
+END
+
+MAP:TournamentTactics
+"Tournament Tactics"
+END
+
+MAP:TournamentTown
+"Tournament Town"
+END
+
+MAP:TournamentValley
+"Tournament Valley"
+END
+
+MAP:UnholyWar
+"Unholy War"
+END
+
+MAP:Unstable
+"Unstable"
+END
+
+MAP:UrbanUprising
+"Urban Uprising"
+END
+
+MAP:VictoryOutlook
+"Victory Outlook"
+END
+
+MAP:VictoryRoad
+"Victory Road"
+END
+
+MAP:NorthAmerica
+"North America"
+END
+
+MAP:Floodplains
+"Floodplains"
+END
+
+MAP:TournamentA
+"Tournament A"
+END
+
+MAP:TournamentB
+"Tournament B"
+END
+
+MAP:Defcon6
+"Defcon 6"
+END
+
+CONTROLBAR:AirF_TooltipUSAUpgradeLaserMissiles
+"Raptor and Stealth Fighter missiles do +12% more damage"
+END
+
+CONTROLBAR:AirF_ToolTipUSAScienceCarpetBomb
+"Allows you to call in a B2 Stealth Bomber to carpet bomb an area  \n  \n Deploy from: Strategy Center"
+END
+


### PR DESCRIPTION
As far as I know, this is the only button without hotkey in ZeroHour and also a pretty important one.
For that reason, I would treat this as bug.

-----

- `generals.str` is auto generated textual representation of `generals.csf`
- This adds hotkey to English localization only, but it shouldn't be hard to add it to other languages.
- The only change in this PR is a new hotkey `&Z: Sell`, that assigns the hotkey `Z` to `Sell` button (line 4546).