### PR TITLE
Fix: Make Reduced Repair Rate On Fortified Structures Explicit

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -643,6 +643,7 @@ End
 
 Armor GLAUpgradedStructureArmor
   Armor = DEFAULT           75%    ; this sets the level for all nonspecified damage types
+  Armor = HEALING           75%   ; Patch104p @bugfix commy2 08/09/2021 Make reduced repair rate explicit. This does not change ingame behaviour.
   Armor = Surrender         0%    ; buildings are immune to normal damage from STUN weapons.
   Armor = SMALL_ARMS        40%
   Armor = GATTLING          7%    ;resistant to gattling tank
@@ -668,6 +669,7 @@ End
 
 Armor GLAUpgradedStructureArmorTough
   Armor = DEFAULT           75%    ; this sets the level for all nonspecified damage types
+  Armor = HEALING           75%   ; Patch104p @bugfix commy2 08/09/2021 Make reduced repair rate explicit. This does not change ingame behaviour.
   Armor = Surrender         0%    ; buildings are immune to normal damage from STUN weapons.
   Armor = SMALL_ARMS        40%
   Armor = GATTLING          7%    ;resistant to gattling tank


### PR DESCRIPTION
- close https://github.com/xezon/GeneralsGamePatch/issues/228

When upgrading GLA buildings with Fortified Structures, damage taken from generic damage types is reduced by -25%. This also affects the rate at which Workers and Dozers repair these structures, because repair is implemented as weapon with negative damage (damage type: HEALING).

It was decided that this is an oversight. It was further decided that resolving this issue would affect gameplay and balance negatively.

This PR makes the reduced healing rate explicit in code, to document that this behaviour is known and accepted. The PR does not change ingame behaviour.