### PR TITLE
Disable Upgrade_GlobalDummyUpgrade for CommandSetUpgrade ScaffoldBuildFix2 to reinstate Skirmish and Campaign map compatibility

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -8728,7 +8728,7 @@ Object AirF_AmericaCommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AirF_AmericaCommandCenterCommandSet
   End
 
@@ -12073,7 +12073,7 @@ Object AirF_AmericaStrategyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AirF_AmericaStrategyCenterCommandSet
   End
 
@@ -13292,7 +13292,7 @@ Object AirF_AmericaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AirF_AmericaAirfieldCommandSet
   End
 
@@ -14136,7 +14136,7 @@ Object AirF_AmericaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AirF_AmericaSupplyCenterCommandSet
   End
 
@@ -15376,7 +15376,7 @@ Object AirF_AmericaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AirF_AmericaBarracksCommandSet
   End
 
@@ -16387,7 +16387,7 @@ Object AirF_AmericaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AirF_AmericaWarFactoryCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -1047,7 +1047,7 @@ Object Chem_GLACommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLACommandCenterCommandSet
   End
 
@@ -2501,7 +2501,7 @@ Object Chem_GLABlackMarket
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLABlackMarketCommandSet
   End
 
@@ -6057,7 +6057,7 @@ Object Chem_GLAStingerSite
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLAStingerSiteCommandSet
   End
 
@@ -6885,7 +6885,7 @@ Object Chem_GLAPalace
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLAPalaceCommandSet
   End
 
@@ -7594,7 +7594,7 @@ Object Chem_GLASupplyStash
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLASupplyStashCommandSet
   End
 
@@ -8980,7 +8980,7 @@ Object Chem_GLABarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLABarracksCommandSet
   End
 
@@ -10591,7 +10591,7 @@ Object Chem_GLAArmsDealer
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLAArmsDealerCommandSet
   End
 
@@ -20391,7 +20391,7 @@ Object Chem_GLATunnelNetwork
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Chem_GLATunnelNetworkCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1180,7 +1180,7 @@ Object Demo_GLACommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLACommandCenterCommandSet
   End
 
@@ -2634,7 +2634,7 @@ Object Demo_GLABlackMarket
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLABlackMarketCommandSet
   End
 
@@ -5392,7 +5392,7 @@ Object Demo_GLATunnelNetwork
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLATunnelNetworkCommandSet
   End
 
@@ -6000,7 +6000,7 @@ Object Demo_GLAStingerSite
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLAStingerSiteCommandSet
   End
 
@@ -6827,7 +6827,7 @@ Object Demo_GLAPalace
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLAPalaceCommandSet
   End
 
@@ -7535,7 +7535,7 @@ Object Demo_GLASupplyStash
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLASupplyStashCommandSet
   End
 
@@ -8951,7 +8951,7 @@ Object Demo_GLABarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLABarracksCommandSet
   End
 
@@ -10562,7 +10562,7 @@ Object Demo_GLAArmsDealer
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Demo_GLAArmsDealerCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -1495,7 +1495,7 @@ Object AmericaCommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AmericaCommandCenterCommandSet
   End
 
@@ -2238,7 +2238,7 @@ Object GLACommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLACommandCenterCommandSet
   End
 
@@ -2973,7 +2973,7 @@ Object FakeGLACommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = FakeGLACommandCenterCommandSet
   End
 
@@ -4084,7 +4084,7 @@ Object ChinaCommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaCommandCenterCommandSet
   End
 
@@ -5188,7 +5188,7 @@ Object AmericaPowerPlant
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AmericaPowerPlantCommandSet
   End
 
@@ -7438,7 +7438,7 @@ Object AmericaStrategyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AmericaStrategyCenterCommandSet
   End
 
@@ -8657,7 +8657,7 @@ Object AmericaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AmericaAirfieldCommandSet
   End
 
@@ -9764,7 +9764,7 @@ Object ChinaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaAirfieldCommandSet
   End
 
@@ -10557,7 +10557,7 @@ Object GLABlackMarket
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLABlackMarketCommandSet
   End
 
@@ -14871,7 +14871,7 @@ Object ChinaNuclearMissileLauncher
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaNuclearMissileCommandSet
   End
 
@@ -15526,7 +15526,7 @@ Object ChinaSpeakerTower
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaSpeakerTowerCommandSet
   End
 
@@ -16313,7 +16313,7 @@ Object GLATunnelNetwork
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLATunnelNetworkCommandSet
   End
 
@@ -17401,7 +17401,7 @@ Object GLAStingerSite
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLAStingerSiteCommandSet
   End
 
@@ -18230,7 +18230,7 @@ Object GLAPalace
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLAPalaceCommandSet
   End
 
@@ -19245,7 +19245,7 @@ Object ChinaPowerPlant
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaPowerPlantCommandSet
   End
 
@@ -20088,7 +20088,7 @@ Object AmericaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AmericaSupplyCenterCommandSet
   End
 
@@ -21327,7 +21327,7 @@ Object GLASupplyStash
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLASupplyStashCommandSet
   End
 
@@ -22682,7 +22682,7 @@ Object ChinaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaSupplyCenterCommandSet
   End
 
@@ -23352,7 +23352,7 @@ Object AmericaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AmericaBarracksCommandSet
   End
 
@@ -24049,7 +24049,7 @@ Object GLABarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLABarracksCommandSet
   End
 
@@ -25450,7 +25450,7 @@ Object ChinaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaBarracksCommandSet
   End
 
@@ -26460,7 +26460,7 @@ Object AmericaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = AmericaWarFactoryCommandSet
   End
 
@@ -27352,7 +27352,7 @@ Object GLAArmsDealer
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLAArmsDealerCommandSet
   End
 
@@ -29326,7 +29326,7 @@ Object ChinaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaWarFactoryCommandSet
   End
 
@@ -31299,7 +31299,7 @@ Object ChinaBunker
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaBunkerCommandSet
   End
 
@@ -32195,7 +32195,7 @@ Object ChinaPropagandaCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaPropagandaCenterCommandSet
   End
 
@@ -33298,7 +33298,7 @@ Object ChinaGattlingCannon
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaGattlingCannonCommandSet
   End
 
@@ -33980,7 +33980,7 @@ Object GLAStingerSiteNoHole
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLAStingerSiteCommandSet
   End
 
@@ -35691,7 +35691,7 @@ Object ChinaInternetCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaInternetCenterCommandSetOne
   End
 
@@ -36963,7 +36963,7 @@ Object GLAArmsDealerNoHole
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = GLAArmsDealerCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -4273,7 +4273,7 @@ Object Infa_ChinaCommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaCommandCenterCommandSet
   End
 
@@ -5382,7 +5382,7 @@ Object Infa_ChinaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaAirfieldCommandSet
   End
 
@@ -6887,7 +6887,7 @@ Object Infa_ChinaNuclearMissileLauncher
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaNuclearMissileCommandSet
   End
 
@@ -9179,7 +9179,7 @@ Object Infa_ChinaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaSupplyCenterCommandSet
   End
 
@@ -9874,7 +9874,7 @@ Object Infa_ChinaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaBarracksCommandSet
   End
 
@@ -10951,7 +10951,7 @@ Object Infa_ChinaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaWarFactoryCommandSet
   End
 
@@ -11853,7 +11853,7 @@ Object Infa_ChinaPropagandaCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaPropagandaCenterCommandSet
   End
 
@@ -12956,7 +12956,7 @@ Object Infa_ChinaGattlingCannon
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaGattlingCannonCommandSet
   End
 
@@ -14039,7 +14039,7 @@ Object Infa_ChinaInternetCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Infa_ChinaInternetCenterCommandSetOne
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -8435,7 +8435,7 @@ Object Lazr_AmericaCommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Lazr_AmericaCommandCenterCommandSet
   End
 
@@ -9535,7 +9535,7 @@ Object Lazr_AmericaPowerPlant
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Lazr_AmericaPowerPlantCommandSet
   End
 
@@ -11777,7 +11777,7 @@ Object Lazr_AmericaStrategyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Lazr_AmericaStrategyCenterCommandSet
   End
 
@@ -12996,7 +12996,7 @@ Object Lazr_AmericaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Lazr_AmericaAirfieldCommandSet
   End
 
@@ -13844,7 +13844,7 @@ Object Lazr_AmericaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Lazr_AmericaSupplyCenterCommandSet
   End
 
@@ -15085,7 +15085,7 @@ Object Lazr_AmericaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Lazr_AmericaBarracksCommandSet
   End
 
@@ -16097,7 +16097,7 @@ Object Lazr_AmericaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Lazr_AmericaWarFactoryCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -5991,7 +5991,7 @@ Object Nuke_ChinaCommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaCommandCenterCommandSet
   End
 
@@ -7100,7 +7100,7 @@ Object Nuke_ChinaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaAirfieldCommandSet
   End
 
@@ -8605,7 +8605,7 @@ Object Nuke_ChinaNuclearMissileLauncher
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaNuclearMissileCommandSet
   End
 
@@ -9260,7 +9260,7 @@ Object Nuke_ChinaSpeakerTower
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaSpeakerTowerCommandSet
   End
 
@@ -10251,7 +10251,7 @@ Object Nuke_ChinaPowerPlant
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaPowerPlantCommandSet
   End
 
@@ -10935,7 +10935,7 @@ Object Nuke_ChinaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaSupplyCenterCommandSet
   End
 
@@ -11625,7 +11625,7 @@ Object Nuke_ChinaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaBarracksCommandSet
   End
 
@@ -12697,7 +12697,7 @@ Object Nuke_ChinaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaWarFactoryCommandSet
   End
 
@@ -13566,7 +13566,7 @@ Object Nuke_ChinaBunker
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaBunkerCommandSet
   End
 
@@ -14462,7 +14462,7 @@ Object Nuke_ChinaPropagandaCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Nuke_ChinaPropagandaCenterCommandSet
   End
 
@@ -15565,7 +15565,7 @@ Object Nuke_ChinaGattlingCannon
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaGattlingCannonCommandSet
   End
 
@@ -16647,7 +16647,7 @@ Object Nuke_ChinaInternetCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaInternetCenterCommandSetOne
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -1049,7 +1049,7 @@ Object Slth_GLACommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLACommandCenterCommandSet
   End
 
@@ -2526,7 +2526,7 @@ Object Slth_GLABlackMarket
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLABlackMarketCommandSet
   End
 
@@ -6078,7 +6078,7 @@ Object Slth_GLATunnelNetwork
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLATunnelNetworkCommandSet
   End
 
@@ -6647,7 +6647,7 @@ Object Slth_GLAStingerSite
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLAStingerSiteCommandSet
   End
 
@@ -7483,7 +7483,7 @@ Object Slth_GLAPalace
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLAPalaceCommandSet
   End
 
@@ -8203,7 +8203,7 @@ Object Slth_GLASupplyStash
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLASupplyStashCommandSet
   End
 
@@ -9621,7 +9621,7 @@ Object Slth_GLABarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLABarracksCommandSet
   End
 
@@ -11259,7 +11259,7 @@ Object Slth_GLAArmsDealer
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Slth_GLAArmsDealerCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -8923,7 +8923,7 @@ Object SupW_AmericaCommandCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = SupW_AmericaCommandCenterCommandSet
   End
 
@@ -11162,7 +11162,7 @@ Object SupW_AmericaStrategyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = SupW_AmericaStrategyCenterCommandSet
   End
 
@@ -12381,7 +12381,7 @@ Object SupW_AmericaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = SupW_AmericaAirfieldCommandSet
   End
 
@@ -13231,7 +13231,7 @@ Object SupW_AmericaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = SupW_AmericaSupplyCenterCommandSet
   End
 
@@ -14472,7 +14472,7 @@ Object SupW_AmericaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = SupW_AmericaBarracksCommandSet
   End
 
@@ -15484,7 +15484,7 @@ Object SupW_AmericaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = SupW_AmericaWarFactoryCommandSet
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -6491,7 +6491,7 @@ Object Tank_ChinaNuclearMissileLauncher
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Tank_ChinaNuclearMissileCommandSet
   End
 
@@ -7146,7 +7146,7 @@ Object Tank_ChinaSpeakerTower
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaSpeakerTowerCommandSet
   End
 
@@ -8819,7 +8819,7 @@ Object Tank_ChinaSupplyCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Tank_ChinaSupplyCenterCommandSet
   End
 
@@ -9508,7 +9508,7 @@ Object Tank_ChinaBarracks
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Tank_ChinaBarracksCommandSet
   End
 
@@ -10629,7 +10629,7 @@ Object Tank_ChinaAirfield
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Tank_ChinaAirfieldCommandSet
   End
 
@@ -11698,7 +11698,7 @@ Object Tank_ChinaWarFactory
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Tank_ChinaWarFactoryCommandSet
   End
 
@@ -13441,7 +13441,7 @@ Object Tank_ChinaPropagandaCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Tank_ChinaPropagandaCenterCommandSet
   End
 
@@ -14544,7 +14544,7 @@ Object Tank_ChinaGattlingCannon
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = Tank_ChinaGattlingCannonCommandSet
   End
 
@@ -15626,7 +15626,7 @@ Object Tank_ChinaInternetCenter
 
   Behavior = CommandSetUpgrade ModuleTag_ScaffoldBuildFix2
     TriggeredBy = Upgrade_DummyUpgrade Upgrade_GlobalDummyUpgrade
-    RequiresAllTriggers = Yes
+    RequiresAllTriggers = No
     CommandSet = ChinaInternetCenterCommandSetOne
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -59,7 +59,7 @@ PlayerTemplate FactionAmerica
   DisplayName       = INI:FactionAmerica
   StartingBuilding  = AmericaCommandCenter
   StartingUnit0     = AmericaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -94,7 +94,7 @@ PlayerTemplate FactionChina
   DisplayName       = INI:FactionChina
   StartingBuilding  = ChinaCommandCenter
   StartingUnit0     = ChinaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -129,7 +129,7 @@ PlayerTemplate FactionGLA
   DisplayName       = INI:FactionGLA
   StartingBuilding  = GLACommandCenter
   StartingUnit0     = GLAInfantryWorker
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -165,7 +165,7 @@ PlayerTemplate FactionAmericaSuperWeaponGeneral
   DisplayName       = INI:FactionAmericaSuperWeaponGeneral
   StartingBuilding  = SupW_AmericaCommandCenter
   StartingUnit0     = SupW_AmericaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -200,7 +200,7 @@ PlayerTemplate FactionAmericaLaserGeneral
   DisplayName       = INI:FactionAmericaLaserGeneral
   StartingBuilding  = Lazr_AmericaCommandCenter
   StartingUnit0     = Lazr_AmericaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -235,7 +235,7 @@ PlayerTemplate FactionAmericaAirForceGeneral
   DisplayName       = INI:FactionAmericaAirForceGeneral
   StartingBuilding  = AirF_AmericaCommandCenter
   StartingUnit0     = AirF_AmericaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = America_ScoreScreen
   LoadScreenImage   = SAFactionLogoPage_US
   LoadScreenMusic   = Load_USA
@@ -270,7 +270,7 @@ PlayerTemplate FactionChinaTankGeneral
   DisplayName       = INI:FactionChinaTankGeneral
   StartingBuilding  = Tank_ChinaCommandCenter
   StartingUnit0     = Tank_ChinaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -305,7 +305,7 @@ PlayerTemplate FactionChinaInfantryGeneral
   DisplayName       = INI:FactionChinaInfantryGeneral
   StartingBuilding  = Infa_ChinaCommandCenter
   StartingUnit0     = Infa_ChinaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -341,7 +341,7 @@ PlayerTemplate FactionChinaNukeGeneral
   DisplayName       = INI:FactionChinaNukeGeneral
   StartingBuilding  = Nuke_ChinaCommandCenter
   StartingUnit0     = Nuke_ChinaVehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -377,7 +377,7 @@ PlayerTemplate FactionGLAToxinGeneral
   DisplayName       = INI:FactionGLAToxinGeneral
   StartingBuilding  = Chem_GLACommandCenter
   StartingUnit0     = Chem_GLAInfantryWorker
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -413,7 +413,7 @@ PlayerTemplate FactionGLADemolitionGeneral
   DisplayName       = INI:FactionGLADemolitionGeneral
   StartingBuilding  = Demo_GLACommandCenter
   StartingUnit0     = Demo_GLAInfantryWorker
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -449,7 +449,7 @@ PlayerTemplate FactionGLAStealthGeneral
   DisplayName       = INI:FactionGLAStealthGeneral
   StartingBuilding  = Slth_GLACommandCenter
   StartingUnit0     = Slth_GLAInfantryWorker
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -484,7 +484,7 @@ PlayerTemplate FactionBossGeneral
   DisplayName       = INI:FactionBossGeneral
   StartingBuilding  = Boss_CommandCenter
   StartingUnit0     = Boss_VehicleDozer
-  StartingUnit9     = GrantGlobalDummyUpgradeObject
+  ;StartingUnit9     = GrantGlobalDummyUpgradeObject
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China


### PR DESCRIPTION
Fixes #215