### PR TITLE
Fix: Mixing Battle Masters From Different Sub-Factions Does Not Grant Horde Bonus

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -6,7 +6,7 @@ https://github.com/commy2/zerohour/issues/228 [DONE]                  Specrte Gu
 https://github.com/commy2/zerohour/issues/227 [DONE][NPROJECT]        Toxin Truck Gains Minimum Range After Anthrax Upgrade
 https://github.com/commy2/zerohour/issues/226 [DONE][NPROJECT]        Propaganda Center And Bunker Use Default Radar Priority
 https://github.com/commy2/zerohour/issues/225 [IMPROVEMENT][NPROJECT] Spectre Loses Team Color When Shot Down
-https://github.com/commy2/zerohour/issues/224 [IMPROVEMENT][NPROJECT] Mixing Battle Masters From Different Sub-Factions Does Not Grant Horde Bonus
+https://github.com/commy2/zerohour/issues/224 [DONE][NPROJECT]        Mixing Battle Masters From Different Sub-Factions Does Not Grant Horde Bonus
 https://github.com/commy2/zerohour/issues/223 [IMPROVEMENT][NPROJECT] Sentry Drone Lacks Voice Line When Leaving Factory
 https://github.com/commy2/zerohour/issues/222 [MAYBE]                 Poison Fields Can Clear Poison Fields
 https://github.com/commy2/zerohour/issues/221 [IMPROVEMENT][NPROJECT] Units Sometimes Waste Shots On Overlord Debris

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -110,13 +110,15 @@ Object ChinaTankBattleMaster
   Locomotor = SET_NORMAL BattleMasterLocomotor
   Locomotor = SET_NORMAL_UPGRADED NuclearBattleMasterLocomotor
 
+  ; Patch104p @bugfix commy2 09/09/2021 Fixed horde bonus required exact match when mixing sub-faction Battle Masters.
+
   Behavior = HordeUpdate ModuleTag_04
     RubOffRadius = 150    ; if I am this close to a real hordesman, I will get to be an honorary hordesman
     UpdateRate = 1000     ; how often to recheck horde status (msec)
     Radius = 75           ; how close other units must be to us to count towards our horde-ness (~30 feet or so)
     KindOf = VEHICLE      ; what KindOf's must match to count towards horde-ness
     AlliesOnly = Yes      ; do we only count allies towards horde status?
-    ExactMatch = Yes      ; do we only count units of our exact same type towards horde status? (overrides kindof)
+    ExactMatch = No       ; do we only count units of our exact same type towards horde status? (overrides kindof)
     Count = 5             ; how many units must be within Radius to grant us horde-ness
     Action = HORDE        ; when horde-ing, grant us the HORDE bonus
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16776,13 +16776,15 @@ Object Nuke_ChinaTankBattleMaster
 
   Locomotor = SET_NORMAL Nuke_FusionBattleMasterLocomotor
 
+  ; Patch104p @bugfix commy2 09/09/2021 Fixed horde bonus required exact match when mixing sub-faction Battle Masters.
+
   Behavior = HordeUpdate ModuleTag_04
     RubOffRadius = 150    ; if I am this close to a real hordesman, I will get to be an honorary hordesman
     UpdateRate = 1000     ; how often to recheck horde status (msec)
     Radius = 75           ; how close other units must be to us to count towards our horde-ness (~30 feet or so)
     KindOf = VEHICLE      ; what KindOf's must match to count towards horde-ness
     AlliesOnly = Yes      ; do we only count allies towards horde status?
-    ExactMatch = Yes      ; do we only count units of our exact same type towards horde status? (overrides kindof)
+    ExactMatch = No       ; do we only count units of our exact same type towards horde status? (overrides kindof)
     Count = 5             ; how many units must be within Radius to grant us horde-ness
     Action = HORDE        ; when horde-ing, grant us the HORDE bonus
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2798,13 +2798,15 @@ Object Tank_ChinaTankBattleMaster
     ScienceRequired = SCIENCE_BattlemasterTraining
   End
 
+  ; Patch104p @bugfix commy2 09/09/2021 Fixed horde bonus required exact match when mixing sub-faction Battle Masters.
+
   Behavior = HordeUpdate ModuleTag_04
     RubOffRadius = 150    ; if I am this close to a real hordesman, I will get to be an honorary hordesman
     UpdateRate = 1000     ; how often to recheck horde status (msec)
     Radius = 75           ; how close other units must be to us to count towards our horde-ness (~30 feet or so)
     KindOf = VEHICLE      ; what KindOf's must match to count towards horde-ness
     AlliesOnly = Yes      ; do we only count allies towards horde status?
-    ExactMatch = Yes      ; do we only count units of our exact same type towards horde status? (overrides kindof)
+    ExactMatch = No       ; do we only count units of our exact same type towards horde status? (overrides kindof)
     Count = 5             ; how many units must be within Radius to grant us horde-ness
     Action = HORDE        ; when horde-ing, grant us the HORDE bonus
   End


### PR DESCRIPTION
ZH 1.04

- 4 Nuke Battle Masters and 1 Tank Battle Master do not count as a Horde, but 4 Nuke Tank Hunters and 1 Tank Tank Hunter do. 
- The unit type has to match exactly instead of having any of 5 hordable tanks\vehicles.

After ZH 1.04

- Any 5 Battle Masters will form a horde, no matter what sub-faction they are from.

I think this is a thing, because in CCG only one vehicle with horde existed, while there always were two different infantry units.