### PR TITLE
Fix: Sentry Drone Lacks Voice Line When Leaving Factory

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -7,7 +7,7 @@ https://github.com/commy2/zerohour/issues/227 [DONE][NPROJECT]        Toxin Truc
 https://github.com/commy2/zerohour/issues/226 [DONE][NPROJECT]        Propaganda Center And Bunker Use Default Radar Priority
 https://github.com/commy2/zerohour/issues/225 [IMPROVEMENT][NPROJECT] Spectre Loses Team Color When Shot Down
 https://github.com/commy2/zerohour/issues/224 [IMPROVEMENT][NPROJECT] Mixing Battle Masters From Different Sub-Factions Does Not Grant Horde Bonus
-https://github.com/commy2/zerohour/issues/223 [IMPROVEMENT][NPROJECT] Sentry Drone Lacks Voice Line When Leaving Factory
+https://github.com/commy2/zerohour/issues/223 [DONE][NPROJECT]        Sentry Drone Lacks Voice Line When Leaving Factory
 https://github.com/commy2/zerohour/issues/222 [MAYBE]                 Poison Fields Can Clear Poison Fields
 https://github.com/commy2/zerohour/issues/221 [IMPROVEMENT][NPROJECT] Units Sometimes Waste Shots On Overlord Debris
 https://github.com/commy2/zerohour/issues/220 [DONE][NPROJECT]        Units Sometimes Waste Shots On Poisoned Or Burned Infantry

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6791,6 +6791,7 @@ Object AirF_AmericaVehicleSentryDrone
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+  ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
@@ -6801,7 +6802,7 @@ Object AirF_AmericaVehicleSentryDrone
   SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
-    VoiceCreate         = NoSound
+    VoiceCreate         = SentryDroneVoiceCreate
     TurretMoveStart     = NoSound
     TurretMoveLoop      = NoSound
     VoiceEnter          = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2158,6 +2158,7 @@ Object AmericaVehicleSentryDrone
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects when damaged.
+  ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
@@ -2168,7 +2169,7 @@ Object AmericaVehicleSentryDrone
   SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
-    VoiceCreate         = NoSound
+    VoiceCreate         = SentryDroneVoiceCreate
     TurretMoveStart     = NoSound
     TurretMoveLoop      = NoSound
     VoiceEnter          = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19718,6 +19718,7 @@ Object Boss_VehicleSentryDrone
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+  ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
@@ -19728,7 +19729,7 @@ Object Boss_VehicleSentryDrone
   SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
-    VoiceCreate         = NoSound
+    VoiceCreate         = SentryDroneVoiceCreate
     TurretMoveStart     = NoSound
     TurretMoveLoop      = NoSound
     VoiceEnter          = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6511,6 +6511,7 @@ Object Lazr_AmericaVehicleSentryDrone
   CommandSet    = Lazr_AmericaVehicleSentryDroneCommandSet
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+  ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
@@ -6521,7 +6522,7 @@ Object Lazr_AmericaVehicleSentryDrone
   SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
-    VoiceCreate         = NoSound
+    VoiceCreate         = SentryDroneVoiceCreate
     TurretMoveStart     = NoSound
     TurretMoveLoop      = NoSound
     VoiceEnter          = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6977,6 +6977,7 @@ Object SupW_AmericaVehicleSentryDrone
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
+  ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
@@ -6987,7 +6988,7 @@ Object SupW_AmericaVehicleSentryDrone
   SoundMoveStartDamaged = SentryDroneMoveStart
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
-    VoiceCreate         = NoSound
+    VoiceCreate         = SentryDroneVoiceCreate
     TurretMoveStart     = NoSound
     TurretMoveLoop      = NoSound
     VoiceEnter          = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -6800,6 +6800,17 @@ End
 ;  Type = ui voice player
 ;End
 
+; Patch104p @bugfix commy2 09/09/2021 Sound used when Sentry Drone leaves factory.
+
+AudioEvent SentryDroneVoiceCreate
+  Sounds = vsenseld
+  Control = random
+  Volume  = 80
+  MinVolume = 70
+  Priority = high
+  Type = world global player
+End
+
 AudioEvent SentryDroneVoiceSelect
   Sounds = vsensela vsenselb vsenselc vsenseld
   Control = random


### PR DESCRIPTION
ZH 1.04

- The Sentry Drone is so ashamed of its poor performance, it's the only unit in the game that does not announce itself when constructed.

After patch:

- beep beep beep boop
- The sound effect is only played for the player, not for the enemy or allies. It works like every other announcer voice line.