### PR TITLE
Fix: Units Sometimes Waste Shots On Overlord Debris

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -9,7 +9,7 @@ https://github.com/commy2/zerohour/issues/225 [IMPROVEMENT][NPROJECT] Spectre Lo
 https://github.com/commy2/zerohour/issues/224 [IMPROVEMENT][NPROJECT] Mixing Battle Masters From Different Sub-Factions Does Not Grant Horde Bonus
 https://github.com/commy2/zerohour/issues/223 [IMPROVEMENT][NPROJECT] Sentry Drone Lacks Voice Line When Leaving Factory
 https://github.com/commy2/zerohour/issues/222 [MAYBE]                 Poison Fields Can Clear Poison Fields
-https://github.com/commy2/zerohour/issues/221 [IMPROVEMENT][NPROJECT] Units Sometimes Waste Shots On Overlord Debris
+https://github.com/commy2/zerohour/issues/221 [DONE][NPROJECT]        Units Sometimes Waste Shots On Overlord Debris
 https://github.com/commy2/zerohour/issues/220 [DONE][NPROJECT]        Units Sometimes Waste Shots On Poisoned Or Burned Infantry
 https://github.com/commy2/zerohour/issues/219 [MAYBE][NPROJECT]       Stinger Site Does Not Benefit From AP Rockets When Engaging Airborne Targets
 https://github.com/commy2/zerohour/issues/218 [NOTRELEVANT]           Hackers Are Bad Late Game Eco

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -128,7 +128,7 @@ Object ChinaTankOverlordBarrelDebris
 ;  RadarPriority = UNIT
 ;  KindOf = PRELOAD CAN_CAST_REFLECTIONS
 
-  ; Patch104p @bugfix commy2 09/09/2021 Fix units attacking Overworld wreck.
+  ; Patch104p @bugfix commy2 09/09/2021 Add UNATTACKABLE to fix units attacking Overworld wreck.
 
   KindOf = UNATTACKABLE
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -128,6 +128,10 @@ Object ChinaTankOverlordBarrelDebris
 ;  RadarPriority = UNIT
 ;  KindOf = PRELOAD CAN_CAST_REFLECTIONS
 
+  ; Patch104p @bugfix commy2 09/09/2021 Fix units attacking Overworld wreck.
+
+  KindOf = UNATTACKABLE
+
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
     InitialHealth   = 1.0


### PR DESCRIPTION
ZH 1.04

- When destroying an Overlord, units will keep firing at the debris launched from the wreck.

After patch:

- Units no longer waste shots on this particular wreck.

~~@alanblack166 please double check if this is sufficient~~

He said yes :)