### PR TITLE
Fix: Weapons And Animations Broken On HiDef Scud Launcher

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -16,7 +16,7 @@ https://github.com/commy2/zerohour/issues/218 [NOTRELEVANT]           Hackers Ar
 https://github.com/commy2/zerohour/issues/217 [DONE][NPROJECT]        Scud Launchers Missing Upgrade Icon For AP Rockets
 https://github.com/commy2/zerohour/issues/216 [IMPROVEMENT]           Nationalism And Patriotism Don't Update For Garrisoned Units
 https://github.com/commy2/zerohour/issues/215 [NOTRELEVANT]           Nationalism And Patriotism Take Effect While Not Horded
-https://github.com/commy2/zerohour/issues/210 [IMPROVEMENT][NPROJECT] Weapons And Animations Broken On HiDef Scud Launcher
+https://github.com/commy2/zerohour/issues/210 [DONE][NPROJECT]        Weapons And Animations Broken On HiDef Scud Launcher
 https://github.com/commy2/zerohour/issues/209 [MAYBE][NPROJECT]       Demo General Combat Bike With Demolitions Upgrade Deals Full Damage When Destroyed Without Terrorist
 https://github.com/commy2/zerohour/issues/208 [MAYBE][NPROJECT]       Demo General Terror Bike Damages Allies Before Demolitions Upgrade
 https://github.com/commy2/zerohour/issues/207 [IMPROVEMENT][NPROJECT] Demo General Terrorist On Bike Missing Red Smoke Effect After Demolitions Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6433,7 +6433,15 @@ Object GLAVehicleBattleBus
   ShadowSizeX = 45  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End
-;------------------------------------------------------------------------------;------------------------------------------------------------------------------
+
+; Patch104p @bugfix commy2 09/09/2021 Fixed problems of this unit.
+; Missile now properly animated when aiming.
+; Fixed upgrade icons.
+; Weapon now matches model (scrapped twice by default)
+; Unit can now be properly disabled by ECM tank.
+; Unit now drops scrap when destroyed by GLA faction.
+
+;------------------------------------------------------------------------------
 Object GLAVehicleScudLauncherHiDef
 
   ; *** ART Parameters ***
@@ -6442,8 +6450,8 @@ Object GLAVehicleScudLauncherHiDef
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing upgrade icon(s).
 
-  UpgradeCameo1 = Upgrade_GLAAPRockets
-  UpgradeCameo2 = Upgrade_GLAAnthraxBeta
+  ;UpgradeCameo1 = Upgrade_GLAAPRockets
+  UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
   UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -6455,12 +6463,12 @@ Object GLAVehicleScudLauncherHiDef
 
     DefaultConditionState
       Model = UVScudLchrHD
-      Turret = TURRET
-      TurretPitch = TURRETEL
-      WeaponLaunchBone = PRIMARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
-      WeaponHideShowBone = PRIMARY MISSILE
-      WeaponHideShowBone = SECONDARY MISSILE
+      Turret = TURRETUP02
+      TurretPitch = TURRETEL02
+      ShowSubObject = TURRETUP02
+      HideSubObject = TURRET TURRETUP01
+      WeaponLaunchBone = PRIMARY WeaponC
+      WeaponLaunchBone = SECONDARY WeaponC
     End
 
     ConditionState = REALLYDAMAGED
@@ -6499,9 +6507,9 @@ Object GLAVehicleScudLauncherHiDef
   TransportSlotCount = 3                 ;how many "slots" we take in a transport (0 == not transportable)
   WeaponSet
     Conditions = None
-    ;Weapon = PRIMARY SCUDLauncherGunExplosive
-    Weapon = PRIMARY SCUDLauncherGunAnthrax
-    Weapon = SECONDARY SCUDLauncherGunAnthrax
+    ;Weapon = PRIMARY SCUDLauncherGunExplosivePlusTwo
+    Weapon = PRIMARY SCUDLauncherGunAnthraxPlusTwo
+    Weapon = SECONDARY SCUDLauncherGunAnthraxPlusTwo
     AutoChooseSources = PRIMARY FROM_SCRIPT FROM_AI
     AutoChooseSources = SECONDARY FROM_SCRIPT FROM_AI
     PreferredAgainst = SECONDARY INFANTRY
@@ -6509,9 +6517,9 @@ Object GLAVehicleScudLauncherHiDef
   End
   WeaponSet
     Conditions = PLAYER_UPGRADE
-    ;Weapon = PRIMARY SCUDLauncherGunExplosive
-    Weapon = PRIMARY Chem_SCUDLauncherGunAnthraxGamma
-    Weapon = SECONDARY Chem_SCUDLauncherGunAnthraxGamma
+    ;Weapon = PRIMARY SCUDLauncherGunExplosivePlusTwo
+    Weapon = PRIMARY Chem_SCUDLauncherGunAnthraxGammaPlusTwo
+    Weapon = SECONDARY Chem_SCUDLauncherGunAnthraxGammaPlusTwo
     AutoChooseSources = PRIMARY FROM_SCRIPT FROM_AI DEFAULT_SWITCH_WEAPON
     AutoChooseSources = SECONDARY FROM_SCRIPT FROM_AI
     PreferredAgainst = SECONDARY INFANTRY
@@ -6567,6 +6575,12 @@ Object GLAVehicleScudLauncherHiDef
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 180.0
     InitialHealth   = 180.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 360
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 50
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6619,6 +6633,10 @@ Object GLAVehicleScudLauncherHiDef
   Behavior = CreateObjectDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED
     CreationList = OCL_CrusaderTank_CrushEffect
+  End
+
+  Behavior = CreateCrateDie ModuleTag_Salvage
+    CrateData = SalvageCrateData
   End
 
   Behavior = FlammableUpdate ModuleTag_21


### PR DESCRIPTION
There is a world builder only Toxin General Scud Launcher variant that starts with scrap +2!
Sadly it's pretty broken.
This PR fixes all issues with it and makes it work properly.