### PR TITLE
Fix: Demo General Terrorist On Bike Missing Red Smoke Effect After Demolitions Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -19,7 +19,7 @@ https://github.com/commy2/zerohour/issues/215 [MAYBE]                 Nationalis
 https://github.com/commy2/zerohour/issues/210 [DONE][NPROJECT]        Weapons And Animations Broken On HiDef Scud Launcher
 https://github.com/commy2/zerohour/issues/209 [MAYBE][NPROJECT]       Demo General Combat Bike With Demolitions Upgrade Deals Full Damage When Destroyed Without Terrorist
 https://github.com/commy2/zerohour/issues/208 [MAYBE][NPROJECT]       Demo General Terror Bike Damages Allies Before Demolitions Upgrade
-https://github.com/commy2/zerohour/issues/207 [IMPROVEMENT][NPROJECT] Demo General Terrorist On Bike Missing Red Smoke Effect After Demolitions Upgrade
+https://github.com/commy2/zerohour/issues/207 [DONE][NPROJECT]        Demo General Terrorist On Bike Missing Red Smoke Effect After Demolitions Upgrade
 https://github.com/commy2/zerohour/issues/206 [MAYBE]                 Combat Chinook Moves Very Close To Target When Passengers Are Ordered To Attack
 https://github.com/commy2/zerohour/issues/205 [IMPROVEMENT]           Listening Outpost Damaged Smoke Effect Sticks After Repair
 https://github.com/commy2/zerohour/issues/204 [MAYBE]                 Fire Base Cannot Order Passengers To Attack Airborne Targets

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6771,7 +6771,7 @@ Weapon Demo_TerroristOnCombatBikeSuicideDynamitePack
   ClipSize = 1
   ClipReloadTime = 0
   AutoReloadsClip = No
-  FireFX = WeaponFX_SuicideDynamitePackDetonation
+  FireFX = WeaponFX_DemoSuicideDynamitePackDetonation ; Patch104p @bugfix commy2 09/09/2021 Fixed Demo Bike was using regular Terrorist explosion.
   FireSound = CarBomberDie
 End
 
@@ -6793,7 +6793,7 @@ Weapon Demo_TerroristOnCombatBikeSuicideDynamitePackPlusFire
   ClipSize = 1
   ClipReloadTime = 0
   AutoReloadsClip = No
-  FireFX = WeaponFX_SuicideDynamitePackDetonationPlusFire
+  FireFX = WeaponFX_DemoSuicideDynamitePackDetonationPlusFire ; Patch104p @bugfix commy2 09/09/2021 Fixed Demo Bike was using regular Terrorist explosion.
   FireSound = CarBomberDie
 End
 


### PR DESCRIPTION
ZH 1.04

- The Demo General's Terrorist does not use the red explosion effects when destroyed or suicided while riding a Bike after being upgraded with Demolitions, but the explosion effects of a normal Terrorist instead.

With patch:

- Correct effect is used. Same as when not riding the Bike.