### PR TITLE
Fix: Nuke Cannons Start With Neutron Shells

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -31,7 +31,7 @@ https://github.com/commy2/zerohour/issues/199 [IMPROVEMENT]           Countermea
 https://github.com/commy2/zerohour/issues/198 [NOTRELEVANT][NPROJECT] Scrapping Up Marauders Twice Quadruples Their Rate Of Fire
 https://github.com/commy2/zerohour/issues/197 [NOTRELEVANT][NPROJECT] Veteran Quad Cannons Double Their Rate Of Fire
 https://github.com/commy2/zerohour/issues/196 [IMPROVEMENT][NPROJECT] Sub-Factions With Free Unit Science Can't Access Units In Other Factories
-https://github.com/commy2/zerohour/issues/195 [IMPROVEMENT]           Nuke Cannons Start With Neutron Shells
+https://github.com/commy2/zerohour/issues/195 [DONE]                  Nuke Cannons Start With Neutron Shells
 https://github.com/commy2/zerohour/issues/194 [DONE][NPROJECT]        Patriot Batteries And Laser Turrets Lag When Assisting
 https://github.com/commy2/zerohour/issues/193 [IMPROVEMENT][NPROJECT] Laser Turret Uses Different Laser Model And Sound When Assisting Or Engaging Airborne Targets
 https://github.com/commy2/zerohour/issues/192 [IMPROVEMENT][NPROJECT] Laser Turret Has 1 Extra Shot When Assisting Or Engaging Airborne Targets Than Intended

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1560,8 +1560,15 @@ Object ChinaVehicleNukeLauncher
   Side = China
   EditorSorting   = VEHICLE
   TransportSlotCount = 10                 ;how many "slots" we take in a transport (0 == not transportable)
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
   WeaponSet
     Conditions = None
+    Weapon = PRIMARY NukeCannonGun
+  End
+  WeaponSet
+    Conditions = PLAYER_UPGRADE
     Weapon = PRIMARY NukeCannonGun
     Weapon = SECONDARY NukeCannonNeutronWeapon
     AutoChooseSources = PRIMARY FROM_PLAYER FROM_SCRIPT FROM_AI
@@ -1697,6 +1704,12 @@ Object ChinaVehicleNukeLauncher
 
   Behavior = ProductionUpdate ModuleTag_12
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
+  End
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
+  Behavior = WeaponSetUpgrade ModuleTag_13
+    TriggeredBy = Upgrade_ChinaNeutronShells
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2200,8 +2200,15 @@ Object Infa_ChinaVehicleNukeLauncher
   Side = ChinaInfantryGeneral
   EditorSorting   = VEHICLE
   TransportSlotCount = 10                 ;how many "slots" we take in a transport (0 == not transportable)
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
   WeaponSet
     Conditions = None
+    Weapon = PRIMARY NukeCannonGun
+  End
+  WeaponSet
+    Conditions = PLAYER_UPGRADE
     Weapon = PRIMARY NukeCannonGun
     Weapon = SECONDARY NukeCannonNeutronWeapon
     AutoChooseSources = PRIMARY FROM_PLAYER FROM_SCRIPT FROM_AI
@@ -2337,6 +2344,12 @@ Object Infa_ChinaVehicleNukeLauncher
 
   Behavior = ProductionUpdate ModuleTag_12
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
+  End
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
+  Behavior = WeaponSetUpgrade ModuleTag_13
+    TriggeredBy = Upgrade_ChinaNeutronShells
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3678,8 +3678,15 @@ Object Nuke_ChinaVehicleNukeLauncher
   Side = ChinaNukeGeneral
   EditorSorting   = VEHICLE
   TransportSlotCount = 10                 ;how many "slots" we take in a transport (0 == not transportable)
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
   WeaponSet
     Conditions = None
+    Weapon = PRIMARY NukeCannonGun
+  End
+  WeaponSet
+    Conditions = PLAYER_UPGRADE
     Weapon = PRIMARY NukeCannonGun
     Weapon = SECONDARY NukeCannonNeutronWeapon
     AutoChooseSources = PRIMARY FROM_PLAYER FROM_SCRIPT FROM_AI
@@ -3814,6 +3821,12 @@ Object Nuke_ChinaVehicleNukeLauncher
 
   Behavior = ProductionUpdate ModuleTag_12
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
+  End
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
+  Behavior = WeaponSetUpgrade ModuleTag_13
+    TriggeredBy = Upgrade_ChinaNeutronShells
   End
 
   Geometry = BOX


### PR DESCRIPTION
- There is an exploit that can be prevented by having the Nuke Cannons upgrade their weapon set with the Neutron Shells upgrade instead of just enabling the button.
