### PR TITLE
Fix: Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -49,7 +49,7 @@ https://github.com/commy2/zerohour/issues/181 [IMPROVEMENT]           Some Units
 https://github.com/commy2/zerohour/issues/180 [DONE][NPROJECT]        Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding
 https://github.com/commy2/zerohour/issues/179 [IMPROVEMENT]           Nuke Cannons May Change Target On Their Own While Unpacking
 https://github.com/commy2/zerohour/issues/178 [IMPROVEMENT][NPROJECT] Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack
-https://github.com/commy2/zerohour/issues/177 [IMPROVEMENT][NPROJECT] Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap
+https://github.com/commy2/zerohour/issues/177 [DONE][NPROJECT]        Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap
 https://github.com/commy2/zerohour/issues/176 [IMPROVEMENT]           Stinger Site Automatically Engages Buildings
 https://github.com/commy2/zerohour/issues/175 [IMPROVEMENT][NPROJECT] Stinger Site Lacks Muzzle Flash And Recoil Animation When Targeting Airborne Targets
 https://github.com/commy2/zerohour/issues/174 [IMPROVEMENT]           Stinger Site Can Double Fire

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12213,7 +12213,7 @@ Object Demo_GLAInfantryRebel
     SpecialPowerTemplate = SpecialAbilityBoobyTrap
     UpdateModuleStartsAttack = Yes
     StartsPaused              = Yes
-;    InitiateSound = TankHunterVoiceTNT
+    InitiateSound = RebelVoiceBoobyTrapInstall  ; Patch104p @bugfix commy2 09/09/2021 Added missing voice line when using Booby Trap.
   End
   Behavior = SpecialAbilityUpdate ModuleTag_21
     SpecialPowerTemplate = SpecialAbilityBoobyTrap

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -12919,7 +12919,7 @@ Object Slth_GLAInfantryRebel
     SpecialPowerTemplate = SpecialAbilityBoobyTrap
     UpdateModuleStartsAttack = Yes
     StartsPaused              = Yes
-;    InitiateSound = TankHunterVoiceTNT
+    InitiateSound = RebelVoiceBoobyTrapInstall  ; Patch104p @bugfix commy2 09/09/2021 Added missing voice line when using Booby Trap.
   End
   Behavior = SpecialAbilityUpdate ModuleTag_21
     SpecialPowerTemplate = SpecialAbilityBoobyTrap


### PR DESCRIPTION
ZH 1.04:

- The Demo General's Rebel does not say his line when the target is chosen for the Booby Trap ability. The normal GLA Rebel does have a voice line for this.

After patch:

- The Demo General Rebel uses the same voice line when a target is chosen for Booby Traps.
- The same change is applied to the Stealthed Rebel for completeness, despite the ability never being unlocked for it.