### PR TITLE
Fix: Battle Bus With Passengers Freezes When Ordered To Attack Out Of Range Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -42,7 +42,7 @@ https://github.com/commy2/zerohour/issues/188 [MAYBE][NPROJECT]       Upgrading 
 https://github.com/commy2/zerohour/issues/187 [IMPROVEMENT][NPROJECT] Nuke Mig Tooltip Claims Unit Can Create Firestorms
 https://github.com/commy2/zerohour/issues/186 [DONE][NPROJECT]        Laser General Aurora Uses Tooltip From Microwave Tank
 https://github.com/commy2/zerohour/issues/185 [IMPROVEMENT][NPROJECT] Fake Supply Stash Uses Portrait As Button
-https://github.com/commy2/zerohour/issues/184 [IMPROVEMENT]           Battle Bus With Passengers Freezes When Attacking Airborne Targets
+https://github.com/commy2/zerohour/issues/184 [DONE]                  Battle Bus With Passengers Freezes When Attacking Airborne Targets
 https://github.com/commy2/zerohour/issues/183 [IMPROVEMENT]           Battle Bus Turns Towards Target When Loaded Troops Are Ordered To Engage Airborne Units
 https://github.com/commy2/zerohour/issues/182 [IMPROVEMENT][NPROJECT] Listening Outpost Lacks Voice Lines For Attacking Enemies
 https://github.com/commy2/zerohour/issues/181 [IMPROVEMENT]           Some Units Lack Voice Line When Ordered To Attack Airborne Targets

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8467,7 +8467,7 @@ End
 Weapon BattleBusDummyWeapon
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
-  AttackRange = 320.0
+  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Bus freezing when ordered to attack out of range targets.
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8467,7 +8467,7 @@ End
 Weapon BattleBusDummyWeapon
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
-  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Bus freezing when ordered to attack out of range airborne targets.
+  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Bus freezing when ordered to attack out of range airborne targets. 150.0 was determined to be the highest range where missile infantry passengers reliably engaged the target.
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8467,7 +8467,7 @@ End
 Weapon BattleBusDummyWeapon
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
-  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Bus freezing when ordered to attack out of range targets.
+  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Bus freezing when ordered to attack out of range airborne targets.
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0


### PR DESCRIPTION
ZH 1.04

- The dummy weapon that allows the Battle Busses passangers to engage airborne targets also makes the Battle Bus freeze long before the Bus is in range when targeting airborne units.

After patch:

- When clicking on an enemy airborne target (e.g. Chinook), the Battle Bus will move into range, so that the troops inside can actually fire.

Note: `BattleBusDummyWeapon` is only used against airborne targets, despite the name being unclear about that.