### PR TITLE
Fix: Battle Bus Turns Chassis When Loaded Troops Are Ordered To Engage Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -43,7 +43,7 @@ https://github.com/commy2/zerohour/issues/187 [IMPROVEMENT][NPROJECT] Nuke Mig T
 https://github.com/commy2/zerohour/issues/186 [DONE][NPROJECT]        Laser General Aurora Uses Tooltip From Microwave Tank
 https://github.com/commy2/zerohour/issues/185 [IMPROVEMENT][NPROJECT] Fake Supply Stash Uses Portrait As Button
 https://github.com/commy2/zerohour/issues/184 [DONE]                  Battle Bus With Passengers Freezes When Attacking Airborne Targets
-https://github.com/commy2/zerohour/issues/183 [IMPROVEMENT]           Battle Bus Turns Towards Target When Loaded Troops Are Ordered To Engage Airborne Units
+https://github.com/commy2/zerohour/issues/183 [DONE]                  Battle Bus Turns Towards Target When Loaded Troops Are Ordered To Engage Airborne Units
 https://github.com/commy2/zerohour/issues/182 [IMPROVEMENT][NPROJECT] Listening Outpost Lacks Voice Lines For Attacking Enemies
 https://github.com/commy2/zerohour/issues/181 [IMPROVEMENT]           Some Units Lack Voice Line When Ordered To Attack Airborne Targets
 https://github.com/commy2/zerohour/issues/180 [DONE][NPROJECT]        Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8485,6 +8485,7 @@ Weapon BattleBusDummyWeapon
   AntiAirborneVehicle = Yes
   AntiAirborneInfantry = Yes
   AntiGround = No
+  AcceptableAimDelta = 180  ; Patch104p @bugfix commy2 10/09/2021 Fix Bus turning when ordered to attack airborne targets.
 End
 
 ; Patch104p @bugfix Dummy weapons used when Scud Storm explodes.


### PR DESCRIPTION
ZH 1.04

- When the Battle Bus with infantry inside is ordered to attack a flying unit, the whole Bus turns towards the target needlessly.

After patch:

- The Bus will order passengers to attack the airborne target and not turn the chassis pointing towards it.