### PR TITLE
Fix: Nuke Cannon May Change Targets While Unpacking

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -47,7 +47,7 @@ https://github.com/commy2/zerohour/issues/183 [IMPROVEMENT]           Battle Bus
 https://github.com/commy2/zerohour/issues/182 [IMPROVEMENT][NPROJECT] Listening Outpost Lacks Voice Lines For Attacking Enemies
 https://github.com/commy2/zerohour/issues/181 [IMPROVEMENT]           Some Units Lack Voice Line When Ordered To Attack Airborne Targets
 https://github.com/commy2/zerohour/issues/180 [DONE][NPROJECT]        Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding
-https://github.com/commy2/zerohour/issues/179 [IMPROVEMENT]           Nuke Cannons May Change Target On Their Own While Unpacking
+https://github.com/commy2/zerohour/issues/179 [DONE]                  Nuke Cannons May Change Target On Their Own While Unpacking
 https://github.com/commy2/zerohour/issues/178 [IMPROVEMENT][NPROJECT] Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack
 https://github.com/commy2/zerohour/issues/177 [DONE][NPROJECT]        Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap
 https://github.com/commy2/zerohour/issues/176 [IMPROVEMENT]           Stinger Site Automatically Engages Buildings

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1648,7 +1648,7 @@ Object ChinaVehicleNukeLauncher
       NaturalTurretAngle    = 0
       InitiallyDisabled     = Yes
     End
-    AutoAcquireEnemiesWhenIdle = No
+    AutoAcquireEnemiesWhenIdle = No NotWhileAttacking ; Patch104p @bugfix commy2 10/09/2021 Fix Nuke Cannon changing to nearest target while unpacking.
     PackTime = 3333
     UnpackTime = 3333
     TurretsFunctionOnlyWhenDeployed = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2288,7 +2288,7 @@ Object Infa_ChinaVehicleNukeLauncher
       NaturalTurretAngle    = 0
       InitiallyDisabled     = Yes
     End
-    AutoAcquireEnemiesWhenIdle = No
+    AutoAcquireEnemiesWhenIdle = No NotWhileAttacking ; Patch104p @bugfix commy2 10/09/2021 Fix Nuke Cannon changing to nearest target while unpacking.
     PackTime = 3333
     UnpackTime = 3333
     TurretsFunctionOnlyWhenDeployed = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3765,7 +3765,7 @@ Object Nuke_ChinaVehicleNukeLauncher
       NaturalTurretAngle    = 0
       InitiallyDisabled     = Yes
     End
-    AutoAcquireEnemiesWhenIdle = No
+    AutoAcquireEnemiesWhenIdle = No NotWhileAttacking ; Patch104p @bugfix commy2 10/09/2021 Fix Nuke Cannon changing to nearest target while unpacking.
     PackTime = 3333
     UnpackTime = 3333
     TurretsFunctionOnlyWhenDeployed = Yes


### PR DESCRIPTION
ZH 1.04

- The Nuke Cannon will target the nearest enemy while ordered to attack any enemy in range. If the auto selected target was close enough in angle, the Nuke Cannon will even waste its first shot before recentering on the ordered target.

After patch:

- The Nuke Cannon will no longer defy the player and change targets on its own. Attack move and Guard mode still work the same.

Note:

- This was not an issue in CCG, because `NotWhileAttacking` did not exist, or rather, was implicit for every unit.