### PR TITLE
Fix: Humvees Without TOW Missiles Upgrade Freeze When Attack Moving Into Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -53,7 +53,7 @@ https://github.com/commy2/zerohour/issues/177 [DONE][NPROJECT]        Demo Gener
 https://github.com/commy2/zerohour/issues/176 [IMPROVEMENT]           Stinger Site Automatically Engages Buildings
 https://github.com/commy2/zerohour/issues/175 [IMPROVEMENT][NPROJECT] Stinger Site Lacks Muzzle Flash And Recoil Animation When Targeting Airborne Targets
 https://github.com/commy2/zerohour/issues/174 [IMPROVEMENT]           Stinger Site Can Double Fire
-https://github.com/commy2/zerohour/issues/173 [IMPROVEMENT]           Humvee Without TOW Missiles Upgrade Freezes When Attack Moving Into Airborne Targets
+https://github.com/commy2/zerohour/issues/173 [DONE]                  Humvee Without TOW Missiles Upgrade Freezes When Attack Moving Into Airborne Targets
 https://github.com/commy2/zerohour/issues/172 [IMPROVEMENT]           Extended Range Exploit
 https://github.com/commy2/zerohour/issues/163 [DONE][NPROJECT]        Destroyed Heroic Toxin Tractor Creates Green Poison Cloud Without Anthrax Beta Upgrade
 https://github.com/commy2/zerohour/issues/162 [NOTRELEVANT][NPROJECT] Boss General Has Some Conflicting Hotkeys

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -677,7 +677,7 @@ End
 Weapon HumveeMissileWeaponAirDummy
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
-  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Humvee freezing when ordered to attack out of range airborne targets.
+  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Humvee freezing when ordered to attack out of range airborne targets. 150.0 was determined to be the highest range where missile infantry passengers reliably engaged the target.
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -677,7 +677,7 @@ End
 Weapon HumveeMissileWeaponAirDummy
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
-  AttackRange = 320.0
+  AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Humvee freezing when ordered to attack out of range airborne targets.
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0


### PR DESCRIPTION
ZH 1.04

- The dummy weapon that allows the Humvee's passangers to engage airborne targets also makes the Humvee freeze when attack moving into a group of units with airborne targets i.e. other Humvees with Scout Drones.
- This is basically the same issue as https://github.com/xezon/GeneralsGamePatch/pull/267

After patch:

- The Humvee will move into range when ordered to attack enemy airborne targets, such that the passenger can fire at the target.
- This does not change anything about the Humvee after the TOW-Missiles upgrade, as that one loses access to this dummy weapon.