### PR TITLE
Fix: Fake Command Centers Lose Sub-Faction Decal After Fortified Structures Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -64,7 +64,7 @@ https://github.com/commy2/zerohour/issues/158 [NOTRELEVANT][NPROJECT] Boss Patri
 https://github.com/commy2/zerohour/issues/157 [NOTRELEVANT][NPROJECT] Boss General Has Strange Selection Of Available Upgrades
 https://github.com/commy2/zerohour/issues/156 [NOTRELEVANT][NPROJECT] Some Boss Infantry Units Lack Chemical Suits Upgrade Icon
 https://github.com/commy2/zerohour/issues/155 [NOTRELEVANT][NPROJECT] Boss General Scud Storm Cannot Upgrade Neutron Mines
-https://github.com/commy2/zerohour/issues/154 [IMPROVEMENT][NPROJECT] Fake Command Centers Lose Sub-Faction Decal After Fortified Structures Upgrade
+https://github.com/commy2/zerohour/issues/154 [DONE][NPROJECT]        Fake Command Centers Lose Sub-Faction Decal After Fortified Structures Upgrade
 https://github.com/commy2/zerohour/issues/153 [DONE][NPROJECT]        Base Defense Scaffolds Set Off Demo Traps
 https://github.com/commy2/zerohour/issues/152 [IMPROVEMENT]           Aurora And Carpet Bomb Model Is Extremely Low Poly
 https://github.com/commy2/zerohour/issues/151 [MAYBE]                 Uranium Shells Leave No Radiation Field

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -1113,6 +1113,8 @@ Object Chem_FakeGLACommandCenter
   ButtonImage            = SUHeadquarters
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
 
+  ; Patch104p @bugfix commy2 10/09/2021 Fix missing sub-faction decal after Fortified Structures upgrade.
+
   ; ----- The actual command center
   Draw                   = W3DModelDraw ModuleTag_01
 
@@ -1139,21 +1141,21 @@ Object Chem_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED
-      Model                = UBCmdHQEG
+      Model                = UBCmdHQCE
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG.UBCmdHQEG
+      Animation            = UBCmdHQCE.UBCmdHQCE
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED
-      Model                = UBCmdHQEG_D
+      Model                = UBCmdHQCE_D
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_D.UBCmdHQEG_D
+      Animation            = UBCmdHQCE_D.UBCmdHQCE_D
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED
-      Model                = UBCmdHQEG_E
+      Model                = UBCmdHQCE_E
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_E.UBCmdHQEG_E
+      Animation            = UBCmdHQCE_E.UBCmdHQCE_E
       AnimationMode        = LOOP
     End
 
@@ -1177,21 +1179,21 @@ Object Chem_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT
-      Model                = UBCmdHQEG_N
+      Model                = UBCmdHQCE_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_N.UBCmdHQEG_N
+      Animation            = UBCmdHQCE_N.UBCmdHQCE_N
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_DN
+      Model                = UBCmdHQCE_DN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DN.UBCmdHQEG_DN
+      Animation            = UBCmdHQCE_DN.UBCmdHQCE_DN
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_EN
+      Model                = UBCmdHQCE_EN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_EN.UBCmdHQEG_EN
+      Animation            = UBCmdHQCE_EN.UBCmdHQCE_EN
       AnimationMode        = LOOP
     End
 
@@ -1215,21 +1217,21 @@ Object Chem_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED SNOW
-      Model                = UBCmdHQEG_S
+      Model                = UBCmdHQCE_S
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_S.UBCmdHQEG_S
+      Animation            = UBCmdHQCE_S.UBCmdHQCE_S
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_DS
+      Model                = UBCmdHQCE_DS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DS.UBCmdHQEG_DS
+      Animation            = UBCmdHQCE_DS.UBCmdHQCE_DS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_ES
+      Model                = UBCmdHQCE_ES
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ES.UBCmdHQEG_ES
+      Animation            = UBCmdHQCE_ES.UBCmdHQCE_ES
       AnimationMode        = LOOP
     End
 
@@ -1253,21 +1255,21 @@ Object Chem_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_NS
+      Model                = UBCmdHQCE_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_NS.UBCmdHQEG_NS
+      Animation            = UBCmdHQCE_NS.UBCmdHQCE_NS
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_DNS
+      Model                = UBCmdHQCE_DNS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DNS.UBCmdHQEG_DNS
+      Animation            = UBCmdHQCE_DNS.UBCmdHQCE_DNS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_ENS
+      Model                = UBCmdHQCE_ENS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ENS.UBCmdHQEG_ENS
+      Animation            = UBCmdHQCE_ENS.UBCmdHQCE_ENS
       AnimationMode        = LOOP
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1246,6 +1246,8 @@ Object Demo_FakeGLACommandCenter
   ButtonImage            = SUHeadquarters
   UpgradeCameo1          = Upgrade_GLAFortifiedStructure
 
+  ; Patch104p @bugfix commy2 10/09/2021 Fix missing sub-faction decal after Fortified Structures upgrade.
+
   ; ----- The actual command center
   Draw                   = W3DModelDraw ModuleTag_01
 
@@ -1272,21 +1274,21 @@ Object Demo_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED
-      Model                = UBCmdHQEG
+      Model                = UBCmdHQDE
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG.UBCmdHQEG
+      Animation            = UBCmdHQDE.UBCmdHQDE
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED
-      Model                = UBCmdHQEG_D
+      Model                = UBCmdHQDE_D
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_D.UBCmdHQEG_D
+      Animation            = UBCmdHQDE_D.UBCmdHQDE_D
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED
-      Model                = UBCmdHQEG_E
+      Model                = UBCmdHQDE_E
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_E.UBCmdHQEG_E
+      Animation            = UBCmdHQDE_E.UBCmdHQDE_E
       AnimationMode        = LOOP
     End
 
@@ -1310,21 +1312,21 @@ Object Demo_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT
-      Model                = UBCmdHQEG_N
+      Model                = UBCmdHQDE_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_N.UBCmdHQEG_N
+      Animation            = UBCmdHQDE_N.UBCmdHQDE_N
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_DN
+      Model                = UBCmdHQDE_DN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DN.UBCmdHQEG_DN
+      Animation            = UBCmdHQDE_DN.UBCmdHQDE_DN
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_EN
+      Model                = UBCmdHQDE_EN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_EN.UBCmdHQEG_EN
+      Animation            = UBCmdHQDE_EN.UBCmdHQDE_EN
       AnimationMode        = LOOP
     End
 
@@ -1348,21 +1350,21 @@ Object Demo_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED SNOW
-      Model                = UBCmdHQEG_S
+      Model                = UBCmdHQDE_S
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_S.UBCmdHQEG_S
+      Animation            = UBCmdHQDE_S.UBCmdHQDE_S
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_DS
+      Model                = UBCmdHQDE_DS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DS.UBCmdHQEG_DS
+      Animation            = UBCmdHQDE_DS.UBCmdHQDE_DS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_ES
+      Model                = UBCmdHQDE_ES
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ES.UBCmdHQEG_ES
+      Animation            = UBCmdHQDE_ES.UBCmdHQDE_ES
       AnimationMode        = LOOP
     End
 
@@ -1386,21 +1388,21 @@ Object Demo_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_NS
+      Model                = UBCmdHQDE_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_NS.UBCmdHQEG_NS
+      Animation            = UBCmdHQDE_NS.UBCmdHQDE_NS
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_DNS
+      Model                = UBCmdHQDE_DNS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DNS.UBCmdHQEG_DNS
+      Animation            = UBCmdHQDE_DNS.UBCmdHQDE_DNS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_ENS
+      Model                = UBCmdHQDE_ENS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ENS.UBCmdHQEG_ENS
+      Animation            = UBCmdHQDE_ENS.UBCmdHQDE_ENS
       AnimationMode        = LOOP
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -1118,6 +1118,9 @@ Object Slth_FakeGLACommandCenter
 
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
   UpgradeCameo2 = Upgrade_GLACamoNetting
+
+  ; Patch104p @bugfix commy2 10/09/2021 Fix missing sub-faction decal after Fortified Structures upgrade.
+
   ; ----- The actual command center
   Draw                   = W3DModelDraw ModuleTag_01
 
@@ -1144,21 +1147,21 @@ Object Slth_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED
-      Model                = UBCmdHQEG
+      Model                = UBCmdHQSE
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG.UBCmdHQEG
+      Animation            = UBCmdHQSE.UBCmdHQSE
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED
-      Model                = UBCmdHQEG_D
+      Model                = UBCmdHQSE_D
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_D.UBCmdHQEG_D
+      Animation            = UBCmdHQSE_D.UBCmdHQSE_D
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED
-      Model                = UBCmdHQEG_E
+      Model                = UBCmdHQSE_E
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_E.UBCmdHQEG_E
+      Animation            = UBCmdHQSE_E.UBCmdHQSE_E
       AnimationMode        = LOOP
     End
 
@@ -1182,21 +1185,21 @@ Object Slth_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT
-      Model                = UBCmdHQEG_N
+      Model                = UBCmdHQSE_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_N.UBCmdHQEG_N
+      Animation            = UBCmdHQSE_N.UBCmdHQSE_N
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_DN
+      Model                = UBCmdHQSE_DN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DN.UBCmdHQEG_DN
+      Animation            = UBCmdHQSE_DN.UBCmdHQSE_DN
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_EN
+      Model                = UBCmdHQSE_EN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_EN.UBCmdHQEG_EN
+      Animation            = UBCmdHQSE_EN.UBCmdHQSE_EN
       AnimationMode        = LOOP
     End
 
@@ -1220,21 +1223,21 @@ Object Slth_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED SNOW
-      Model                = UBCmdHQEG_S
+      Model                = UBCmdHQSE_S
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_S.UBCmdHQEG_S
+      Animation            = UBCmdHQSE_S.UBCmdHQSE_S
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_DS
+      Model                = UBCmdHQSE_DS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DS.UBCmdHQEG_DS
+      Animation            = UBCmdHQSE_DS.UBCmdHQSE_DS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_ES
+      Model                = UBCmdHQSE_ES
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ES.UBCmdHQEG_ES
+      Animation            = UBCmdHQSE_ES.UBCmdHQSE_ES
       AnimationMode        = LOOP
     End
 
@@ -1258,21 +1261,21 @@ Object Slth_FakeGLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_NS
+      Model                = UBCmdHQSE_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_NS.UBCmdHQEG_NS
+      Animation            = UBCmdHQSE_NS.UBCmdHQSE_NS
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_DNS
+      Model                = UBCmdHQSE_DNS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DNS.UBCmdHQEG_DNS
+      Animation            = UBCmdHQSE_DNS.UBCmdHQSE_DNS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_ENS
+      Model                = UBCmdHQSE_ENS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ENS.UBCmdHQEG_ENS
+      Animation            = UBCmdHQSE_ENS.UBCmdHQSE_ENS
       AnimationMode        = LOOP
     End
 


### PR DESCRIPTION
ZH 1.04

- When upgraded with Fortified Structures, the Fake Command Centers of the Stealth, Tox and Demo General lose their sub-faction decal. They look like a regular GLA Command Center with Fortified Structures.

After patch:

- The Fake Command Centers will keep their sub-faction decal after being upgraded with Fortified Structures.