### PR TITLE
Fix: Toxin General RPG-Trooper On A Bike Fires Generic Missiles (No Anthrax Trail, Gamma Damage)

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -73,7 +73,7 @@ https://github.com/commy2/zerohour/issues/149 [MAYBE][NPROJECT]       Demo Gener
 https://github.com/commy2/zerohour/issues/148 [MAYBE][NPROJECT]       Anthrax Gamma Upgrade Does Not Increase Damage Over Time Of Any Poison Field
 https://github.com/commy2/zerohour/issues/147 [MAYBE][NPROJECT]       Anthrax Beta Upgrade Decreases Area Of Effect Of Small Poison Clouds
 https://github.com/commy2/zerohour/issues/146 [IMPROVEMENT][NPROJECT] Demo General RPG-Trooper On A Bike Fires Generic Missiles (No Red Smoke)
-https://github.com/commy2/zerohour/issues/145 [IMPROVEMENT][NPROJECT] Toxin General RPG-Trooper On A Bike Fires Generic Missiles (No Anthrax Trail)
+https://github.com/commy2/zerohour/issues/145 [DONE][NPROJECT]        Toxin General RPG-Trooper On A Bike Fires Generic Missiles (No Anthrax Trail)
 https://github.com/commy2/zerohour/issues/144 [IMPROVEMENT]           Overlord Does Not Fit Into Chinook But Only Takes 3 Slots Inside Helix
 https://github.com/commy2/zerohour/issues/143 [IMPROVEMENT]           GPS Scrambled Rangers And Red Guards Remain Stealthed While Capturing Buildings
 https://github.com/commy2/zerohour/issues/142 [IMPROVEMENT][NPROJECT] Fire Base Shoots At Awkward Angle

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7190,6 +7190,9 @@ Weapon Chem_ScorpionMissileWeaponPlusTwo
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP weapon upgrade
   ProjectileDetonationOCL     = OCL_PoisonFieldUpgradedSmall
 End
+
+; Patch104p @bugfix commy2 10/09/2021 Make Tox Biker RPG fire the same weapon as regular Tox RPG.
+
 ;------------------------------------------------------------------------------
 Weapon Chem_TunnelDefenderBikerRocketWeapon
   PrimaryDamage               = 40.0
@@ -7201,7 +7204,7 @@ Weapon Chem_TunnelDefenderBikerRocketWeapon
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
-  ProjectileExhaust           = MissileExhaust
+  ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   ScatterRadius               = 0      ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly
@@ -7223,7 +7226,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_TunnelDefenderBikerRocketWeaponGamma
-  PrimaryDamage               = 40.0
+  PrimaryDamage               = 52.0
   PrimaryDamageRadius         = 5.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 175.0
@@ -7232,7 +7235,7 @@ Weapon Chem_TunnelDefenderBikerRocketWeaponGamma
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
-  ProjectileExhaust           = MissileExhaust
+  ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   ScatterRadius               = 0      ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly


### PR DESCRIPTION
ZH 1.04

- The Toxin General's RPG Troopers fire essentially the same missiles as the normal GLA RPG Troopers. The blue or pink trails, and the extra damage from Anthrax Gamma are missing.

After patch:

- Toxin General's RPG Trooper fire the same missiles while on bike as when on foot.
- This also increases the damage +30% after the Anthrax Gamma upgrade - the same bonus as the RPG Trooper on foot in 1.04.


- [x] rename commit when squashing