### PR TITLE
Fix: Demo Charge Buttons Are Placed Differently On Jarmen Kell Than On Colonel Burton

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -82,7 +82,7 @@ https://github.com/commy2/zerohour/issues/140 [IMPROVEMENT][NPROJECT] Gattling H
 https://github.com/commy2/zerohour/issues/139 [IMPROVEMENT][NPROJECT] Dummy Weapons Cause Notifications And Hit Effects
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button
 https://github.com/commy2/zerohour/issues/137 [IMPROVEMENT][NPROJECT] Tracer Emerges Below Jarmen Kell When Using Sniper Attack
-https://github.com/commy2/zerohour/issues/136 [MAYBE][NPROJECT]       Demo Charge Buttons Are Placed Differently On Jarmen Kell Than On Colonel Burton
+https://github.com/commy2/zerohour/issues/136 [DONE][NPROJECT]        Demo Charge Buttons Are Placed Differently On Jarmen Kell Than On Colonel Burton
 https://github.com/commy2/zerohour/issues/135 [IMPROVEMENT][NPROJECT] Tunnel And Palace Lack Stop Button
 https://github.com/commy2/zerohour/issues/134 [IMPROVEMENT][NPROJECT] Air Force Carpet Bomber Tooltip Claims 2:30 Cooldown Instead Of True 4:00
 https://github.com/commy2/zerohour/issues/133 [MAYBE][NPROJECT]       Fire Base Command Button Order Misaligned With Other Buildings

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2117,11 +2117,13 @@ CommandSet Demo_GLAInfantryAngryMobCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @bugfix commy2 10/09/2021 Adjust Demo Charge buttons to occupy same slots as on Colonel Burton.
+
 CommandSet Demo_GLAInfantryJarmenKellCommandSet
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack
   2 = Demo_Command_KellTimedDemoCharge
-  3 = Demo_Command_KellRemoteDemoCharge
-  4 = Demo_Command_KellDetonateCharges
+  4 = Demo_Command_KellRemoteDemoCharge
+  6 = Demo_Command_KellDetonateCharges
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -2417,11 +2419,13 @@ CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   14 = Command_Stop
 End
 
+; Patch104p @bugfix commy2 10/09/2021 Adjust Demo Charge buttons to occupy same slots as on Colonel Burton.
+
 CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack
   2 = Demo_Command_KellTimedDemoCharge
-  3 = Demo_Command_KellRemoteDemoCharge
-  4 = Demo_Command_KellDetonateCharges
+  4 = Demo_Command_KellRemoteDemoCharge
+  6 = Demo_Command_KellDetonateCharges
   11 = Command_AttackMove
   12 = Demo_Command_TertiarySuicide
   13 = Command_Guard


### PR DESCRIPTION
This is extremely minor. And it annoys me. I think this is the best place to fix it. Consistency is good.