### PR TITLE
Fix: Demo General Combat Bike Uses Portrait Image As Button Art

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -88,7 +88,7 @@ https://github.com/commy2/zerohour/issues/134 [IMPROVEMENT][NPROJECT] Air Force 
 https://github.com/commy2/zerohour/issues/133 [MAYBE][NPROJECT]       Fire Base Command Button Order Misaligned With Other Buildings
 https://github.com/commy2/zerohour/issues/132 [MAYBE][NPROJECT]       Raptor Guard Air Button Misplaced
 https://github.com/commy2/zerohour/issues/131 [IMPROVEMENT][NPROJECT] Demo General Combat Bike With Demolitions Upgrade Deals No Damage When Destroyed By Gamma Poison
-https://github.com/commy2/zerohour/issues/130 [IMPROVEMENT][NPROJECT] Demo Combat Bike Uses Portrait As Button
+https://github.com/commy2/zerohour/issues/130 [DONE][NPROJECT]        Demo Combat Bike Uses Portrait As Button
 https://github.com/commy2/zerohour/issues/129 [MAYBE][NPROJECT]       Selling Air Force Supply Center Does Refund Less Than Half Of Build Value
 https://github.com/commy2/zerohour/issues/128 [IMPROVEMENT][NPROJECT] Repair And Reinforcement Pads Reward XP When Killed
 https://github.com/commy2/zerohour/issues/127 [IMPROVEMENT][NPROJECT] Aurora Alpha Fuel Air Explosion May Trigger Before Bomb Hits

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5060,7 +5060,7 @@ CommandButton Demo_Command_ConstructGLAVehicleCombatBike
   Command       = UNIT_BUILD
   Object        = Demo_GLAVehicleCombatBike
   TextLabel     = CONTROLBAR:ConstructGLAVehicleCombatBike
-  ButtonImage   = SUComBike_L
+  ButtonImage   = SUComBike ; Patch104p @bugfix commy2 10/09/2021 Fix button using portrait image as art.
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildCombatBikeTerrorist
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17011,7 +17011,7 @@ Object Demo_GLAVehicleCombatBike
 
   ; *** ART Parameters ***
   SelectPortrait         = SUComBike_L
-  ButtonImage            = SUComBike_L
+  ButtonImage            = SUComBike  ; Patch104p @bugfix commy2 10/09/2021 Fix button using portrait image as art.
 
   UpgradeCameo1 = Upgrade_GLAJunkRepair
   UpgradeCameo2 = Demo_Upgrade_SuicideBomb


### PR DESCRIPTION
ZH 1.04

- The Demo General's Combat Bike uses its portrait as button in the control bar as well as the production queue, unlike the other Combat Bikes.

After patch:

- The intended image is used as button art.