### PR TITLE
Fix: Dummy Weapons Cause Notifications And Hit Effects

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -79,7 +79,7 @@ https://github.com/commy2/zerohour/issues/143 [IMPROVEMENT]           GPS Scramb
 https://github.com/commy2/zerohour/issues/142 [IMPROVEMENT][NPROJECT] Fire Base Shoots At Awkward Angle
 https://github.com/commy2/zerohour/issues/141 [IMPROVEMENT][NPROJECT] Toxin General RPG-Trooper Shoots Stinger Missiles
 https://github.com/commy2/zerohour/issues/140 [IMPROVEMENT][NPROJECT] Gattling Helix Sometimes Fires At Airborne Units
-https://github.com/commy2/zerohour/issues/139 [IMPROVEMENT][NPROJECT] Dummy Weapons Cause Notifications And Hit Effects
+https://github.com/commy2/zerohour/issues/139 [DONE][NPROJECT]        Dummy Weapons Cause Notifications And Hit Effects
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button
 https://github.com/commy2/zerohour/issues/137 [IMPROVEMENT][NPROJECT] Tracer Emerges Below Jarmen Kell When Using Sniper Attack
 https://github.com/commy2/zerohour/issues/136 [DONE][NPROJECT]        Demo Charge Buttons Are Placed Differently On Jarmen Kell Than On Colonel Burton

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2860,3 +2860,46 @@ End
 
 
 
+;------------------------------------------------------------------------------
+Object DummyWeaponProjectile
+
+  ; ***DESIGN parameters ***
+  DisplayName      = OBJECT:RangerTeamMissile
+  EditorSorting   = SYSTEM
+  VisionRange = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = InvulnerableAllArmor
+    DamageFX        = None
+  End
+
+  ; *** ENGINEERING Parameters ***
+  KindOf = PROJECTILE
+  Body = ActiveBody ModuleTag_02
+    MaxHealth       = 100.0
+    InitialHealth   = 100.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    ; A projectile is not disabled, but instead loses target and scatters
+    SubdualDamageCap = 200
+    SubdualDamageHealRate = 100000
+    SubdualDamageHealAmount = 50
+  End
+
+  Behavior = PhysicsBehavior ModuleTag_06
+    Mass = 1
+  End
+  Behavior = MissileAIUpdate ModuleTag_07
+    TryToFollowTarget               = Yes;;;;;;;;;No
+    FuelLifetime                    = 1
+    InitialVelocity                 = 0                ; in dist/sec
+    IgnitionDelay                   = 0
+    DistanceToTravelBeforeTurning   = 0
+  End
+  Locomotor = SET_NORMAL MissileDefenderMissileLocomotor
+  Geometry = Sphere
+  GeometryIsSmall = Yes
+  GeometryMajorRadius = 2.0
+
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -572,7 +572,7 @@ Weapon TunnelNetworkGunDUMMY
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 99999         ; dist/sec
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   DelayBetweenShots = 1000         ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
@@ -681,7 +681,7 @@ Weapon HumveeMissileWeaponAirDummy
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 500
   ClipSize = 0
@@ -1310,7 +1310,7 @@ Weapon GattlingBuildingGunAirDummy
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0       ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 500            ; time between shots, msec
   ClipSize              = 0              ; how many shots in a Clip (0 == infinite)
@@ -3697,7 +3697,7 @@ Weapon TroopCrawlerAssault
   DamageType = DEPLOY
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 1000               ; time between shots, msec
@@ -3714,7 +3714,7 @@ Weapon AircraftCarrierOrderLaunch
   DamageType = DEPLOY
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
   DelayBetweenShots = 1000               ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
@@ -4350,7 +4350,7 @@ Weapon BattleshipBogusGun
   DamageType = UNRESISTABLE
   DeathType = NORMAL
   WeaponSpeed = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = WeaponFX_BattleshipBogusGun
   FireSound = BattleshipWeapon
   RadiusDamageAffects = ENEMIES NEUTRALS
@@ -4529,7 +4529,7 @@ Weapon GLAAngryMobNexusHarmlessWeapon
   DamageType = UNRESISTABLE
   DeathType = NORMAL
   WeaponSpeed = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = NONE
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 99999        ; time between shots, msec
@@ -4609,7 +4609,7 @@ Weapon GLAAngryMobAK47Weapon
   DamageType            = MOLOTOV_COCKTAIL  ;SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = NONE
+  ProjectileObject      = DummyWeaponProjectile
   FireFX                = WeaponFX_RangerAdvancedCombatRifleFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicRangerAdvancedCombatRifleFire
   FireSound             = AngryMobWeaponAK47
@@ -5611,7 +5611,7 @@ End
 ;  DamageType                  = COMANCHE_VULCAN  ;used only for this weapon so stinger sites don't lose their guys but otherwise acts just like Small_Arms
 ;  DeathType                   = NORMAL
 ;  WeaponSpeed                 = 999999.0          ; dist/sec (huge value == effectively instant)
-;  ProjectileObject            = NONE
+;  ProjectileObject            = DummyWeaponProjectile
 ;  RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
 ;  DelayBetweenShots           = 100         ; time between shots, msec
 ;  ClipSize                    = 0                    ; how many shots in a Clip (0 == infinite)
@@ -5749,7 +5749,7 @@ Weapon RadarVanBogusWeapon
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 1000               ; time between shots, msec
@@ -6598,7 +6598,7 @@ Weapon ListeningOutpostUpgradedDummyWeapon
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 1000               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -6617,7 +6617,7 @@ Weapon BattleBusPassengerDummyWeapon
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 10000               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -6633,7 +6633,7 @@ Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 10000               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -8457,7 +8457,7 @@ Weapon AvengerAirLaserDummy
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 999999.0
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 200
   ClipSize = 0
@@ -8476,7 +8476,7 @@ Weapon BattleBusDummyWeapon
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0
-  ProjectileObject = NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 500
   ClipSize = 0


### PR DESCRIPTION
ZH 1.04:

- Objects with dummy weapons do a tiny amount of damage that triggers the "we're under attack!" notifications, and cause hit effects (sparks and impact sounds).

After patch:

- No more notifications or impact effects / sounds by dummy weapons.

Repro (one notorious example):

- Place a Sneak Attack. Force-fire with the Sneak Attack on a nearby unit.

Note:

- more thorough implementation of:
- close https://github.com/xezon/GeneralsGamePatch/pull/136