### PR TITLE
Fix: Helix With Gattling Gun Sometimes Fires At Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -78,7 +78,7 @@ https://github.com/commy2/zerohour/issues/144 [IMPROVEMENT]           Overlord D
 https://github.com/commy2/zerohour/issues/143 [IMPROVEMENT]           GPS Scrambled Rangers And Red Guards Remain Stealthed While Capturing Buildings
 https://github.com/commy2/zerohour/issues/142 [IMPROVEMENT][NPROJECT] Fire Base Shoots At Awkward Angle
 https://github.com/commy2/zerohour/issues/141 [IMPROVEMENT][NPROJECT] Toxin General RPG-Trooper Shoots Stinger Missiles
-https://github.com/commy2/zerohour/issues/140 [IMPROVEMENT][NPROJECT] Gattling Helix Sometimes Fires At Airborne Units
+https://github.com/commy2/zerohour/issues/140 [DONE][NPROJECT]        Gattling Helix Sometimes Fires At Airborne Units
 https://github.com/commy2/zerohour/issues/139 [DONE][NPROJECT]        Dummy Weapons Cause Notifications And Hit Effects
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button
 https://github.com/commy2/zerohour/issues/137 [IMPROVEMENT][NPROJECT] Tracer Emerges Below Jarmen Kell When Using Sniper Attack

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -394,12 +394,15 @@ Object ChinaHelixGattlingCannon
   Side             = China
   EditorSorting    = SYSTEM
   TransportSlotCount = 1
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Helix Gatling sometimes attacks airborne units.
+
   WeaponSet
     Conditions          = None
     Weapon              = PRIMARY   GattlingBuildingGun
     PreferredAgainst    = PRIMARY INFANTRY
-    Weapon              = SECONDARY GattlingBuildingGunAir
-    PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ;Weapon              = SECONDARY GattlingBuildingGunAir
+    ;PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
   End
 
   ArmorSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -673,12 +673,15 @@ Object Nuke_ChinaHelixGattlingCannon
   Side             = ChinaNukeGeneral
   EditorSorting    = SYSTEM
   TransportSlotCount = 1
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Helix Gatling sometimes attacks airborne units.
+
   WeaponSet
     Conditions          = None
     Weapon              = PRIMARY   GattlingBuildingGun
     PreferredAgainst    = PRIMARY INFANTRY
-    Weapon              = SECONDARY GattlingBuildingGunAir
-    PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ;Weapon              = SECONDARY GattlingBuildingGunAir
+    ;PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
   End
 
   ArmorSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -401,12 +401,15 @@ Object Tank_ChinaHelixGattlingCannon
   Side             = ChinaTankGeneral
   EditorSorting    = SYSTEM
   TransportSlotCount = 1
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Helix Gatling sometimes attacks airborne units.
+
   WeaponSet
     Conditions          = None
     Weapon              = PRIMARY   GattlingBuildingGun
     PreferredAgainst    = PRIMARY INFANTRY
-    Weapon              = SECONDARY GattlingBuildingGunAir
-    PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ;Weapon              = SECONDARY GattlingBuildingGunAir
+    ;PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
   End
 
   ArmorSet


### PR DESCRIPTION
ZH 1.04:

- A Helix with the Gatling upgrade may fire at airborne units if they are right in front of the helicopter (0° angle between heli direction and 2d heli-target vector). However the Gatling Cannon cannot turn to aim at airborne units directly.

After patch:

- The Helix Gatling Gun will never attack airborne units.