### PR TITLE
Fix: Extended Range Exploit

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -54,7 +54,7 @@ https://github.com/commy2/zerohour/issues/176 [IMPROVEMENT]           Stinger Si
 https://github.com/commy2/zerohour/issues/175 [IMPROVEMENT][NPROJECT] Stinger Site Lacks Muzzle Flash And Recoil Animation When Targeting Airborne Targets
 https://github.com/commy2/zerohour/issues/174 [IMPROVEMENT]           Stinger Site Can Double Fire
 https://github.com/commy2/zerohour/issues/173 [DONE]                  Humvee Without TOW Missiles Upgrade Freezes When Attack Moving Into Airborne Targets
-https://github.com/commy2/zerohour/issues/172 [IMPROVEMENT]           Extended Range Exploit
+https://github.com/commy2/zerohour/issues/172 [DONE]                  Extended Range Exploit
 https://github.com/commy2/zerohour/issues/163 [DONE][NPROJECT]        Destroyed Heroic Toxin Tractor Creates Green Poison Cloud Without Anthrax Beta Upgrade
 https://github.com/commy2/zerohour/issues/162 [NOTRELEVANT][NPROJECT] Boss General Has Some Conflicting Hotkeys
 https://github.com/commy2/zerohour/issues/161 [MAYBE][NPROJECT]       Terrorist And Terror Bike Have To Force-Fire Ground To Detonate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5260,13 +5260,16 @@ Object AirF_AmericaVehicleHumvee
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = TransportAIUpdate ModuleTag_03
     Turret
       TurretTurnRate = 180
       RecenterTime = 5000   ; how long to wait during idle before recentering
       ControlledWeaponSlots = PRIMARY SECONDARY TERTIARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL HumveeLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -153,13 +153,16 @@ Object AmericaVehicleHumvee
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = TransportAIUpdate ModuleTag_03
     Turret
       TurretTurnRate = 180
       RecenterTime = 5000   ; how long to wait during idle before recentering
       ControlledWeaponSlots = PRIMARY SECONDARY TERTIARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL HumveeLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20854,6 +20854,9 @@ Object Boss_TankGattling
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       ControlledWeaponSlots = PRIMARY SECONDARY
@@ -20864,7 +20867,7 @@ Object Boss_TankGattling
       NaturalTurretPitch  = 45 ; this keeps it aimed half way between land and sky
                                ; since you never know from whence cometh danger
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
   Locomotor       = SET_NORMAL GattlingTankLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16965,6 +16965,8 @@ Object Chem_GLAVehicleQuadCannon
     SubdualDamageHealAmount = 50
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       TurretTurnRate = 360
@@ -16972,7 +16974,7 @@ Object Chem_GLAVehicleQuadCannon
       AllowsPitch = Yes
       ControlledWeaponSlots = PRIMARY SECONDARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1893,6 +1893,9 @@ Object ChinaTankGattling
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       ControlledWeaponSlots = PRIMARY SECONDARY
@@ -1903,7 +1906,7 @@ Object ChinaTankGattling
       NaturalTurretPitch  = 45 ; this keeps it aimed half way between land and sky
                                ; since you never know from whence cometh danger
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -18220,6 +18220,8 @@ Object Demo_GLAVehicleQuadCannon
     SubdualDamageHealAmount = 50
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       TurretTurnRate = 360
@@ -18227,7 +18229,7 @@ Object Demo_GLAVehicleQuadCannon
       AllowsPitch = Yes
       ControlledWeaponSlots = PRIMARY SECONDARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2528,6 +2528,8 @@ Object GC_Chem_GLAVehicleQuadCannon
     InitialHealth   = 220.0
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       TurretTurnRate = 360
@@ -2535,7 +2537,7 @@ Object GC_Chem_GLAVehicleQuadCannon
       AllowsPitch = Yes
       ControlledWeaponSlots = PRIMARY SECONDARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -6789,6 +6789,8 @@ Object GC_Slth_GLAVehicleQuadCannon
     InitialHealth   = 220.0
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       TurretTurnRate = 360
@@ -6796,7 +6798,7 @@ Object GC_Slth_GLAVehicleQuadCannon
       AllowsPitch = Yes
       ControlledWeaponSlots = PRIMARY SECONDARY TERTIARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3263,6 +3263,8 @@ Object GLAVehicleQuadCannon
     SubdualDamageHealAmount = 50
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       TurretTurnRate = 360
@@ -3270,7 +3272,7 @@ Object GLAVehicleQuadCannon
       AllowsPitch = Yes
       ControlledWeaponSlots = PRIMARY SECONDARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2533,6 +2533,9 @@ Object Infa_ChinaTankGattling
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       ControlledWeaponSlots = PRIMARY SECONDARY
@@ -2543,7 +2546,7 @@ Object Infa_ChinaTankGattling
       NaturalTurretPitch  = 45 ; this keeps it aimed half way between land and sky
                                ; since you never know from whence cometh danger
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
   Locomotor       = SET_NORMAL GattlingTankLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4507,13 +4507,16 @@ Object Lazr_AmericaVehicleHumvee
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = TransportAIUpdate ModuleTag_03
     Turret
       TurretTurnRate = 180
       RecenterTime = 5000   ; how long to wait during idle before recentering
       ControlledWeaponSlots = PRIMARY SECONDARY TERTIARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL HumveeLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4010,6 +4010,9 @@ Object Nuke_ChinaTankGattling
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       ControlledWeaponSlots = PRIMARY SECONDARY
@@ -4020,7 +4023,7 @@ Object Nuke_ChinaTankGattling
       NaturalTurretPitch  = 45 ; this keeps it aimed half way between land and sky
                                ; since you never know from whence cometh danger
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
   Locomotor       = SET_NORMAL GattlingTankLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18390,6 +18390,8 @@ Object Slth_GLAVehicleQuadCannon
     SubdualDamageHealAmount = 50
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       TurretTurnRate = 360
@@ -18397,7 +18399,7 @@ Object Slth_GLAVehicleQuadCannon
       AllowsPitch = Yes
       ControlledWeaponSlots = PRIMARY SECONDARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4987,13 +4987,16 @@ Object SupW_AmericaVehicleHumvee
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = TransportAIUpdate ModuleTag_03
     Turret
       TurretTurnRate = 180
       RecenterTime = 5000   ; how long to wait during idle before recentering
       ControlledWeaponSlots = PRIMARY SECONDARY TERTIARY
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL HumveeLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4136,6 +4136,9 @@ Object Tank_ChinaTankGattling
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Add NotWhileAttacking to prevent target switching when ordered to attack out of range target. This prevents the extended range bug.
+
   Behavior = AIUpdateInterface ModuleTag_03
     Turret
       ControlledWeaponSlots = PRIMARY SECONDARY
@@ -4147,7 +4150,7 @@ Object Tank_ChinaTankGattling
                                ; since you never know from whence cometh danger
     End
     MoodAttackCheckRate        = 250
-    AutoAcquireEnemiesWhenIdle = Yes
+    AutoAcquireEnemiesWhenIdle = Yes NotWhileAttacking
   End
   Locomotor       = SET_NORMAL GattlingTankLocomotor
   Behavior          = PhysicsBehavior ModuleTag_04


### PR DESCRIPTION
ZH 1.04

- It is possible to make Tow-Humvees, Quad Cannons and Gatling Tanks shoot with the extended range against air units while firing at ground units.

After patch:

- The AA weapons can no longer switch target to engage ground units.