### PR TITLE
Fix: Paradrop Ability Spawns Wrong Ranger Type

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -96,7 +96,7 @@ https://github.com/commy2/zerohour/issues/126 [MAYBE]                 Microwave 
 https://github.com/commy2/zerohour/issues/125 [IMPROVEMENT][NPROJECT] USA War Factory Displays Generic Tank On Button
 https://github.com/commy2/zerohour/issues/124 [IMPROVEMENT][NPROJECT] Super Weapon Particle Cannon Uses Normal Particle Cannon Portrait
 https://github.com/commy2/zerohour/issues/123 [IMPROVEMENT][NPROJECT] Super Weapon General Particle Cannon Uses Some Blue Effects
-https://github.com/commy2/zerohour/issues/122 [IMPROVEMENT][NPROJECT] Paradrop Spawns Wrong Ranger Type
+https://github.com/commy2/zerohour/issues/122 [DONE][NPROJECT]        Paradrop Spawns Wrong Ranger Type
 https://github.com/commy2/zerohour/issues/121 [IMPROVEMENT]           Countermeasures Tooltip Claims 50% Evasion Rate Instead Of True 30%
 https://github.com/commy2/zerohour/issues/120 [MAYBE][NPROJECT]       Vehicles Can Shoot Out Of Combat Chinook
 https://github.com/commy2/zerohour/issues/119 [IMPROVEMENT]           Car Bomb May Bug Out And Be Unable To Attack

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -8603,11 +8603,14 @@ Object AirF_AmericaCommandCenter
     OCL                  = SUPERWEAPON_SpyDrone
     CreateLocation       = CREATE_ABOVE_LOCATION
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Paradrop spawning vanilla USA Rangers.
+
   Behavior           = OCLSpecialPower ModuleTag_22
     SpecialPowerTemplate = SuperweaponParadropAmerica
-    UpgradeOCL           = SCIENCE_Paradrop3 SUPERWEAPON_Paradrop3
-    UpgradeOCL           = SCIENCE_Paradrop2 SUPERWEAPON_Paradrop2
-    OCL                  = SUPERWEAPON_Paradrop1
+    UpgradeOCL           = SCIENCE_Paradrop3 AirF_SUPERWEAPON_Paradrop3
+    UpgradeOCL           = SCIENCE_Paradrop2 AirF_SUPERWEAPON_Paradrop2
+    OCL                  = AirF_SUPERWEAPON_Paradrop1
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
     OCLAdjustPositionToPassable = Yes ;Like RA2, shift target to passable cell so we don't land in water and on cliffs.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -8333,11 +8333,14 @@ Object Lazr_AmericaCommandCenter
     OCL                  = SUPERWEAPON_SpyDrone
     CreateLocation       = CREATE_ABOVE_LOCATION
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Paradrop spawning vanilla USA Rangers.
+
   Behavior           = OCLSpecialPower ModuleTag_22
     SpecialPowerTemplate = SuperweaponParadropAmerica
-    UpgradeOCL           = SCIENCE_Paradrop3 SUPERWEAPON_Paradrop3
-    UpgradeOCL           = SCIENCE_Paradrop2 SUPERWEAPON_Paradrop2
-    OCL                  = SUPERWEAPON_Paradrop1
+    UpgradeOCL           = SCIENCE_Paradrop3 Lazr_SUPERWEAPON_Paradrop3
+    UpgradeOCL           = SCIENCE_Paradrop2 Lazr_SUPERWEAPON_Paradrop2
+    OCL                  = Lazr_SUPERWEAPON_Paradrop1
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
     OCLAdjustPositionToPassable = Yes ;Like RA2, shift target to passable cell so we don't land in water and on cliffs.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -8801,11 +8801,14 @@ Object SupW_AmericaCommandCenter
     OCL                  = SUPERWEAPON_SpyDrone
     CreateLocation       = CREATE_ABOVE_LOCATION
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Paradrop spawning vanilla USA Rangers.
+
   Behavior           = OCLSpecialPower ModuleTag_22
     SpecialPowerTemplate = SuperweaponParadropAmerica
-    UpgradeOCL           = SCIENCE_Paradrop3 SUPERWEAPON_Paradrop3
-    UpgradeOCL           = SCIENCE_Paradrop2 SUPERWEAPON_Paradrop2
-    OCL                  = SUPERWEAPON_Paradrop1
+    UpgradeOCL           = SCIENCE_Paradrop3 SupW_SUPERWEAPON_Paradrop3
+    UpgradeOCL           = SCIENCE_Paradrop2 SupW_SUPERWEAPON_Paradrop2
+    OCL                  = SupW_SUPERWEAPON_Paradrop1
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
     OCLAdjustPositionToPassable = Yes ;Like RA2, shift target to passable cell so we don't land in water and on cliffs.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5301,6 +5301,341 @@ ObjectCreationList SUPERWEAPON_Paradrop3
   End
 End
 
+; Patch104p @bugfix commy2 11/09/2021 Lists used to spawn sub-faction specific Rangers via Paradrop ability.
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList AirF_SUPERWEAPON_Paradrop1
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 150         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = AirF_AmericaInfantryRanger 5
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList AirF_SUPERWEAPON_Paradrop2
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = AirF_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList AirF_SUPERWEAPON_Paradrop3
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = AirF_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = No
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = AirF_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList SupW_SUPERWEAPON_Paradrop1
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 150         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = SupW_AmericaInfantryRanger 5
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList SupW_SUPERWEAPON_Paradrop2
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = SupW_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList SupW_SUPERWEAPON_Paradrop3
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = SupW_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = No
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = SupW_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList Lazr_SUPERWEAPON_Paradrop1
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 150         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = Lazr_AmericaInfantryRanger 5
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList Lazr_SUPERWEAPON_Paradrop2
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = Lazr_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = Lazr_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+  DeliverPayload
+    Transport = AmericaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = No
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 80        ; time in between each item dropped (if more than one)
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    PutInContainer = AmericaParachute
+    Payload = Lazr_AmericaInfantryRanger 10
+    DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
+    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    DeliveryDecalRadius = 50
+    DeliveryDecal
+      Texture           = SCCParadrop_USA
+      Style             = SHADOW_ALPHA_DECAL
+      OpacityMin        = 25%
+      OpacityMax        = 50%
+      OpacityThrobTime  = 500
+      Color             = R:227 G:229 B:22 A:255
+      OnlyVisibleToOwningPlayer = Yes
+    End
+    ;RequiresLivePlayer = Yes ; I want to require a live player, but I'll settle for dropping neutral rangers instead
+  End
+End
+
 ; -----------------------------------------------------------------------------
 ; -----------------------------------------------------------------------------
 ObjectCreationList SUPERWEAPON_ClusterMines


### PR DESCRIPTION
- similar to https://github.com/xezon/GeneralsGamePatch/pull/73

ZH 1.04:

- Paradrop ability always spawns the Rangers of the normal USA faction, even as Air Force, Super Weapon or Laser General.

Repro:

- Build a Ranger as Air Force General. Use the Paradrop ability. Double click on a Ranger -> won't select both

After patch:

- The Rangers from the correct sub-faction are dropped via Paradrop, so they can be easily selected by double clicking when mixed with Barracks build Rangers or Rangers dropped from destroyed buildings.