### PR TITLE
Fix: Some Units Lack Voice Line When Ordered To Attack Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -45,7 +45,7 @@ https://github.com/commy2/zerohour/issues/185 [IMPROVEMENT][NPROJECT] Fake Suppl
 https://github.com/commy2/zerohour/issues/184 [DONE]                  Battle Bus With Passengers Freezes When Attacking Airborne Targets
 https://github.com/commy2/zerohour/issues/183 [DONE]                  Battle Bus Turns Towards Target When Loaded Troops Are Ordered To Engage Airborne Units
 https://github.com/commy2/zerohour/issues/182 [IMPROVEMENT][NPROJECT] Listening Outpost Lacks Voice Lines For Attacking Enemies
-https://github.com/commy2/zerohour/issues/181 [IMPROVEMENT]           Some Units Lack Voice Line When Ordered To Attack Airborne Targets
+https://github.com/commy2/zerohour/issues/181 [DONE]                  Some Units Lack Voice Line When Ordered To Attack Airborne Targets
 https://github.com/commy2/zerohour/issues/180 [DONE][NPROJECT]        Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding
 https://github.com/commy2/zerohour/issues/179 [DONE]                  Nuke Cannons May Change Target On Their Own While Unpacking
 https://github.com/commy2/zerohour/issues/178 [IMPROVEMENT][NPROJECT] Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20215,6 +20215,7 @@ Object Boss_TankOverlord
   VoiceMove = OverlordTankVoiceMove
   VoiceGuard = OverlordTankVoiceMove
   VoiceAttack = OverlordTankVoiceAttack
+  VoiceAttackAir = OverlordTankVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
 
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
@@ -20827,6 +20828,7 @@ Object Boss_TankGattling
   VoiceMove       = GattlingTankVoiceMove
   VoiceGuard      = GattlingTankVoiceMove
   VoiceAttack     = GattlingTankVoiceAttack
+  VoiceAttackAir  = GattlingTankVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart  = GattlingTankMoveStart
   SoundMoveStartDamaged = GattlingTankMoveStart
 
@@ -21807,6 +21809,7 @@ Object Boss_VehicleCombatBikeTerrorist
   VoiceSelect = RocketBuggyVoiceSelect
   ;VoiceMove = RocketBuggyVoiceMove
   VoiceAttack = RocketBuggyVoiceAttack
+  VoiceAttackAir = RocketBuggyVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = RocketBuggyVoiceMove

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -12398,6 +12398,7 @@ Object Chem_GLAInfantryTunnelDefender
   VoiceMove = RPGTrooperVoiceMove
   VoiceGuard = RPGTrooperVoiceMove
   VoiceAttack = RPGTrooperVoiceAttack
+  VoiceAttackAir = RPGTrooperVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceFear = RPGTrooperVoiceFear
   UnitSpecificSounds
     VoiceCreate          = RPGTrooperVoiceCreate
@@ -16470,6 +16471,7 @@ Object Chem_GLAVehicleCombatBike
   VoiceSelect = CombatCycleVoiceSelect
   VoiceMove = CombatCycleVoiceMove
   VoiceAttack = CombatCycleVoiceAttack
+  VoiceAttackAir = CombatCycleVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = CombatCycleVoiceMove
@@ -19692,6 +19694,7 @@ Object Chem_GLAVehicleBattleBus
   VoiceMove = BattleBusVoiceMove
   VoiceGuard = BattleBusVoiceMove
   VoiceAttack = BattleBusVoiceAttack
+  VoiceAttackAir = BattleBusVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = BattleBusMoveStart
   SoundMoveStartDamaged = BattleBusMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -290,6 +290,7 @@ Object ChinaTankOverlord
   VoiceMove = OverlordTankVoiceMove
   VoiceGuard = OverlordTankVoiceMove
   VoiceAttack = OverlordTankVoiceAttack
+  VoiceAttackAir = OverlordTankVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
 
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
@@ -1866,6 +1867,7 @@ Object ChinaTankGattling
   VoiceMove       = GattlingTankVoiceMove
   VoiceGuard      = GattlingTankVoiceMove
   VoiceAttack     = GattlingTankVoiceAttack
+  VoiceAttackAir  = GattlingTankVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart  = GattlingTankMoveStart
   SoundMoveStartDamaged = GattlingTankMoveStart
 
@@ -2622,6 +2624,7 @@ Object ChinaVehicleListeningOutpost
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
   VoiceAttack = ListeningOutpostVoiceAttack
+  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12892,6 +12892,7 @@ Object Demo_GLAInfantryTunnelDefender
   VoiceMove = RPGTrooperVoiceMove
   VoiceGuard = RPGTrooperVoiceMove
   VoiceAttack = RPGTrooperVoiceAttack
+  VoiceAttackAir = RPGTrooperVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceFear = RPGTrooperVoiceFear
   UnitSpecificSounds
     VoiceCreate          = RPGTrooperVoiceCreate
@@ -17694,6 +17695,7 @@ Object Demo_GLAVehicleCombatBike
   VoiceSelect = CombatCycleVoiceSelect
   VoiceMove = CombatCycleVoiceMove
   VoiceAttack = CombatCycleVoiceAttack
+  VoiceAttackAir = CombatCycleVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = CombatCycleVoiceMove
@@ -21177,6 +21179,7 @@ Object Demo_GLAVehicleBattleBus
   VoiceMove = BattleBusVoiceMove
   VoiceGuard = BattleBusVoiceMove
   VoiceAttack = BattleBusVoiceAttack
+  VoiceAttackAir = BattleBusVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = BattleBusMoveStart
   SoundMoveStartDamaged = BattleBusMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -835,6 +835,7 @@ Object GC_Chem_GLAInfantryTunnelDefender
   VoiceMove = RPGTrooperVoiceMove
   VoiceGuard = RPGTrooperVoiceMove
   VoiceAttack = RPGTrooperVoiceAttack
+  VoiceAttackAir = RPGTrooperVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceFear = RPGTrooperVoiceFear
   UnitSpecificSounds
     VoiceCreate          = RPGTrooperVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -813,6 +813,7 @@ Object GC_Slth_GLAInfantryTunnelDefender
   VoiceMove = RPGTrooperVoiceMove
   VoiceGuard = RPGTrooperVoiceMove
   VoiceAttack = RPGTrooperVoiceAttack
+  VoiceAttackAir = RPGTrooperVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceFear = RPGTrooperVoiceFear
   UnitSpecificSounds
     VoiceCreate          = RPGTrooperVoiceCreate
@@ -3933,6 +3934,7 @@ Object GC_Slth_GLAVehicleBattleBus
   VoiceMove = BattleBusVoiceMove
   VoiceGuard = BattleBusVoiceMove
   VoiceAttack = BattleBusVoiceAttack
+  VoiceAttackAir = BattleBusVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = BattleBusMoveStart
   SoundMoveStartDamaged = BattleBusMoveStart
   UnitSpecificSounds
@@ -4695,6 +4697,7 @@ Object GC_Slth_GLAVehicleCombatBike
   VoiceSelect = RocketBuggyVoiceSelect
   ;VoiceMove = RocketBuggyVoiceMove
   VoiceAttack = RocketBuggyVoiceAttack
+  VoiceAttackAir = RocketBuggyVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = RocketBuggyVoiceMove
@@ -5493,6 +5496,7 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
   VoiceSelect = RocketBuggyVoiceSelect
   ;VoiceMove = RocketBuggyVoiceMove
   VoiceAttack = RocketBuggyVoiceAttack
+  VoiceAttackAir = RocketBuggyVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = RocketBuggyVoiceMove
@@ -6291,6 +6295,7 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
   VoiceSelect = RocketBuggyVoiceSelect
   ;VoiceMove = RocketBuggyVoiceMove
   VoiceAttack = RocketBuggyVoiceAttack
+  VoiceAttackAir = RocketBuggyVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = RocketBuggyVoiceMove

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -839,6 +839,7 @@ Object GLAInfantryTunnelDefender
   VoiceMove = RPGTrooperVoiceMove
   VoiceGuard = RPGTrooperVoiceMove
   VoiceAttack = RPGTrooperVoiceAttack
+  VoiceAttackAir = RPGTrooperVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceFear = RPGTrooperVoiceFear
   UnitSpecificSounds
     VoiceCreate          = RPGTrooperVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -1190,6 +1190,7 @@ Object GLAVehicleCombatBike
   VoiceSelect = CombatCycleVoiceSelect
   VoiceMove = CombatCycleVoiceMove
   VoiceAttack = CombatCycleVoiceAttack
+  VoiceAttackAir = CombatCycleVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = CombatCycleVoiceMove
@@ -2013,6 +2014,7 @@ Object GLAVehicleCombatBikeRocket
   VoiceSelect = CombatCycleVoiceSelect
   VoiceMove = CombatCycleVoiceMove
   VoiceAttack = CombatCycleVoiceAttack
+  VoiceAttackAir = CombatCycleVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = CombatCycleVoiceMove
@@ -2817,6 +2819,7 @@ Object GLAVehicleCombatBikeTerrorist
   VoiceSelect = CombatCycleVoiceSelect
   VoiceMove = CombatCycleVoiceMove
   VoiceAttack = CombatCycleVoiceAttack
+  VoiceAttackAir = CombatCycleVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = CombatCycleVoiceMove
@@ -6292,6 +6295,7 @@ Object GLAVehicleBattleBus
   VoiceMove = BattleBusVoiceMove
   VoiceGuard = BattleBusVoiceMove
   VoiceAttack = BattleBusVoiceAttack
+  VoiceAttackAir = BattleBusVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = BattleBusMoveStart
   SoundMoveStartDamaged = BattleBusMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2506,6 +2506,7 @@ Object Infa_ChinaTankGattling
   VoiceMove       = GattlingTankVoiceMove
   VoiceGuard      = GattlingTankVoiceMove
   VoiceAttack     = GattlingTankVoiceAttack
+  VoiceAttackAir  = GattlingTankVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart  = GattlingTankMoveStart
   SoundMoveStartDamaged = GattlingTankMoveStart
 
@@ -15290,6 +15291,7 @@ Object Infa_ChinaInfantryMiniGunner
   VoiceMove = RedGuardVoiceMove
   VoiceGuard = RedGuardVoiceMove
   VoiceAttack = RedMinigunnerVoiceAttack
+  VoiceAttackAir = RedMinigunnerVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceGroupSelect = BattleCrySound
   VoiceFear = RedGuardVoiceFear
   VoiceTaskComplete = RedGuardVoiceCaptureComplete
@@ -15527,6 +15529,7 @@ Object Infa_ChinaVehicleTroopCrawler
   VoiceMove = TroopCrawlerVoiceMove
   VoiceGuard = TroopCrawlerVoiceMove
   VoiceAttack = AssaultTroopCrawlerVoiceAttack
+  VoiceAttackAir = AssaultTroopCrawlerVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = TroopCrawlerMoveStart
   SoundMoveStartDamaged = TroopCrawlerMoveStart
   SoundEnter = HumveeEnter
@@ -15819,6 +15822,7 @@ Object Infa_ChinaVehicleListeningOutpost
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
   VoiceAttack = ListeningOutpostVoiceAttack
+  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3986,6 +3986,7 @@ Object Nuke_ChinaTankGattling
   VoiceMove       = GattlingTankVoiceMove
   VoiceGuard      = GattlingTankVoiceMove
   VoiceAttack     = GattlingTankVoiceAttack
+  VoiceAttackAir  = GattlingTankVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart  = GattlingTankMoveStart
   SoundMoveStartDamaged = GattlingTankMoveStart
 
@@ -4730,6 +4731,7 @@ Object Nuke_ChinaVehicleListeningOutpost
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
   VoiceAttack = ListeningOutpostVoiceAttack
+  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter
@@ -16971,6 +16973,7 @@ Object Nuke_ChinaTankOverlord
   VoiceMove = OverlordTankVoiceMove
   VoiceGuard = OverlordTankVoiceMove
   VoiceAttack = OverlordTankVoiceAttack
+  VoiceAttackAir = OverlordTankVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
 
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13432,6 +13432,7 @@ Object Slth_GLAInfantryTunnelDefender
   VoiceMove = RPGTrooperVoiceMove
   VoiceGuard = RPGTrooperVoiceMove
   VoiceAttack = RPGTrooperVoiceAttack
+  VoiceAttackAir = RPGTrooperVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceFear = RPGTrooperVoiceFear
   UnitSpecificSounds
     VoiceCreate          = RPGTrooperVoiceCreate
@@ -17937,6 +17938,7 @@ Object Slth_GLAVehicleCombatBike
   VoiceSelect = CombatCycleVoiceSelect
   VoiceMove = CombatCycleVoiceMove
   VoiceAttack = CombatCycleVoiceAttack
+  VoiceAttackAir = CombatCycleVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = CombatBikeMoveStart
   SoundMoveStartDamaged = CombatBikeMoveStart
   VoiceGuard = CombatCycleVoiceMove
@@ -21211,6 +21213,7 @@ Object Slth_GLAVehicleBattleBus
   VoiceMove = BattleBusVoiceMove
   VoiceGuard = BattleBusVoiceMove
   VoiceAttack = BattleBusVoiceAttack
+  VoiceAttackAir = BattleBusVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = BattleBusMoveStart
   SoundMoveStartDamaged = BattleBusMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2977,6 +2977,7 @@ Object Tank_ChinaTankEmperor
   VoiceMove = EmperorTankVoiceMove
   VoiceGuard = EmperorTankVoiceMove
   VoiceAttack = OverlordTankVoiceAttack
+  VoiceAttackAir = OverlordTankVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
 
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
@@ -4112,6 +4113,7 @@ Object Tank_ChinaTankGattling
   VoiceMove       = GattlingTankVoiceMove
   VoiceGuard      = GattlingTankVoiceMove
   VoiceAttack     = GattlingTankVoiceAttack
+  VoiceAttackAir  = GattlingTankVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart  = GattlingTankMoveStart
   SoundMoveStartDamaged = GattlingTankMoveStart
 
@@ -4866,6 +4868,7 @@ Object Tank_ChinaVehicleListeningOutpost
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
   VoiceAttack = ListeningOutpostVoiceAttack
+  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter


### PR DESCRIPTION
ZH 1.04

- Some units do not play a voice line when targeting airborne units. These include: Gattling Tank, Overlord (Gattling Turret upgrade), Mini Gunner, Assault Troop Crawler, Listening Outpost, RPG-Soldier, Battle Bus, Combat Cycle.

Repro:

- Target an airborne unit with any of these units. Note that targeting friendly airborne units with force-fire will always play the line for attacking ground targets, so chose an enemy target instead.

After patch:

- The same effect for firing at ground units is used against airborne targets. Mostly fits. Better than staying silent.

Note:

- In CCG `VoiceAttackAir` did not exist. Instead `VoiceAttack` was played against ground and airborne targets. `VoiceAttackAir` however was not added to every unit that can attack air. For some reason, they also did not make `VoiceAttackAir` fall back to `VoiceAttack` when undefined. So while units talk in CCG, they don't in ZH against air.
- The Overlord can attack air when upgraded with Gatling. The Combat Bike when a RPG-Soldier is riding it.