### PR TITLE
Fix: Stinger Site Can Double Fire

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -52,7 +52,7 @@ https://github.com/commy2/zerohour/issues/178 [IMPROVEMENT][NPROJECT] Jarmen Kel
 https://github.com/commy2/zerohour/issues/177 [DONE][NPROJECT]        Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap
 https://github.com/commy2/zerohour/issues/176 [IMPROVEMENT]           Stinger Site Automatically Engages Buildings
 https://github.com/commy2/zerohour/issues/175 [IMPROVEMENT][NPROJECT] Stinger Site Lacks Muzzle Flash And Recoil Animation When Targeting Airborne Targets
-https://github.com/commy2/zerohour/issues/174 [IMPROVEMENT]           Stinger Site Can Double Fire
+https://github.com/commy2/zerohour/issues/174 [DONE]                  Stinger Site Can Double Fire
 https://github.com/commy2/zerohour/issues/173 [DONE]                  Humvee Without TOW Missiles Upgrade Freezes When Attack Moving Into Airborne Targets
 https://github.com/commy2/zerohour/issues/172 [DONE]                  Extended Range Exploit
 https://github.com/commy2/zerohour/issues/163 [DONE][NPROJECT]        Destroyed Heroic Toxin Tractor Creates Green Poison Cloud Without Anthrax Beta Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -12621,6 +12621,7 @@ Object Chem_GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY Chem_StingerMissileWeaponAirBeta
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
   End
   WeaponSet
     Conditions          = PLAYER_UPGRADE
@@ -12628,6 +12629,7 @@ Object Chem_GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY Chem_StingerMissileWeaponAirGamma
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
   End
   ArmorSet
     Conditions      = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13140,6 +13140,7 @@ Object Demo_GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY StingerMissileWeaponAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
     Weapon = TERTIARY TerroristSuicideNotARealWeapon
     AutoChooseSources = TERTIARY NONE
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -185,6 +185,7 @@ Object GC_Chem_GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY GC_Chem_StingerMissileWeaponAirBeta
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
   End
   WeaponSet
     Conditions          = PLAYER_UPGRADE
@@ -192,6 +193,7 @@ Object GC_Chem_GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY GC_Chem_StingerMissileWeaponAirGamma
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
   End
   ArmorSet
     Conditions      = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -521,6 +521,7 @@ Object GC_Slth_GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY StingerMissileWeaponAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
   End
   ArmorSet
     Conditions      = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1057,6 +1057,7 @@ Object GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY StingerMissileWeaponAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
   End
   ArmorSet
     Conditions      = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13649,6 +13649,7 @@ Object Slth_GLAInfantryStingerSoldier
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY StingerMissileWeaponAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix commy2 11/09/2021 Fix double firing against ground and air targets.
   End
   ArmorSet
     Conditions      = None


### PR DESCRIPTION
ZH 1.04

- The Stinger Site has separate reload times for engaging ground and airborne targets, thus being able to double the rate of fire by switching targets during reload.

Repro:

- Place a Stinger Site next to a Supply Center with Chinooks. Switch between shooting at the Supply Stash and the Chinooks.

After patch:

- Ground and air weapons share their reload time.