### PR TITLE
Fix: Stinger Site Automatically Engages Buildings

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -50,7 +50,7 @@ https://github.com/commy2/zerohour/issues/180 [DONE][NPROJECT]        Vanilla GL
 https://github.com/commy2/zerohour/issues/179 [DONE]                  Nuke Cannons May Change Target On Their Own While Unpacking
 https://github.com/commy2/zerohour/issues/178 [IMPROVEMENT][NPROJECT] Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack
 https://github.com/commy2/zerohour/issues/177 [DONE][NPROJECT]        Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap
-https://github.com/commy2/zerohour/issues/176 [IMPROVEMENT]           Stinger Site Automatically Engages Buildings
+https://github.com/commy2/zerohour/issues/176 [DONE]                  Stinger Site Automatically Engages Buildings
 https://github.com/commy2/zerohour/issues/175 [IMPROVEMENT][NPROJECT] Stinger Site Lacks Muzzle Flash And Recoil Animation When Targeting Airborne Targets
 https://github.com/commy2/zerohour/issues/174 [IMPROVEMENT]           Stinger Site Can Double Fire
 https://github.com/commy2/zerohour/issues/173 [DONE]                  Humvee Without TOW Missiles Upgrade Freezes When Attack Moving Into Airborne Targets

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -12667,8 +12667,10 @@ Object Chem_GLAInfantryStingerSoldier
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Stinger Site automatically engaging buildings.
+
   Behavior = AIUpdateInterface ModuleTag_03
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed ATTACK_BUILDINGS
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13181,8 +13181,10 @@ Object Demo_GLAInfantryStingerSoldier
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Stinger Site automatically engaging buildings.
+
   Behavior = AIUpdateInterface ModuleTag_03
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed ATTACK_BUILDINGS
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -231,8 +231,10 @@ Object GC_Chem_GLAInfantryStingerSoldier
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Stinger Site automatically engaging buildings.
+
   Behavior = AIUpdateInterface ModuleTag_03
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed ATTACK_BUILDINGS
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -557,8 +557,10 @@ Object GC_Slth_GLAInfantryStingerSoldier
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Stinger Site automatically engaging buildings.
+
   Behavior = AIUpdateInterface ModuleTag_03
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed ATTACK_BUILDINGS Stealthed
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1096,8 +1096,10 @@ Object GLAInfantryStingerSoldier
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Stinger Site automatically engaging buildings.
+
   Behavior = AIUpdateInterface ModuleTag_03
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed ATTACK_BUILDINGS
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13688,8 +13688,10 @@ Object Slth_GLAInfantryStingerSoldier
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Stinger Site automatically engaging buildings.
+
   Behavior = AIUpdateInterface ModuleTag_03
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed ATTACK_BUILDINGS
+    AutoAcquireEnemiesWhenIdle = Yes Stealthed
     MoodAttackCheckRate        = 250
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor


### PR DESCRIPTION
ZH 1.04

- The Stinger Site automatically engages enemy buildings. And no other base defense does this. In fact, no other unit does this, aside from one or two SP faction only units.

After patch:

- The Stinger Site does no longer automatically fire at nearby enemy buildings.