### PR TITLE
Fix: Stinger Site Does Not Benefit From AP Rockets When Engaging Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -11,7 +11,7 @@ https://github.com/commy2/zerohour/issues/223 [DONE][NPROJECT]        Sentry Dro
 https://github.com/commy2/zerohour/issues/222 [MAYBE]                 Poison Fields Can Clear Poison Fields
 https://github.com/commy2/zerohour/issues/221 [IMPROVEMENT][NPROJECT] Units Sometimes Waste Shots On Overlord Debris
 https://github.com/commy2/zerohour/issues/220 [DONE][NPROJECT]        Units Sometimes Waste Shots On Poisoned Or Burned Infantry
-https://github.com/commy2/zerohour/issues/219 [MAYBE][NPROJECT]       Stinger Site Does Not Benefit From AP Rockets When Engaging Airborne Targets
+https://github.com/commy2/zerohour/issues/219 [DONE][NPROJECT]        Stinger Site Does Not Benefit From AP Rockets When Engaging Airborne Targets
 https://github.com/commy2/zerohour/issues/218 [NOTRELEVANT]           Hackers Are Bad Late Game Eco
 https://github.com/commy2/zerohour/issues/217 [DONE][NPROJECT]        Scud Launchers Missing Upgrade Icon For AP Rockets
 https://github.com/commy2/zerohour/issues/216 [IMPROVEMENT]           Nationalism And Patriotism Don't Update For Garrisoned Units

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2273,6 +2273,7 @@ Weapon StingerMissileWeaponAir
   AntiAirborneInfantry = No
   AntiGround = No
   AntiBallisticMissile = Yes
+  WeaponBonus = PLAYER_UPGRADE DAMAGE 125%  ; Patch104p @bugfix commy2 11/09/2021 Fix AP Rockets now working against airborne targets.
 
   ; note, these only apply to units that aren't the explicit target
   ; (ie, units that just happen to "get in the way"... projectiles
@@ -5184,6 +5185,7 @@ Weapon GC_Chem_StingerMissileWeaponAirBeta
   AntiAirborneInfantry = No
   AntiGround = No
   AntiBallisticMissile = Yes
+  WeaponBonus = PLAYER_UPGRADE DAMAGE 125%  ; Patch104p @bugfix commy2 11/09/2021 Fix AP Rockets now working against airborne targets.
 End
 
 Weapon GC_Chem_StingerMissileWeaponGamma
@@ -5236,6 +5238,7 @@ Weapon GC_Chem_StingerMissileWeaponAirGamma
   AntiAirborneInfantry = No
   AntiGround = No
   AntiBallisticMissile = Yes
+  WeaponBonus = PLAYER_UPGRADE DAMAGE 125%  ; Patch104p @bugfix commy2 11/09/2021 Fix AP Rockets now working against airborne targets.
 End
 
 
@@ -6892,6 +6895,7 @@ Weapon Chem_StingerMissileWeaponAirBeta
   AntiAirborneInfantry = No
   AntiGround = No
   AntiBallisticMissile = Yes
+  WeaponBonus = PLAYER_UPGRADE DAMAGE 125%  ; Patch104p @bugfix commy2 11/09/2021 Fix AP Rockets now working against airborne targets.
 End
 
 Weapon Chem_StingerMissileWeaponGamma
@@ -6944,6 +6948,7 @@ Weapon Chem_StingerMissileWeaponAirGamma
   AntiAirborneInfantry = No
   AntiGround = No
   AntiBallisticMissile = Yes
+  WeaponBonus = PLAYER_UPGRADE DAMAGE 125%  ; Patch104p @bugfix commy2 11/09/2021 Fix AP Rockets now working against airborne targets.
 End
 
 


### PR DESCRIPTION
ZH 1.04

- AP Rockets does not work on Stinger Sites when they are engaging airborne units. It works only against ground targets.

After patch:

- AP Rockets increases damage against air and ground targets.

Notes: 
- Was in a mood to finish all issues with the Stinger Site.
- I don't think (m)any peope even know about this.
- This needs to be discussed for balance, I think.