### PR TITLE
Fix: Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub-Faction Command Centers

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -103,7 +103,7 @@ https://github.com/commy2/zerohour/issues/119 [IMPROVEMENT]           Car Bomb M
 https://github.com/commy2/zerohour/issues/118 [MAYBE][NPROJECT]       Some ECM Tanks Automatically Engage Enemy Vehicles
 https://github.com/commy2/zerohour/issues/117 [DONE][NPROJECT]        Some Rebels Are Missing Upgrade Icons
 https://github.com/commy2/zerohour/issues/116 [MAYBE][NPROJECT]       Tactical Nuke Mig Upgrade Not Buildable While Low On Power
-https://github.com/commy2/zerohour/issues/115 [IMPROVEMENT][NPROJECT] Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub Faction Command Centers
+https://github.com/commy2/zerohour/issues/115 [DONE][NPROJECT]        Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub Faction Command Centers
 https://github.com/commy2/zerohour/issues/114 [DONE][NPROJECT]        Hitting Battle Bus In Hull Mode Causes Screen Shake
 https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs Cannot Target Stinger Sites
 https://github.com/commy2/zerohour/issues/112 [IMPROVEMENT][NPROJECT] Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1310,10 +1310,25 @@ Object Boss_CommandCenter
     MoneyAmount          = 1000  ; amount of money to steal
   End
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix bugging out shortcut for Carpet Bomber when controlling different sub-faction Command Centers.
+  ; This is required, because the Rank 5 and the Nuke Carpet Bomber share the same special power
+  ; enum (SPECIAL_CHINA_CARPET_BOMB). A OCLSpecialPower module for every ability variant prevents
+  ; the issue.
+
   Behavior           = OCLSpecialPower ModuleTag_22;this has been removed from everywhere but the ChinaAirfield in CHI05
-   SpecialPowerTemplate = SuperweaponChinaCarpetBomb
-   OCL                  = SUPERWEAPON_ChinaCarpetBomb
-   CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+    SpecialPowerTemplate = SuperweaponChinaCarpetBomb
+    OCL                  = SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Early
+    SpecialPowerTemplate = Early_SuperweaponChinaCarpetBomb
+    OCL                  = SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Nuke
+    SpecialPowerTemplate = Nuke_SuperweaponChinaCarpetBomb
+    OCL                  = Nuke_SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
   End
 
   Behavior = SpecialAbility ModuleTag_91

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -4036,8 +4036,24 @@ Object ChinaCommandCenter
     OCL                  = SUPERWEAPON_RepairVehicles1
     CreateLocation       = CREATE_AT_LOCATION
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix bugging out shortcut for Carpet Bomber when controlling different sub-faction Command Centers.
+  ; This is required, because the Rank 5 and the Nuke Carpet Bomber share the same special power
+  ; enum (SPECIAL_CHINA_CARPET_BOMB). A OCLSpecialPower module for every ability variant prevents
+  ; the issue.
+
   Behavior           = OCLSpecialPower ModuleTag_22;this has been removed from everywhere but the ChinaAirfield in CHI05
     SpecialPowerTemplate = Early_SuperweaponChinaCarpetBomb
+    OCL                  = SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Nuke
+    SpecialPowerTemplate = Nuke_SuperweaponChinaCarpetBomb
+    OCL                  = Nuke_SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Tank
+    SpecialPowerTemplate = SuperweaponChinaCarpetBomb
     OCL                  = SUPERWEAPON_ChinaCarpetBomb
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
   End
@@ -15673,7 +15689,7 @@ Object GLADemoTrap
     FriendlyOpacityMin = 100.0%
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
-  
+
   ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
   ; Demo Traps will no longer be triggered by base defense and building scaffolds.
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -4227,8 +4227,24 @@ Object Infa_ChinaCommandCenter
     OCL                  = SUPERWEAPON_RepairVehicles1
     CreateLocation       = CREATE_AT_LOCATION
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix bugging out shortcut for Carpet Bomber when controlling different sub-faction Command Centers.
+  ; This is required, because the Rank 5 and the Nuke Carpet Bomber share the same special power
+  ; enum (SPECIAL_CHINA_CARPET_BOMB). A OCLSpecialPower module for every ability variant prevents
+  ; the issue.
+
   Behavior           = OCLSpecialPower ModuleTag_22;this has been removed from everywhere but the ChinaAirfield in CHI05
     SpecialPowerTemplate = Early_SuperweaponChinaCarpetBomb
+    OCL                  = SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Nuke
+    SpecialPowerTemplate = Nuke_SuperweaponChinaCarpetBomb
+    OCL                  = Nuke_SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Tank
+    SpecialPowerTemplate = SuperweaponChinaCarpetBomb
     OCL                  = SUPERWEAPON_ChinaCarpetBomb
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -5961,9 +5961,25 @@ Object Nuke_ChinaCommandCenter
     OCL                  = SUPERWEAPON_RepairVehicles1
     CreateLocation       = CREATE_AT_LOCATION
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix bugging out shortcut for Carpet Bomber when controlling different sub-faction Command Centers.
+  ; This is required, because the Rank 5 and the Nuke Carpet Bomber share the same special power
+  ; enum (SPECIAL_CHINA_CARPET_BOMB). A OCLSpecialPower module for every ability variant prevents
+  ; the issue.
+
   Behavior           = OCLSpecialPower ModuleTag_22;this has been removed from everywhere but the ChinaAirfield in CHI05
     SpecialPowerTemplate = Nuke_SuperweaponChinaCarpetBomb
     OCL                  = Nuke_SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Early
+    SpecialPowerTemplate = Early_SuperweaponChinaCarpetBomb
+    OCL                  = SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Tank
+    SpecialPowerTemplate = SuperweaponChinaCarpetBomb
+    OCL                  = SUPERWEAPON_ChinaCarpetBomb
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16727,9 +16727,25 @@ Object Tank_ChinaCommandCenter
     OCL                  = SUPERWEAPON_RepairVehicles1
     CreateLocation       = CREATE_AT_LOCATION
   End
+
+  ; Patch104p @bugfix commy2 11/09/2021 Fix bugging out shortcut for Carpet Bomber when controlling different sub-faction Command Centers.
+  ; This is required, because the Rank 5 and the Nuke Carpet Bomber share the same special power
+  ; enum (SPECIAL_CHINA_CARPET_BOMB). A OCLSpecialPower module for every ability variant prevents
+  ; the issue.
+
   Behavior           = OCLSpecialPower ModuleTag_22;this has been removed from everywhere but the ChinaAirfield in CHI05
     SpecialPowerTemplate = SuperweaponChinaCarpetBomb
     OCL                  = SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Early
+    SpecialPowerTemplate = Early_SuperweaponChinaCarpetBomb
+    OCL                  = SUPERWEAPON_ChinaCarpetBomb
+    CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
+  End
+  Behavior           = OCLSpecialPower ModuleTag_22Nuke
+    SpecialPowerTemplate = Nuke_SuperweaponChinaCarpetBomb
+    OCL                  = Nuke_SUPERWEAPON_ChinaCarpetBomb
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
   End
 


### PR DESCRIPTION
ZH 1.04

- The Rank 3 and Nuke Carpet Bombers become unavailable if the player controls a Nuke Command Center as well as either a normal China or an Infantry General Command Center at the same time.

Repro:

- Purchase the Rank 3 Carpet Bomber as normal China or Infantry General. Build a Command Center. Capture a Nuke General's Command Center. Try to use the Carpet Bomber from the special power shortcut bar.
- Alternatively, purchase the Nuke Carpet Bomber as Nuke General. Build a Command Center. Capture a normal China or Infantry General Command Center. Try to use the Nuke Carpet Bomber from the special power shortcut bar.

After patch:

- The Carpet Bomber can be used from the shortcut, no matter what Command Centers are controlled by the player.