### PR TITLE
Fix: Some Generals Power Buttons Disappear From Infantry And Nuke General Command Center After Land Mines Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -115,7 +115,7 @@ https://github.com/commy2/zerohour/issues/107 [IMPROVEMENT][NPROJECT] Pilots Hav
 https://github.com/commy2/zerohour/issues/106 [IMPROVEMENT][NPROJECT] Cargo Planes With Countermeasures Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/105 [DONE][NPROJECT]        Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned
 https://github.com/commy2/zerohour/issues/104 [IMPROVEMENT][NPROJECT] China Command Center Missing Radar Upgrade Icon
-https://github.com/commy2/zerohour/issues/103 [IMPROVEMENT][NPROJECT] Some Special Power Buttons Disappear From Command Center After Mines Upgrade
+https://github.com/commy2/zerohour/issues/103 [DONE][NPROJECT]        Some Special Power Buttons Disappear From Command Center After Mines Upgrade
 https://github.com/commy2/zerohour/issues/102 [DONE][NPROJECT]        Tank Hunter Missing Patriotism Upgrade Icon
 https://github.com/commy2/zerohour/issues/101 [IMPROVEMENT][NPROJECT] Speaker Tower Lacks Mine Upgrade
 https://github.com/commy2/zerohour/issues/100 [IMPROVEMENT][NPROJECT] Overlord Turns Chassis When Gattling Cannon Is Aiming At Air Unit

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -3072,6 +3072,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   14 = Command_Sell
 End
 
+; Patch104p @bugfix commy2 11/09/2021 Fix Frenzy disappearing from command bar after Landmines upgrade.
+
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   1  = Nuke_Command_ConstructChinaDozer
   2  = Nuke_Command_ChinaCarpetBomb
@@ -3082,6 +3084,7 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
   9  = Command_UpgradeChinaRadar
+  10 = Command_Frenzy
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3809,16 +3812,18 @@ CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
  14 = Command_Sell
 End
 
+; Patch104p @bugfix commy2 11/09/2021 Fix Carpet Bomber and Frenzy disappearing from command bar after Landmines upgrade.
+
 CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   1  = Infa_Command_ConstructChinaDozer
-  2  = Command_ChinaCarpetBomb
-  3  = Command_NapalmStrike
+  2  = Early_Command_ChinaCarpetBomb
+  3  = Infa_Command_Paradrop
   4  = Command_ClusterMines
-  5  = Infa_Command_Paradrop
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
   9  = Command_UpgradeChinaRadar
+  10 = Early_Command_Frenzy
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell


### PR DESCRIPTION
ZH 1.04

- The Frenzy ability on the Infantry and Nuke General's Command Centers controlbar disappears after the building has been upgraded with Mines.
- The Carpet Bomb button disappears from the Infantry Command Center.
- The Paradrop button moves position to the right for the Infantry Command Center.

Repro:

- Play as Infantry General and unlock Frenzy. Then upgrade the Command Center with Landmines and observe how the button disappears when the Neutron Mines button replaces the Landmines button.

After patch:

- The special power buttons stay were they are.

Note:

- The abilities could always be used from the shortcut bar on the right.