### PR TITLE
Fix: Car Bomb May Bug Out And Be Unable To Attack

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -99,7 +99,7 @@ https://github.com/commy2/zerohour/issues/123 [DONE][NPROJECT]        Super Weap
 https://github.com/commy2/zerohour/issues/122 [DONE][NPROJECT]        Paradrop Spawns Wrong Ranger Type
 https://github.com/commy2/zerohour/issues/121 [IMPROVEMENT]           Countermeasures Tooltip Claims 50% Evasion Rate Instead Of True 30%
 https://github.com/commy2/zerohour/issues/120 [MAYBE][NPROJECT]       Vehicles Can Shoot Out Of Combat Chinook
-https://github.com/commy2/zerohour/issues/119 [IMPROVEMENT]           Car Bomb May Bug Out And Be Unable To Attack
+https://github.com/commy2/zerohour/issues/119 [DONE]                  Car Bomb May Bug Out And Be Unable To Attack
 https://github.com/commy2/zerohour/issues/118 [MAYBE][NPROJECT]       Some ECM Tanks Automatically Engage Enemy Vehicles
 https://github.com/commy2/zerohour/issues/117 [DONE][NPROJECT]        Some Rebels Are Missing Upgrade Icons
 https://github.com/commy2/zerohour/issues/116 [MAYBE][NPROJECT]       Tactical Nuke Mig Upgrade Not Buildable While Low On Power

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2328,6 +2328,7 @@ Weapon SuicideCarBomb
   PrimaryDamageRadius = 20.0
   SecondaryDamage = 100.0
   SecondaryDamageRadius = 50.0
+  LeechRangeWeapon = Yes  ; Patch104p @bugfix commy2 11/09/2021 Fix car bomb bugging out when target moving away from car.
   AttackRange = 5.0       ; must be very close to use this weapon!
   DamageType = EXPLOSION
   DeathType = SUICIDED


### PR DESCRIPTION
ZH 1.04

- When aiming a Carbomb at a unit that is driving away, the Carbomb may fail to explode and be no longer able to explode at all.

Repro:

- Take over a civilian car with a Terrorist. Force-fire one of your Scorpions. Drive the Scorpion away from the Carbomb. Try to target the Scorpion after the Carbomb stopped.

Patched:

- Carbomb immediately explodes instead of ever bugging out.