### PR TITLE
Fix: Some Tech Buildings Reward XP When Killed

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -90,7 +90,7 @@ https://github.com/commy2/zerohour/issues/132 [MAYBE][NPROJECT]       Raptor Gua
 https://github.com/commy2/zerohour/issues/131 [DONE][NPROJECT]        Demo General Combat Bike With Demolitions Upgrade Deals No Damage When Destroyed By Gamma Poison
 https://github.com/commy2/zerohour/issues/130 [DONE][NPROJECT]        Demo Combat Bike Uses Portrait As Button
 https://github.com/commy2/zerohour/issues/129 [MAYBE][NPROJECT]       Selling Air Force Supply Center Does Refund Less Than Half Of Build Value
-https://github.com/commy2/zerohour/issues/128 [IMPROVEMENT][NPROJECT] Repair And Reinforcement Pads Reward XP When Killed
+https://github.com/commy2/zerohour/issues/128 [DONE][NPROJECT]        Repair And Reinforcement Pads Reward XP When Killed
 https://github.com/commy2/zerohour/issues/127 [IMPROVEMENT][NPROJECT] Aurora Alpha Fuel Air Explosion May Trigger Before Bomb Hits
 https://github.com/commy2/zerohour/issues/126 [MAYBE]                 Microwave Tank Vulnerable To Infantry Missiles
 https://github.com/commy2/zerohour/issues/125 [IMPROVEMENT][NPROJECT] USA War Factory Displays Generic Tank On Button

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -403,7 +403,8 @@ Object TechReinforcementPad
     Armor             = StructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  ExperienceValue     = 200 200 200 200  ; Experience point value at each level
+  ; Patch104p @bugfix commy2 11/09/2021 Removed experience yield when destroying this enemy controlled tech building.
+  ;ExperienceValue     = 200 200 200 200  ; Experience point value at each level
   ; *** AUDIO Parameters ***
   VoiceSelect = SupplyDropZoneSelect
 
@@ -625,7 +626,8 @@ Object TechRepairPad
     Armor             = StructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  ExperienceValue     = 200 200 200 200  ; Experience point value at each level
+  ; Patch104p @bugfix commy2 11/09/2021 Removed experience yield when destroying this enemy controlled tech building.
+  ;ExperienceValue     = 200 200 200 200  ; Experience point value at each level
  ;**FIX**?
  ;CommandSet          = TechReinforcementPadCommandSet
   ; *** AUDIO Parameters ***
@@ -821,7 +823,8 @@ Object TechRepairbay
     Armor             = StructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  ExperienceValue     = 200 200 200 200  ; Experience point value at each level
+  ; Patch104p @bugfix commy2 11/09/2021 Removed experience yield when destroying this enemy controlled tech building.
+  ;ExperienceValue     = 200 200 200 200  ; Experience point value at each level
   ; *** AUDIO Parameters ***
   VoiceSelect = SupplyDropZoneSelect
 


### PR DESCRIPTION
ZH 1.04

- The Repair Bay and Reinforcement Pad grant 200 XP when destroyed if controlled by the enemy, while Oil Derricks, Hospitals and Artillery Platforms do not.

After patch:

- None of the enemy captured tech buildings reward experience when destroyed.