### PR TITLE
Fix: Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -48,7 +48,7 @@ https://github.com/commy2/zerohour/issues/182 [IMPROVEMENT][NPROJECT] Listening 
 https://github.com/commy2/zerohour/issues/181 [DONE]                  Some Units Lack Voice Line When Ordered To Attack Airborne Targets
 https://github.com/commy2/zerohour/issues/180 [DONE][NPROJECT]        Vanilla GLA Battle Bus Missing Sound Effect When Power Sliding
 https://github.com/commy2/zerohour/issues/179 [DONE]                  Nuke Cannons May Change Target On Their Own While Unpacking
-https://github.com/commy2/zerohour/issues/178 [IMPROVEMENT][NPROJECT] Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack
+https://github.com/commy2/zerohour/issues/178 [DONE][NPROJECT]        Jarmen Kell On A Bike Lacks Muzzle Flash Effect When Using Sniper Attack
 https://github.com/commy2/zerohour/issues/177 [DONE][NPROJECT]        Demo General Rebel Lacks Voice Line When Targetting Building With Booby Trap
 https://github.com/commy2/zerohour/issues/176 [DONE]                  Stinger Site Automatically Engages Buildings
 https://github.com/commy2/zerohour/issues/175 [DONE][NPROJECT]        Stinger Site Lacks Muzzle Flash And Recoil Animation When Targeting Airborne Targets

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -21243,6 +21243,7 @@ Object Boss_VehicleCombatBikeTerrorist
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -21254,6 +21255,9 @@ Object Boss_VehicleCombatBikeTerrorist
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
     End
     AliasConditionState RIDER1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -15789,6 +15789,7 @@ Object Chem_GLAVehicleCombatBike
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -15800,6 +15801,9 @@ Object Chem_GLAVehicleCombatBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
 
       HideSubObject = BOMBBIKE ; Hide from all states except terrorist (rider 5)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17018,6 +17018,7 @@ Object Demo_GLAVehicleCombatBike
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -17029,6 +17030,9 @@ Object Demo_GLAVehicleCombatBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
 
       HideSubObject = BOMBBIKE ; Hide from all states except terrorist (rider 5)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -4112,6 +4112,7 @@ Object GC_Slth_GLAVehicleCombatBike
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -4123,6 +4124,9 @@ Object GC_Slth_GLAVehicleCombatBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
     End
     AliasConditionState RIDER1
@@ -4911,6 +4915,7 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -4922,6 +4927,9 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
     End
     AliasConditionState RIDER1
@@ -5710,6 +5718,7 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -5721,6 +5730,9 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
     End
     AliasConditionState RIDER1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -510,6 +510,7 @@ Object GLAVehicleCombatBike
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -521,6 +522,9 @@ Object GLAVehicleCombatBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
 
       HideSubObject = BOMBBIKE ; Hide from all states except terrorist (rider 5)
@@ -1432,6 +1436,7 @@ Object GLAVehicleCombatBikeRocket
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -1443,6 +1448,9 @@ Object GLAVehicleCombatBikeRocket
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
     End
     AliasConditionState RIDER1
@@ -2236,6 +2244,7 @@ Object GLAVehicleCombatBikeTerrorist
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -2247,6 +2256,9 @@ Object GLAVehicleCombatBikeTerrorist
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
     End
     AliasConditionState RIDER1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17260,6 +17260,7 @@ Object Slth_GLAVehicleCombatBike
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell on Bike missing muzzle flash when using Sniper Attack.
 
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -17271,6 +17272,9 @@ Object Slth_GLAVehicleCombatBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
       WeaponMuzzleFlash   = PRIMARY MuzzleFX_B
+      WeaponFireFXBone    = SECONDARY Muzzle_B
+      WeaponLaunchBone    = SECONDARY RocketFX03
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX_B
       ParticleSysBone     = SMOKE CombatBikeSmokeLight
 
       HideSubObject = BOMBBIKE ; Hide from all states except terrorist (rider 5)


### PR DESCRIPTION
ZH 1.04

- The Combat Bike lacks a muzzle effect for the Sniper Attack.

After patch:

- Muzzle flash is used. Tracer emerges from muzzle.

Note:

- Sniper Attack is where he kills the pilot. Not the regular anti infantry weapon.
- This is purely cosmetical.