### PR TITLE
Fix: Tracer Emerges Below Jarmen Kell When Using Sniper Attack

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -81,7 +81,7 @@ https://github.com/commy2/zerohour/issues/141 [IMPROVEMENT][NPROJECT] Toxin Gene
 https://github.com/commy2/zerohour/issues/140 [DONE][NPROJECT]        Gattling Helix Sometimes Fires At Airborne Units
 https://github.com/commy2/zerohour/issues/139 [DONE][NPROJECT]        Dummy Weapons Cause Notifications And Hit Effects
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button
-https://github.com/commy2/zerohour/issues/137 [IMPROVEMENT][NPROJECT] Tracer Emerges Below Jarmen Kell When Using Sniper Attack
+https://github.com/commy2/zerohour/issues/137 [DONE][NPROJECT]        Tracer Emerges Below Jarmen Kell When Using Sniper Attack
 https://github.com/commy2/zerohour/issues/136 [DONE][NPROJECT]        Demo Charge Buttons Are Placed Differently On Jarmen Kell Than On Colonel Burton
 https://github.com/commy2/zerohour/issues/135 [IMPROVEMENT][NPROJECT] Tunnel And Palace Lack Stop Button
 https://github.com/commy2/zerohour/issues/134 [IMPROVEMENT][NPROJECT] Air Force Carpet Bomber Tooltip Claims 2:30 Cooldown Instead Of True 4:00

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18650,6 +18650,8 @@ Object Boss_InfantryJarmenKell
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -18662,6 +18664,8 @@ Object Boss_InfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
       TransitionKey     = TRANS_Stand
     End
 
@@ -18686,13 +18690,16 @@ Object Boss_InfantryJarmenKell
       TransitionKey     = TRANS_FiringA
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
       AnimationMode     = ONCE
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -18700,6 +18707,7 @@ Object Boss_InfantryJarmenKell
       TransitionKey     = TRANS_FiringAInjured
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -18707,7 +18715,9 @@ Object Boss_InfantryJarmenKell
       Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
+    AliasConditionState = RELOADING_B REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -18723,8 +18733,11 @@ Object Boss_InfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A
+    AliasConditionState = MOVING FIRING_B
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING RELOADING_B
     AliasConditionState = MOVING DOCKING
     AliasConditionState = MOVING DOCKING_BEGINNING
     AliasConditionState = MOVING DOCKING_ACTIVE
@@ -18737,8 +18750,11 @@ Object Boss_InfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_B REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -11924,6 +11924,8 @@ Object Chem_GLAInfantryJarmenKell
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -11936,6 +11938,8 @@ Object Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
       TransitionKey     = TRANS_Stand
     End
 
@@ -11960,13 +11964,16 @@ Object Chem_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringA
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
       AnimationMode     = ONCE
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -11974,6 +11981,7 @@ Object Chem_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringAInjured
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -11981,7 +11989,9 @@ Object Chem_GLAInfantryJarmenKell
       Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
+    AliasConditionState = RELOADING_B REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -11997,8 +12007,11 @@ Object Chem_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A
+    AliasConditionState = MOVING FIRING_B
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState      = MOVING REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IRNA 30
@@ -12008,8 +12021,11 @@ Object Chem_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_B REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12319,6 +12319,8 @@ Object Demo_GLAInfantryJarmenKell
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -12331,6 +12333,8 @@ Object Demo_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
       TransitionKey     = TRANS_Stand
     End
 
@@ -12355,13 +12359,16 @@ Object Demo_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringA
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
       AnimationMode     = ONCE
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -12369,6 +12376,7 @@ Object Demo_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringAInjured
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -12376,7 +12384,9 @@ Object Demo_GLAInfantryJarmenKell
       Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
+    AliasConditionState = RELOADING_B REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -12392,8 +12402,11 @@ Object Demo_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A
+    AliasConditionState = MOVING FIRING_B
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING RELOADING_B
     AliasConditionState = MOVING DOCKING
     AliasConditionState = MOVING DOCKING_BEGINNING
     AliasConditionState = MOVING DOCKING_ACTIVE
@@ -12406,8 +12419,11 @@ Object Demo_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_B REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -3100,6 +3100,8 @@ Object GC_Chem_GLAInfantryJarmenKell
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -3112,6 +3114,8 @@ Object GC_Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
       TransitionKey     = TRANS_Stand
     End
 
@@ -3136,13 +3140,16 @@ Object GC_Chem_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringA
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
       AnimationMode     = ONCE
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -3150,6 +3157,7 @@ Object GC_Chem_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringAInjured
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -3157,7 +3165,9 @@ Object GC_Chem_GLAInfantryJarmenKell
       Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
+    AliasConditionState = RELOADING_B REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -3173,8 +3183,11 @@ Object GC_Chem_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A
+    AliasConditionState = MOVING FIRING_B
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState      = MOVING REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IRNA 30
@@ -3184,8 +3197,11 @@ Object GC_Chem_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_B REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -958,6 +958,8 @@ Object GC_Slth_GLAInfantryJarmenKell
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -970,6 +972,8 @@ Object GC_Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
       WeaponFireFXBone  = TERTIARY Muzzle
       WeaponMuzzleFlash = TERTIARY MuzzleFX
       TransitionKey     = TRANS_Stand
@@ -996,13 +1000,16 @@ Object GC_Slth_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringA
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
       AnimationMode     = ONCE
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -1010,6 +1017,7 @@ Object GC_Slth_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringAInjured
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -1017,7 +1025,9 @@ Object GC_Slth_GLAInfantryJarmenKell
       Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
+    AliasConditionState = RELOADING_B REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -1033,8 +1043,11 @@ Object GC_Slth_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A
+    AliasConditionState = MOVING FIRING_B
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState      = MOVING REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IRNA 30
@@ -1044,8 +1057,11 @@ Object GC_Slth_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_B REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -380,6 +380,8 @@ Object GLAInfantryJarmenKell
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -392,6 +394,8 @@ Object GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
       TransitionKey     = TRANS_Stand
     End
 
@@ -416,13 +420,16 @@ Object GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringA
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
       AnimationMode     = ONCE
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -430,6 +437,7 @@ Object GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringAInjured
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -437,7 +445,9 @@ Object GLAInfantryJarmenKell
       Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
+    AliasConditionState = RELOADING_B REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -453,8 +463,11 @@ Object GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A
+    AliasConditionState = MOVING FIRING_B
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING RELOADING_B
     AliasConditionState = MOVING DOCKING
     AliasConditionState = MOVING DOCKING_BEGINNING
     AliasConditionState = MOVING DOCKING_ACTIVE
@@ -467,8 +480,11 @@ Object GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_B REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -12966,6 +12966,8 @@ Object Slth_GLAInfantryJarmenKell
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -12978,6 +12980,8 @@ Object Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
       TransitionKey     = TRANS_Stand
     End
 
@@ -13002,13 +13006,16 @@ Object Slth_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringA
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
       AnimationMode     = ONCE
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -13016,6 +13023,7 @@ Object Slth_GLAInfantryJarmenKell
       TransitionKey     = TRANS_FiringAInjured
       AnimationSpeedFactorRange = 1.5 1.5
     End
+    AliasConditionState = FIRING_B REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -13023,7 +13031,9 @@ Object Slth_GLAInfantryJarmenKell
       Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
+    AliasConditionState = RELOADING_B REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -13039,8 +13049,11 @@ Object Slth_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A
+    AliasConditionState = MOVING FIRING_B
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING RELOADING_B
     AliasConditionState = MOVING DOCKING
     AliasConditionState = MOVING DOCKING_BEGINNING
     AliasConditionState = MOVING DOCKING_ACTIVE
@@ -13053,8 +13066,11 @@ Object Slth_GLAInfantryJarmenKell
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_B REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING


### PR DESCRIPTION
ZH 1.04

- When using the Snipe Attak only, the tracer emerges from the feet of Jarmen Kell instead his weapon.

After patch:

- Tracer emerges from weapon muzzle.

Notes:
- This is purely cosmetical.
- Sniper Attack is killing the vehicle driver, not regular infantry.