### PR TITLE
Mark "Heroic Pathfinders And Jarmen Kell Don't Use Red Tracers" as done

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -211,7 +211,7 @@ https://github.com/commy2/zerohour/issues/8   [DONE][NPROJECT]        Supply Tru
 https://github.com/commy2/zerohour/issues/7   [DONE][NPROJECT]        Mini-Gunner Has Broken Squish Detection
 https://github.com/commy2/zerohour/issues/6   [IMPROVEMENT][NPROJECT] Mini-Gunner Has Broken Sound And Fire Animation When Aiming At Airborne Targets
 https://github.com/commy2/zerohour/issues/5   [DONE][NPROJECT]        Heroic Pathfinders And Jarmen Kell Don't Use Red Tracers
-https://github.com/commy2/zerohour/issues/4   [IMPROVEMENT][NPROJECT] Vet 3 Jarmen Kell Has Tracer For Sniper Attack But Not For Normal Attack
+https://github.com/commy2/zerohour/issues/4   [DONE][NPROJECT]        Vet 3 Jarmen Kell Has Tracer For Sniper Attack But Not For Normal Attack
 https://github.com/commy2/zerohour/issues/3   [MAYBE]                 Frenzy-Scan Bug
 https://github.com/commy2/zerohour/issues/2   [DONE][NPROJECT]        Microwave-Supply Drop Zone-Bug
 https://github.com/commy2/zerohour/issues/1   [DONE][NPROJECT]        Scud-Bug


### PR DESCRIPTION
Was already done in https://github.com/xezon/GeneralsGamePatch/pull/76, but not checked in tasklist.