### PR TITLE
Fix: Minigunner Has Broken Recoil Animation; Also Tracer Emerges From Below Unit When Aiming At Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -209,7 +209,7 @@ https://github.com/commy2/zerohour/issues/10  [IMPROVEMENT][NPROJECT] Quad Canno
 https://github.com/commy2/zerohour/issues/9   [DONE][NPROJECT]        Camo-Netted Palace Not Revealed When Garrisoned Troops Fire
 https://github.com/commy2/zerohour/issues/8   [DONE][NPROJECT]        Supply Truck Has Extremely Low Mass
 https://github.com/commy2/zerohour/issues/7   [DONE][NPROJECT]        Mini-Gunner Has Broken Squish Detection
-https://github.com/commy2/zerohour/issues/6   [IMPROVEMENT][NPROJECT] Mini-Gunner Has Broken Sound And Fire Animation When Aiming At Airborne Targets
+https://github.com/commy2/zerohour/issues/6   [DONE][NPROJECT]        Mini-Gunner Has Broken Sound And Fire Animation When Aiming At Airborne Targets
 https://github.com/commy2/zerohour/issues/5   [DONE][NPROJECT]        Heroic Pathfinders And Jarmen Kell Don't Use Red Tracers
 https://github.com/commy2/zerohour/issues/4   [IMPROVEMENT][NPROJECT] Vet 3 Jarmen Kell Has Tracer For Sniper Attack But Not For Normal Attack
 https://github.com/commy2/zerohour/issues/3   [MAYBE]                 Frenzy-Scan Bug

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15019,6 +15019,9 @@ Object Infa_ChinaInfantryMiniGunner
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Minigunner tracer emerges from feet instead of muzzle when aiming at airborne targets.
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Minigunner weapon recoil animation did not fit rate of fire.
+
   Draw = W3DModelDraw ModuleTag_01
 
     OkToChangeModelColor = Yes
@@ -15039,6 +15042,8 @@ Object Infa_ChinaInfantryMiniGunner
       AnimationMode       = ONCE
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       TransitionKey       = TRANS_Stand
     End
 
@@ -15053,24 +15058,28 @@ Object Infa_ChinaInfantryMiniGunner
     ConditionState      = USING_WEAPON_A
       Animation         = NICNSC_SKL.NICNSC_ATA
       AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 4 4
       TransitionKey     = TRANS_Firing
     End
 
     ConditionState      = USING_WEAPON_A REALLYDAMAGED
       Animation         = NICNSC_SKL.NICNSC_ATC
       AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 4 4
       TransitionKey     = TRANS_FiringDamaged
     End
 
     ConditionState      = USING_WEAPON_B
       Animation         = NICNSC_SKL.NICNSC_ATA2
       AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 4 4
  ;    TransitionKey     = TRANS_Firing
     End
 
     ConditionState      = USING_WEAPON_B REALLYDAMAGED
       Animation         = NICNSC_SKL.NICNSC_ATC2
       AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 4 4
  ;    TransitionKey     = TRANS_FiringDamaged
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6280,7 +6280,7 @@ Weapon Infa_MiniGunnerGunAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_GenericMachineGunFire
   VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
-  FireSound             = RedGuardMinigunnerWeapon  ; Patch104p @bugfix commy2 11/09/2021 Fix weapon changing sound when aiming at airborne targets.
+  FireSound             = GattlingTankWeapon
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 500               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6280,7 +6280,7 @@ Weapon Infa_MiniGunnerGunAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_GenericMachineGunFire
   VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
-  FireSound             = GattlingTankWeapon
+  FireSound             = RedGuardMinigunnerWeapon  ; Patch104p @bugfix commy2 11/09/2021 Fix weapon changing sound when aiming at airborne targets.
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 500               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)


### PR DESCRIPTION
This is three seperate issues really.

ZH 1.04:

- The Minigunner uses the Red Guards rifle style recoil animation when firing.
- When firing at airborne targets only, the tracer emerges from the feet of the Minigunner instead his weapon.

After patch:

- Recoil animation is speed up 4 times, which makes it look pretty good (as far as ZH goes)
- The tracer emerges from the muzzle, even when aiming at air units.