### PR TITLE
Fix: Overlord Turns Chassis When Gatling Cannon Is Aiming At Airborne Target

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -118,7 +118,7 @@ https://github.com/commy2/zerohour/issues/104 [IMPROVEMENT][NPROJECT] China Comm
 https://github.com/commy2/zerohour/issues/103 [DONE][NPROJECT]        Some Special Power Buttons Disappear From Command Center After Mines Upgrade
 https://github.com/commy2/zerohour/issues/102 [DONE][NPROJECT]        Tank Hunter Missing Patriotism Upgrade Icon
 https://github.com/commy2/zerohour/issues/101 [IMPROVEMENT][NPROJECT] Speaker Tower Lacks Mine Upgrade
-https://github.com/commy2/zerohour/issues/100 [IMPROVEMENT][NPROJECT] Overlord Turns Chassis When Gattling Cannon Is Aiming At Air Unit
+https://github.com/commy2/zerohour/issues/100 [DONE][NPROJECT]        Overlord Turns Chassis When Gattling Cannon Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/99  [MAYBE][NPROJECT]       Emperor Overlord Incompatible With Subliminal Messaging
 https://github.com/commy2/zerohour/issues/98  [?][NPROJECT]           Nuke Cannon Animation Inconsistency
 https://github.com/commy2/zerohour/issues/97  [NOTRELEVANT][NPROJECT] Infantry General Gattling Tank Starts As Veteran

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1320,6 +1320,7 @@ Weapon GattlingBuildingGunAirDummy
   AntiSmallMissile      = No
   AntiBallisticMissile  = Yes
   AntiGround            = No
+  AcceptableAimDelta    = 180 ; Patch104p @bugfix commy2 10/09/2021 Fix Overlord turning when Gatling is ordered to attack airborne targets.
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
ZH 1.04

- Overlords with a Gattling Cannon will turn their chassis needlessly towards an air unit - on its own and when ordered to attack one.

After patch:

- Only the Gatling turret will aim towards the air unit, while the Overlord either stays as is or aims and shoots at ground targets.