### PR TITLE
Fix: Avenger Turns Chassis When Turret Is Aiming At Airborne Target

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -143,7 +143,7 @@ https://github.com/commy2/zerohour/issues/78  [MAYBE][NPROJECT]       Spectre In
 https://github.com/commy2/zerohour/issues/77  [DONE][NPROJECT]        Non-Vanilla USA Pilots Are Missing Voice Lines When Garrisoning Buildings
 https://github.com/commy2/zerohour/issues/76  [IMPROVEMENT][NPROJECT] Chem Suit Rangers Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/75  [IMPROVEMENT][NPROJECT] Some Hellfire Drones Use Scout Drone Model
-https://github.com/commy2/zerohour/issues/74  [IMPROVEMENT][NPROJECT] Avenger Turns Chassis When Turret Is Aiming At Air Unit
+https://github.com/commy2/zerohour/issues/74  [DONE][NPROJECT]        Avenger Turns Chassis When Turret Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/73  [MAYBE][NPROJECT]       Avenger Turret Inconsistencies
 https://github.com/commy2/zerohour/issues/72  [DONE][NPROJECT]        Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds
 https://github.com/commy2/zerohour/issues/71  [IMPROVEMENT][NPROJECT] Some Paladins Missing Hellfire Drone Upgrade Icon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8467,6 +8467,7 @@ Weapon AvengerAirLaserDummy
   AntiAirborneInfantry = No
   AntiGround = No
   ProjectileCollidesWith = ENEMIES STRUCTURES WALLS SHRUBBERY
+  AcceptableAimDelta = 180  ; Patch104p @bugfix commy2 10/09/2021 Fix Avenger turning when ordered to attack airborne targets.
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
ZH 1.04

- When the Avenger's turret is aiming at an air unit, the whole Avenger turns towards the target needlessly - on its own and when ordered to attack one.

After patch:

- Only the anti-air laser turret will aim towards the air unit, while the Avenger either stays as is or aims with the blue laser marker at ground targets.