### PR TITLE
Fix: Minigunner Uses Gatling Tank Sound When Aiming At Airborne Targets

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6280,7 +6280,7 @@ Weapon Infa_MiniGunnerGunAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_GenericMachineGunFire
   VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
-  FireSound             = GattlingTankWeapon
+  FireSound             = RedGuardMinigunnerWeapon  ; Patch104p @bugfix commy2 11/09/2021 Fix weapon changing sound when aiming at airborne targets.
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 500               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)


### PR DESCRIPTION
This is three seperate issues really.

ZH 1.04:

- When firing at airborne targets only, the Minigunner uses the weapon sound effect of the Gatling Tank instead of his normal effect.

After patch:

- The weapon sound does not change when aiming at air units.