### PR TITLE
Fix: Match Demo Terrorist suicide flags with flags of other faction Terrorist

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13391,7 +13391,7 @@ Object Demo_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death08
     DeathWeapon   = Demo_SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED
+    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
   End
 
 


### PR DESCRIPTION
The Demolition General's Terrorist, with this commit, will now explode when crushed, burned, or exploded like other faction's terrorists. This was a change done previously by 1.06, and their reasoning is quite succinct:
`One question: why didn't they explode when driven over? This weakness doesn't make any sense, especially since it's Juhziz's Terrorist, who is supposed to be better.`

This is now ported to this patch.