### PR TITLE
Fix: Speaker Tower Lacks Mine Upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -117,7 +117,7 @@ https://github.com/commy2/zerohour/issues/105 [DONE][NPROJECT]        Some Ameri
 https://github.com/commy2/zerohour/issues/104 [IMPROVEMENT][NPROJECT] China Command Center Missing Radar Upgrade Icon
 https://github.com/commy2/zerohour/issues/103 [DONE][NPROJECT]        Some Special Power Buttons Disappear From Command Center After Mines Upgrade
 https://github.com/commy2/zerohour/issues/102 [DONE][NPROJECT]        Tank Hunter Missing Patriotism Upgrade Icon
-https://github.com/commy2/zerohour/issues/101 [IMPROVEMENT][NPROJECT] Speaker Tower Lacks Mine Upgrade
+https://github.com/commy2/zerohour/issues/101 [DONE][NPROJECT]        Speaker Tower Lacks Mine Upgrade
 https://github.com/commy2/zerohour/issues/100 [DONE][NPROJECT]        Overlord Turns Chassis When Gattling Cannon Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/99  [MAYBE][NPROJECT]       Emperor Overlord Incompatible With Subliminal Messaging
 https://github.com/commy2/zerohour/issues/98  [?][NPROJECT]           Nuke Cannon Animation Inconsistency

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -971,13 +971,15 @@ CommandSet ChinaPowerPlantCommandSetUpgrade
  14 = Command_Sell
 End
 
+; Patch104p @bugfix commy2 11/09/2021 Add Landmines to Speaker Tower.
+
 CommandSet ChinaSpeakerTowerCommandSet
-; 10 = Command_UpgradeChinaMines
+ 12 = Command_UpgradeChinaMines
  14 = Command_Sell
 End
 
 CommandSet ChinaSpeakerTowerCommandSetUpgrade
-; 10 = Command_UpgradeEMPMines
+ 12 = Command_UpgradeEMPMines
  14 = Command_Sell
 End
 


### PR DESCRIPTION
ZH 1.04

- Speaker Towers are the only Chinese building that can not be upgraded with Landmines.

After patch:

- All Chinese buildings can upgrade Landmines.

This is obviously not a bug, but some design decission made by EA. I just don't get why. The minefield is just as small as it is for the Gatling and Bunker. I could not find any glitches or crashes with this either.