### PR TITLE
Fix: Boss Paladin Missing Hellfire Drone Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -146,7 +146,7 @@ https://github.com/commy2/zerohour/issues/75  [IMPROVEMENT][NPROJECT] Some Hellf
 https://github.com/commy2/zerohour/issues/74  [DONE][NPROJECT]        Avenger Turns Chassis When Turret Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/73  [MAYBE][NPROJECT]       Avenger Turret Inconsistencies
 https://github.com/commy2/zerohour/issues/72  [DONE][NPROJECT]        Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds
-https://github.com/commy2/zerohour/issues/71  [IMPROVEMENT][NPROJECT] Some Paladins Missing Hellfire Drone Upgrade Icon
+https://github.com/commy2/zerohour/issues/71  [DONE][NPROJECT]        Some Paladins Missing Hellfire Drone Upgrade Icon
 https://github.com/commy2/zerohour/issues/70  [NOTRELEVANT][NPROJECT] Boss Sentry Drone Inconsistencies
 https://github.com/commy2/zerohour/issues/69  [DONE][NPROJECT]        Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds
 https://github.com/commy2/zerohour/issues/68  [DONE]                  Spy Drone Seleced By Q-Shortcut

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2000,7 +2000,7 @@ Object AmericaTankPaladin
     UpgradeObject = OCL_AmericanHellfireDrone
     TriggeredBy   = Upgrade_AmericaHellfireDrone
     ConflictsWith = Upgrade_AmericaBattleDrone Upgrade_AmericaScoutDrone
-  End Upgrade_AmericaHallfireDrone
+  End
 
   Behavior = ProductionUpdate ModuleTag_10
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19410,11 +19410,13 @@ Object Boss_TankPaladin
   SelectPortrait         = SAPaladin_L
   ButtonImage            = SAPaladin
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add missing Hellfire Drone upgrade.
+
   UpgradeCameo1 = Upgrade_AmericaBattleDrone
   UpgradeCameo2 = Upgrade_AmericaScoutDrone
-  UpgradeCameo3 = Upgrade_AmericaAdvancedTraining
-  UpgradeCameo4 = Upgrade_AmericaCompositeArmor
-  UpgradeCameo5 = Upgrade_AmericaHallfireDrone
+  UpgradeCameo3 = Upgrade_AmericaHellfireDrone
+  UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
+  UpgradeCameo5 = Upgrade_AmericaCompositeArmor
 
   Draw = W3DTankDraw ModuleTag_01
 
@@ -19585,7 +19587,7 @@ Object Boss_TankPaladin
     UpgradeObject = OCL_AmericanHellfireDrone
     TriggeredBy   = Upgrade_AmericaHellfireDrone
     ConflictsWith = Upgrade_AmericaBattleDrone Upgrade_AmericaScoutDrone
-  End Upgrade_AmericaHallfireDrone
+  End
 
   Behavior = ProductionUpdate ModuleTag_10
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6176,11 +6176,13 @@ Object Lazr_AmericaTankPaladin
   SelectPortrait         = SAPaladin_L
   ButtonImage            = SAPaladin
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix order of upgrade icons.
+
   UpgradeCameo1 = Upgrade_AmericaBattleDrone
   UpgradeCameo2 = Upgrade_AmericaScoutDrone
-  UpgradeCameo3 = Upgrade_AmericaAdvancedTraining
-  UpgradeCameo4 = Upgrade_AmericaCompositeArmor
-  UpgradeCameo5 = Upgrade_AmericaHellfireDrone
+  UpgradeCameo3 = Upgrade_AmericaHellfireDrone
+  UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
+  UpgradeCameo5 = Upgrade_AmericaCompositeArmor
 
   Draw = W3DTankDraw ModuleTag_01
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6647,11 +6647,13 @@ Object SupW_AmericaTankPaladin
   SelectPortrait         = SAPaladin_L
   ButtonImage            = SAPaladin
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix order of upgrade icons.
+
   UpgradeCameo1 = Upgrade_AmericaBattleDrone
   UpgradeCameo2 = Upgrade_AmericaScoutDrone
-  UpgradeCameo3 = Upgrade_AmericaAdvancedTraining
-  UpgradeCameo4 = Upgrade_AmericaCompositeArmor
-  UpgradeCameo5 = Upgrade_AmericaHallfireDrone
+  UpgradeCameo3 = Upgrade_AmericaHellfireDrone
+  UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
+  UpgradeCameo5 = Upgrade_AmericaCompositeArmor
 
   Draw = W3DTankDraw ModuleTag_01
 


### PR DESCRIPTION
ZH 1.04

- The Boss General's Paladin Tank is missing the Hellfire Drone upgrade icon.
- The other World Builder only Paladin tanks have a different order of upgrade icons compared to the vanilla USA Paladin.
- There're some rogue (and misspelled) keywords related to the "Hallfire" Drone floating in the code.

After patch:

- Boss Paladin shows Hellfire Drone upgrade icon
- consistent upgrade order
- clean code
