### PR TITLE
Fix: Non-Vanilla USA Hellfire Drones Use Scout Drone Model

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -142,7 +142,7 @@ https://github.com/commy2/zerohour/issues/80  [IMPROVEMENT][NPROJECT] Air Force 
 https://github.com/commy2/zerohour/issues/78  [MAYBE][NPROJECT]       Spectre Inconsistencies
 https://github.com/commy2/zerohour/issues/77  [DONE][NPROJECT]        Non-Vanilla USA Pilots Are Missing Voice Lines When Garrisoning Buildings
 https://github.com/commy2/zerohour/issues/76  [IMPROVEMENT][NPROJECT] Chem Suit Rangers Are Missing Hit Effects
-https://github.com/commy2/zerohour/issues/75  [IMPROVEMENT][NPROJECT] Some Hellfire Drones Use Scout Drone Model
+https://github.com/commy2/zerohour/issues/75  [DONE][NPROJECT]        Some Hellfire Drones Use Scout Drone Model
 https://github.com/commy2/zerohour/issues/74  [DONE][NPROJECT]        Avenger Turns Chassis When Turret Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/73  [MAYBE][NPROJECT]       Avenger Turret Inconsistencies
 https://github.com/commy2/zerohour/issues/72  [DONE][NPROJECT]        Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6225,16 +6225,18 @@ Object AirF_AmericaVehicleHellfireDrone
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Hellfire Drone model.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     DefaultConditionState
-      Model = AVScoutDr
+      Model = AVHellDrone
       WeaponLaunchBone = PRIMARY WeaponA
     End
 
     ConditionState = REALLYDAMAGED
-      Model = AVScoutDr_d
+      Model = AVHellDrone_d
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5474,16 +5474,18 @@ Object Lazr_AmericaVehicleHellfireDrone
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Hellfire Drone model.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     DefaultConditionState
-      Model = AVScoutDr
+      Model = AVHellDrone
       WeaponLaunchBone = PRIMARY WeaponA
     End
 
     ConditionState = REALLYDAMAGED
-      Model = AVScoutDr_d
+      Model = AVHellDrone_d
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5950,16 +5950,18 @@ Object SupW_AmericaVehicleHellfireDrone
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 11/09/2021 Fix Hellfire Drone model.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     DefaultConditionState
-      Model = AVScoutDr
+      Model = AVHellDrone
       WeaponLaunchBone = PRIMARY WeaponA
     End
 
     ConditionState = REALLYDAMAGED
-      Model = AVScoutDr_d
+      Model = AVHellDrone_d
     End
   End
 


### PR DESCRIPTION
ZH 1.04

- The Hellfire Drone of the Airforce, Super Weapon and Laser Generals use the Scout Drone's model.
- Note that these are World Builder / scripting only units: All Generals use the vanilla USA Hellfire Drone in skirmish, campaign and multiplayer.

After patch:

- The correct models are used for all Hellfire Drones.