### PR TITLE
Fix: Spectre Button, Portrait And Countermeasures Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -137,7 +137,7 @@ https://github.com/commy2/zerohour/issues/85  [MAYBE][NPROJECT]       King Rapto
 https://github.com/commy2/zerohour/issues/84  [MAYBE]                 Air Force General MOAB B2-Bomber Lacks Point Defense Laser
 https://github.com/commy2/zerohour/issues/83  [MAYBE]                 Some Airplane Countermeasures Evasion Rates Are 50% Instead Of 30%
 https://github.com/commy2/zerohour/issues/82  [?]                     B2 Carpet Bomber Has Extremely Tight Turn Radius
-https://github.com/commy2/zerohour/issues/81  [IMPROVEMENT][NPROJECT] Spectre Missing Portrait And Upgrade Icons
+https://github.com/commy2/zerohour/issues/81  [DONE][NPROJECT]        Spectre Missing Portrait And Upgrade Icons
 https://github.com/commy2/zerohour/issues/80  [IMPROVEMENT][NPROJECT] Air Force And Super Weapon Spectre Tooltip Claims 4:00 Cooldown Instead Of True 3:00
 https://github.com/commy2/zerohour/issues/78  [MAYBE][NPROJECT]       Spectre Inconsistencies
 https://github.com/commy2/zerohour/issues/77  [DONE][NPROJECT]        Non-Vanilla USA Pilots Are Missing Voice Lines When Garrisoning Buildings

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -284,13 +284,16 @@ CommandButton Command_A10ThunderboltMissileStrikeFromShortcut
   InvalidCursorName     = GenericInvalid
 End
 
+; Patch104p @bugfix commy2 11/09/2021 Fix Spectre button art.
+; This Spectre lasts as long as the level 2 Spectre, so use the same button.
+
 CommandButton Command_SpectreGunship
   Command           = SPECIAL_POWER
   SpecialPower      = SuperweaponSpectreGunship
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   Science           = SCIENCE_SpectreGunshipSolo ;These will cause the buttons to change icons, nothing more
   TextLabel         = CONTROLBAR:SpectreGunship
-  ButtonImage       = SASpGunship; until Samm makes a new cameo for this...
+  ButtonImage       = SASpGunship2; until Samm makes a new cameo for this...
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipSpectreGunship
   RadiusCursorType  = SPECTREGUNSHIP
@@ -303,7 +306,7 @@ CommandButton Command_SpectreGunshipFromShortcut
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   Science           = SCIENCE_SpectreGunshipSolo ;These will cause the buttons to change icons, nothing more
   TextLabel         = CONTROLBAR:SpectreGunshipFromShortcut
-  ButtonImage       = SASpGunship; until Samm makes a new cameo for this...
+  ButtonImage       = SASpGunship2; until Samm makes a new cameo for this...
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipSpectreGunship
   RadiusCursorType  = SPECTREGUNSHIP
@@ -3325,10 +3328,13 @@ CommandButton Early_Command_PurchaseScienceLeafletDrop
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
+; Patch104p @bugfix commy2 11/09/2021 Fix Spectre button art.
+; This Spectre lasts as long as the level 2 Spectre, so use the same button.
+
 CommandButton Command_PurchaseScienceSpectreGunship
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_SpectreGunshipSolo
-  ButtonImage       = SASpGunship ; awaiting Samm's new cameo textures
+  ButtonImage       = SASpGunship2 ; awaiting Samm's new cameo textures
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -325,7 +325,12 @@ End
 ;--------------------------------
 Object AirF_AmericaJetSpectreGunship1
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add portrait and Countermeasures upgrade icon.
+
   ; *** ART Parameters ***
+  SelectPortrait = SASpGunship_L
+
+  UpgradeCameo1 = Upgrade_AmericaCountermeasures
 
   Draw = W3DOverlordAircraftDraw ModuleTag_01 ; Works with the dependencyModelDraw of the upgrade portable structures
 
@@ -646,7 +651,12 @@ End
 ;--------------------------------
 Object AirF_AmericaJetSpectreGunship2
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add portrait and Countermeasures upgrade icon.
+
   ; *** ART Parameters ***
+  SelectPortrait = SASpGunship2_L
+
+  UpgradeCameo1 = Upgrade_AmericaCountermeasures
 
   Draw = W3DOverlordAircraftDraw ModuleTag_01 ; Works with the dependencyModelDraw of the upgrade portable structures
 
@@ -967,7 +977,12 @@ End
 ;--------------------------------
 Object AirF_AmericaJetSpectreGunship3
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add portrait and Countermeasures upgrade icon.
+
   ; *** ART Parameters ***
+  SelectPortrait = SASpGunship3_L
+
+  UpgradeCameo1 = Upgrade_AmericaCountermeasures
 
   Draw = W3DOverlordAircraftDraw ModuleTag_01 ; Works with the dependencyModelDraw of the upgrade portable structures
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -1,7 +1,12 @@
 ;--------------------------------
 Object AmericaJetSpectreGunship
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add portrait and Countermeasures upgrade icon.
+
   ; *** ART Parameters ***
+  SelectPortrait = SASpGunship2_L
+
+  UpgradeCameo1 = Upgrade_AmericaCountermeasures
 
   Draw = W3DOverlordAircraftDraw ModuleTag_01 ; Works with the dependencyModelDraw of the upgrade portable structures
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -14640,7 +14640,12 @@ End
 ;--------------------------------
 Object Boss_JetSpectreGunship
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add portrait and Countermeasures upgrade icon.
+
   ; *** ART Parameters ***
+  SelectPortrait = SASpGunship2_L
+
+  UpgradeCameo1 = Upgrade_AmericaCountermeasures
 
   Draw = W3DOverlordAircraftDraw ModuleTag_01 ; Works with the dependencyModelDraw of the upgrade portable structures
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -1,7 +1,12 @@
 ;--------------------------------
 Object Lazr_AmericaJetSpectreGunship
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add portrait and Countermeasures upgrade icon.
+
   ; *** ART Parameters ***
+  SelectPortrait = SASpGunship2_L
+
+  UpgradeCameo1 = Upgrade_AmericaCountermeasures
 
   Draw = W3DOverlordAircraftDraw ModuleTag_01 ; Works with the dependencyModelDraw of the upgrade portable structures
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -474,7 +474,12 @@ End
 ;--------------------------------
 Object SupW_AmericaJetSpectreGunship
 
+  ; Patch104p @bugfix commy2 11/09/2021 Add portrait and Countermeasures upgrade icon.
+
   ; *** ART Parameters ***
+  SelectPortrait = SASpGunship2_L
+
+  UpgradeCameo1 = Upgrade_AmericaCountermeasures
 
   Draw = W3DOverlordAircraftDraw ModuleTag_01 ; Works with the dependencyModelDraw of the upgrade portable structures
 


### PR DESCRIPTION
ZH 1.04

- The Spectre is missing a portrait when selected.
- The Spectre also lacks the upgrade icon for Countermeasures.
- The Rank 5 Spectre uses the art of the Level 1 Rank 3 Spectre. However, it lasts as long as the Level 2 Rank 3 Spectre. Therefore the art is misleading.

After patch

- Spectre uses the portrait.
- Spectre has Countermeasures upgrade icon
- Rank 5 Spectre generals power of vanilla USA and Laser General use the Level 2 Spectre art.

Note:

- Rank 3 Level 1: 10 seconds
- Rank 3 Level 2: 15 seconds
- Rank 5 Level 3: 20 seconds
- Rank 5 Full Spectre: 15 seconds