### PR TITLE
Fix: Chem Suit Rangers Are Missing Hit Effects

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -141,7 +141,7 @@ https://github.com/commy2/zerohour/issues/81  [IMPROVEMENT][NPROJECT] Spectre Mi
 https://github.com/commy2/zerohour/issues/80  [IMPROVEMENT][NPROJECT] Air Force And Super Weapon Spectre Tooltip Claims 4:00 Cooldown Instead Of True 3:00
 https://github.com/commy2/zerohour/issues/78  [MAYBE][NPROJECT]       Spectre Inconsistencies
 https://github.com/commy2/zerohour/issues/77  [DONE][NPROJECT]        Non-Vanilla USA Pilots Are Missing Voice Lines When Garrisoning Buildings
-https://github.com/commy2/zerohour/issues/76  [IMPROVEMENT][NPROJECT] Chem Suit Rangers Are Missing Hit Effects
+https://github.com/commy2/zerohour/issues/76  [DONE][NPROJECT]        Chem Suit Rangers Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/75  [IMPROVEMENT][NPROJECT] Some Hellfire Drones Use Scout Drone Model
 https://github.com/commy2/zerohour/issues/74  [DONE][NPROJECT]        Avenger Turns Chassis When Turret Is Aiming At Air Unit
 https://github.com/commy2/zerohour/issues/73  [MAYBE][NPROJECT]       Avenger Turret Inconsistencies

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -3657,9 +3657,9 @@ Object AirF_AmericaInfantryRanger
     DamageFX        = InfantryDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = ChemSuitHumanArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = ChemSuitHumanArmor
+    DamageFX        = InfantryDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Chemical Suits upgrade.
   End
   VisionRange = 100
   ShroudClearingRange = 400

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -869,9 +869,9 @@ Object AmericaInfantryRanger
     DamageFX        = InfantryDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = ChemSuitHumanArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = ChemSuitHumanArmor
+    DamageFX        = InfantryDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Chemical Suits upgrade.
   End
   VisionRange = 100
   ShroudClearingRange = 400

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -16970,9 +16970,9 @@ Object Boss_InfantryRanger
     DamageFX        = InfantryDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = ChemSuitHumanArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = ChemSuitHumanArmor
+    DamageFX        = InfantryDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Chemical Suits upgrade.
   End
   VisionRange = 100
   ShroudClearingRange = 400

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -3227,9 +3227,9 @@ Object Lazr_AmericaInfantryRanger
     DamageFX        = InfantryDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = ChemSuitHumanArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = ChemSuitHumanArmor
+    DamageFX        = InfantryDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Chemical Suits upgrade.
   End
   VisionRange = 100
   ShroudClearingRange = 400

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -3700,9 +3700,9 @@ Object SupW_AmericaInfantryRanger
     DamageFX        = InfantryDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = ChemSuitHumanArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = ChemSuitHumanArmor
+    DamageFX        = InfantryDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Chemical Suits upgrade.
   End
   VisionRange = 100
   ShroudClearingRange = 400


### PR DESCRIPTION
ZH 1.04

- After upgrading the Ranger with Chem Suits, they no longer display a hit effect when damaged. 

After patch:

- The hit effect stays, even after Chem Suits, just like it does on every other American infantry unit.
