### PR TITLE
Fix: Cargo Planes With Countermeasures Are Missing Hit Effects

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -112,7 +112,7 @@ https://github.com/commy2/zerohour/issues/110 [IMPROVEMENT][NPROJECT] Anthrax Be
 https://github.com/commy2/zerohour/issues/109 [IMPROVEMENT][NPROJECT] Some Helixes Missing Napalm Bomb Upgrade Icon
 https://github.com/commy2/zerohour/issues/108 [IMPROVEMENT][NPROJECT] Chinook and Supply Center Upgrade Icons
 https://github.com/commy2/zerohour/issues/107 [IMPROVEMENT][NPROJECT] Pilots Have Misleading Upgrade Icons
-https://github.com/commy2/zerohour/issues/106 [IMPROVEMENT][NPROJECT] Cargo Planes With Countermeasures Are Missing Hit Effects
+https://github.com/commy2/zerohour/issues/106 [DONE][NPROJECT]        Cargo Planes With Countermeasures Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/105 [DONE][NPROJECT]        Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned
 https://github.com/commy2/zerohour/issues/104 [IMPROVEMENT][NPROJECT] China Command Center Missing Radar Upgrade Icon
 https://github.com/commy2/zerohour/issues/103 [DONE][NPROJECT]        Some Special Power Buttons Disappear From Command Center After Mines Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1454,9 +1454,9 @@ Object AirF_AmericaJetB52
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 
@@ -2626,9 +2626,9 @@ Object AirF_AmericaJetCargoPlane
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 
@@ -18177,9 +18177,9 @@ Object AirF_AmericaJetB3
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -1058,9 +1058,9 @@ Object AmericaJetB52
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 
@@ -2435,9 +2435,9 @@ Object AmericaJetCargoPlane
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -816,9 +816,9 @@ Object Lazr_AmericaJetB52
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 
@@ -2194,9 +2194,9 @@ Object Lazr_AmericaJetCargoPlane
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
@@ -91,9 +91,9 @@ Object AmericaJetB3
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -1289,9 +1289,9 @@ Object SupW_AmericaJetB52
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 
@@ -2667,9 +2667,9 @@ Object SupW_AmericaJetCargoPlane
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 
@@ -19120,9 +19120,9 @@ Object SupW_AmericaJetB3
     DamageFX        = TankDamageFX
   End
   ArmorSet
-    Conditions            = PLAYER_UPGRADE
-    Armor                 = CountermeasuresAirplaneArmor
-    DamageFX              = None
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
   End
   CommandSet        = Command_ScriptedTransportDrops
 


### PR DESCRIPTION
ZH 1.04

- After upgrading Countermeasures, the American Cargo planes no longer display a hit effect when damaged.

After patch:

- The hit effect stays, even after Countermeasures, like it does on all the other USA planes.
