### PR TITLE
Fix: Scud Storm Does Not Damage Itself

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -188,7 +188,7 @@ https://github.com/commy2/zerohour/issues/31  [DONE]                  Some Aveng
 https://github.com/commy2/zerohour/issues/30  [DONE][NPROJECT]        Crushing Marauder With Overlord Creates Indestructible Wreck
 https://github.com/commy2/zerohour/issues/29  [DONE][NPROJECT]        GLA Base Defense Hole Sufficient For Player Survival
 https://github.com/commy2/zerohour/issues/28  [MAYBE][NPROJECT]       Demo General Terrorist Does Not Explode When Crushed, Burned Or Blown Up
-https://github.com/commy2/zerohour/issues/27  [IMPROVEMENT][NPROJECT] Scud Storm Does Not Damage Itself
+https://github.com/commy2/zerohour/issues/27  [DONE][NPROJECT]        Scud Storm Does Not Damage Itself
 https://github.com/commy2/zerohour/issues/26  [DONE][NPROJECT]        Saboteur Uses Wrong Art For Sabotage Building-Ability
 https://github.com/commy2/zerohour/issues/25  [NOTRELEVANT][NPROJECT] Boss Tomahawk Launcher Never Drops Scrap
 https://github.com/commy2/zerohour/issues/24  [IMPROVEMENT][NPROJECT] GLA Buildings Don't Create Scrap

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1653,7 +1653,7 @@ Weapon ScudStormDamageWeapon
   WeaponSpeed = 600         ; dist/sec
   FireFX = ScudStormMissileDetonation
   FireOCL = OCL_PoisonFieldLarge  ; So this weapon will do normal damage, and create this object
-  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  RadiusDamageAffects = SELF ALLIES ENEMIES NEUTRALS  ; Patch104p @bugfix commy2 11/09/2021 Fix Scud Storm immune when hitting itself.
   DelayBetweenShots = 0               ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
@@ -1671,7 +1671,7 @@ Weapon ScudStormDamageWeaponUpgraded
   WeaponSpeed = 600         ; dist/sec
   FireFX = ScudStormMissileDetonationUpgraded   ; Patch104p @bugfix Use blue particle effect when missile is upgraded with Anthrax Beta. commy2 27/08/2021
   FireOCL = OCL_PoisonFieldUpgradedLarge  ; So this weapon will do normal damage, and create this object
-  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  RadiusDamageAffects = SELF ALLIES ENEMIES NEUTRALS  ; Patch104p @bugfix commy2 11/09/2021 Fix Scud Storm immune when hitting itself.
   DelayBetweenShots = 0               ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
@@ -6585,7 +6585,7 @@ Weapon Chem_ScudStormDamageWeaponGamma
   WeaponSpeed = 600         ; dist/sec
   FireFX = Chem_ScudStormMissileDetonationGamma   ; Patch104p @bugfix Use pink particle effect when missile is upgraded with Anthrax Gamma. commy2 27/08/2021
   FireOCL = OCL_PoisonFieldGammaLarge  ; So this weapon will do normal damage, and create this object
-  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  RadiusDamageAffects = SELF ALLIES ENEMIES NEUTRALS  ; Patch104p @bugfix commy2 11/09/2021 Fix Scud Storm immune when hitting itself.
   DelayBetweenShots = 0               ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
@@ -7592,7 +7592,7 @@ Weapon Demo_ScudStormDamageWeapon
   DeathType = EXPLODED
   WeaponSpeed = 700         ; dist/sec
   FireFX = Demo_ScudStormMissileDetonation
-  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  RadiusDamageAffects = SELF ALLIES ENEMIES NEUTRALS  ; Patch104p @bugfix commy2 11/09/2021 Fix Scud Storm immune when hitting itself.
   DelayBetweenShots = 0               ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec


### PR DESCRIPTION
ZH 1.04:

- A Scud Storm does not damage itself when fired at its own position. Particle Cannons and Nuke Silos do.

After patch:

- Scud Storm fired at itself damages itself.

Note:

- Itself means literally the same building, not other Scud Storms (same faction or not).