### PR TITLE
Fix: Sub-Factions With Free Unit Science Can't Access Units In Other Factories

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -30,7 +30,7 @@ https://github.com/commy2/zerohour/issues/200 [NOTRELEVANT][NPROJECT] Air Force 
 https://github.com/commy2/zerohour/issues/199 [IMPROVEMENT]           Countermeasures Reduce AA Gun Damage By 37.5% Instead Of The Intended 25% (Adjust text or damage)
 https://github.com/commy2/zerohour/issues/198 [NOTRELEVANT][NPROJECT] Scrapping Up Marauders Twice Quadruples Their Rate Of Fire
 https://github.com/commy2/zerohour/issues/197 [NOTRELEVANT][NPROJECT] Veteran Quad Cannons Double Their Rate Of Fire
-https://github.com/commy2/zerohour/issues/196 [IMPROVEMENT][NPROJECT] Sub-Factions With Free Unit Science Can't Access Units In Other Factories
+https://github.com/commy2/zerohour/issues/196 [DONE][NPROJECT]        Sub-Factions With Free Unit Science Can't Access Units In Other Factories
 https://github.com/commy2/zerohour/issues/195 [DONE]                  Nuke Cannons Start With Neutron Shells
 https://github.com/commy2/zerohour/issues/194 [DONE][NPROJECT]        Patriot Batteries And Laser Turrets Lag When Assisting
 https://github.com/commy2/zerohour/issues/193 [IMPROVEMENT][NPROJECT] Laser Turret Uses Different Laser Model And Sound When Assisting Or Engaging Airborne Targets

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -220,7 +220,7 @@ PlayerTemplate FactionAmericaAirForceGeneral
   PlayableSide      = Yes
   StartMoney        = 0
   PreferredColor    = R:0 G:0 B:255
-  IntrinsicSciences = SCIENCE_AMERICA
+  IntrinsicSciences = SCIENCE_AMERICA SCIENCE_StealthFighter  ; Patch104p @bugfix commy2 12/09/2021 Fix AFG cannot build Stealth Fighters in other Airfields.
   PurchaseScienceCommandSetRank1  = AirF_SCIENCE_AMERICA_CommandSetRank1
   PurchaseScienceCommandSetRank3  = AirF_SCIENCE_AMERICA_CommandSetRank3
   PurchaseScienceCommandSetRank8  = AirF_SCIENCE_AMERICA_CommandSetRank8
@@ -323,7 +323,7 @@ PlayerTemplate FactionChinaNukeGeneral
   PlayableSide      = Yes
   StartMoney        = 0
   PreferredColor    = R:255 G:0 B:0
-  IntrinsicSciences = SCIENCE_CHINA
+  IntrinsicSciences = SCIENCE_CHINA SCIENCE_NukeLauncher  ; Patch104p @bugfix commy2 12/09/2021 Fix Nuke General cannot build Nuke Launchers in other War Factories.
   PurchaseScienceCommandSetRank1 = Nuke_SCIENCE_CHINA_CommandSetRank1
   PurchaseScienceCommandSetRank3 = Nuke_SCIENCE_CHINA_CommandSetRank3
   PurchaseScienceCommandSetRank8 = Nuke_SCIENCE_CHINA_CommandSetRank8
@@ -428,7 +428,7 @@ PlayerTemplate FactionGLAStealthGeneral
   PlayableSide      = Yes
   StartMoney        = 0
   PreferredColor    = R:0 G:255 B:0
-  IntrinsicSciences = SCIENCE_GLA
+  IntrinsicSciences = SCIENCE_GLA SCIENCE_Hijacker  ; Patch104p @bugfix commy2 12/09/2021 Fix Stealth General cannot build Hijackers in other GLA Barracks.
   PurchaseScienceCommandSetRank1 = Slth_SCIENCE_GLA_CommandSetRank1
   PurchaseScienceCommandSetRank3 = Slth_SCIENCE_GLA_CommandSetRank3
   PurchaseScienceCommandSetRank8 = Slth_SCIENCE_GLA_CommandSetRank8


### PR DESCRIPTION
ZH 1.04

- The Stealth General has no way to unlock building Hijackers in a vanilla GLA Barracks.
- The Nuke General has no way to unlock building Nuke Cannons in a vanilla China or Infantry General War Factories.
- The Air Force General has no way to unlock building Stealth Fighters in a non-AFG Air Fields. 

And this bothers me.

After patch:

- Specialized generals can build their science units in captured cross faction factories.