### PR TITLE
Fix: Some Objects In Wrong Faction In World Builder

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -321,10 +321,10 @@ https://github.com/commy2/zerohour/issues/164                         USA05 Tox 
 
 WORLD BUILDER
 
-https://github.com/commy2/zerohour/issues/214 [IMPROVEMENT][NPROJECT] Air Force General Chinook Listed Under Vanilla USA In World Builder
-https://github.com/commy2/zerohour/issues/213 [IMPROVEMENT][NPROJECT] Laser General Hellfire Drone Listed Under Super Weapon General In World Builder
-https://github.com/commy2/zerohour/issues/212 [IMPROVEMENT][NPROJECT] All Bombs Listed Under USA In World Builder
-https://github.com/commy2/zerohour/issues/211 [IMPROVEMENT][NPROJECT] Helix Wreck Props Listed Under USA In World Builder
-https://github.com/commy2/zerohour/issues/79  [IMPROVEMENT][NPROJECT] Spectre Hardpoints Listed Under Normal China In World Builder
-https://github.com/commy2/zerohour/issues/40  [IMPROVEMENT][NPROJECT] Infantry General Gattling Tank Listed Under Tank General In World Builder
-https://github.com/commy2/zerohour/issues/39  [IMPROVEMENT][NPROJECT] Tank General Air Field Listed Under Vanilla China In World Builder
+https://github.com/commy2/zerohour/issues/214 [DONE][NPROJECT]        Air Force General Chinook Listed Under Vanilla USA In World Builder
+https://github.com/commy2/zerohour/issues/213 [DONE][NPROJECT]        Laser General Hellfire Drone Listed Under Super Weapon General In World Builder
+https://github.com/commy2/zerohour/issues/212 [DONE][NPROJECT]        All Bombs Listed Under USA In World Builder
+https://github.com/commy2/zerohour/issues/211 [DONE][NPROJECT]        Helix Wreck Props Listed Under USA In World Builder
+https://github.com/commy2/zerohour/issues/79  [DONE][NPROJECT]        Spectre Hardpoints Listed Under Normal China In World Builder
+https://github.com/commy2/zerohour/issues/40  [DONE][NPROJECT]        Infantry General Gattling Tank Listed Under Tank General In World Builder
+https://github.com/commy2/zerohour/issues/39  [DONE][NPROJECT]        Tank General Air Field Listed Under Vanilla China In World Builder

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -132,7 +132,7 @@ Object AirF_AuroraBomb
   End
 
   ; ***DESIGN parameters ***
-  Side = America
+  Side = AmericaAirForceGeneral ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting     = SYSTEM
   ArmorSet
     Conditions      = None
@@ -17416,7 +17416,7 @@ Object AFG_AmericaVehicleChinook
   ; ***DESIGN parameters ***
   DisplayName         = OBJECT:Chinook
   EditorSorting       = VEHICLE
-  Side                = America
+  Side                = AmericaAirForceGeneral  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   VisionRange         = 300.0
   ShroudClearingRange = 600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -343,7 +343,7 @@ Object SpectreGunshipGattlingCannon
   End
 
   ; ***DESIGN parameters ***
-  Side             = China
+  Side             = America  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting    = SYSTEM
   TransportSlotCount = 1
   WeaponSet
@@ -413,7 +413,7 @@ Object SpectreGunshipHowitzer
   End
 
   ; ***DESIGN parameters ***
-  Side             = China
+  Side             = America  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting    = SYSTEM
   TransportSlotCount = 1
   WeaponSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -1002,7 +1002,7 @@ Object HelixBlades
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Comanche
-  Side = America
+  Side = China  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
 
   ; *** ENGINEERING Parameters ***
   KindOf = PRELOAD IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -471,7 +471,7 @@ Object HelixRubbleHull
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:ComancheHull
-  Side = America
+  Side = China  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
 
   ; *** ENGINEERING Parameters ***
   KindOf = IMMOBILE NO_COLLIDE HULK

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2469,7 +2469,7 @@ Object Infa_ChinaTankGattling
 
   ; ***DESIGN parameters ***
   DisplayName               = OBJECT:GattlingTank
-  Side                      = ChinaTankGeneral
+  Side                      = ChinaInfantryGeneral  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting             = VEHICLE
   TransportSlotCount        = 3            ;how many "slots" we take in a transport (0 == not transportable)
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5496,7 +5496,7 @@ Object Lazr_AmericaVehicleHellfireDrone
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:HellfireDrone
-  Side = AmericaSuperWeaponGeneral
+  Side = AmericaLaserGeneral  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting   = VEHICLE
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17222,7 +17222,7 @@ Object Nuke_ChinaCarpetBomb
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:CarpetBomb
-  Side = America
+  Side = ChinaNukeGeneral ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting   = SYSTEM
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)
   VisionRange = 300.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -10421,7 +10421,7 @@ Object Tank_ChinaAirfield
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Airfield
-  Side             = China
+  Side             = ChinaTankGeneral ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting    = STRUCTURE
   Prerequisites
     Object = Tank_ChinaSupplyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -338,7 +338,7 @@ Object ChinaCarpetBomb
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:CarpetBomb
-  Side = America
+  Side = China  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
   EditorSorting   = SYSTEM
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)
   VisionRange = 300.0


### PR DESCRIPTION
ZH 1.04

- The Air Force General's normal Chinook (not the Combat Chinook) shows up in the World Builder as a vanilla USA unit.
- The Tank General's Airfield is listed under "China" in the World Builder.
- The Laser General's Hellfire Drone appears as Super Weapon General unit in the World Builder.
- The China Carpet Bomber and the Aurora Alphas bombs are all listed under vanilla USA in the World Builder instead of the appropriate (sub-)faction.
- The Infantry General's Gatling Tank (World Builder exclusive unit) is listed under "ChinaTankGeneral" in the World Builder.
- The wreck and blown off rotorblade props of the Helix are listed under the American faction in the world builder.
- The Spectre gatling cannon and howitzer are listed under the China faction instead of the America faction in the world builder.

After patch:

All objects are found under the faction tab one should expect.