### PR TITLE
Fix: Units Sometimes Waste Shots On Wrecks

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
@@ -1,4 +1,4 @@
-; Patch104p @bugfix commy2 09/09/2021 Fix units attacking wrecks.
+; Patch104p @bugfix commy2 09/09/2021 Add UNATTACKABLE to fix units attacking wrecks.
 
 
 ;------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
@@ -1,3 +1,4 @@
+; Patch104p @bugfix commy2 09/09/2021 Fix units attacking wrecks.
 
 
 ;------------------------------------------------------------------------------
@@ -22,7 +23,7 @@ Object GLARocketBuggyFullDebris
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority         = UNIT
-  KindOf                = CAN_CAST_REFLECTIONS
+  KindOf                = CAN_CAST_REFLECTIONS UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -78,7 +79,7 @@ Object GLACombatBikeFullDebris
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority         = UNIT
-  KindOf                = CAN_CAST_REFLECTIONS
+  KindOf                = CAN_CAST_REFLECTIONS UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -130,7 +131,7 @@ Object GLACombatBikeToppledHulk
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority         = UNIT
-  KindOf                = CAN_CAST_REFLECTIONS
+  KindOf                = CAN_CAST_REFLECTIONS UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -1,3 +1,5 @@
+; Patch104p @bugfix commy2 09/09/2021 Fix units attacking wrecks.
+
 Object DeadMicrowaveHulk
 
   ; *** ART Parameters ***
@@ -17,7 +19,7 @@ Object DeadMicrowaveHulk
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -74,7 +76,7 @@ Object AmericaVehicleHumveeDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -556,7 +558,7 @@ Object ChinaVehicleBattleMasterDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -615,7 +617,7 @@ Object ChinaTankOverlordDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -676,7 +678,7 @@ Object ChinaTankDragonDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -736,7 +738,7 @@ Object ChinaVehicleTroopCrawlerDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -788,7 +790,7 @@ Object ChinaVehicleAssaultTroopCrawlerDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -1874,7 +1876,7 @@ Object ChinaVehicleListeningOutpostDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -1,4 +1,4 @@
-; Patch104p @bugfix commy2 09/09/2021 Fix units attacking wrecks.
+; Patch104p @bugfix commy2 09/09/2021 Add UNATTACKABLE to fix units attacking wrecks.
 
 Object DeadMicrowaveHulk
 


### PR DESCRIPTION
ZH 1.04:

- Units will attack certain wrecks.

After patch:

- All wrecks are left alone.

Related: https://github.com/xezon/GeneralsGamePatch/pull/257