### PR TITLE
Change to cheaper texture for BinaryDataStream to potentially cut performance cost

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -297,19 +297,25 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
+; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
+; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
+; Change Segments (20) to save as much as 60% performance impact.
+; Change TilingScalar (0.25) to unstretch the texture.
+
 Object AirF_PatriotBinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream32.tga
+    Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 5                ;The total width of beam; Patch104p: Increase from 4 to 5 to make beam not look as thin
+    InnerBeamWidth = 2                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20; Patch104p: Reduce from 20 to 3 to improve performance
+    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.50                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural); Patch104p: Increase from 0.25 to 0.50 to reduce texture stretching
+    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -308,11 +308,11 @@ Object AirF_PatriotBinaryDataStream
   Draw = W3DLaserDraw ModuleTag_01
     Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2                ;The total width of beam
+    InnerBeamWidth = 2.75             ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
+    Segments = 5                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
     TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1,17 +1,23 @@
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
+; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
+; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
+; Change Segments (20) to save as much as 60% performance impact.
+; Change TilingScalar (0.25) to unstretch the texture.
+
 Object Boss_PatriotBinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream32.tga
+    Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 5                ;The total width of beam; Patch104p: Increase from 4 to 5 to make beam not look as thin
+    InnerBeamWidth = 2                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20; Patch104p: Reduce from 20 to 3 to improve performance
+    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.50                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural); Patch104p: Increase from 0.25 to 0.50 to reduce texture stretching
+    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -10,11 +10,11 @@ Object Boss_PatriotBinaryDataStream
   Draw = W3DLaserDraw ModuleTag_01
     Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2                ;The total width of beam
+    InnerBeamWidth = 2.75             ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
+    Segments = 5                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
     TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -29519,19 +29519,25 @@ Object ChinaMoat
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
+; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
+; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
+; Change Segments (20) to save as much as 60% performance impact.
+; Change TilingScalar (0.25) to unstretch the texture.
+
 Object PatriotBinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream32.tga
+    Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 5                ;The total width of beam; Patch104p: Increase from 4 to 5 to make beam not look as thin
+    InnerBeamWidth = 2                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20; Patch104p: Reduce from 20 to 3 to improve performance
+    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.50                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural); Patch104p: Increase from 0.25 to 0.50 to reduce texture stretching
+    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -29530,11 +29530,11 @@ Object PatriotBinaryDataStream
   Draw = W3DLaserDraw ModuleTag_01
     Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2                ;The total width of beam
+    InnerBeamWidth = 2.75             ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
+    Segments = 5                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
     TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4409,19 +4409,25 @@ Object SupW_ParticleUplinkCannon_OrbitalLaser
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
+; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
+; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
+; Change Segments (20) to save as much as 60% performance impact.
+; Change TilingScalar (0.25) to unstretch the texture.
+
 Object BinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream32.tga
+    Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 5                ;The total width of beam; Patch104p: Increase from 4 to 5 to make beam not look as thin
+    InnerBeamWidth = 2                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20; Patch104p: Reduce from 20 to 3 to improve performance
+    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.50                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural); Patch104p: Increase from 0.25 to 0.50 to reduce texture stretching
+    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4420,11 +4420,11 @@ Object BinaryDataStream
   Draw = W3DLaserDraw ModuleTag_01
     Texture = EXBinaryStream.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2                ;The total width of beam
+    InnerBeamWidth = 2.75             ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
-    Segments = 3                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
+    Segments = 10                     ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
     TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)


### PR DESCRIPTION
Change to cheaper texture for BinaryDataStream to potentially cut performance cost. On my machine I could not observe any performance difference.

Set Patriot stream segment count to 5.
Set Lotus and Hacker segment count to 10.