### PR TITLE
Fixed up Quad Cannon draw code

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16607,11 +16607,14 @@ Object Chem_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch 1.04p @bugfix GeneralCamo 13/09/2021 - Fixed animations, set dust trail to the correct particle, and corrected salvage level 1 to properly use damaged model
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -16626,6 +16629,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -16640,6 +16645,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -16654,6 +16661,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -16667,7 +16676,9 @@ Object Chem_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -16681,7 +16692,9 @@ Object Chem_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -16696,6 +16709,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -16710,6 +16725,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -16724,6 +16741,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -16742,7 +16761,7 @@ Object Chem_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17834,11 +17834,14 @@ Object Demo_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch 1.04p @bugfix GeneralCamo 13/09/2021 - Fixed animations, set dust trail to the correct particle, and corrected salvage level 1 to properly use damaged model
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -17853,6 +17856,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -17867,6 +17872,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -17881,6 +17888,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -17894,7 +17903,9 @@ Object Demo_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -17908,7 +17919,9 @@ Object Demo_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -17923,6 +17936,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -17937,6 +17952,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -17951,6 +17968,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -17969,7 +17988,7 @@ Object Demo_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3054,11 +3054,14 @@ Object GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch 1.04p @bugfix GeneralCamo 13/09/2021 - Fixed animations, set dust trail to the correct particle, and corrected salvage level 1 to properly use damaged model
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -3073,6 +3076,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -3087,6 +3092,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -3101,6 +3108,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -3114,7 +3123,9 @@ Object GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -3128,7 +3139,9 @@ Object GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -3143,6 +3156,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -3157,6 +3172,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -3171,6 +3188,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -3189,7 +3208,7 @@ Object GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18019,11 +18019,14 @@ Object Slth_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch 1.04p @bugfix GeneralCamo 13/09/2021 - Fixed animations, set dust trail to the correct particle, and corrected salvage level 1 to properly use damaged model
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -18038,6 +18041,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -18052,6 +18057,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -18066,6 +18073,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -18079,7 +18088,9 @@ Object Slth_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -18093,7 +18104,9 @@ Object Slth_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -18108,6 +18121,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -18122,6 +18137,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -18136,6 +18153,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -18154,7 +18173,7 @@ Object Slth_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,


### PR DESCRIPTION
- Fixed radar dish animation wasn't showing. ~commy2
- Level 1 salvaged quad cannon now properly uses damaged model
- Corrected dust trail to use the Quad Cannon's particle rather than the Rocket buggy's