### PR TITLE
Fix: Demo General Combat Bike Suicide Button Does Not Work

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -172,7 +172,7 @@ https://github.com/commy2/zerohour/issues/49  [DONE][NPROJECT]        Demo Gener
 https://github.com/commy2/zerohour/issues/48  [MAYBE][NPROJECT]       Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed
 https://github.com/commy2/zerohour/issues/47  [DONE]                  Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided
 https://github.com/commy2/zerohour/issues/46  [DONE][NPROJECT]        Technical Has To Recenter Turret To Suicide
-https://github.com/commy2/zerohour/issues/45  [IMPROVEMENT]           Combat Bike Has Disabled Suicide Ability Button
+https://github.com/commy2/zerohour/issues/45  [DONE]   	              Combat Bike Has Disabled Suicide Ability Button
 https://github.com/commy2/zerohour/issues/44  [MAYBE][NPROJECT]       Terrorist And Bomb Truck Missing Suicide Ability
 https://github.com/commy2/zerohour/issues/43  [DONE][NPROJECT]        Suicide Ability Button Is Placed Inconsistently
 https://github.com/commy2/zerohour/issues/42  [DONE]                  Worker Has Disabled Suicide Button Before Demolitions Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2181,6 +2181,16 @@ End
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
   1  = Command_ScuttleCombatBike
   11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
+  13 = Command_Guard
+  14 = Command_Stop
+End
+
+CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
+  1  = Command_ScuttleCombatBike
+  2  = Command_GLAInfantryJarmenKellSnipeVehicleAttack
+  11 = Command_AttackMove
+  12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17489,29 +17489,46 @@ Object Demo_GLAVehicleCombatBike
   Side                = GLADemolitionGeneral
   EditorSorting       = VEHICLE
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
+
+  ; Patch104p @bugfix commy2 13/09/2021 Fix permanently disabled Suicide ability button.
+
   WeaponSet
     Conditions = None
-    Weapon = PRIMARY NONE
+    Weapon = PRIMARY None
+    Weapon = SECONDARY None
+    Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     Conditions = WEAPON_RIDER2
     Weapon = PRIMARY GLARebelBikerMachineGun
+    Weapon = SECONDARY None
+    Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     Conditions = WEAPON_RIDER3
     Weapon = PRIMARY DEMO_TunnelDefenderBikerRocketWeapon
+    Weapon = SECONDARY None
+    Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     Conditions = WEAPON_RIDER4
     Weapon = PRIMARY GLABikerKellSniperRifle
     Weapon = SECONDARY GLAJarmenKellVehiclePilotSniperRifle
+    Weapon = TERTIARY TerroristSuicideNotARealWeapon
     AutoChooseSources = SECONDARY NONE
+    AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     ;Kill himself so we can use FireWeaponWhenDead to fire the real weapon -- and use UNRESISTABLE
     ;damage to do ini logic for type of death to play -- unresistable for success.
     Conditions = WEAPON_RIDER5
     Weapon = PRIMARY TerroristSuicideWeapon
+    Weapon = SECONDARY None
+    Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    AutoChooseSources = TERTIARY NONE
   End
   ArmorSet
     Conditions      = None
@@ -17690,19 +17707,21 @@ Object Demo_GLAVehicleCombatBike
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
   End
 
+  ; Patch104p @bugfix commy2 13/09/2021 Fix command sets lacking button for Suicide ability.
+
   Behavior = RiderChangeContain ModuleTag_16
     ;A list of each valid rider that is allowed to ride this object. Each rider is
     ;assigned a modelcondition state, a weaponset flag, an object status bit, and
     ;a commandset override. The actual object is hidden inside the container so the
     ;visible rider is fluff. Also riders are deleted (not killed) when the bike is
     ;destroyed, so all deaths must be OCLs on the bike.
-    Rider1 = Demo_GLAInfantryWorker         RIDER1 WEAPON_RIDER1 STATUS_RIDER1 GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
-    Rider2 = Demo_GLAInfantryRebel          RIDER2 WEAPON_RIDER2 STATUS_RIDER2 GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
-    Rider3 = Demo_GLAInfantryTunnelDefender RIDER3 WEAPON_RIDER3 STATUS_RIDER3 GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
-    Rider4 = Demo_GLAInfantryJarmenKell     RIDER4 WEAPON_RIDER4 STATUS_RIDER4 GLAVehicleCombatBikeJarmenKellCommandSet SET_NORMAL
-    Rider5 = Demo_GLAInfantryTerrorist      RIDER5 WEAPON_RIDER5 STATUS_RIDER5 GLAVehicleCombatBikeDefaultCommandSet SET_SLUGGISH
-    Rider6 = Demo_GLAInfantryHijacker       RIDER6 WEAPON_RIDER6 STATUS_RIDER6 GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
-    Rider7 = Demo_GLAInfantrySaboteur       RIDER7 WEAPON_RIDER7 STATUS_RIDER7 GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
+    Rider1 = Demo_GLAInfantryWorker         RIDER1 WEAPON_RIDER1 STATUS_RIDER1 Demo_GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
+    Rider2 = Demo_GLAInfantryRebel          RIDER2 WEAPON_RIDER2 STATUS_RIDER2 Demo_GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
+    Rider3 = Demo_GLAInfantryTunnelDefender RIDER3 WEAPON_RIDER3 STATUS_RIDER3 Demo_GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
+    Rider4 = Demo_GLAInfantryJarmenKell     RIDER4 WEAPON_RIDER4 STATUS_RIDER4 Demo_GLAVehicleCombatBikeJarmenKellCommandSet SET_NORMAL
+    Rider5 = Demo_GLAInfantryTerrorist      RIDER5 WEAPON_RIDER5 STATUS_RIDER5 Demo_GLAVehicleCombatBikeDefaultCommandSet SET_SLUGGISH
+    Rider6 = Demo_GLAInfantryHijacker       RIDER6 WEAPON_RIDER6 STATUS_RIDER6 Demo_GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
+    Rider7 = Demo_GLAInfantrySaboteur       RIDER7 WEAPON_RIDER7 STATUS_RIDER7 Demo_GLAVehicleCombatBikeDefaultCommandSet SET_NORMAL
     ScuttleDelay          = 1500
     ScuttleStatus         = TOPPLED
 
@@ -17802,12 +17821,6 @@ Object Demo_GLAVehicleCombatBike
     RequiresAllTriggers = Yes;
     DeathTypes     = NONE +SUICIDED
   End;
-
-  Behavior = CommandSetUpgrade ModuleTag_23
-    CommandSet = Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
-    TriggeredBy = Demo_Upgrade_SuicideBomb
-  End
-
 
   Geometry = BOX
   GeometryMajorRadius = 11.0


### PR DESCRIPTION
ZH 1.04

- If you have a Demo General Bike, and then upgrade Demolitions, it will gain a Suicide button.
- This button will always be greyed out and not work.
- If you switch Riders, the button will disappear.
- If you build a new bike, it will not have this button, only old ones will have it.
- If you have a Demo General Bike with Jarmen Kell, and then upgrade Demolitions, it will lose the Sniper Attack button...
- Getting Jarmen off the Bike and on again will make the Sniper Attack button show again.

After patch:

- The Suicide ability button will always show.
- It will stay disabled until the Demolitions upgrade has been bought. It will work correctly and suicide the Bike.
- The Sniper Attack button will not disappear.

Drawback:

- The button will show as disabled before the Demolitions upgrade. This is the same as the Worker in 1.04 (though fixed already in this patch by this commit https://github.com/TheSuperHackers/GeneralsGamePatch/pull/161). Best I can do with the interaction of Rider logic and command set upgrades.

Since this is essentially a new feature that changes micromanagement of the dreaded Demo Bikes, I'll mark this as controversial.