### PR TITLE
Fix: China Command Center Missing Radar Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -114,7 +114,7 @@ https://github.com/commy2/zerohour/issues/108 [IMPROVEMENT][NPROJECT] Chinook an
 https://github.com/commy2/zerohour/issues/107 [IMPROVEMENT][NPROJECT] Pilots Have Misleading Upgrade Icons
 https://github.com/commy2/zerohour/issues/106 [DONE][NPROJECT]        Cargo Planes With Countermeasures Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/105 [DONE][NPROJECT]        Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned
-https://github.com/commy2/zerohour/issues/104 [IMPROVEMENT][NPROJECT] China Command Center Missing Radar Upgrade Icon
+https://github.com/commy2/zerohour/issues/104 [DONE][NPROJECT]        China Command Center Missing Radar Upgrade Icon
 https://github.com/commy2/zerohour/issues/103 [DONE][NPROJECT]        Some Special Power Buttons Disappear From Command Center After Mines Upgrade
 https://github.com/commy2/zerohour/issues/102 [DONE][NPROJECT]        Tank Hunter Missing Patriotism Upgrade Icon
 https://github.com/commy2/zerohour/issues/101 [DONE][NPROJECT]        Speaker Tower Lacks Mine Upgrade

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -287,10 +287,14 @@ End
 Object Boss_CommandCenter
 
   ; *** ART Parameters ***
-
-  ; ------------ the main building itself -----------------
   SelectPortrait         = SNComCentr_L
   ButtonImage            = SNComCentr
+
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing Radar upgrade icon.
+
+  UpgradeCameo1 = Upgrade_ChinaRadar
+
+  ; ------------ the main building itself -----------------
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -2929,10 +2929,14 @@ End
 Object ChinaCommandCenter
 
   ; *** ART Parameters ***
-
-  ; ------------ the main building itself -----------------
   SelectPortrait         = SNComCentr_L
   ButtonImage            = SNComCentr
+
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing Radar upgrade icon.
+
+  UpgradeCameo1 = Upgrade_ChinaRadar
+
+  ; ------------ the main building itself -----------------
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -14672,7 +14676,7 @@ Object ChinaNuclearMissileLauncher
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  
+
   Geometry            = BOX
   GeometryMajorRadius = 45.0
   GeometryMinorRadius = 55.0
@@ -19760,7 +19764,7 @@ Object AmericaSupplyCenter
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
-  
+
   Geometry            = BOX
   GeometryMajorRadius = 44.0
   GeometryMinorRadius = 45.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -3187,10 +3187,14 @@ End
 Object Infa_ChinaCommandCenter
 
   ; *** ART Parameters ***
-
-  ; ------------ the main building itself -----------------
   SelectPortrait         = SNComCentr_L
   ButtonImage            = SNComCentr
+
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing Radar upgrade icon.
+
+  UpgradeCameo1 = Upgrade_ChinaRadar
+
+  ; ------------ the main building itself -----------------
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4922,10 +4922,14 @@ End
 Object Nuke_ChinaCommandCenter
 
   ; *** ART Parameters ***
-
-  ; ------------ the main building itself -----------------
   SelectPortrait         = SNComCentr_L
   ButtonImage            = SNComCentr
+
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing Radar upgrade icon.
+
+  UpgradeCameo1 = Upgrade_ChinaRadar
+
+  ; ------------ the main building itself -----------------
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15498,10 +15498,12 @@ End
 Object Tank_ChinaCommandCenter
 
   ; *** ART Parameters ***
-
-  ; ------------ the main building itself -----------------
   SelectPortrait         = SNComCentr_L
   ButtonImage            = SNComCentr
+
+  UpgradeCameo1 = Upgrade_ChinaRadar
+
+  ; ------------ the main building itself -----------------
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; DAY ************************************


### PR DESCRIPTION
ZH 1.04

- The China Command Center has no icon for the Radar upgrade.

After patch:

- The China Command Center has an icon for the Radar upgrade.

Note:

- This does not help the enemy in any way, since the actual model already shows the radar dish.