### PR TITLE
Fix: Chinook And Supply Center Swapped Supply Lines Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -110,7 +110,7 @@ https://github.com/commy2/zerohour/issues/112 [IMPROVEMENT][NPROJECT] Stealth Fa
 https://github.com/commy2/zerohour/issues/111 [DONE][NPROJECT]        Stealth General Saboteur Uses Rebel Death Scream
 https://github.com/commy2/zerohour/issues/110 [IMPROVEMENT][NPROJECT] Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects
 https://github.com/commy2/zerohour/issues/109 [IMPROVEMENT][NPROJECT] Some Helixes Missing Napalm Bomb Upgrade Icon
-https://github.com/commy2/zerohour/issues/108 [IMPROVEMENT][NPROJECT] Chinook and Supply Center Upgrade Icons
+https://github.com/commy2/zerohour/issues/108 [DONE][NPROJECT]        Chinook and Supply Center Upgrade Icons
 https://github.com/commy2/zerohour/issues/107 [IMPROVEMENT][NPROJECT] Pilots Have Misleading Upgrade Icons
 https://github.com/commy2/zerohour/issues/106 [DONE][NPROJECT]        Cargo Planes With Countermeasures Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/105 [DONE][NPROJECT]        Some American And Chinese Units Use GLA Death Scream When Gamma Poisoned

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -13273,7 +13273,8 @@ Object AirF_AmericaSupplyCenter
   ; *** ART Parameters ***
   SelectPortrait         = SASupplyCntr_L
   ButtonImage            = SASupplyCntr
-  UpgradeCameo1          = Upgrade_AmericaSupplyLines
+
+  ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -17332,7 +17333,9 @@ Object AFG_AmericaVehicleChinook
   SelectPortrait         = SAChinook_L
   ButtonImage            = SAChinook
 
-  ;UpgradeCameo1 = Upgrade_AmericaCountermeasures
+  ; Patch104p @bugfix commy2 13/09/2021 Added Supply Lines upgrade icon.
+
+  UpgradeCameo1 = Upgrade_AmericaSupplyLines
   ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
@@ -17568,7 +17571,9 @@ Object AirF_AmericaVehicleChinook
   SelectPortrait         = SAComChinok_L
   ButtonImage            = SAComChinok
 
-  ;UpgradeCameo1 = Upgrade_AmericaCountermeasures
+  ; Patch104p @bugfix commy2 13/09/2021 Added Supply Lines upgrade icon.
+
+  UpgradeCameo1 = Upgrade_AmericaSupplyLines
   ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -2116,8 +2116,9 @@ Object AmericaVehicleChinook
   SelectPortrait         = SAChinook_L
   ButtonImage            = SAChinook
 
-  ;UpgradeCameo1 = Upgrade_AmericaCountermeasures
-  ;UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
+  ; Patch104p @bugfix commy2 13/09/2021 Added Supply Lines upgrade icon.
+
+  UpgradeCameo1 = Upgrade_AmericaSupplyLines
   ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -14672,7 +14672,7 @@ Object ChinaNuclearMissileLauncher
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  
+
   Geometry            = BOX
   GeometryMajorRadius = 45.0
   GeometryMinorRadius = 55.0
@@ -18957,7 +18957,7 @@ Object AmericaSupplyCenter
   SelectPortrait         = SASupplyCntr_L
   ButtonImage            = SASupplyCntr
 
-  UpgradeCameo1 = Upgrade_AmericaSupplyLines
+  ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -19760,7 +19760,7 @@ Object AmericaSupplyCenter
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
-  
+
   Geometry            = BOX
   GeometryMajorRadius = 44.0
   GeometryMinorRadius = 45.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -1874,7 +1874,9 @@ Object Lazr_AmericaVehicleChinook
   SelectPortrait         = SAChinook_L
   ButtonImage            = SAChinook
 
-  ;UpgradeCameo1 = Upgrade_AmericaCountermeasures
+  ; Patch104p @bugfix commy2 13/09/2021 Added Supply Lines upgrade icon.
+
+  UpgradeCameo1 = Upgrade_AmericaSupplyLines
   ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
@@ -12961,7 +12963,9 @@ Object Lazr_AmericaSupplyCenter
   ; *** ART Parameters ***
   SelectPortrait         = SASupplyCntr_L
   ButtonImage            = SASupplyCntr
-  UpgradeCameo1 = Upgrade_AmericaSupplyLines
+
+  ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -2347,7 +2347,9 @@ Object SupW_AmericaVehicleChinook
   SelectPortrait         = SAChinook_L
   ButtonImage            = SAChinook
 
-  ;UpgradeCameo1 = Upgrade_AmericaCountermeasures
+  ; Patch104p @bugfix commy2 13/09/2021 Added Supply Lines upgrade icon.
+
+  UpgradeCameo1 = Upgrade_AmericaSupplyLines
   ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
@@ -12389,7 +12391,7 @@ Object SupW_AmericaSupplyCenter
   SelectPortrait         = SASupplyCntr_L
   ButtonImage            = SASupplyCntr
 
-  UpgradeCameo1 = Upgrade_AmericaSupplyLines
+  ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes


### PR DESCRIPTION
- The Supply Lines upgrade icon should be moved from the Supply Center to the Chinook, because the cash bonus is linked to the Chinook and not the Supply Center: A Chinook collecting on a GLA or China Supply Stash will drop the boosted $660, while a Supply Truck will drop the regular $300 on a USA Supply Center.