### PR TITLE
Fix: Stealth General Fake Arms Dealer Missing Camo Netting Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -106,7 +106,7 @@ https://github.com/commy2/zerohour/issues/116 [MAYBE][NPROJECT]       Tactical N
 https://github.com/commy2/zerohour/issues/115 [DONE][NPROJECT]        Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub Faction Command Centers
 https://github.com/commy2/zerohour/issues/114 [DONE][NPROJECT]        Hitting Battle Bus In Hull Mode Causes Screen Shake
 https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs Cannot Target Stinger Sites
-https://github.com/commy2/zerohour/issues/112 [IMPROVEMENT][NPROJECT] Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon
+https://github.com/commy2/zerohour/issues/112 [DONE][NPROJECT]        Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon
 https://github.com/commy2/zerohour/issues/111 [DONE][NPROJECT]        Stealth General Saboteur Uses Rebel Death Scream
 https://github.com/commy2/zerohour/issues/110 [IMPROVEMENT][NPROJECT] Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects
 https://github.com/commy2/zerohour/issues/109 [IMPROVEMENT][NPROJECT] Some Helixes Missing Napalm Bomb Upgrade Icon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -1791,6 +1791,7 @@ Object Slth_GLABlackMarket
 
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
   UpgradeCameo2 = Upgrade_GLACamoNetting
+
   Draw                = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -6612,12 +6613,13 @@ End
 ;------------------------------------------------------------------------------
 Object Slth_GLAPalace
 
-  UpgradeCameo1 = Upgrade_GLAFortifiedStructure
-  UpgradeCameo2 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUPalace_L
   ButtonImage            = SUPalace
+
+  UpgradeCameo1 = Upgrade_GLAFortifiedStructure
+  UpgradeCameo2 = Upgrade_GLACamoNetting
+
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
 
@@ -7435,14 +7437,12 @@ End
 ;------------------------------------------------------------------------------
 Object Slth_GLASupplyStash
 
-  UpgradeCameo1 = Upgrade_GLAFortifiedStructure
-  UpgradeCameo2 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUSupplyCenter_L
   ButtonImage            = SUSupplyCenter
 
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
+  UpgradeCameo2 = Upgrade_GLACamoNetting
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -8143,14 +8143,12 @@ End
 ;------------------------------------------------------------------------------
 Object Slth_FakeGLASupplyStash
 
-  UpgradeCameo1 = Upgrade_GLAFortifiedStructure
-  UpgradeCameo2 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUSupplyCenter_L
   ButtonImage            = SUSupplyCenter
 
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
+  UpgradeCameo2 = Upgrade_GLACamoNetting
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -8805,14 +8803,12 @@ End
 ;GLA Barracks
 Object Slth_GLABarracks
 
-  UpgradeCameo1 = Upgrade_GLAFortifiedStructure
-  UpgradeCameo2 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUBarracks_L
   ButtonImage            = SUBarracks
 
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
+  UpgradeCameo2 = Upgrade_GLACamoNetting
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -9499,14 +9495,12 @@ End
 ;Fake GLA Barracks
 Object Slth_FakeGLABarracks
 
-  UpgradeCameo1 = Upgrade_GLAFortifiedStructure
-  UpgradeCameo2 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUBarracks_L
   ButtonImage            = SUBarracks
 
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
+  UpgradeCameo2 = Upgrade_GLACamoNetting
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -10232,14 +10226,12 @@ End
 ;GLA Arms Dealer
 Object Slth_GLAArmsDealer
 
-  UpgradeCameo1 = Upgrade_GLAFortifiedStructure
-  UpgradeCameo2 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUArmsDealer_L
   ButtonImage            = SUArmsDealer
 
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
+  UpgradeCameo2 = Upgrade_GLACamoNetting
 
   ; ----------------- Main Building -------------------
   Draw = W3DModelDraw ModuleTag_01
@@ -11154,13 +11146,14 @@ End
 ;GLA Arms Dealer
 Object Slth_FakeGLAArmsDealer
 
-  UpgradeCameo1 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUArmsDealer_L
   ButtonImage            = SUArmsDealer
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing Camo Netting upgrade icon.
+
   UpgradeCameo1 = Upgrade_GLAFortifiedStructure
+  UpgradeCameo2 = Upgrade_GLACamoNetting
 
   ; ----------------- Main Building -------------------
   Draw = W3DModelDraw ModuleTag_01


### PR DESCRIPTION
ZH 1.04

- The Stealth General's Fake Arms Dealer has no upgrade icon for Camo Netting, even though the real Arms Dealer has.

After patch:

- There is no cheap way for the enemy to tell fake and real Arms Dealer apart.

Controversial? May change some tactics, but this is a really stupid detail if you ask me. Unfair to the Stealth at worst.