### PR TITLE
Fix: Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -108,7 +108,7 @@ https://github.com/commy2/zerohour/issues/114 [DONE][NPROJECT]        Hitting Ba
 https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs Cannot Target Stinger Sites
 https://github.com/commy2/zerohour/issues/112 [IMPROVEMENT][NPROJECT] Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon
 https://github.com/commy2/zerohour/issues/111 [DONE][NPROJECT]        Stealth General Saboteur Uses Rebel Death Scream
-https://github.com/commy2/zerohour/issues/110 [IMPROVEMENT][NPROJECT] Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects
+https://github.com/commy2/zerohour/issues/110 [DONE][NPROJECT]        Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects
 https://github.com/commy2/zerohour/issues/109 [IMPROVEMENT][NPROJECT] Some Helixes Missing Napalm Bomb Upgrade Icon
 https://github.com/commy2/zerohour/issues/108 [IMPROVEMENT][NPROJECT] Chinook and Supply Center Upgrade Icons
 https://github.com/commy2/zerohour/issues/107 [IMPROVEMENT][NPROJECT] Pilots Have Misleading Upgrade Icons

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -4635,6 +4635,10 @@ Object Boss_ScudStorm
   SelectPortrait         = SUScudStorm_L
   ButtonImage            = SUScudStorm
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
+  UpgradeCameo1 = Upgrade_GLAAnthraxBeta
+
   ; Patch104p @bugfix commy2 27/08/2021 Moved Scud Storm weapon to secondary slot to prevent Scud-bug exploit.
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -3238,6 +3238,10 @@ Object Chem_GLAScudStorm
   SelectPortrait         = SUScudStorm_L
   ButtonImage            = SUScudStorm
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
+
+  UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
+
   ; Patch104p @bugfix commy2 27/08/2021 Moved Scud Storm weapon to secondary slot to prevent Scud-bug exploit.
   ; Patch104p @bugfix commy2 27/08/2021 Use blue goo by default, since this Scud starts with Anthrax Beta missiles.
 
@@ -5497,8 +5501,10 @@ Object Chem_GLAStingerSite
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
+
   UpgradeCameo1          = Upgrade_GLAAPRockets
-  ;UpgradeCameo2          = Upgrade_GLACamoNetting
+  UpgradeCameo2          = Chem_Upgrade_GLAAnthraxGamma
   ;UpgradeCameo3          = NONE
   ;UpgradeCameo4          = NONE
   ;UpgradeCameo5          = NONE
@@ -12126,8 +12132,10 @@ Object Chem_GLAInfantryTunnelDefender
   SelectPortrait         = SURPG_L
   ButtonImage            = SURPG
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
+
   UpgradeCameo1 = Upgrade_GLAAPRockets
-  ;UpgradeCameo2 = NONE
+  UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -15125,11 +15133,13 @@ Object Chem_GLATankScorpion
   SelectPortrait         = SUScorpion_L
   ButtonImage            = SUScorpion
 
+  ; Patch104p @bugfix commy2 13/09/2021 Rearrange upgrade icons for consistency with other units.
+
   UpgradeCameo1 = Upgrade_GLAScorpionRocket
   UpgradeCameo2 = Upgrade_GLAAPRockets
   UpgradeCameo3 = Upgrade_GLAToxinShells
-  UpgradeCameo4 = Upgrade_GLAJunkRepair
-  UpgradeCameo5 = Chem_Upgrade_GLAAnthraxGamma
+  UpgradeCameo4 = Chem_Upgrade_GLAAnthraxGamma
+  UpgradeCameo5 = Upgrade_GLAJunkRepair
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -17336,10 +17346,12 @@ Object Chem_GLAVehicleBombTruck
   SelectPortrait         = SUBombTruck_L
   ButtonImage            = SUBombTruck
 
-  UpgradeCameo1 = Upgrade_GLABombTruckBioBomb
-  UpgradeCameo2 = Upgrade_GLAJunkRepair
+  ; Patch104p @bugfix commy2 13/09/2021 Rearrange upgrade icons for consistency with other units.
+
+  ;UpgradeCameo1 = Upgrade_GLABombTruckHighExplosiveBomb
+  UpgradeCameo2 = Upgrade_GLABombTruckBioBomb
   UpgradeCameo3 = Chem_Upgrade_GLAAnthraxGamma
-  ;UpgradeCameo4 = NONE
+  UpgradeCameo4 = Upgrade_GLAJunkRepair
   ;UpgradeCameo5 = NONE
 
 
@@ -18849,9 +18861,11 @@ Object Chem_GLATankMarauder
   SelectPortrait         = SUMarauder_L
   ButtonImage            = SUMarauder
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
+
   UpgradeCameo1 = Upgrade_GLAToxinShells
-  UpgradeCameo2 = Upgrade_GLAJunkRepair
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16277,11 +16277,13 @@ Object Demo_GLATankScorpion
   SelectPortrait         = SUScorpion_L
   ButtonImage            = SUScorpion
 
+  ; Patch104p @bugfix commy2 13/09/2021 Rearrange upgrade icons for consistency with other units.
+
   UpgradeCameo1 = Upgrade_GLAScorpionRocket
   UpgradeCameo2 = Upgrade_GLAAPRockets
-  UpgradeCameo3 = Upgrade_GLAJunkRepair
-  UpgradeCameo4 = Demo_Upgrade_SuicideBomb
-  ;UpgradeCameo5 = NONE
+  ;UpgradeCameo3 = Upgrade_GLAToxinShells
+  UpgradeCameo4 = Demo_Upgrade_SuicideBomb ;Upgrade_GLAAnthraxBeta
+  UpgradeCameo5 = Upgrade_GLAJunkRepair
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -18181,9 +18183,11 @@ Object Demo_GLAVehicleToxinTruck
   SelectPortrait         = SUToxinTractor_L
   ButtonImage            = SUToxinTractor
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
-  UpgradeCameo2 = Demo_Upgrade_SuicideBomb
-  ;UpgradeCameo3 = NONE
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
+  UpgradeCameo1 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo2 = Upgrade_GLAJunkRepair
+  UpgradeCameo3 = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
@@ -18642,10 +18646,12 @@ Object Demo_GLAVehicleBombTruck
   SelectPortrait         = SUBombTruck_L
   ButtonImage            = SUBombTruck
 
+  ; Patch104p @bugfix commy2 13/09/2021 Rearrange upgrade icons for consistency with other units.
+
   UpgradeCameo1 = Upgrade_GLABombTruckHighExplosiveBomb
-  UpgradeCameo2 = Upgrade_GLAJunkRepair
+  ;UpgradeCameo2 = Upgrade_GLABombTruckBioBomb
   UpgradeCameo3 = Demo_Upgrade_SuicideBomb
-  ;UpgradeCameo4 = NONE
+  UpgradeCameo4 = Upgrade_GLAJunkRepair
   ;UpgradeCameo5 = NONE
 
 
@@ -20240,10 +20246,12 @@ Object Demo_GLATankMarauder
   SelectPortrait         = SUMarauder_L
   ButtonImage            = SUMarauder
 
-  UpgradeCameo1 = Upgrade_GLAJunkRepair
-  UpgradeCameo2 = Demo_Upgrade_SuicideBomb
-  ;UpgradeCameo3 = NONE
-  ;UpgradeCameo4 = NONE
+  ; Patch104p @bugfix commy2 13/09/2021 Rearrange upgrade icons for consistency with other units.
+
+  ;UpgradeCameo1 = Upgrade_GLAToxinShells
+  ;UpgradeCameo2 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
+  UpgradeCameo4 = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo5 = NONE
 
   Draw = W3DTankDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -495,8 +495,11 @@ Object GC_Chem_GLAStingerSite
   ; *** ART Parameters ***
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
+
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
+
   UpgradeCameo1          = Upgrade_GLAAPRockets
-  ;UpgradeCameo2          = Upgrade_GLACamoNetting
+  UpgradeCameo2          = Chem_Upgrade_GLAAnthraxGamma
   ;UpgradeCameo3          = NONE
   ;UpgradeCameo4          = NONE
   ;UpgradeCameo5          = NONE
@@ -5433,6 +5436,10 @@ Object GC_Chem_GLAScudStorm
   ; *** ART Parameters ***
   SelectPortrait         = SUScudStorm_L
   ButtonImage            = SUScudStorm
+
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
+
+  UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
 
   ; Patch104p @bugfix commy2 27/08/2021 Moved Scud Storm weapon to secondary slot to prevent Scud-bug exploit.
   ; Patch104p @bugfix commy2 27/08/2021 Use blue goo by default, since this Scud starts with Anthrax Beta missiles.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -708,8 +708,11 @@ Object GC_Chem_GLAInfantryTunnelDefender
   SelectPortrait         = SUToxinRPG_L
   ButtonImage            = SUToxinRPG
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
+
   UpgradeCameo1 = Upgrade_GLAAPRockets
-;  UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
+  UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -1816,10 +1819,12 @@ Object GC_Chem_GLAVehicleBombTruck
   SelectPortrait         = SUBombTruck_L
   ButtonImage            = SUBombTruck
 
-  UpgradeCameo1 = Upgrade_GLABombTruckHighExplosiveBomb
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma and remove unavailable HE upgrade icon.
+
+  ;UpgradeCameo1 = Upgrade_GLABombTruckHighExplosiveBomb
   UpgradeCameo2 = Upgrade_GLABombTruckBioBomb
-  UpgradeCameo3 = Upgrade_GLAJunkRepair
-  ;UpgradeCameo4 = NONE
+  UpgradeCameo3 = Chem_Upgrade_GLAAnthraxGamma
+  UpgradeCameo4 = Upgrade_GLAJunkRepair
   ;UpgradeCameo5 = NONE
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -5780,6 +5780,10 @@ Object GC_Slth_GLAScudStorm
   SelectPortrait         = SUScudStorm_L
   ButtonImage            = SUScudStorm
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
+  UpgradeCameo1 = Upgrade_GLAAnthraxBeta
+
   ; Patch104p @bugfix commy2 27/08/2021 Moved Scud Storm weapon to secondary slot to prevent Scud-bug exploit.
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6,11 +6,13 @@ Object GLATankScorpion
   SelectPortrait         = SUScorpion_L
   ButtonImage            = SUScorpion
 
+  ; Patch104p @bugfix commy2 13/09/2021 Rearrange upgrade icons for consistency with other units.
+
   UpgradeCameo1 = Upgrade_GLAScorpionRocket
   UpgradeCameo2 = Upgrade_GLAAPRockets
   UpgradeCameo3 = Upgrade_GLAToxinShells
-  UpgradeCameo4 = Upgrade_GLAJunkRepair
-  UpgradeCameo5 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo4 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo5 = Upgrade_GLAJunkRepair
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -3781,10 +3783,12 @@ Object GLAVehicleBombTruck
   SelectPortrait         = SUBombTruck_L
   ButtonImage            = SUBombTruck
 
+  ; Patch104p @bugfix commy2 13/09/2021 Rearrange upgrade icons for consistency with other units.
+
   UpgradeCameo1 = Upgrade_GLABombTruckHighExplosiveBomb
   UpgradeCameo2 = Upgrade_GLABombTruckBioBomb
-  UpgradeCameo3 = Upgrade_GLAJunkRepair
-  UpgradeCameo4 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo3 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo4 = Upgrade_GLAJunkRepair
   ;UpgradeCameo5 = NONE
 
 
@@ -5608,9 +5612,11 @@ Object GLATankMarauder
   SelectPortrait         = SUMarauder_L
   ButtonImage            = SUMarauder
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
   UpgradeCameo1 = Upgrade_GLAToxinShells
-  UpgradeCameo2 = Upgrade_GLAJunkRepair
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo2 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -3274,11 +3274,14 @@ End
 ;------------------------------------------------------------------------------
 Object Slth_GLAScudStorm
 
-  UpgradeCameo1 = Upgrade_GLACamoNetting
-
   ; *** ART Parameters ***
   SelectPortrait         = SUScudStorm_L
   ButtonImage            = SUScudStorm
+
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
+  UpgradeCameo1 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo2 = Upgrade_GLACamoNetting
 
   ; Patch104p @bugfix commy2 27/08/2021 Moved Scud Storm weapon to secondary slot to prevent Scud-bug exploit.
 
@@ -16607,11 +16610,13 @@ Object Slth_GLATankScorpion
   SelectPortrait         = SUScorpion_L
   ButtonImage            = SUScorpion
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
   UpgradeCameo1 = Upgrade_GLAScorpionRocket
   UpgradeCameo2 = Upgrade_GLAAPRockets
   UpgradeCameo3 = Upgrade_GLAToxinShells
-  UpgradeCameo4 = Upgrade_GLAJunkRepair
-  ;UpgradeCameo5 = NONE
+  UpgradeCameo4 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo5 = Upgrade_GLAJunkRepair
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -18746,10 +18751,12 @@ Object Slth_GLAVehicleBombTruck
   SelectPortrait         = SUBombTruck_L
   ButtonImage            = SUBombTruck
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
   UpgradeCameo1 = Upgrade_GLABombTruckHighExplosiveBomb
   UpgradeCameo2 = Upgrade_GLABombTruckBioBomb
-  UpgradeCameo3 = Upgrade_GLAJunkRepair
-  ;UpgradeCameo4 = NONE
+  UpgradeCameo3 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo4 = Upgrade_GLAJunkRepair
   ;UpgradeCameo5 = NONE
 
 
@@ -20365,9 +20372,11 @@ Object Slth_GLATankMarauder
   SelectPortrait         = SUMarauder_L
   ButtonImage            = SUMarauder
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
+
   UpgradeCameo1 = Upgrade_GLAToxinShells
-  UpgradeCameo2 = Upgrade_GLAJunkRepair
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo2 = Upgrade_GLAAnthraxBeta
+  UpgradeCameo3 = Upgrade_GLAJunkRepair
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 


### PR DESCRIPTION
ZH 1.04

- A lot of units and buildings benefit from the Anthrax Beta and Anthrax Gamma upgrade, but do not display the respective upgrade icon.
- Sometimes the upgrade icon order is inconsistent with other units or the same unit of another sub-faction.

After patch:

- The Anthrax upgrade icons are where they should be.
