### PR TITLE
Testing Minigunner Range Penalty Hanfield Edition

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15523,6 +15523,7 @@ Object Boss_VehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15526,6 +15526,10 @@ Object Boss_VehicleHelix
     WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
+  Behavior = WeaponBonusUpgrade ModuleTag_30
+    TriggeredBy = Upgrade_ChinaHelixBattleBunker
+  End
+
   Behavior = SpecialAbility ModuleTag_32
     SpecialPowerTemplate = SpecialAbilityHelixNapalmBomb
     UpdateModuleStartsAttack = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15523,7 +15523,7 @@ Object Boss_VehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
-    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -256,6 +256,7 @@ Object ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -256,7 +256,7 @@ Object ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
-    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -259,6 +259,10 @@ Object ChinaVehicleHelix
     WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
+  Behavior = WeaponBonusUpgrade ModuleTag_30
+    TriggeredBy = Upgrade_ChinaHelixBattleBunker
+  End
+
   Behavior = SpecialAbility ModuleTag_32
     SpecialPowerTemplate = SpecialAbilityHelixNapalmBomb
     UpdateModuleStartsAttack = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16002,7 +16002,7 @@ Object Infa_ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
-    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
   ;--------------------------
 
@@ -16139,7 +16139,7 @@ Object Infa_ChinaHelixBattleBunker
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = Yes
-    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
   Behavior             = DestroyDie ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16002,6 +16002,7 @@ Object Infa_ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
   End
   ;--------------------------
 
@@ -16138,6 +16139,7 @@ Object Infa_ChinaHelixBattleBunker
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = Yes
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
   End
 
   Behavior             = DestroyDie ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16004,6 +16004,10 @@ Object Infa_ChinaVehicleHelix
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
     WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
+
+  Behavior = WeaponBonusUpgrade ModuleTag_30
+    TriggeredBy = Upgrade_Infa_ChinaHelixBattleBunker
+  End
   ;--------------------------
 
   Behavior = SpecialAbility ModuleTag_32
@@ -16140,6 +16144,10 @@ Object Infa_ChinaHelixBattleBunker
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = Yes
     WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
+  End
+
+  Behavior = WeaponBonusUpgrade ModuleTag_30
+    TriggeredBy = Upgrade_Infa_ChinaHelixBattleBunker
   End
 
   Behavior             = DestroyDie ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -530,6 +530,7 @@ Object Nuke_ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -530,7 +530,7 @@ Object Nuke_ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
-    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -533,6 +533,10 @@ Object Nuke_ChinaVehicleHelix
     WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
+  Behavior = WeaponBonusUpgrade ModuleTag_30
+    TriggeredBy = Upgrade_ChinaHelixBattleBunker
+  End
+
   Behavior = SpecialAbility ModuleTag_32
     SpecialPowerTemplate = Nuke_SpecialAbilityHelixNukeBomb
     UpdateModuleStartsAttack = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -258,7 +258,7 @@ Object Tank_ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
-    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -258,6 +258,7 @@ Object Tank_ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
     ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
+    WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
   End
 
   Behavior = SpecialAbility ModuleTag_32

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -261,6 +261,10 @@ Object Tank_ChinaVehicleHelix
     WeaponBonusPassedToPassengers = Yes ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   End
 
+  Behavior = WeaponBonusUpgrade ModuleTag_30
+    TriggeredBy = Upgrade_ChinaHelixBattleBunker
+  End
+
   Behavior = SpecialAbility ModuleTag_32
     SpecialPowerTemplate = SpecialAbilityHelixNapalmBomb
     UpdateModuleStartsAttack = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6264,7 +6264,7 @@ Weapon Infa_MiniGunnerGun
   ContinuousFireCoast   = 1000 ; msec we can coast without firing before we lose Continuous Fire
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
-  WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
+  ;WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
   AntiAirborneVehicle   = No
   AntiAirborneInfantry  = No
   AntiGround = Yes
@@ -6291,7 +6291,8 @@ Weapon Infa_MiniGunnerGunAir
   ContinuousFireCoast   = 1000 ; msec we can coast without firing before we lose Continuous Fire
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
-  WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
+  ;WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
+  WeaponBonus           = PLAYER_UPGRADE RANGE 35%  ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = Yes
   AntiGround            = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6292,7 +6292,7 @@ Weapon Infa_MiniGunnerGunAir
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
   ;WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
-  WeaponBonus           = PLAYER_UPGRADE RANGE 35%  ; Patch104p @bugfix commy2 14/09/2021 Remove range bonus from Minigunner inside Helix.
+  WeaponBonus           = PLAYER_UPGRADE RANGE 77%  ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner when inside Helix.
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = Yes
   AntiGround            = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6292,7 +6292,7 @@ Weapon Infa_MiniGunnerGunAir
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
   ;WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
-  WeaponBonus           = PLAYER_UPGRADE RANGE 77%  ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner when inside Helix.
+  WeaponBonus           = PLAYER_UPGRADE RANGE 77%  ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets when inside Helix.
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = Yes
   AntiGround            = No


### PR DESCRIPTION
This pull request introduces a series of modifications and bug fixes across several files within the `Patch104pZH` directory. The changes primarily focus on the `Helix` vehicle and its interaction with passengers, specifically regarding weapon bonuses and their effects on airborne targets. Below are the detailed changes:

#### 1. Modifications to `BossGeneral.ini`
- **Path**: `Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini`
  - **Lines Modified**: 15523-15532
  - **Changes**:
    - Added `WeaponBonusPassedToPassengers = Yes` to ensure that the weapon bonuses are passed to passengers inside the `Boss_VehicleHelix`.
    - Introduced a new `Behavior` module `WeaponBonusUpgrade` triggered by `Upgrade_ChinaHelixBattleBunker`.

#### 2. Modifications to `ChinaAir.ini`
- **Path**: `Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini`
  - **Lines Modified**: 256-265
  - **Changes**:
    - Added `WeaponBonusPassedToPassengers = Yes` to ensure that the weapon bonuses are passed to passengers inside the `ChinaVehicleHelix`.
    - Introduced a new `Behavior` module `WeaponBonusUpgrade` triggered by `Upgrade_ChinaHelixBattleBunker`.

#### 3. Modifications to `InfantryGeneral.ini`
- **Path**: `Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini`
  - **Lines Modified**: 16002-16012, 16138-16153
  - **Changes**:
    - Added `WeaponBonusPassedToPassengers = Yes` to ensure that the weapon bonuses are passed to passengers inside the `Infa_ChinaVehicleHelix` and `Infa_ChinaHelixBattleBunker`.
    - Introduced a new `Behavior` module `WeaponBonusUpgrade` triggered by `Upgrade_Infa_ChinaHelixBattleBunker`.

#### 4. Modifications to `NukeGeneral.ini`
- **Path**: `Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini`
  - **Lines Modified**: 530-540
  - **Changes**:
    - Added `WeaponBonusPassedToPassengers = Yes` to ensure that the weapon bonuses are passed to passengers inside the `Nuke_ChinaVehicleHelix`.
    - Introduced a new `Behavior` module `WeaponBonusUpgrade` triggered by `Upgrade_ChinaHelixBattleBunker`.

#### 5. Modifications to `TankGeneral.ini`
- **Path**: `Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini`
  - **Lines Modified**: 258-268
  - **Changes**:
    - Added `WeaponBonusPassedToPassengers = Yes` to ensure that the weapon bonuses are passed to passengers inside the `Tank_ChinaVehicleHelix`.
    - Introduced a new `Behavior` module `WeaponBonusUpgrade` triggered by `Upgrade_ChinaHelixBattleBunker`.

#### 6. Modifications to `Weapon.ini`
- **Path**: `Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini`
  - **Lines Modified**: 6264-6270, 6291-6298
  - **Changes**:
    - Commented out the `WeaponBonus` line for `PLAYER_UPGRADE DAMAGE 125%` for both `Infa_MiniGunnerGun` and `Infa_MiniGunnerGunAir`.
    - Added a new `WeaponBonus` for `PLAYER_UPGRADE RANGE 77%` to remove the garrisoned range bonus from `Minigunner` versus airborne targets when inside the `Helix`.

### Summary
These changes aim to improve the gameplay mechanics by ensuring the proper application of weapon bonuses to passengers in various `Helix` vehicles across different general types. Additionally, bug fixes related to weapon upgrades and range bonuses have been addressed to enhance the overall balance and functionality.

