### PR TITLE
Fix: Quad Cannon Scrap One Does Not Use Damage Model

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16617,6 +16617,8 @@ Object Chem_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 16/09/2021 Fix unit not using damaged model when scrapped up once.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -16677,7 +16679,7 @@ Object Chem_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -16691,7 +16693,7 @@ Object Chem_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17849,6 +17849,8 @@ Object Demo_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 16/09/2021 Fix unit not using damaged model when scrapped up once.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -17909,7 +17911,7 @@ Object Demo_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -17923,7 +17925,7 @@ Object Demo_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2314,6 +2314,8 @@ Object GC_Chem_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 16/09/2021 Fix unit not using damaged model when scrapped up once.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -2374,7 +2376,7 @@ Object GC_Chem_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -2388,7 +2390,7 @@ Object GC_Chem_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -6552,6 +6552,8 @@ Object GC_Slth_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 16/09/2021 Fix unit not using damaged model when scrapped up once.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -6624,7 +6626,7 @@ Object GC_Slth_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -6641,7 +6643,7 @@ Object GC_Slth_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3056,6 +3056,8 @@ Object GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 16/09/2021 Fix unit not using damaged model when scrapped up once.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -3116,7 +3118,7 @@ Object GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -3130,7 +3132,7 @@ Object GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18017,6 +18017,8 @@ Object Slth_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 16/09/2021 Fix unit not using damaged model when scrapped up once.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -18077,7 +18079,7 @@ Object Slth_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -18091,7 +18093,7 @@ Object Slth_GLAVehicleQuadCannon
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
-      Model = UVQuadCann
+      Model = UVQuadCann_D
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS


### PR DESCRIPTION
ref: #340

ZH 1.04

- When scrapped up once, the Quad Cannon never uses the damaged model.

After patch:

- The Quad Cannon uses the damaged model when appropriate, no matter how many scraps it picked up.