### PR TITLE
Change: Enable Quad Cannon Radar Dish Animation

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16617,11 +16617,15 @@ Object Chem_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add radar dish animation.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -16636,6 +16640,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -16650,6 +16656,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -16664,6 +16672,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -16678,6 +16688,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -16692,6 +16704,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -16706,6 +16720,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -16720,6 +16736,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -16734,6 +16752,8 @@ Object Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17849,11 +17849,15 @@ Object Demo_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add radar dish animation.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -17868,6 +17872,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -17882,6 +17888,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -17896,6 +17904,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -17910,6 +17920,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -17924,6 +17936,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -17938,6 +17952,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -17952,6 +17968,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -17966,6 +17984,8 @@ Object Demo_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2314,11 +2314,15 @@ Object GC_Chem_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add radar dish animation.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -2333,6 +2337,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -2347,6 +2353,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -2361,6 +2369,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -2375,6 +2385,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -2389,6 +2401,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -2403,6 +2417,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -2417,6 +2433,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -2431,6 +2449,8 @@ Object GC_Chem_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -6552,11 +6552,15 @@ Object GC_Slth_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add radar dish animation.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -6574,6 +6578,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -6591,6 +6597,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -6608,6 +6616,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -6625,6 +6635,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -6642,6 +6654,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -6659,6 +6673,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -6676,6 +6692,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -6693,6 +6711,8 @@ Object GC_Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3056,11 +3056,15 @@ Object GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add radar dish animation.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -3075,6 +3079,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -3089,6 +3095,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -3103,6 +3111,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -3117,6 +3127,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -3131,6 +3143,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -3145,6 +3159,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -3159,6 +3175,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -3173,6 +3191,8 @@ Object GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18017,11 +18017,15 @@ Object Slth_GLAVehicleQuadCannon
   ;UpgradeCameo4 = XXX
   ;UpgradeCameo5 = XXX
 
+  ; Patch104p @bugfix commy2 13/09/2021 Add radar dish animation.
+
   Draw = W3DTankTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
     ConditionState = NONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -18036,6 +18040,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -18050,6 +18056,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRET
       TurretPitch = TURRETEL
       WeaponFireFXBone  = PRIMARY   BarrelMS
@@ -18064,6 +18072,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -18078,6 +18088,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE REALLYDAMAGED
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -18092,6 +18104,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVQuadCann
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP01
       TurretPitch = TURRETEL01
       WeaponFireFXBone  = PRIMARY   BarrelUp01MS
@@ -18106,6 +18120,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
+      Animation = UVQuadCann.UVQuadCann
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -18120,6 +18136,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS
@@ -18134,6 +18152,8 @@ Object Slth_GLAVehicleQuadCannon
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVQuadCann_D
+      Animation = UVQuadCann_D.UVQuadCann_D
+      AnimationMode = LOOP
       Turret = TURRETUP02
       TurretPitch = TURRETEL02
       WeaponFireFXBone  = PRIMARY   BarrelUp02MS


### PR DESCRIPTION
ref: #340

There apparently is an animation for the radar dish on the Quad, which is not un-used.

Note:

- Should check if RUBBLE state should have this. When kaputt, it may be better to stop the animation?