### PR TITLE
Change: Use Unique Dust Effect For Quad Cannon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16752,7 +16752,7 @@ Object Chem_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust ; Patch104p @bugfix commy2 16/09/2021 Use unique dust effect.
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17984,7 +17984,7 @@ Object Demo_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust ; Patch104p @bugfix commy2 16/09/2021 Use unique dust effect.
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2449,7 +2449,7 @@ Object GC_Chem_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust ; Patch104p @bugfix commy2 16/09/2021 Use unique dust effect.
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -6714,7 +6714,7 @@ Object GC_Slth_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust ; Patch104p @bugfix commy2 16/09/2021 Use unique dust effect.
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3191,7 +3191,7 @@ Object GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust ; Patch104p @bugfix commy2 16/09/2021 Use unique dust effect.
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18152,7 +18152,7 @@ Object Slth_GLAVehicleQuadCannon
     TreadDriveSpeedFraction = 0.3  ; fraction of locomotor speed below which treads stop moving.
     TreadPivotSpeedFraction = 0.6  ; fraction of locomotor speed below which we allow pivoting.
 
-    Dust = RocketBuggyDust
+    Dust = QuadCannonDust ; Patch104p @bugfix commy2 16/09/2021 Use unique dust effect.
     DirtSpray = RocketBuggyDirtSpray
 
     ; These parameters are only used if the model has a separate suspension,


### PR DESCRIPTION
ref: #340 

Apparently there is a unique dust effect for the Quad Cannon. In ZH 1.04, it shares the effect with the Rocket Buggy (and many other units).

I do not know if this effect looks better or not.