### PR TITLE
Fix: Laser Turret Has 1 Extra Shot When Assisting Or Engaging Airborne Targets Than Intended

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -34,7 +34,7 @@ https://github.com/commy2/zerohour/issues/196 [DONE][NPROJEC!]        Sub-Factio
 https://github.com/commy2/zerohour/issues/195 [DONE]                  Nuke Cannons Start With Neutron Shells
 https://github.com/commy2/zerohour/issues/194 [DONE][NPROJEC!]        Patriot Batteries And Laser Turrets Lag When Assisting
 https://github.com/commy2/zerohour/issues/193 [DONE][NPROJEC!]        Laser Turret Uses Different Laser Model And Sound When Assisting Or Engaging Airborne Targets
-https://github.com/commy2/zerohour/issues/192 [IMPROVEMENT][NPROJECT] Laser Turret Has 1 Extra Shot When Assisting Or Engaging Airborne Targets Than Intended
+https://github.com/commy2/zerohour/issues/192 [DONE][NPROJECT]        Laser Turret Has 1 Extra Shot When Assisting Or Engaging Airborne Targets Than Intended
 https://github.com/commy2/zerohour/issues/191 [IMPROVEMENT]           Patriot Battery And Laser Turret Extended Range Exploit
 https://github.com/commy2/zerohour/issues/190 [IMPROVEMENT]           Black Lotus Seleced By Q-Shortcut
 https://github.com/commy2/zerohour/issues/189 [DONE][NPROJEC!]        China Dozer Movement Behavior

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -17084,8 +17084,10 @@ Object Lazr_AmericaPatriotBattery
     MoodAttackCheckRate        = 250
   End
 
+  ; Patch104p @bugfix commy2 13/09/2021 Fix ammo count when assisting to match normal weapon.
+
   Behavior = AssistedTargetingUpdate ModuleTag_07
-    AssistingClipSize = 4                       ; How many shots to make when asked by someone of my kind who has a RequestAssistRange weapon
+    AssistingClipSize = 3                       ; How many shots to make when asked by someone of my kind who has a RequestAssistRange weapon
     AssistingWeaponSlot = SECONDARY             ; And the weapon to use.  Should have huge range and no natural clip.
     LaserFromAssisted = PatriotBinaryDataStream ; Stream to draw from the requestor to me
     LaserToTarget = PatriotBinaryDataStream     ; Stream to draw from me to the target

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6530,7 +6530,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeaponAir
-  PrimaryDamage               = 35.0
+  PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 3.0
   AttackRange                 = 350.0
   DamageType                  = EXPLOSION
@@ -6556,7 +6556,7 @@ End
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 Weapon Lazr_PatriotMissileAssistWeapon
-  PrimaryDamage               = 35.0
+  PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 3.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6526,6 +6526,7 @@ Weapon Lazr_PatriotMissileWeapon
 End
 
 ; Patch104p @bugfix commy2 13/09/2021 Fix sound and effect used against airborne targets and when assisting to match normal anti ground weapon.
+; Patch104p @bugfix commy2 13/09/2021 Reduce ammo against air and when assisting to match normal anti ground weapon.
 
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeaponAir
@@ -6540,7 +6541,7 @@ Weapon Lazr_PatriotMissileWeaponAir
   FireFX                  = Lazr_WeaponFX_LaserCrusader
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
-  ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
+  ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
   AntiAirborneVehicle         = Yes
@@ -6567,7 +6568,7 @@ Weapon Lazr_PatriotMissileAssistWeapon
   FireFX                  = Lazr_WeaponFX_LaserCrusader
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
-  ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
+  ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
   AntiAirborneVehicle         = Yes


### PR DESCRIPTION
ZH 1.04

- The Laser Turret is intended to fire 3 shots instead of 4 rockets like the Patriot Battery. However, when engaging airborne units or when assisting other Laser Turrets, it still uses the original 4 shots.

After patch:

- The Laser Turret shoots in salvos of 3, no matter against what target and in what mode.

This makes it weaker against air targets and in general when assisting. Therefore, controversial?