### PR TITLE
Fix: Laser Turret Uses Different Laser Model And Sound When Assisting Or Engaging Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -33,7 +33,7 @@ https://github.com/commy2/zerohour/issues/197 [NOTRELEVANT][NPROJECT] Veteran Qu
 https://github.com/commy2/zerohour/issues/196 [DONE][NPROJECT]        Sub-Factions With Free Unit Science Can't Access Units In Other Factories
 https://github.com/commy2/zerohour/issues/195 [DONE]                  Nuke Cannons Start With Neutron Shells
 https://github.com/commy2/zerohour/issues/194 [DONE][NPROJECT]        Patriot Batteries And Laser Turrets Lag When Assisting
-https://github.com/commy2/zerohour/issues/193 [IMPROVEMENT][NPROJECT] Laser Turret Uses Different Laser Model And Sound When Assisting Or Engaging Airborne Targets
+https://github.com/commy2/zerohour/issues/193 [DONE][NPROJECT]        Laser Turret Uses Different Laser Model And Sound When Assisting Or Engaging Airborne Targets
 https://github.com/commy2/zerohour/issues/192 [IMPROVEMENT][NPROJECT] Laser Turret Has 1 Extra Shot When Assisting Or Engaging Airborne Targets Than Intended
 https://github.com/commy2/zerohour/issues/191 [IMPROVEMENT]           Patriot Battery And Laser Turret Extended Range Exploit
 https://github.com/commy2/zerohour/issues/190 [IMPROVEMENT]           Black Lotus Seleced By Q-Shortcut

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6430,6 +6430,8 @@ Weapon Lazr_PatriotMissileWeapon
   ProjectileCollidesWith      = STRUCTURES
 End
 
+; Patch104p @bugfix commy2 13/09/2021 Fix sound and effect used against airborne targets and when assisting to match normal anti ground weapon.
+
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeaponAir
   PrimaryDamage               = 35.0
@@ -6438,9 +6440,9 @@ Weapon Lazr_PatriotMissileWeaponAir
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
   WeaponSpeed                 = 999999.0
-  LaserName               = Lazr_PaladinLaserBeam
+  LaserName               = Lazr_PatriotLaserBeam
   LaserBoneName           = WEAPONA01
-  FireFX                  = Lazr_WeaponFX_Laser
+  FireFX                  = Lazr_WeaponFX_LaserCrusader
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
@@ -6465,9 +6467,9 @@ Weapon Lazr_PatriotMissileAssistWeapon
   DamageType                  = EXPLOSION          ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 999999.0               ; ignored for projectile weapons
-  LaserName               = Lazr_PaladinLaserBeam
+  LaserName               = Lazr_PatriotLaserBeam
   LaserBoneName           = WEAPONA01
-  FireFX                  = Lazr_WeaponFX_Laser
+  FireFX                  = Lazr_WeaponFX_LaserCrusader
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)


### PR DESCRIPTION
ZH 1.04

- The Laser Turret uses a different sound effect and laser beam when either assisting or when attacking airborne targets.
- The sound effect used is the PDL anti missile / infantry zap of the Paladin. (Different FXList, but same sound ultimately.)

After patch:

- The same laser model is used, regardless of the target.