### PR TITLE
Fix: Boss General Does Not Get Any Unit From Reinforcement Pad

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -421,6 +421,8 @@ Object TechReinforcementPad
     InitialHealth     = 1000.0
   End
 
+  ; Patch104p @bugfix commy2 16/09/2021 Fix Boss does not get any unit from Reinforcement Pad.
+
   Behavior       = OCLUpdate ModuleTag_05 ; Context window is a reaction to this, no CommandSet
     MinDelay     = 120000
     MaxDelay     = 120000
@@ -441,6 +443,8 @@ Object TechReinforcementPad
     FactionOCL   = Faction:GLAToxinGeneral           OCL:OCL_ToxGen_ReinforcementPadGLAVehicle
     FactionOCL   = Faction:GLADemolitionGeneral      OCL:OCL_DemoGen_ReinforcementPadGLAVehicle
     FactionOCL   = Faction:GLAStealthGeneral         OCL:OCL_StlthGen_ReinforcementPadGLAVehicle
+
+    FactionOCL   = Faction:FactionBossGeneral        OCL:OCL_BossGen_ReinforcementPadCHIVehicle
   End
 
   Behavior = DestroyDie ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -7949,6 +7949,26 @@ ObjectCreationList OCL_StlthGen_ReinforcementPadGLAVehicle
   End
 End
 
+; Patch104p @bugfix commy2 16/09/2021 Add unit spawned by Reinforcement Pad for Boss General.
+
+; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+ObjectCreationList OCL_BossGen_ReinforcementPadCHIVehicle
+  DeliverPayload
+    Transport = ChinaJetCargoPlane
+    StartAtPreferredHeight = Yes
+    StartAtMaxSpeed = Yes
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-5
+    DropDelay = 400
+    PutInContainer = LargeParachute
+    Payload = Boss_TankDragon 1
+    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ; up on the target instead of parachuting to the spot below their drop point.
+    DeliveryDistance = 250
+  End
+End
+
 
 ; -----------------------------------------------------------------------------
 ; GENERALS CHALLENGE OCLs


### PR DESCRIPTION
- fix https://github.com/xezon/GeneralsGamePatch/issues/363

ZH 1.04

- In case you find yourself spawning as Boss General on a map with Reinforcement Pad, you do not gain any unit from it.

After patch:

- The Reinforcement Pad drops a Boss General Dragon Tank for the Boss General. (The Boss General Dragon Tank is a normal Dragon Tank that can be upgraded with Composite Armor.)

Feel free to suggest another unit.