### PR TITLE
Fix: Tactical Nuke Mig Upgrade Not Buildable While Low On Power

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -102,7 +102,7 @@ https://github.com/commy2/zerohour/issues/120 [MAYBE][NPROJECT]       Vehicles C
 https://github.com/commy2/zerohour/issues/119 [DONE]                  Car Bomb May Bug Out And Be Unable To Attack
 https://github.com/commy2/zerohour/issues/118 [MAYBE][NPROJECT]       Some ECM Tanks Automatically Engage Enemy Vehicles
 https://github.com/commy2/zerohour/issues/117 [DONE][NPROJECT]        Some Rebels Are Missing Upgrade Icons
-https://github.com/commy2/zerohour/issues/116 [MAYBE][NPROJECT]       Tactical Nuke Mig Upgrade Not Buildable While Low On Power
+https://github.com/commy2/zerohour/issues/116 [DONE][NPROJECT]        Tactical Nuke Mig Upgrade Not Buildable While Low On Power
 https://github.com/commy2/zerohour/issues/115 [DONE][NPROJECT]        Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub Faction Command Centers
 https://github.com/commy2/zerohour/issues/114 [DONE][NPROJECT]        Hitting Battle Bus In Hull Mode Causes Screen Shake
 https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs Cannot Target Stinger Sites

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -2515,6 +2515,7 @@ End
 CommandButton Command_UpgradeChinaTacticalNukeMig
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_ChinaTacticalNukeMig
+  Options       = IGNORES_UNDERPOWERED  ; @bugfix commy2 17/09/2021 Fix upgrade not buildable when low on power.
   TextLabel     = CONTROLBAR:UpgradeChinaTacticalNukeMig
   ButtonImage   = SSMigNuke
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
@@ -6521,7 +6522,6 @@ End
 CommandButton Nuke_Command_UpgradeChinaIsotopeStability
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_ChinaIsotopeStability
-  Options       = IGNORES_UNDERPOWERED
   TextLabel     = UPGRADE:UpgradeChinaIsotopeStability
   ButtonImage   = SNIsoStab
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is


### PR DESCRIPTION
ZH

- The Tactical Nuke Mig upgrade cannot be purchased from the Nuclear Missile Silo while low on power. Neutron Shells, as well as Nuclear Tanks and Uranium Shells for other factions, can still be bought while low on power.
- If the upgrade has already been queued, but is not finished yet, it can still progress to completion even when low on power.
- When the building is disabled by an EMP strike however, none of the upgrades can be purchased and their progress will freeze... Except when the building is low on power AND disabled by an EMP strike: Then none of the upgrades can be purchased, but already queued upgrades will progress... The progress will freeze again once the building has enough power, but is still disabled by EMP... ...

After patch:

- The Tactical Nuke Mig upgrade behaves like every other upgrade on the Nuclear Missile Silo.

Note:

- Apparently, in an earlier build of the game, Tactical Nuke Mig was a Propaganda Center upgrade, while Isotope Stability was a Nuke Silo upgrade. I moved the flag away from the Isotope Stability, because a Propaganda Center, while it consumes power, cannot be low on power (not to be confused with "disabled" by EMP).