### PR TITLE
Fix: Boss Patriot Battery Has Unique Stop Button Position

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -60,7 +60,7 @@ https://github.com/commy2/zerohour/issues/162 [IMPROVEMENT][NPROJECT] Boss Gener
 https://github.com/commy2/zerohour/issues/161 [MAYBE][NPROJECT]       Terrorist And Terror Bike Have To Force-Fire Ground To Detonate
 https://github.com/commy2/zerohour/issues/160 [MAYBE]                 Slow Units Can Outrun Comanche Missiles
 https://github.com/commy2/zerohour/issues/159 [IMPROVEMENT][NPROJECT] Boss Nationalism Upgrade Changes Tooltip After Land Mines Upgrade
-https://github.com/commy2/zerohour/issues/158 [IMPROVEMENT][NPROJECT] Boss Patriot Battery Has Unique Stop Button Position
+https://github.com/commy2/zerohour/issues/158 [DONE][NPROJECT]        Boss Patriot Battery Has Unique Stop Button Position
 https://github.com/commy2/zerohour/issues/157 [MAYBE][NPROJECT]       Boss General Has Strange Selection Of Available Upgrades
 https://github.com/commy2/zerohour/issues/156 [IMPROVEMENT][NPROJECT] Some Boss Infantry Units Lack Chemical Suits Upgrade Icon
 https://github.com/commy2/zerohour/issues/155 [IMPROVEMENT][NPROJECT] Boss General Scud Storm Cannot Upgrade Neutron Mines

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -4880,15 +4880,17 @@ CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
  14 = Command_Sell
 End
 
+; @bugfix commy2 18/09/2021 Fix position of Stop command.
+
 CommandSet Boss_AmericaPatriotBatteryCommandSet
-  11 = Command_Stop
   12 = Command_UpgradeChinaMines
+  13 = Command_Stop
   14 = Command_Sell
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
-  11 = Command_Stop
   12 = Command_UpgradeEMPMines
+  13 = Command_Stop
   14 = Command_Sell
 End
 


### PR DESCRIPTION
ZH 1.04:

- The Boss General's Patriot Battery has the Stop command button on the left of the Landmines upgrade instead of above the Sell button like every other base defense building.

Patch:

- The Stop button is placed at the same position as on other buildings.

Note:

- Slot 11 is the position used in CCG (where only 12 buttons are available), which indicates that this commandset was crated (copy-pasted) very early in development of ZH.