### PR TITLE
Fix: Boss Scud Storm Cannot Upgrade Neutron Mines

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -63,7 +63,7 @@ https://github.com/commy2/zerohour/issues/159 [IMPROVEMENT][NPROJECT] Boss Natio
 https://github.com/commy2/zerohour/issues/158 [IMPROVEMENT][NPROJECT] Boss Patriot Battery Has Unique Stop Button Position
 https://github.com/commy2/zerohour/issues/157 [MAYBE][NPROJECT]       Boss General Has Strange Selection Of Available Upgrades
 https://github.com/commy2/zerohour/issues/156 [IMPROVEMENT][NPROJECT] Some Boss Infantry Units Lack Chemical Suits Upgrade Icon
-https://github.com/commy2/zerohour/issues/155 [IMPROVEMENT][NPROJECT] Boss General Scud Storm Cannot Upgrade Neutron Mines
+https://github.com/commy2/zerohour/issues/155 [DONE][NPROJECT]        Boss General Scud Storm Cannot Upgrade Neutron Mines
 https://github.com/commy2/zerohour/issues/154 [DONE][NPROJECT]        Fake Command Centers Lose Sub-Faction Decal After Fortified Structures Upgrade
 https://github.com/commy2/zerohour/issues/153 [DONE][NPROJECT]        Base Defense Scaffolds Set Off Demo Traps
 https://github.com/commy2/zerohour/issues/152 [DONE]                  Aurora And Carpet Bomb Model Is Extremely Low Poly

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -6665,6 +6665,13 @@ Object Boss_ScudStorm
     ; nothing
   End
 
+  ; @bugfix commy2 18/09/2021 Fix building lacks button to upgrade Neutron Mines.
+
+  Behavior = CommandSetUpgrade ModuleTag_25
+    CommandSet = Boss_GLAScudStormCommandSetUpgrade
+    TriggeredBy = Upgrade_ChinaMines
+  End
+
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
   End


### PR DESCRIPTION
ZH 1.04:

- The Boss General's Scud Storm can not further upgrade Landmines to Neutron Mines. All other Boss buildings can.


Patch:

- All buildings can upgrade Landmines to Neutron Mines.

Note:

- The commandset already exists, but is never used/unlocked.