### PR TITLE
Fix: Toxin General RPG-Trooper Shoots Stinger Missiles

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -77,7 +77,7 @@ https://github.com/commy2/zerohour/issues/145 [DONE][NPROJECT]        Toxin Gene
 https://github.com/commy2/zerohour/issues/144 [IMPROVEMENT]           Overlord Does Not Fit Into Chinook But Only Takes 3 Slots Inside Helix
 https://github.com/commy2/zerohour/issues/143 [IMPROVEMENT]           GPS Scrambled Rangers And Red Guards Remain Stealthed While Capturing Buildings
 https://github.com/commy2/zerohour/issues/142 [IMPROVEMENT][NPROJECT] Fire Base Shoots At Awkward Angle
-https://github.com/commy2/zerohour/issues/141 [DONE][NPROJECT] 		  Toxin General RPG-Trooper Shoots Stinger Missiles
+https://github.com/commy2/zerohour/issues/141 [DONE][NPROJECT]        Toxin General RPG-Trooper Shoots Stinger Missiles
 https://github.com/commy2/zerohour/issues/140 [DONE][NPROJECT]        Gattling Helix Sometimes Fires At Airborne Units
 https://github.com/commy2/zerohour/issues/139 [DONE][NPROJECT]        Dummy Weapons Cause Notifications And Hit Effects
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button
@@ -172,7 +172,7 @@ https://github.com/commy2/zerohour/issues/49  [DONE][NPROJECT]        Demo Gener
 https://github.com/commy2/zerohour/issues/48  [MAYBE][NPROJECT]       Demo General Scud Launcher With Demolitions Upgrade Deals Full Damage When Destroyed
 https://github.com/commy2/zerohour/issues/47  [DONE]                  Demo General Battle Bus Is Deleted Without Dealing Damage When Suicided
 https://github.com/commy2/zerohour/issues/46  [DONE][NPROJECT]        Technical Has To Recenter Turret To Suicide
-https://github.com/commy2/zerohour/issues/45  [DONE]   	              Combat Bike Has Disabled Suicide Ability Button
+https://github.com/commy2/zerohour/issues/45  [DONE]                  Combat Bike Has Disabled Suicide Ability Button
 https://github.com/commy2/zerohour/issues/44  [MAYBE][NPROJECT]       Terrorist And Bomb Truck Missing Suicide Ability
 https://github.com/commy2/zerohour/issues/43  [DONE][NPROJECT]        Suicide Ability Button Is Placed Inconsistently
 https://github.com/commy2/zerohour/issues/42  [DONE]                  Worker Has Disabled Suicide Button Before Demolitions Upgrade

--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -77,7 +77,7 @@ https://github.com/commy2/zerohour/issues/145 [DONE][NPROJECT]        Toxin Gene
 https://github.com/commy2/zerohour/issues/144 [IMPROVEMENT]           Overlord Does Not Fit Into Chinook But Only Takes 3 Slots Inside Helix
 https://github.com/commy2/zerohour/issues/143 [IMPROVEMENT]           GPS Scrambled Rangers And Red Guards Remain Stealthed While Capturing Buildings
 https://github.com/commy2/zerohour/issues/142 [IMPROVEMENT][NPROJECT] Fire Base Shoots At Awkward Angle
-https://github.com/commy2/zerohour/issues/141 [IMPROVEMENT][NPROJECT] Toxin General RPG-Trooper Shoots Stinger Missiles
+https://github.com/commy2/zerohour/issues/141 [DONE][NPROJECT] 		  Toxin General RPG-Trooper Shoots Stinger Missiles
 https://github.com/commy2/zerohour/issues/140 [DONE][NPROJECT]        Gattling Helix Sometimes Fires At Airborne Units
 https://github.com/commy2/zerohour/issues/139 [DONE][NPROJECT]        Dummy Weapons Cause Notifications And Hit Effects
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6961,7 +6961,7 @@ Weapon Chem_TunnelDefenderRocketWeaponBeta
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -6990,7 +6990,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGamma
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -7001,8 +7001,8 @@ Weapon Chem_TunnelDefenderRocketWeaponGamma
   AutoReloadsClip             = Yes
   FireSound                   = RPGTrooperWeapon
   FireFX                      = None
-  ProjectileDetonationFX = WeaponFX_StingerMissileDetonation
-; ProjectileDetonationOCL = OCL_PoisonFieldGammaSmall
+  ProjectileDetonationFX      = WeaponFX_RocketBuggyMissileDetonation
+; ProjectileDetonationOCL     = OCL_PoisonFieldUpgradedSmall
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle = No
   AntiAirborneInfantry = No
@@ -7019,7 +7019,7 @@ Weapon Chem_TunnelDefenderRocketWeaponBetaAir
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -7047,7 +7047,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGammaAir
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -7058,7 +7058,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGammaAir
   AutoReloadsClip             = Yes
   FireSound                   = RPGTrooperWeapon
   FireFX                      = None
-  ProjectileDetonationFX = WeaponFX_StingerMissileDetonation
+  ProjectileDetonationFX      = WeaponFX_RocketBuggyMissileDetonation
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle = Yes
   AntiAirborneInfantry = No


### PR DESCRIPTION
ZH 1.04

- The Toxin RPG-Trooper shoots stinger missiles.

patch:

- The Toxin RPG-Trooper shoots "RPG" "missiles"