### PR TITLE
Fix: Tunnel And Palace Lack Stop Button

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -83,7 +83,7 @@ https://github.com/commy2/zerohour/issues/139 [DONE][NPROJECT]        Dummy Weap
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button
 https://github.com/commy2/zerohour/issues/137 [DONE][NPROJECT]        Tracer Emerges Below Jarmen Kell When Using Sniper Attack
 https://github.com/commy2/zerohour/issues/136 [DONE][NPROJECT]        Demo Charge Buttons Are Placed Differently On Jarmen Kell Than On Colonel Burton
-https://github.com/commy2/zerohour/issues/135 [IMPROVEMENT][NPROJECT] Tunnel And Palace Lack Stop Button
+https://github.com/commy2/zerohour/issues/135 [DONE][NPROJECT]        Tunnel And Palace Lack Stop Button
 https://github.com/commy2/zerohour/issues/134 [IMPROVEMENT][NPROJECT] Air Force Carpet Bomber Tooltip Claims 2:30 Cooldown Instead Of True 4:00
 https://github.com/commy2/zerohour/issues/133 [MAYBE][NPROJECT]       Fire Base Command Button Order Misaligned With Other Buildings
 https://github.com/commy2/zerohour/issues/132 [MAYBE][NPROJECT]       Raptor Guard Air Button Misplaced

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1221,6 +1221,7 @@ CommandSet GLAPalaceCommandSet
   9  = Command_UpgradeGLACamouflage
   10 = Command_UpgradeGLAToxinShells
   11 = Command_UpgradeGLAAnthraxBeta
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -1244,8 +1245,7 @@ CommandSet GLATunnelNetworkCommandSet
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
   12 = Command_UpgradeGLACamoNetting
-;  12 = Command_Stop
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -1497,6 +1497,7 @@ CommandSet GC_Chem_GLAPalaceCommandSet
   7  = Command_UpgradeGLAFortifiedStructure
   8  = Command_UpgradeGLAArmTheMob
   11 = GC_Chem_Command_UpgradeGLAAnthraxGamma
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -1639,8 +1640,7 @@ CommandSet GC_Slth_GLATunnelNetworkCommandSet
   9  = Command_StructureExit
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
-  12 = Command_Stop
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -1664,6 +1664,7 @@ CommandSet GC_Slth_GLAPalaceCommandSet
   6  = Command_Evacuate
   7  = Command_UpgradeGLAFortifiedStructure
   9  = GC_Slth_Command_UpgradeGLAQuadCannonSnipeGun
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2014,8 +2015,9 @@ CommandSet Demo_GLAPalaceCommandSet
   6  = Command_Evacuate
   7  = Command_UpgradeGLAFortifiedStructure
   8  = Command_UpgradeGLAArmTheMob
+  11 = Demo_UpgradeSuicideBomb
 ; 12 = Demo_Command_UpgradeGLADemoTrapHighExplosiveBomb
-  13 = Demo_UpgradeSuicideBomb
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2064,8 +2066,7 @@ CommandSet Demo_GLATunnelNetworkCommandSet
   9  = Command_StructureExit
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
-  12 = Command_Stop
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2334,8 +2335,9 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   6  = Command_Evacuate
   7  = Command_UpgradeGLAFortifiedStructure
   8  = Command_UpgradeGLAArmTheMob
+  11 = Demo_Command_TertiarySuicide
 ; 12 = Demo_Command_UpgradeGLADemoTrapHighExplosiveBomb
-  12 = Demo_Command_TertiarySuicide
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2387,7 +2389,7 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
   12 = Demo_Command_TertiarySuicide
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2610,6 +2612,7 @@ CommandSet Slth_GLAPalaceCommandSet
 ; 9  = Command_UpgradeGLACamouflage ;comes free for stealth general
   11 = Command_UpgradeGLAAnthraxBeta
   12 = Command_UpgradeGLACamoNetting
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2661,8 +2664,7 @@ CommandSet Slth_GLATunnelNetworkCommandSet
   9  = Command_StructureExit
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
-  12 = Command_Stop
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2885,8 +2887,7 @@ CommandSet Chem_GLATunnelNetworkCommandSet
   9  = Command_StructureExit
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
-  12 = Command_Stop
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -2918,6 +2919,7 @@ CommandSet Chem_GLAPalaceCommandSet
   7  = Command_UpgradeGLAFortifiedStructure
   8  = Command_UpgradeGLAArmTheMob
   11 = Chem_Command_UpgradeGLAAnthraxGamma
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -4845,7 +4847,7 @@ CommandSet Boss_GLATunnelNetworkCommandSet
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 
@@ -4862,7 +4864,7 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+  13 = Command_Stop
   14 = Command_Sell
 End
 


### PR DESCRIPTION
ZH 1.04

- The Palace has no Stop button, even though S can be used to make passengers stop firing. The Bunker and Fire Base however do have a Stop button.
- The Demo General's Tunnel Network has no Stop button, even though other Tunnels do have one.
- The Stop buttons of the non-Demo General Tunnels are placed differently than on other Base Defeneses to make room for the Rallypoint button (that spot is taken by Suicide). Other Base Defenses like the Fire Base and Bunker do not have a Rallypoint button at all. The Rallypoint button is also superfluous, since left clicking already sets a Rallypoint without using that button.

After patch:

- The Stop buttons are placed consistently for all base defenses and exist for Demo General and all Palaces.