### PR TITLE
Fix: Fire Base Command Button Placement

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -85,7 +85,7 @@ https://github.com/commy2/zerohour/issues/137 [DONE][NPROJECT]        Tracer Eme
 https://github.com/commy2/zerohour/issues/136 [DONE][NPROJECT]        Demo Charge Buttons Are Placed Differently On Jarmen Kell Than On Colonel Burton
 https://github.com/commy2/zerohour/issues/135 [IMPROVEMENT][NPROJECT] Tunnel And Palace Lack Stop Button
 https://github.com/commy2/zerohour/issues/134 [IMPROVEMENT][NPROJECT] Air Force Carpet Bomber Tooltip Claims 2:30 Cooldown Instead Of True 4:00
-https://github.com/commy2/zerohour/issues/133 [MAYBE][NPROJECT]       Fire Base Command Button Order Misaligned With Other Buildings
+https://github.com/commy2/zerohour/issues/133 [DONE][NPROJECT]        Fire Base Command Button Order Misaligned With Other Buildings
 https://github.com/commy2/zerohour/issues/132 [MAYBE][NPROJECT]       Raptor Guard Air Button Misplaced
 https://github.com/commy2/zerohour/issues/131 [DONE][NPROJECT]        Demo General Combat Bike With Demolitions Upgrade Deals No Damage When Destroyed By Gamma Poison
 https://github.com/commy2/zerohour/issues/130 [DONE][NPROJECT]        Demo Combat Bike Uses Portrait As Button

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -227,8 +227,8 @@ CommandSet AmericaFireBaseCommandSet
   3 = Command_FireBaseExit
   4 = Command_FireBaseExit
   6 = Command_Evacuate
-  12 = Command_Sell
-  14 = Command_Stop
+  13 = Command_Stop
+  14 = Command_Sell
 End
 
 CommandSet CivilianVehicleLimoCommandSet
@@ -1834,8 +1834,8 @@ CommandSet AirF_AmericaFireBaseCommandSet
   3 = Command_FireBaseExit
   4 = Command_FireBaseExit
   6 = Command_Evacuate
-  12 = Command_Sell
-  14 = Command_Stop
+  13 = Command_Stop
+  14 = Command_Sell
 End
 
 CommandSet AirF_AmericaAirfieldCommandSet
@@ -3672,8 +3672,8 @@ CommandSet SupW_AmericaFireBaseCommandSet
   3 = Command_FireBaseExit
   4 = Command_FireBaseExit
   6 = Command_Evacuate
-  12 = Command_Sell
-  14 = Command_Stop
+  13 = Command_Stop
+  14 = Command_Sell
 End
 
 
@@ -4304,8 +4304,8 @@ CommandSet Lazr_AmericaFireBaseCommandSet
   4 = Command_FireBaseExit
   6 = Command_Evacuate
 ; 7  = Lazr_Command_AmericaLaserGuidedHowitzer
-  12 = Command_Sell
-  14 = Command_Stop
+  13 = Command_Stop
+  14 = Command_Sell
 End
 
 CommandSet Lazr_AmericaPowerPlantCommandSet


### PR DESCRIPTION
ZH 1.04

- The Fire Base is the only building with the Sell action button placed one left of the bottom right slot. The Stop button is placed where it is usually for units, but not base defeneses.

After patch:

- The Fire Base has the same button placement as other base defenses (Stinger / Patriot / Gatling etc.)