### PR TITLE
Fix: Boss Destroyed American Buildings Spawn Wrong Ranger Type

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -156,7 +156,7 @@ https://github.com/commy2/zerohour/issues/65  [DONE][NPROJECT]        Laser Gene
 https://github.com/commy2/zerohour/issues/64  [MAYBE][NPROJECT]       Battle Drone Gains Double The Intended Bonus From Drone Armor
 https://github.com/commy2/zerohour/issues/63  [MAYBE][NPROJECT]       Paladins And Microwaves Gain Slightly Less Than Intended From Composite Armor
 https://github.com/commy2/zerohour/issues/62  [MAYBE][NPROJECT]       Crusader And Laser Tanks Receive Composite Armor Health Bonus Twice
-https://github.com/commy2/zerohour/issues/61  [IMPROVEMENT][NPROJECT] Destroyed American Boss Buildings Spawn Wrong Ranger Type
+https://github.com/commy2/zerohour/issues/61  [DONE][NPROJECT]        Destroyed American Boss Buildings Spawn Wrong Ranger Type
 https://github.com/commy2/zerohour/issues/60  [DONE][NPROJECT]        Destroyed Particle Cannons Spawn Wrong Ranger Type
 https://github.com/commy2/zerohour/issues/59  [IMPROVEMENT]           Air Force General Name Misspelling
 https://github.com/commy2/zerohour/issues/58  [IMPROVEMENT][NPROJECT] Some Combat Bikes Missing DoorOpenTime Entry

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -10723,7 +10723,7 @@ Object AirF_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_AirF_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Airforce General Rangers.
+    OCL            = FINAL   AirF_OCL_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Airforce General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -2440,7 +2440,7 @@ Object Boss_PowerPlant
   End
   Behavior             = CreateObjectDie ModuleTag_12
   ;**FIX**
-    CreationList  = OCL_AmericanRangerDebris02
+    CreationList  = Boss_OCL_AmericanRangerDebris02 ; @bugfix commy2 19/09/2021 Fix building spawning vanilla USA Rangers when destroyed.
     ExemptStatus  = UNDER_CONSTRUCTION
   End
   Behavior        = FXListDie ModuleTag_13
@@ -3423,7 +3423,7 @@ Object Boss_ParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_ParticleUplinkDeathFinal
+    OCL            = FINAL   Boss_OCL_ParticleUplinkDeathFinal
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19
@@ -12373,7 +12373,7 @@ Object Boss_PatriotBattery
     ;nothing
   End
   Behavior             = CreateObjectDie ModuleTag_09
-    CreationList  = OCL_AmericanRangerDebris03
+    CreationList  = Boss_OCL_AmericanRangerDebris03 ; @bugfix commy2 19/09/2021 Fix building spawning vanilla USA Rangers when destroyed.
     ExemptStatus  = UNDER_CONSTRUCTION
   End
   Behavior             = FXListDie ModuleTag_10

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -10432,7 +10432,7 @@ Object Lazr_AmericaParticleCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
+    OCL            = FINAL   Lazr_OCL_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19
@@ -18054,7 +18054,7 @@ Object Lazr_AmericaLaserCannonUplink
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
+    OCL            = FINAL   Lazr_OCL_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19
@@ -19006,7 +19006,7 @@ Object Lazr_AmericaLaserCannon
     FX             = INITIAL FX_ParticleUplinkDeathInitial
     OCL            = INITIAL OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_Lazr_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
+    OCL            = FINAL   Lazr_OCL_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Laser General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -9834,7 +9834,7 @@ Object SupW_AmericaParticleCannonUplink
     FX             = INITIAL SupW_FX_ParticleUplinkDeathInitial
     OCL            = INITIAL SupW_OCL_SDILinkLasers
     FX             = FINAL   FX_StructureMediumDeath
-    OCL            = FINAL   OCL_SupW_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Superweapon General Rangers.
+    OCL            = FINAL   SupW_OCL_ParticleUplinkDeathFinal ; Patch104p @bugfix hanfield 26/08/2021 Added proper death OCL to spawn Superweapon General Rangers.
   End
 
   Behavior = InstantDeathBehavior ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -2327,7 +2327,7 @@ End
 ; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Airforce General Particle Cannon.
 
 ; ----------------------------------------------
-ObjectCreationList OCL_AirF_ParticleUplinkDeathFinal
+ObjectCreationList AirF_OCL_ParticleUplinkDeathFinal
 ; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
   CreateObject
     ObjectNames = AirF_AmericaInfantryRanger
@@ -2433,7 +2433,7 @@ End
 ; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Laser General Particle Cannon.
 
 ; ----------------------------------------------
-ObjectCreationList OCL_Lazr_ParticleUplinkDeathFinal
+ObjectCreationList Lazr_OCL_ParticleUplinkDeathFinal
 ; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
   CreateObject
     ObjectNames = Lazr_AmericaInfantryRanger
@@ -2539,10 +2539,116 @@ End
 ; Patch104p @bugfix hanfield 26/08/2021 Added death OCL for Superweapon General Particle Cannon.
 
 ; ----------------------------------------------
-ObjectCreationList OCL_SupW_ParticleUplinkDeathFinal
+ObjectCreationList SupW_OCL_ParticleUplinkDeathFinal
 ; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
   CreateObject
     ObjectNames = SupW_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 6
+    RequiresLivePlayer = Yes
+  End
+
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:5
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:15 Z:15
+
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-15 Y:15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:15 Y:-15 Z:15
+    Mass = 30.0
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:25
+    Mass = 30.0
+    Count = 10
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d21 ABPwrPlant_d22 ABPwrPlant_d23 ABPwrPlant_d24 ABPwrPlant_d25 ABPwrPlant_d26 ABPwrPlant_d27 ABPwrPlant_d28 ABPwrPlant_d29 ABPwrPlant_d30
+    Offset = X:0 Y:0 Z:40
+    Mass = 30.0
+    Count = 5
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound       = BuildingDebris
+  End
+End
+
+; @bugfix commy2 19/09/2021 Used when Boss General Particle Cannon is destroyed.
+
+; ----------------------------------------------
+ObjectCreationList Boss_OCL_ParticleUplinkDeathFinal
+; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
+  CreateObject
+    ObjectNames = Boss_InfantryRanger
     IgnorePrimaryObstacle = Yes
     Disposition = SEND_IT_OUT
     DispositionIntensity = 4
@@ -8517,6 +8623,19 @@ End
 ObjectCreationList AirF_OCL_AmericanRangerDebris02
   CreateObject
     ObjectNames = AirF_AmericaInfantryRanger
+    IgnorePrimaryObstacle = Yes
+    Disposition = SEND_IT_OUT
+    DispositionIntensity = 4
+    Count = 2
+    RequiresLivePlayer = Yes
+  End
+End
+
+; @bugfix commy2 19/09/2021 Used when Boss General Fusion Reactor is destroyed.
+
+ObjectCreationList Boss_OCL_AmericanRangerDebris02
+  CreateObject
+    ObjectNames = Boss_InfantryRanger
     IgnorePrimaryObstacle = Yes
     Disposition = SEND_IT_OUT
     DispositionIntensity = 4


### PR DESCRIPTION
ZH 1.04

- Boss General Fusion Reactor, Patriot Battery and Particle Cannon drop the normal USA Rangers when destroyed instead of the Boss General's Rangers.

After patch:

- The Boss General buildings drop the Boss General Rangers.

I also renamed hanfields object creation lists from PR-#73. {faction}_OCL_whatever is consistent with the OCL's EA already uses.

Note that `Boss_OCL_AmericanRangerDebris03` already exists (as well as the unused `Boss_OCL_AmericanRangerDebris04`). `Boss_OCL_AmericanRangerDebris02` however did not, so it had to be added.