### PR TITLE
Fix: Boss General Tomahawk Launcher And USA05 Campaign Scud Launchers Never Drop Scrap

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -190,7 +190,7 @@ https://github.com/commy2/zerohour/issues/29  [DONE][NPROJECT]        GLA Base D
 https://github.com/commy2/zerohour/issues/28  [MAYBE][NPROJECT]       Demo General Terrorist Does Not Explode When Crushed, Burned Or Blown Up
 https://github.com/commy2/zerohour/issues/27  [DONE][NPROJECT]        Scud Storm Does Not Damage Itself
 https://github.com/commy2/zerohour/issues/26  [DONE][NPROJECT]        Saboteur Uses Wrong Art For Sabotage Building-Ability
-https://github.com/commy2/zerohour/issues/25  [IMPROVEMENT][NPROJECT] Boss Tomahawk Launcher Never Drops Scrap
+https://github.com/commy2/zerohour/issues/25  [DONE][NPROJECT]        Boss Tomahawk Launcher Never Drops Scrap
 https://github.com/commy2/zerohour/issues/24  [IMPROVEMENT][NPROJECT] GLA Buildings Don't Create Scrap
 https://github.com/commy2/zerohour/issues/23  [DONE][NPROJECT]        Demo General Jarmen Kell Repeats Voice Line When Planting Timed Demo Charge
 https://github.com/commy2/zerohour/issues/22  [IMPROVEMENT]           Build Scorpion Tank-Button Misspelling

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19385,6 +19385,10 @@ Object Boss_VehicleTomahawk
     CreationList = OCL_CrusaderTank_CrushEffect
   End
 
+  Behavior = CreateCrateDie ModuleTag_Salvage
+    CrateData = SalvageCrateData
+  End
+
 ;  Behavior = FXListDie
 ;    DeathTypes = ALL -CRUSHED -SPLATTED
 ;    DeathFX = FX_GenericTankDeathEffect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19385,6 +19385,8 @@ Object Boss_VehicleTomahawk
     CreationList = OCL_CrusaderTank_CrushEffect
   End
 
+  ; @bugfix commy2 19/09/2021 Fix unit doesn't drop scrap when destroyed by GLA.
+
   Behavior = CreateCrateDie ModuleTag_Salvage
     CrateData = SalvageCrateData
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2803,6 +2803,10 @@ Object GC_Chem_GLAVehicleScudLauncher
     CreationList = OCL_CrusaderTank_CrushEffect
   End
 
+  Behavior = CreateCrateDie ModuleTag_Salvage
+    CrateData = SalvageCrateData
+  End
+
   Behavior = FlammableUpdate ModuleTag_21
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 3       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2803,6 +2803,8 @@ Object GC_Chem_GLAVehicleScudLauncher
     CreationList = OCL_CrusaderTank_CrushEffect
   End
 
+  ; @bugfix commy2 19/09/2021 Fix unit doesn't drop scrap when destroyed by GLA.
+
   Behavior = CreateCrateDie ModuleTag_Salvage
     CrateData = SalvageCrateData
   End


### PR DESCRIPTION
ZH 1.04

- The Boss Generals Tomahawk Launcher never drops scrap.
- The USA05 campaign Scud Launchers never drops scrap.

After patch:

- All units drop scrap when destroyed by GLA.
