### PR TITLE
Fix: Tomahawk And Non Demo General Scud Launcher Scrap Creation Module Tags

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5556,7 +5556,7 @@ Object AirF_AmericaVehicleTomahawk
     AddXPScalar = 1.0 ;Increases experience gained by an additional 100%
   End
 
-  Behavior = CreateCrateDie ModuleTag SalvageData
+  Behavior = CreateCrateDie ModuleTag_Salvage ; @bugfix commy2 19/09/2021 Fix broken module tag.
     CrateData = SalvageCrateData
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -438,7 +438,7 @@ Object AmericaVehicleTomahawk
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
-  Behavior = CreateCrateDie ModuleTag SalvageData
+  Behavior = CreateCrateDie ModuleTag_Salvage ; @bugfix commy2 19/09/2021 Fix broken module tag.
     CrateData = SalvageCrateData
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -17869,7 +17869,7 @@ Object Chem_GLAVehicleScudLauncher
     CreationList = OCL_CrusaderTank_CrushEffect
   End
 
-  Behavior = CreateCrateDie ModuleTag SalvageData
+  Behavior = CreateCrateDie ModuleTag_Salvage ; @bugfix commy2 19/09/2021 Fix broken module tag.
     CrateData = SalvageCrateData
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4411,7 +4411,7 @@ Object GLAVehicleScudLauncher
     CreationList = OCL_CrusaderTank_CrushEffect
   End
 
-  Behavior = CreateCrateDie ModuleTag SalvageData
+  Behavior = CreateCrateDie ModuleTag_Salvage ; @bugfix commy2 19/09/2021 Fix broken module tag.
     CrateData = SalvageCrateData
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4811,7 +4811,7 @@ Object Lazr_AmericaVehicleTomahawk
     CreationList = OCL_CrusaderTank_CrushEffect
   End
 
-  Behavior = CreateCrateDie ModuleTag SalvageData
+  Behavior = CreateCrateDie ModuleTag_Salvage ; @bugfix commy2 19/09/2021 Fix broken module tag.
     CrateData = SalvageCrateData
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19365,7 +19365,7 @@ Object Slth_GLAVehicleScudLauncher
     DeathFX = FX_CarCrush
   End
 
-  Behavior = CreateCrateDie ModuleTag SalvageData
+  Behavior = CreateCrateDie ModuleTag_Salvage ; @bugfix commy2 19/09/2021 Fix broken module tag.
     CrateData = SalvageCrateData
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5282,7 +5282,7 @@ Object SupW_AmericaVehicleTomahawk
     DeathFX = FX_CarCrush
   End
 
-  Behavior = CreateCrateDie ModuleTag SalvageData
+  Behavior = CreateCrateDie ModuleTag_Salvage ; @bugfix commy2 19/09/2021 Fix broken module tag.
     CrateData = SalvageCrateData
   End
 


### PR DESCRIPTION
Module tags can't contain spaces. `SalvageData` is just a free floating string and the actal module names becomes just `ModuleTag`.

ModuleTags are used for ReplaceModule and RemoveModule in map.ini files.

Strangely this does not affect the Demo Generals Scud Launcher, which uses `ModuleTag_Salvage` with and underscore. This is why I went with that name.