### PR TITLE
Fix: Vanilla China And Tank General Helix Missing Napalm Bomb Upgrade Icon

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -109,7 +109,7 @@ https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs
 https://github.com/commy2/zerohour/issues/112 [DONE][NPROJECT]        Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon
 https://github.com/commy2/zerohour/issues/111 [DONE][NPROJECT]        Stealth General Saboteur Uses Rebel Death Scream
 https://github.com/commy2/zerohour/issues/110 [DONE][NPROJECT]        Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects
-https://github.com/commy2/zerohour/issues/109 [IMPROVEMENT][NPROJECT] Some Helixes Missing Napalm Bomb Upgrade Icon
+https://github.com/commy2/zerohour/issues/109 [DONE][NPROJECT]        Some Helixes Missing Napalm Bomb Upgrade Icon
 https://github.com/commy2/zerohour/issues/108 [DONE][NPROJECT]        Chinook and Supply Center Upgrade Icons
 https://github.com/commy2/zerohour/issues/107 [IMPROVEMENT][NPROJECT] Pilots Have Misleading Upgrade Icons
 https://github.com/commy2/zerohour/issues/106 [DONE][NPROJECT]        Cargo Planes With Countermeasures Are Missing Hit Effects

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15286,6 +15286,10 @@ Object Boss_VehicleHelix
   SelectPortrait         = SNHelix_L
   ButtonImage            = SNHelix
 
+  ; @bugfix commy2 19/09/2021 Add upgrade icons for Napalm Bomb and Black Napalm.
+
+  UpgradeCameo1 = Upgrade_HelixNapalmBomb
+  UpgradeCameo2 = Upgrade_ChinaBlackNapalm
   UpgradeCameo3 = Upgrade_ChinaHelixGattlingCannon
   UpgradeCameo4 = Upgrade_ChinaHelixPropagandaTower
   UpgradeCameo5 = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -5,6 +5,9 @@ Object ChinaVehicleHelix
   SelectPortrait         = SNHelix_L
   ButtonImage            = SNHelix
 
+  ; @bugfix commy2 19/09/2021 Add upgrade icon for Napalm Bomb.
+
+  UpgradeCameo1 = Upgrade_HelixNapalmBomb
   UpgradeCameo2 = Upgrade_ChinaBlackNapalm
   UpgradeCameo3 = Upgrade_ChinaHelixGattlingCannon
   UpgradeCameo4 = Upgrade_ChinaHelixPropagandaTower

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -275,8 +275,10 @@ Object Nuke_ChinaVehicleHelix
   SelectPortrait         = SNHelix_L
   ButtonImage            = SNHelix
 
+  ; @bugfix commy2 19/09/2021 Moved upgrade icon for Nuke Bomb for cross faction consistency.
 
-  UpgradeCameo2 = Nuke_Upgrade_HelixNukeBomb
+  UpgradeCameo1 = Nuke_Upgrade_HelixNukeBomb
+  ;UpgradeCameo2 = Upgrade_ChinaBlackNapalm
   UpgradeCameo3 = Upgrade_ChinaHelixGattlingCannon
   UpgradeCameo4 = Upgrade_ChinaHelixPropagandaTower
   UpgradeCameo5 = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5,6 +5,9 @@ Object Tank_ChinaVehicleHelix
   SelectPortrait         = SNHelix_L
   ButtonImage            = SNHelix
 
+  ; @bugfix commy2 19/09/2021 Add upgrade icon for Napalm Bomb.
+
+  UpgradeCameo1 = Upgrade_HelixNapalmBomb
   UpgradeCameo2 = Upgrade_ChinaBlackNapalm
   UpgradeCameo3 = Upgrade_ChinaHelixGattlingCannon
   UpgradeCameo4 = Upgrade_ChinaHelixPropagandaTower


### PR DESCRIPTION
ZH 1.04

- The normal China and Tank General's Helix helicopters are missing the upgrade icon for the Napalm Bomb.
- The Nuke General has the Nuke Bomb icon on a different slot than Infantry General has the Napalm Bomb.
- The Boss General Helix has no upgrade icon for Napalm Bomb or Black Napalm at all.

After patch:

- Upgrade icons on the Helix where one would expect them to be.

Note:

- Checking the upgrade icons has no benefit for the enemy, as the Helix model already changes when Napalm/Nuke Bombs are upgraded.