### PR TITLE
Fix: Double Scrapped Scorpion Tank Creates Blue Poison Cloud Even After Anthrax Gamma Upgrade

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7121,7 +7121,7 @@ Weapon Chem_ScorpionMissileWeaponGamma
   ClipReloadTime = 15000  ; how long to reload a Clip, msec
   AutoReloadsClip = Yes
   ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
-  ProjectileDetonationOCL     = OCL_PoisonFieldGammaSmall
+  ;ProjectileDetonationOCL     = OCL_PoisonFieldGammaSmall
 
   ; note, these only apply to units that aren't the explicit target
   ; (ie, units that just happen to "get in the way"... projectiles
@@ -7163,6 +7163,8 @@ Weapon Chem_ScorpionTankGunPlusOne
   ProjectileDetonationOCL     = OCL_PoisonFieldUpgradedSmall
 End
 
+; Patch104p @bugfix commy2 19/09/2021 Fix double/scrap +2 Scorpion Rocket spawns blue poison after Anthrax Gamma upgrade.
+
 ;------------------------------------------------------------------------------
 Weapon Chem_ScorpionMissileWeaponPlusTwo
   PrimaryDamage = 100.0
@@ -7192,7 +7194,7 @@ Weapon Chem_ScorpionMissileWeaponPlusTwo
   ; always collide with the Designated Target, regardless of these flags
   ProjectileCollidesWith = STRUCTURES
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP weapon upgrade
-  ProjectileDetonationOCL     = OCL_PoisonFieldUpgradedSmall
+  ;ProjectileDetonationOCL     = OCL_PoisonFieldUpgradedSmall
 End
 
 ; Patch104p @bugfix commy2 10/09/2021 Make Tox Biker RPG fire the same weapon as regular Tox RPG.


### PR DESCRIPTION
ZH 1.04

- The Toxin General's Scorpion tank creates two poison clouds per Scorpion Rocket after the Scorpion tank has been scrapped up twice (so a total of 4 per clip).
- This does not happen with the single Scorpion Rocket (scrap 0 or scrap +1).
- Only one of the two poison fields can be upgraded with Anthrax Gamma. The other poison field will always remain blue.
- If a vanilla GLA happens to capture a Toxin General's Scorpion tank and upgrades it with Toxin Shells (but neither Anthrax Beta nor Anthrax Gamma), once the Scorpion has been scrapped up twice, each Scorpion Rocket will spawn both a green and a blue poison field.

<p align="center">
  <img src="https://i.imgur.com/rmA8wPA.jpeg">
</p>

<p align="center">
  I find this behaviour to be very unusual.
</p>

After patch:

- Every Scorpion Rocket will only spawn one poison field (after Toxin Shells upgrade). The poison cloud will use the correct color depending on the current Anthrax upgrades.

Note:

- `Chem_ScorpionMissileWeaponGamma` is not actually used by the game, but would suffer the same issue, so I also fixed that one.