### PR TITLE
Fix: Toxin General Terrorist Without Anthrax Beta Upgrade Creates No Poison Cloud

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -197,7 +197,7 @@ https://github.com/commy2/zerohour/issues/22  [IMPROVEMENT]           Build Scor
 https://github.com/commy2/zerohour/issues/21  [IMPROVEMENT][NPROJECT] Demo And Tox Rebel Ambush Tooltips Are Wrong
 https://github.com/commy2/zerohour/issues/20  [DONE][NPROJECT]        Demo Rocket Buggy Loses Red Missile Detonation Effect After Buggy Ammo Upgrade
 https://github.com/commy2/zerohour/issues/19  [DONE][NPROJECT]        Emerging Sneak Attack Uses Tunnel Network Portrait
-https://github.com/commy2/zerohour/issues/18  [MAYBE][NPROJECT]       Toxin General Terrorist Without Anthrax Beta Upgrade Creates No Poison Cloud
+https://github.com/commy2/zerohour/issues/18  [DONE][NPROJECT]        Toxin General Terrorist Without Anthrax Beta Upgrade Creates No Poison Cloud
 https://github.com/commy2/zerohour/issues/17  [MAYBE][NPROJECT]       Toxin General Terrorist Does Extra Damage Before Anthrax Gamma Upgrade
 https://github.com/commy2/zerohour/issues/16  [DONE][NPROJECT]        Toxin Demo Trap Creates Poison Cloud Before It Explodes
 https://github.com/commy2/zerohour/issues/15  [DONE][NPROJECT]        Gamma Toxin Streams Create Green Particles When Clearing Buildings

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -12905,7 +12905,7 @@ Object Chem_GLAInfantryTerrorist
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_93
     DeathWeapon   = Chem_SuicideWeapon
-    StartsActive  = No                      ; turned on by upgrade
+    StartsActive  = Yes ; @bugfix commy2 22/09/2021 Fix Toxin Terrorist creates no poison cloud when used by other factions.
     ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
   End
 
@@ -16567,7 +16567,7 @@ Object Chem_GLAVehicleCombatBike
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_93
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon   = Chem_SuicideWeapon
-    StartsActive  = No                      ; turned on by upgrade
+    StartsActive  = Yes ; @bugfix commy2 22/09/2021 Fix Toxin Terrorist creates no poison cloud when used by other factions.
     ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7947,7 +7947,7 @@ Weapon Chem_SuicideWeapon ; No extra damage, just lays down a damage field
   DeathType = EXPLODED
   WeaponSpeed = 99999.0
   ProjectileObject = NONE
-  FireFX = WeaponFX_ToxinShellWeapon
+;  FireFX = WeaponFX_ToxinShellWeapon
   FireOCL = OCL_PoisonFieldSmall
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 0                   ; time between shots, msec


### PR DESCRIPTION
ZH 1.04

- When using a Toxin General Terrorist as any other faction without Anthrax Beta upgrade, the Terrorist does not create any poison cloud.
- There is a module that would make it create a green poison cloud, but it starts disabled and is impossible to turn on. This implies to me that the unit was supposed to create a green poison cloud in this rare state, but the devs fucked up.

After patch:

- The Toxin Terrorist creates a green poison cloud when used without Anthrax Beta upgrade instead of failing to create any poison cloud.

Tagged as MAYBE, but it being a bug seems obvious to me (tooltip claims the unit "explodes in a cloud of toxin"). It also has an unimaginably small balance impact (extremely rare unit without Anthrax Beta ... you need to take over a Toxin Barracks or let a Toxin team mate surrender).