### PR TITLE
Fix: Raptor Has Misplaced Guard Air Button

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -86,7 +86,7 @@ https://github.com/commy2/zerohour/issues/136 [DONE][NPROJECT]        Demo Charg
 https://github.com/commy2/zerohour/issues/135 [DONE][NPROJECT]        Tunnel And Palace Lack Stop Button
 https://github.com/commy2/zerohour/issues/134 [IMPROVEMENT][NPROJECT] Air Force Carpet Bomber Tooltip Claims 2:30 Cooldown Instead Of True 4:00
 https://github.com/commy2/zerohour/issues/133 [DONE][NPROJECT]        Fire Base Command Button Order Misaligned With Other Buildings
-https://github.com/commy2/zerohour/issues/132 [MAYBE][NPROJECT]       Raptor Guard Air Button Misplaced
+https://github.com/commy2/zerohour/issues/132 [DONE][NPROJECT]        Raptor Guard Air Button Misplaced
 https://github.com/commy2/zerohour/issues/131 [DONE][NPROJECT]        Demo General Combat Bike With Demolitions Upgrade Deals No Damage When Destroyed By Gamma Poison
 https://github.com/commy2/zerohour/issues/130 [DONE][NPROJECT]        Demo Combat Bike Uses Portrait As Button
 https://github.com/commy2/zerohour/issues/129 [MAYBE][NPROJECT]       Selling Air Force Supply Center Does Refund Less Than Half Of Build Value

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -562,9 +562,11 @@ CommandSet AmericaVehicleTomahawkCommandSet
   14 = Command_Stop
 End
 
+; @bugfix commy2 22/09/2021 Fix button position for Guard Air.
+
 CommandSet AmericaJetRaptorCommandSet
-  10 = Command_GuardFlyingUnitsOnly
   11 = Command_AttackMove
+  12 = Command_GuardFlyingUnitsOnly
   13 = Command_Guard
   14 = Command_Stop
 End


### PR DESCRIPTION
ZH 1.04

- The Guard Air button on the Raptor and King Raptor is placed differently than on the Migs. It appears that the developers forgot to move this button in the transition from the 12 button command sets in CCG to the 14 button command sets in ZH.

After patch:

- Raptor Guard Air button is placed in the free corner slot, same as Mig.

Dunno why it is tagged MAYBE. This improves the game by at least 200 % when playing any USA.