### PR TITLE
Fix: Worldbuilder Only Non Vanilla USA Avenger Turret Guard Range

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -144,7 +144,7 @@ https://github.com/commy2/zerohour/issues/77  [DONE][NPROJEC!]        Non-Vanill
 https://github.com/commy2/zerohour/issues/76  [DONE][NPROJEC!]        Chem Suit Rangers Are Missing Hit Effects
 https://github.com/commy2/zerohour/issues/75  [DONE][NPROJEC!]        Some Hellfire Drones Use Scout Drone Model
 https://github.com/commy2/zerohour/issues/74  [DONE][NPROJEC!]        Avenger Turns Chassis When Turret Is Aiming At Air Unit
-https://github.com/commy2/zerohour/issues/73  [MAYBE][NPROJECT]       Avenger Turret Inconsistencies
+https://github.com/commy2/zerohour/issues/73  [DONE][NPROJECT]        Avenger Turret Guard Range
 https://github.com/commy2/zerohour/issues/72  [DONE][NPROJEC!]        Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds
 https://github.com/commy2/zerohour/issues/71  [DONE][NPROJEC!]        Some Paladins Missing Hellfire Drone Upgrade Icon
 https://github.com/commy2/zerohour/issues/70  [MAYBE][NPROJECT]       Boss Sentry Drone Inconsistencies

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6999,7 +6999,7 @@ Object AirF_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
     Conditions     = None
     Armor          = InvulnerableAllArmor ; We can't be hurt on the field.  We share damage from the Avenger with his damage module
   End
-  VisionRange     = 0
+  VisionRange     = 200 ; Patch104p @bugfix commy2 23/09/2021 Add missing guard range to turret.
 
   ; *** AUDIO Parameters ***
   UnitSpecificSounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6709,7 +6709,7 @@ Object Lazr_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
     Conditions     = None
     Armor          = InvulnerableAllArmor ; We can't be hurt on the field.  We share damage from the Avenger with his damage module
   End
-  VisionRange     = 0
+  VisionRange     = 200 ; Patch104p @bugfix commy2 23/09/2021 Add missing guard range to turret.
 
   ; *** AUDIO Parameters ***
   UnitSpecificSounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7175,7 +7175,7 @@ Object SupW_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
     Conditions     = None
     Armor          = InvulnerableAllArmor ; We can't be hurt on the field.  We share damage from the Avenger with his damage module
   End
-  VisionRange     = 0
+  VisionRange     = 200 ; Patch104p @bugfix commy2 23/09/2021 Add missing guard range to turret.
 
   ; *** AUDIO Parameters ***
   UnitSpecificSounds


### PR DESCRIPTION
ZH 1.04

- The non-vanilla USA Avenger turrets have no "vision range", while the other turrets like Gattling Cannons and the vanilla USA Avenger turret do.
- These turrets are not used in skirmish or normal multiplayer, since all sub-faction Avengers use the same turret from vanilla USA, which makes this a worldbuilder only thing essentially.

After patch:

- All turret objects have the same health.

This is helpful for map.ini, because sadly you cannot patch VisionRange that way. The Laser General Avenger turret is slightly different in that it has one AA Laser and one Laser tank gun, so it makes for a possible gimmick base defense.