### PR TITLE
Change: Make Nuke Missiles Destroy GLA Holes

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -320,6 +320,8 @@ Object SupW_NeutronMissile
     SpecialPowerTemplate = SupW_SuperweaponNeutronMissile
   End
 
+  ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_06
     DestructionDelay    = 3501
     ScorchMarkSize      = 320
@@ -329,8 +331,8 @@ Object SupW_NeutronMissile
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 60.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -339,8 +341,8 @@ Object SupW_NeutronMissile
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -349,8 +351,8 @@ Object SupW_NeutronMissile
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -359,8 +361,8 @@ Object SupW_NeutronMissile
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -369,8 +371,8 @@ Object SupW_NeutronMissile
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -378,9 +380,9 @@ Object SupW_NeutronMissile
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 60.0    ;objects inside this get the full damage
+    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 3500.0  ;damage within inner radius of blast
+    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
     Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2639,6 +2639,8 @@ Object BaikonurRocketDetonation
     SpecialPowerTemplate = SuperweaponLaunchBaikonurRocket
   End
 
+  ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_08
     DestructionDelay    = 3501
     ScorchMarkSize      = 320
@@ -2648,8 +2650,8 @@ Object BaikonurRocketDetonation
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 60.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -2658,8 +2660,8 @@ Object BaikonurRocketDetonation
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -2668,8 +2670,8 @@ Object BaikonurRocketDetonation
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -2678,8 +2680,8 @@ Object BaikonurRocketDetonation
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -2688,8 +2690,8 @@ Object BaikonurRocketDetonation
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -2697,9 +2699,9 @@ Object BaikonurRocketDetonation
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 60.0    ;objects inside this get the full damage
+    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 3500.0  ;damage within inner radius of blast
+    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
     Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1877,6 +1877,8 @@ Object NeutronMissile
     SpecialPowerTemplate = SuperweaponNeutronMissile
   End
 
+  ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_06
     DestructionDelay    = 3501
     ScorchMarkSize      = 320
@@ -1886,8 +1888,8 @@ Object NeutronMissile
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 60.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -1896,8 +1898,8 @@ Object NeutronMissile
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -1906,8 +1908,8 @@ Object NeutronMissile
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -1916,8 +1918,8 @@ Object NeutronMissile
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -1926,8 +1928,8 @@ Object NeutronMissile
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -1935,9 +1937,9 @@ Object NeutronMissile
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 60.0    ;objects inside this get the full damage
+    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 3500.0  ;damage within inner radius of blast
+    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
     Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
@@ -1999,6 +2001,8 @@ Object CargoTruckNuke
     MaxLifetime = 3000   ; max lifetime in msec
   End
 
+  ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_03
     DestructionDelay = 3501
     ScorchMarkSize      = 320
@@ -2008,8 +2012,8 @@ Object CargoTruckNuke
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 60.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -2018,8 +2022,8 @@ Object CargoTruckNuke
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -2028,8 +2032,8 @@ Object CargoTruckNuke
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -2038,8 +2042,8 @@ Object CargoTruckNuke
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -2048,8 +2052,8 @@ Object CargoTruckNuke
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 0.0     ;damage within inner radius of blast
+    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -2057,10 +2061,10 @@ Object CargoTruckNuke
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 60.0    ;objects inside this get the full damage
+    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 3500.0  ;damage within inner radius of blast
-    Blast6MinDamage     = 200.0   ;always do at least this much damage to objects
+    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
+    Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 


### PR DESCRIPTION
* As discussed in https://github.com/TheSuperHackers/GeneralsGamePatch/issues/237

ZH 1.04

- The Nuclear Missile is a single explosion, so even when overkilling GLA buildings, it always leaves behind a GLA hole.

After patch:

- The Nuclear Missile is divided up to 6 smaller explosions that total to the same amount of damage, but also may destroy GLA holes (and bunkered Battle Buses).

The PR also changes the worldbuilder only USA SWG Nuclear Missile explosion, the Nuke Truck from the Nuke General GC mission, and the unused Baikonour explosion dummy object from the CCG campaign, because all of these use the exact same logic and values for their mushroom cloud explosions.

damage before:
![https://i.imgur.com/D0PbAZF.png](https://i.imgur.com/D0PbAZF.png)
damage after:
![https://i.imgur.com/mfHgiqT.png](https://i.imgur.com/mfHgiqT.png)

distance ... distance from center of nuke to object
damage ... damage the object receives from nuke

<details><summary>script used to plot the damage</summary>

```python
import sys
from dataclasses import dataclass

import numpy as np
import matplotlib.pyplot as plt

@dataclass
class Explosion:
    delay: float
    dmg_min: float
    dmg_max: float
    r_inner: float
    r_outer: float

    def damage_at(self, x: float) -> float:
        if x < self.r_inner:
            return self.dmg_max

        if x > self.r_outer:
            return 0.0

        if self.r_outer <= self.r_inner:
            return 0.0

        return (
            self.dmg_min +
            (self.dmg_max - self.dmg_min) * (self.r_outer - x) /
            (self.r_outer - self.r_inner)
        )

@dataclass
class TotalDamage:
    explosions: list[Explosion]

    def __iter__(self):
        yield from self.explosions

    def time_steps(self):
        return np.array([ e.delay for e in self.explosions ])

    def total_time(self):
        return max(self.time_steps())

    def step_range(self):
        max_ = max(e.r_outer for e in self.explosions)
        return np.arange(0, round(max_) + 10, 0.001)

    def curve_at_time(self, time):
        explosions = [ e for e in self.explosions if e.delay <= time ]

        damage_values = []
        for x in self.step_range():
            total = sum(e.damage_at(x) for e in explosions)
            damage_values.append(total)

        return (np.array(self.step_range()), np.array(damage_values))


def main():
    delay = [580, 660, 720, 850, 1000, 1180]

    #title = "Nuke Missile 1.04"
    #r_inner = [60, 90, 120, 150, 180, 60]
    #r_outer = [60, 90, 120, 150, 180, 210]
    #dmg_min = [0, 0, 0, 0, 0, 300]
    #dmg_max = [0, 0, 0, 0, 0, 3500]
    title = "Nuke Missile patched"
    r_inner = [60, 90, 120, 150, 180, 210]
    r_outer = [90, 120, 150, 180, 210, 210]
    dmg_min = [0, 0, 0, 0, 0, 300]
    dmg_max = [640, 640, 640, 640, 640, 300]

    explosions = [ Explosion(*vals) for vals in zip(delay, dmg_min, dmg_max, r_inner, r_outer) ]
    nuke = TotalDamage(explosions)

    for explosion in nuke:
        time = explosion.delay
        x, y = nuke.curve_at_time(time)
        plt.plot(x, y, label=f"{time} ms")

    plt.title(title)
    plt.xlabel("distance")
    plt.ylabel("damage")
    plt.legend()
    plt.show()

    return 0


if __name__ == "__main__":
    sys.exit(main())
```

</details>