### PR TITLE
Change: Reduce XP reward for regular ground tanks by 30%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7394,7 +7394,10 @@ Object AirF_AmericaTankMicrowave
     Object = AirF_AmericaWarFactory
     Object = AirF_AmericaStrategyCenter
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7395,9 +7395,7 @@ Object AirF_AmericaTankMicrowave
     Object = AirF_AmericaStrategyCenter
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1441,9 +1441,7 @@ Object AmericaTankCrusader
     Object = AmericaWarFactory
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
@@ -1913,9 +1911,7 @@ Object AmericaTankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience
@@ -2733,9 +2729,7 @@ Object AmericaTankMicrowave
     Object = AmericaStrategyCenter
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1440,7 +1440,10 @@ Object AmericaTankCrusader
   Prerequisites
     Object = AmericaWarFactory
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
@@ -1910,7 +1913,9 @@ Object AmericaTankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience
@@ -2727,7 +2732,10 @@ Object AmericaTankMicrowave
     Object = AmericaWarFactory
     Object = AmericaStrategyCenter
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19608,7 +19608,9 @@ Object Boss_TankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19608,9 +19608,7 @@ Object Boss_TankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19191,7 +19191,9 @@ Object Chem_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue = 80 80 160 240     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19193,7 +19193,7 @@ Object Chem_GLATankMarauder
 
   ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
 
-  ExperienceValue = 80 80 160 240     ;Experience point value at each level
+  ExperienceValue = 80 80 160 320     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19191,9 +19191,7 @@ Object Chem_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue = 80 80 160 320     ;Experience point value at each level
+  ExperienceValue = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -60,7 +60,9 @@ Object ChinaTankBattleMaster
     Object = ChinaWarFactory
   End
 
-  ExperienceValue = 100 100 200 400    ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue = 80 80 160 320    ;Experience point value at each level
   ExperienceRequired = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -60,9 +60,7 @@ Object ChinaTankBattleMaster
     Object = ChinaWarFactory
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue = 80 80 160 320    ;Experience point value at each level
+  ExperienceValue = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -57,7 +57,10 @@ Object MilitiaTank
   Prerequisites
     Object = AmericaWarFactory
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -58,9 +58,7 @@ Object MilitiaTank
     Object = AmericaWarFactory
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
@@ -242,7 +240,8 @@ Object MammothTank
   ShroudClearingRange = 300
   Prerequisites
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 3  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20674,9 +20674,7 @@ Object Demo_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue = 80 80 160 320     ;Experience point value at each level
+  ExperienceValue = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20674,7 +20674,9 @@ Object Demo_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue = 80 80 160 240     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20676,7 +20676,7 @@ Object Demo_GLATankMarauder
 
   ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
 
-  ExperienceValue = 80 80 160 240     ;Experience point value at each level
+  ExperienceValue = 80 80 160 320     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6002,7 +6002,9 @@ Object GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue = 80 80 160 240     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6004,7 +6004,7 @@ Object GLATankMarauder
 
   ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
 
-  ExperienceValue = 80 80 160 240     ;Experience point value at each level
+  ExperienceValue = 80 80 160 320     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6002,9 +6002,7 @@ Object GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue = 80 80 160 320     ;Experience point value at each level
+  ExperienceValue = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5815,7 +5815,10 @@ Object Lazr_AmericaTankCrusader
   Prerequisites
     Object = Lazr_AmericaWarFactory
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
@@ -6281,7 +6284,9 @@ Object Lazr_AmericaTankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience
@@ -7097,7 +7102,10 @@ Object Lazr_AmericaTankMicrowave
     Object = Lazr_AmericaWarFactory
     Object = Lazr_AmericaStrategyCenter
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5816,9 +5816,7 @@ Object Lazr_AmericaTankCrusader
     Object = Lazr_AmericaWarFactory
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
@@ -6284,9 +6282,7 @@ Object Lazr_AmericaTankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience
@@ -7103,9 +7099,7 @@ Object Lazr_AmericaTankMicrowave
     Object = Lazr_AmericaStrategyCenter
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16557,7 +16557,9 @@ Object Nuke_ChinaTankBattleMaster
     Object = Nuke_ChinaWarFactory
   End
 
-  ExperienceValue = 100 100 200 400    ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue = 80 80 160 320    ;Experience point value at each level
   ExperienceRequired = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16557,9 +16557,7 @@ Object Nuke_ChinaTankBattleMaster
     Object = Nuke_ChinaWarFactory
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue = 80 80 160 320    ;Experience point value at each level
+  ExperienceValue = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20723,7 +20723,9 @@ Object Slth_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue = 80 80 160 240     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20723,9 +20723,7 @@ Object Slth_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue = 80 80 160 320     ;Experience point value at each level
+  ExperienceValue = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20725,7 +20725,7 @@ Object Slth_GLATankMarauder
 
   ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
 
-  ExperienceValue = 80 80 160 240     ;Experience point value at each level
+  ExperienceValue = 80 80 160 320     ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6297,7 +6297,10 @@ Object SupW_AmericaTankCrusader
   Prerequisites
     Object = SupW_AmericaWarFactory
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
@@ -6750,7 +6753,9 @@ Object SupW_AmericaTankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience
@@ -7565,7 +7570,10 @@ Object SupW_AmericaTankMicrowave
     Object = SupW_AmericaWarFactory
     Object = SupW_AmericaStrategyCenter
   End
-  ExperienceValue        = 100 100 200 400 ;Experience point value at each level
+
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6298,9 +6298,7 @@ Object SupW_AmericaTankCrusader
     Object = SupW_AmericaWarFactory
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
@@ -6753,9 +6751,7 @@ Object SupW_AmericaTankPaladin
     Science = SCIENCE_PaladinTank
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
   IsTrainable     = Yes  ;Can gain experience
@@ -7571,9 +7567,7 @@ Object SupW_AmericaTankMicrowave
     Object = SupW_AmericaStrategyCenter
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue        = 80 80 160 320 ;Experience point value at each level
+  ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2774,9 +2774,7 @@ Object Tank_ChinaTankBattleMaster
     Object = Tank_ChinaWarFactory
   End
 
-  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
-
-  ExperienceValue = 80 80 160 320    ;Experience point value at each level
+  ExperienceValue = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2774,7 +2774,9 @@ Object Tank_ChinaTankBattleMaster
     Object = Tank_ChinaWarFactory
   End
 
-  ExperienceValue = 100 100 200 400    ;Experience point value at each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce tank experience reward by 20%.
+
+  ExperienceValue = 80 80 160 320    ;Experience point value at each level
   ExperienceRequired = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles


### PR DESCRIPTION
Fixes #395
Closes #779
Closes #780
Closes #781

## Original

* Tanks (Crusader, Paladin, Microwave, Battle Master, Marauder) grant 100% more experience than almost all other vehicles at 100 100 200 400
* This especially snowballs when combined with Vet 2 (e.g. Elite Battle Master Training), because Vet 2 vehicles grant double the amount of experience, making it 4 times as much XP per kill.

## Patched

* XP granted by killing regular Tanks is reduced by 30% to 70 70 140 280. This means that tank like units now grant only 40% more experience instead of 100% more experience when compared to other vehicles.

This change does not touch Overlords and Scorpion tanks. Scorpion tanks already only grant 20% more experience compared to other vehicles.

# Rationale

## Stats
In the following chart we see how many kills of different units it takes to reach a certain General Rank. Originally it would take 13 HERO tank kills to reach Rank 5. With this change it will take 18 HERO tank kills to reach Rank 5. The XP reward granted for these tanks is still significantly higher than light vehicles, long range vehicles and aircraft.

![tanks_exp_edit](https://user-images.githubusercontent.com/4720891/182416248-1406cbae-ff47-4daa-a8cc-7240193e7b6a.png)

## Conclusion
The original kill rewards for tanks are high. Since tanks are typically not that difficult to take out with Rocket Soldiers, Long Range Vehicles and Aircraft, it appears unwarranted to award that much kill experience. A XP reduction by 30% is logical.
