### PR TITLE
Change: Lotus XP Requirements And Rewards

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17756,8 +17756,10 @@ Object Boss_InfantryBlackLotus
   MaxSimultaneousOfType = 1
   CommandSet            = ChinaInfantryBlackLotusCommandSet
 
-  ExperienceValue       = 50 100 150 400    ;Experience point value at each level
-  ExperienceRequired    = 0 150 450 900  ;Experience points needed to gain each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+
+  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
+  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = ChinaInfantryBlackLotusCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -644,8 +644,10 @@ Object ChinaInfantryBlackLotus
   MaxSimultaneousOfType = 1
   CommandSet            = ChinaInfantryBlackLotusCommandSet
 
-  ExperienceValue       = 50 100 150 400    ;Experience point value at each level
-  ExperienceRequired    = 0 150 450 900  ;Experience points needed to gain each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+
+  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
+  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = ChinaInfantryBlackLotusCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -733,8 +733,10 @@ Object Infa_ChinaInfantryBlackLotus
   BuildTime             = 20.0          ;in seconds
   MaxSimultaneousOfType = 1
 
-  ExperienceValue       = 50 100 150 400    ;Experience point value at each level
-  ExperienceRequired    = 0 150 450 900  ;Experience points needed to gain each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+
+  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
+  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Infa_ChinaInfantryBlackLotusCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2063,8 +2063,10 @@ Object Nuke_ChinaInfantryBlackLotus
   MaxSimultaneousOfType = 1
   CommandSet            = Nuke_ChinaInfantryBlackLotusCommandSet
 
-  ExperienceValue       = 50 100 150 400    ;Experience point value at each level
-  ExperienceRequired    = 0 150 450 900  ;Experience points needed to gain each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+
+  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
+  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Nuke_ChinaInfantryBlackLotusCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1794,8 +1794,10 @@ Object Tank_ChinaInfantryBlackLotus
   MaxSimultaneousOfType = 1
   CommandSet            = Tank_ChinaInfantryBlackLotusCommandSet
 
-  ExperienceValue       = 50 100 150 400    ;Experience point value at each level
-  ExperienceRequired    = 0 150 450 900  ;Experience points needed to gain each level
+  ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+
+  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
+  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Tank_ChinaInfantryBlackLotusCommandSet


### PR DESCRIPTION
Fixes #718

ZH 1.04

- Lotus requires to hack (steal or capture) 8, 23 and 45 buildings to vet up, which is impossible in any serious game beyond vet 1 in very rare cases.
- A vetted Lotus grants insane amounts of experience. At vet 3, it grants as much as [18 vet 0/1 Gatling tanks] / [9 vet 1/2 Battle Masters] / [180 vet 0/1 Red Guards] / [1.5 vet 3 Overlords].

After patch:

- Lotus requires 5, 10 and 20 building hacks to vet up.
- Lotus grants the same amount of experience when killed as Burton and Jarmen Kell (which is the same as almost all non-tank like vehicles). This is the same value at vet 0 before and after the patch, but raises significantly slower when leveled up.

Notes:
- This increases her HP and gives healing at vet 2. No hack ability is made faster or gets extended range or anything else similar to that by vetting up.
- Disabling vehicles does not grant any experience before or after this patch.