### PR TITLE
Change: Make Hellfire Drone Kills Reward XP Like Battle Drones

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6271,6 +6271,10 @@ Object AirF_AmericaVehicleHellfireDrone
   ShroudClearingRange = 500
   IsTrainable     = No  ;Can gain experience
 
+  ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.
+
+  ExperienceValue     = 10 10 10 10 ;Experience point value at each level
+
   ; *** AUDIO Parameters ***
   VoiceSelect = NoSound
   VoiceMove = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1147,6 +1147,10 @@ Object AmericaVehicleHellfireDrone
   ShroudClearingRange = 500
   IsTrainable     = No  ;Can gain experience
 
+  ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.
+
+  ExperienceValue     = 10 10 10 10 ;Experience point value at each level
+
   ; *** AUDIO Parameters ***
   VoiceSelect = NoSound
   VoiceMove = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5512,6 +5512,10 @@ Object Lazr_AmericaVehicleHellfireDrone
   ShroudClearingRange = 500
   IsTrainable     = No  ;Can gain experience
 
+  ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.
+
+  ExperienceValue     = 10 10 10 10 ;Experience point value at each level
+
   ; *** AUDIO Parameters ***
   VoiceSelect = NoSound
   VoiceMove = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5988,6 +5988,10 @@ Object SupW_AmericaVehicleHellfireDrone
   ShroudClearingRange = 500
   IsTrainable     = No  ;Can gain experience
 
+  ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.
+
+  ExperienceValue     = 10 10 10 10 ;Experience point value at each level
+
   ; *** AUDIO Parameters ***
   VoiceSelect = NoSound
   VoiceMove = NoSound


### PR DESCRIPTION
- close https://github.com/xezon/GeneralsGamePatch/issues/398

Hellfire gets it. Scout Drone and Spy Drone don't since they are unarmed. Keeps in line with the spirit of CCG.

The amount is tiny regardless (half a Ranger / MD, a fifth of a Humvee).