### PR TITLE
Reverting some changes (other than Camouflage upgrade).

### DIFF
--- a/Patch104pZH/Design/Changes/game_balance.md
+++ b/Patch104pZH/Design/Changes/game_balance.md
@@ -35,7 +35,7 @@
 | Red Guard         |      |      | 10 |  9   |
 | Tank Hunter       |      |      |  5 |  4.5 |
 | Hacker            |  625 |  550 | 20 | 15   |
-| Battlemaster      |  800 |  650 |    |      |
+| Battlemaster      |  800 |  700 |    |      |
 | Gattling Tank     |  800 |  700 |    |      |
 | Dragon Tank       |  800 |  700 |    |      |
 | ECM Tank          |  800 |  750 |    |      |
@@ -56,7 +56,6 @@
 | Helix            |      |      |  20 |  25   |
 | Inferno Cannon   | 1100 | 1000 |  15 |  14   |
 | Nuke Cannon      | 1600 | 1400 |  20 |  18   |
-| Fortified Bunker |  700 |  750 |   8 |   9   |
 
 ### Nuke China
 
@@ -110,13 +109,12 @@ Composite Armour now gives 25% HP (fixed for all units)
 
 | ___________ Object ___________ | Old price ($) | New price ($) | Old time (s) | New time (s) |
 |--------------------------------|--------------:|--------------:|-------------:|-------------:|
-| Patriot Battery | 1000 |  700 | 25 | 30 |
-| Crusader        |  900 |  850 |    |    |
-| Paladin         | 1100 | 1000 | 12 | 10 |
+| Patriot Battery | 1000 |  750 |    |    |
+| Paladin         | 1100 | 1000 |    |    |
 | Ambulance       |  600 |  700 |    |    |
-| Raptor          | 1400 |  900 |    |    |
+| Raptor          | 1400 | 1100 |    |    |
 | Comanche        | 1500 | 1350 |    |    |
-| Stealth Fighter | 1600 |  900 |    |    |
+| Stealth Fighter | 1600 | 1250 |    |    |
 | Aurora          | 2500 | 2000 |    |    |
 | Sentry Drone    |  800 |  500 | 10 |  8 |
 
@@ -126,22 +124,20 @@ Composite Armour now gives 25% HP (fixed for all units)
 |--------------------------------|--------------:|--------------:|-------------:|-------------:|
 | Early Emergency Repair |      |      | 240 | 120 |
 | Carpet Bomb            |      |      | 240 | 360 |
-| Patriot                | 1000 |  700 |  25 |  30 |
+| Patriot                | 1000 |  750 |     |     |
 | Chinook                |  950 | 1200 |     |     |
 | Combat Chinook         |      |      |  25 |  30 |
 | Sentry Drone           |  850 |  500 |  10 |   8 |
-| Stealth Fighter        | 1250 |  950 |     |     |
 
 ### Laser USA
 
 | ___________ Object ___________ | Old price ($) | New price ($) | Old time (s) | New time (s) |
 |--------------------------------|--------------:|--------------:|-------------:|-------------:|
-| Laser Crusader  |  900 |  850 |    |    |
 | Ambulance       |  600 |  700 |    |    |
 | Sentry Drone    |  800 |  500 | 10 |  8 |
-| Raptor          | 1400 |  900 |    |    |
+| Raptor          | 1400 | 1100 |    |    |
 | Comanche        | 1500 | 1350 |    |    |
-| Stealth Fighter | 1600 |  900 |    |    |
+| Stealth Fighter | 1600 | 1250 |    |    |
 | Aurora          | 2500 | 2000 |    |    |
 
 ### Superweapon USA
@@ -154,8 +150,8 @@ Composite Armour now gives 25% HP (fixed for all units)
 | Humvee                 |  850 |  800 |    |    |
 | Sentry Drone           | 1000 |  500 | 10 |  8 |
 | Tomahawk               | 1400 | 1200 |    |    |
-| Raptor                 | 1400 |  900 |    |    |
-| Stealth Fighter        | 1600 |  900 |    |    |
+| Raptor                 | 1400 | 1100 |    |    |
+| Stealth Fighter        | 1600 | 1250 |    |    |
 | Comanche               | 1800 | 1350 |    |    |
 | Alpha Aurora Bomber    | 2000 | 2500 |    |    |
 
@@ -167,7 +163,6 @@ Composite Armour now gives 25% HP (fixed for all units)
 | BioBomb             |  500 |  300 |     |     |
 | HighExplosiveBomb   |  500 |  400 |     |     |
 | FortifiedStructures | 1000 | 1500 |     |     |
-| Scud Storm          |      |      | 300 | 360 |
 | Scud Launcher       |      |      |  15 |  14 |
 
 ### GLA
@@ -175,7 +170,7 @@ Composite Armour now gives 25% HP (fixed for all units)
 | ___________ Object ___________ | Old price ($) | New price ($) | Old time (s) | New time (s) |
 |--------------------------------|--------------:|--------------:|-------------:|-------------:|
 | Booby Trap   | 1000 |  400 | 40 | 15 |
-| Camouflage   | 2000 | 1000 | 60 | 30 |
+| Camouflage   | 2000 |  800 | 60 | 30 |
 | Hijacker     |      |      | 10 |  5 |
 | Saboteur     |      |      | 15 | 10 |
 | Bomb Truck   | 1200 | 1100 | 15 | 12 |

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -16652,8 +16652,8 @@ Object AirF_AmericaPatriotBattery
   Prerequisites
     Object = AirF_AmericaPowerPlant
   End
-  BuildCost        = 700
-  BuildTime        = 30.0           ; in seconds
+  BuildCost        = 750
+  BuildTime        = 25.0           ; in seconds
   EnergyProduction = -3
   WeaponSet
     Conditions          = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1961,7 +1961,7 @@ Object AirF_AmericaJetStealthFighter
     DamageFX              = None
   End
 
-  BuildCost           = 950
+  BuildCost           = 1250
   BuildTime           = 20.0            ;in seconds
   ExperienceValue     = 100 100 200 300 ;Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -595,7 +595,7 @@ Object AmericaJetRaptor
   End
 
 
-  BuildCost               = 900
+  BuildCost               = 1100
   BuildTime               = 20
   ExperienceValue         = 50 50 100 150  ;Experience point value at each level
   ExperienceRequired      = 0 100 200 400   ;Experience points needed to gain each level
@@ -1548,7 +1548,7 @@ Object AmericaJetStealthFighter
     DamageFX              = None
   End
 
-  BuildCost           = 900
+  BuildCost           = 1250
   BuildTime           = 20.0            ;in seconds
   ExperienceValue     = 100 100 200 300 ;Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1429,7 +1429,7 @@ Object AmericaTankCrusader
   ;  Armor                = UpgradedTankArmor
   ;  DamageFX             = TankDamageFX
   ;End
-  BuildCost              = 850
+  BuildCost              = 900
   BuildTime              = 10.0          ;in seconds
   VisionRange            = 150
   ShroudClearingRange = 300
@@ -1889,7 +1889,7 @@ Object AmericaTankPaladin
   ;  DamageFX        = TankDamageFX
   ;End
   BuildCost       = 1000  ; Patch104p @balance 05/09/2021 Original=1100
-  BuildTime       = 10.0          ;in seconds
+  BuildTime       = 12.0          ;in seconds
   VisionRange     = 150
   ShroudClearingRange = 300
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -52,7 +52,7 @@ Object ChinaTankBattleMaster
     Armor           = TankArmor
     DamageFX        = TankDamageFX
   End
-  BuildCost       = 650
+  BuildCost       = 700
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 150
   ShroudClearingRange = 300

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -29814,8 +29814,8 @@ Object AmericaPatriotBattery
   Prerequisites
     Object = AmericaPowerPlant
   End
-  BuildCost        = 700
-  BuildTime        = 30.0           ; in seconds
+  BuildCost        = 750
+  BuildTime        = 25.0           ; in seconds
   EnergyProduction = -3
   WeaponSet
     Conditions          = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -14635,8 +14635,8 @@ Object Infa_ChinaBunker
   Prerequisites
     Object = Infa_ChinaBarracks
   End
-  BuildCost         = 750
-  BuildTime         = 9.0           ; in seconds
+  BuildCost         = 700
+  BuildTime         = 8.0           ; in seconds
   EnergyProduction  = 0
   VisionRange       = 300.0         ; Shroud clearing distance
   ShroudClearingRange = 200

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5789,7 +5789,7 @@ Object Lazr_AmericaTankCrusader
     DamageFX             = TankDamageFX
   End
 
-  BuildCost              = 850
+  BuildCost              = 900
   BuildTime              = 10.0          ;in seconds
   VisionRange            = 150
   ShroudClearingRange = 300

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -597,7 +597,7 @@ Object Lazr_AmericaJetRaptor
   End
 
 
-  BuildCost               = 900
+  BuildCost               = 1100
   BuildTime               = 20
   ExperienceValue         = 50 50 100 150  ;Experience point value at each level
   ExperienceRequired      = 0 100 200 400   ;Experience points needed to gain each level
@@ -1306,7 +1306,7 @@ Object Lazr_AmericaJetStealthFighter
     DamageFX              = None
   End
 
-  BuildCost           = 900
+  BuildCost           = 1250
   BuildTime           = 20.0            ;in seconds
   ExperienceValue     = 100 100 200 300 ;Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -1070,7 +1070,7 @@ Object SupW_AmericaJetRaptor
   End
 
 
-  BuildCost               = 900
+  BuildCost               = 1100
   BuildTime               = 20
   ExperienceValue         = 50 50 100 150  ;Experience point value at each level
   ExperienceRequired      = 0 100 200 400   ;Experience points needed to gain each level
@@ -1779,7 +1779,7 @@ Object SupW_AmericaJetStealthFighter
     DamageFX              = None
   End
 
-  BuildCost           = 900
+  BuildCost           = 1250
   BuildTime           = 20.0            ;in seconds
   ExperienceValue     = 100 100 200 300 ;Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -240,7 +240,7 @@ End
 ;-----------------------------------------------------------------------------
 SpecialPower SuperweaponScudStorm
   Enum                = SPECIAL_SCUD_STORM
-  ReloadTime          = 360000   ; in milliseconds. min is 2x door/open close time!
+  ReloadTime          = 300000   ; in milliseconds. min is 2x door/open close time!
   InitiateSound       = ScudStormInitiated
   PublicTimer         = Yes
   ViewObjectDuration  = 40000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -521,7 +521,7 @@ End
 Upgrade Upgrade_GLACamouflage
   DisplayName        = UPGRADE:Camouflage
   BuildTime          = 30.0
-  BuildCost          = 1000
+  BuildCost          = 800
   ButtonImage        = SSCamoflage
   ResearchSound      = RebelVoiceUpgradeCamouflage
 End


### PR DESCRIPTION
Reverting some changes

Scud Storm revert to 5 mins:
Nerf was unnecessary. The main approach of 1.04p is to buff the weaknesses. A nerf is only used in cases where an unfair advantage is present relative to other factions (Air Force Chinook e.g.). With the Build Time included the balance is now like so: 
Particle Cannon 4+1 minutes, Nuclear Missile 5+1 minutes, Scud Storm 5+2 minutes.

Air/USA Patriots slight change to $750/25s:
BT reverted, the trade is a slight price increase again to make the overall change more minimalistic and more predictable for the user.

Inf Bunker revert build time and price ($700/8s):
Nerf was unnecessary (see Scud Storm motivation).

All Raptors to $1100:
To prevent unpredictable scenarios (potential over-buff), the Vanilla Raptor price reduction has been reverted to match the King Raptor. There should no reason why this inferior unit should be more expensive than the King Raptor.

All Stealth Fighters to $1250:
Same scenario, all Stealth Fighters have been matched to the Airforce price.

Crusader Tank price revert to 1.04 ($900):
Unnecessary buff that potentially can harm balance. Already an effective unit in specific situations. 

Paladin build time revert to 1.04 (12s):
Paladin drops have proved to be quite effective vs GLA's, a build time buff was not necessary. To see better quantities on the field in later game scenarios (relative to Crusader tank), the price reduction to $1000 is maintained.

Laser Crusader revert price ($900):
Same scenario as Vanilla Crusader.

China BM slight change to $700:
Same scenario as the Vanilla Raptor/Stealth Fighter. Price has been matched with Tank's Vetted Battle Master. 

Camouflage Upgrade to $800:
$1000 still seemed like an expensive upgrade for rebels in late game scenarios. Typically the ambush was most useful to capture sniped units like Overlords, killing Hackers or base scouting (to initiate Sneak Attacks), for which level 1 was sufficient without the upgrade. With the upgrade, it might now be viable in certain situations to pick higher level Ambushes and/or use them for different tactical purposes, like 'permanent' base scouting, or making base captures more efficient. 