### PR TITLE
Change: Make Lotus Earn XP When Hacking Vehicles

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17933,7 +17933,7 @@ Object Boss_InfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 0
+    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -760,7 +760,7 @@ Object ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 0
+    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -837,7 +837,7 @@ Object Infa_ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 0
+    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2182,7 +2182,7 @@ Object Nuke_ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 0
+    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1913,7 +1913,7 @@ Object Tank_ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 0
+    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12


### PR DESCRIPTION
Reference:
* #416

This change rewards China Black Lotus Vehicle Hack with 5 XP per hack.

A Building Hack gives 20 XP as per original.

The rewarded XP gives General XP, just like building captures and unit kills do.

In theory it can be abused to grind XP when an enemy unit has been trapped. Find below hack XP time estimations based on the proposed XP value of 5. A vehicle hack takes around 5 seconds to complete.

## Black Lotus vehicle hack XP times

| Veterancy | ExperienceRequired | req. Vehicle Hack count | req. Vehicle Hack time |
|-----------|--------------------|-------------------------|------------------------|
| 1         | 100                | 20                      | 100 seconds (01:40) |
| 2         | 200                | 40                      | 200 seconds (03:20) |
| 3         | 400                | 80                      | 400 seconds (06:40) |

| General Rank | SkillPointsNeeded | req. Vehicle Hack count | req. Vehicle Hack time |
|--------------|-------------------|-------------------------|------------------------|
| 2            | 800               | 160                     | 0800 seconds (13:20) |
| 3            | 1500              | 300                     | 1500 seconds (25:00) |
| 4            | 2500              | 500                     | 2500 seconds (41:40) |
| 5            | 5000              | 1000                    | 5000 seconds (83:20) |

Farming XP with Black Lotus is unpractical. Even just reaching Rank 2 would take over 13 minutes of non stop Lotus hacking. It is simply not worth the time. We can conclude, that a Vehicle Hack XP reward around 5 is low and safe to use.

https://user-images.githubusercontent.com/4720891/182186932-7dac4887-636e-4b19-8d69-84db425529b1.mp4

## Super Hacker

For Super Hacker the XP farming becomes a different story. Since a player can build unlimited amounts of Hackers and all of them can attack the same target vehicle at the same time over and over again, the rewards multiply depending on the number of Hackers. Therefore it is not safe to grant XP rewards on Super Hacker Vehicle Hack and Building Hack.

https://user-images.githubusercontent.com/4720891/182187063-faede770-fb90-4c87-8c0c-a978a6755279.mp4
