### PR TITLE
Change: Make Supply Truck Able To Reverse Move

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -1080,6 +1080,9 @@ Locomotor SupplyTruckLocomotor
   MaximumWheelCompression         = 0 ; Maximum distance the wheel will move up into the chassis.
   FrontWheelTurnAngle             = 22      ; How many degrees the front wheels can turn.
 
+  ; Patch104p @balance 01/10/2021 Add reverse gear for better collecting.
+
+  CanMoveBackwards        = Yes   ; Can move backwards.
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
- ref close TheSuperHackers/GeneralsGamePatch#435

Demos:

<details><summary>Manual control</summary>

https://user-images.githubusercontent.com/6576312/135605862-8d140e0d-8a76-4f8b-b8fc-8eeee0bf32da.mp4

</details>

<details><summary>Mine-Supply glitch interaction (ref TheSuperHackers/GeneralsGameCode#2776)</summary>

https://user-images.githubusercontent.com/6576312/135605866-d9cb9ace-2242-4164-bf78-100cc191ecbb.mp4

</details>

<details><summary>Small Pile collection</summary>

https://user-images.githubusercontent.com/6576312/135605905-7de4a6e6-c8ed-458e-9482-0f83adca4389.mp4

</details>

<details><summary>Noob supply placement</summary>

https://user-images.githubusercontent.com/6576312/135605909-f5842d25-7781-40cf-96b6-37f7becf8889.mp4

</details>