### PR TITLE
Fix: Demo Traps Are Triggered By Nearby Enemy Poison And Radiation Fields

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5395,8 +5395,9 @@ Object Chem_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
   
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added STRUCTURE to list of ignored target types.
   ; Demo Traps will no longer be triggered by base defense and building scaffolds.
+  ; Patch104p @bugfix commy2 01/10/2021 Fix enemy hazard fields triggering demo traps.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -5404,7 +5405,7 @@ Object Chem_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE STRUCTURE CLEANUP_HAZARD
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
     DetonateWhenKilled        = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4712,8 +4712,9 @@ Object Demo_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
   
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added STRUCTURE to list of ignored target types.
   ; Demo Traps will no longer be triggered by base defense and building scaffolds.
+  ; Patch104p @bugfix commy2 01/10/2021 Fix enemy hazard fields triggering demo traps.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -4721,7 +4722,7 @@ Object Demo_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE STRUCTURE CLEANUP_HAZARD
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -15454,8 +15454,9 @@ Object GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
 
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added STRUCTURE to list of ignored target types.
   ; Demo Traps will no longer be triggered by base defense and building scaffolds.
+  ; Patch104p @bugfix commy2 01/10/2021 Fix enemy hazard fields triggering demo traps.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -15463,7 +15464,7 @@ Object GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE STRUCTURE CLEANUP_HAZARD
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1141,13 +1141,15 @@ Object GC_Chem_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
 
+  ; Patch104p @bugfix commy2 01/10/2021 Fix enemy buildings and hazard fields triggering demo traps.
+
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
     DetonationWeaponSlot      = PRIMARY   ;The slot the weapon is in when it detonates.
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE STRUCTURE CLEANUP_HAZARD
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -5708,13 +5708,15 @@ Object GC_Slth_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
 
+  ; Patch104p @bugfix commy2 01/10/2021 Fix enemy buildings and hazard fields triggering demo traps.
+
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
     DetonationWeaponSlot      = PRIMARY   ;The slot the weapon is in when it detonates.
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE STRUCTURE CLEANUP_HAZARD
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5453,8 +5453,9 @@ Object Slth_GLADemoTrap
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
   
-  ; Patch104p @bugfix hanfield 28/08/2021 Added FS_BASE_DEFENSE and STRUCTURE to list of ignored target types.
+  ; Patch104p @bugfix hanfield 28/08/2021 Added STRUCTURE to list of ignored target types.
   ; Demo Traps will no longer be triggered by base defense and building scaffolds.
+  ; Patch104p @bugfix commy2 01/10/2021 Fix enemy hazard fields triggering demo traps.
 
   Behavior = DemoTrapUpdate ModuleTag_04
     DefaultProximityMode      = Yes       ;If yes, defaults to proximity mode, otherwise defaults to manual.
@@ -5462,7 +5463,7 @@ Object Slth_GLADemoTrap
     ProximityModeWeaponSlot   = SECONDARY ;The slot proximity mode is determined by (bogus weapon)
     ManualModeWeaponSlot      = TERTIARY  ;The slot manual mode is determined by (bogus weapon)
     TriggerDetonationRange    = 40.0      ;Detonation range when in proximity mode (and must be on ground)
-    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE FS_BASE_DEFENSE STRUCTURE
+    IgnoreTargetTypes         = PROJECTILE UNATTACKABLE STRUCTURE CLEANUP_HAZARD
     AutoDetonationWithFriendsInvolved = Yes ;GLA are low tech
 ;    DetonationWeapon          = DemoTrapDetonationWeapon
     DetonateWhenKilled        = Yes


### PR DESCRIPTION
- fix #305

ZH 1.04:

- A Demo Trap triggers once the enemy places a poison or radiation field nearby.

After patch:

- A Demo Trap does not trigger by poison or radiation, only when destroyed or by actual enemies.

Took out `FS_BASE_DEFENSE`, because those are a proper sub-set of `STRUCTURE`, to keep the list short and comprehensible.

I also applied the fix of PR-#94 to the single player only GC GLA faction Demo Traps.