### PR TITLE
Fix: ECM Tank Cannot Disable Heroic (Vet 3) Quad Cannons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16840,7 +16840,7 @@ Object Chem_GLAVehicleQuadCannon
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
-    SubdualDamageCap = 440
+    SubdualDamageCap = 600  ; Patch104p @bugfix commy2 01/10/2021 Fix ECM Tank failing to disable heroic unit.
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -18078,7 +18078,7 @@ Object Demo_GLAVehicleQuadCannon
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
-    SubdualDamageCap = 440
+    SubdualDamageCap = 600  ; Patch104p @bugfix commy2 01/10/2021 Fix ECM Tank failing to disable heroic unit.
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3492,7 +3492,7 @@ Object GLAVehicleQuadCannon
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
-    SubdualDamageCap = 440
+    SubdualDamageCap = 600  ; Patch104p @bugfix commy2 01/10/2021 Fix ECM Tank failing to disable heroic unit.
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18240,7 +18240,7 @@ Object Slth_GLAVehicleQuadCannon
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
-    SubdualDamageCap = 440
+    SubdualDamageCap = 600  ; Patch104p @bugfix commy2 01/10/2021 Fix ECM Tank failing to disable heroic unit.
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End


### PR DESCRIPTION
- fix https://github.com/xezon/GeneralsGamePatch/issues/396

600 comes from the health x 2 formula used by every other unit in the game. It was 440, because Quad Cannon health used to be 220.

This fix does not include the single player only GC Quads, because those have no logic at all for ECM (will probably fix that later when those factions are to be done).

I could not find any reason to set it to 450 as suggested. They wake up in the proper order for me (vet 3 first, no vet last etc.). Following the formula makes it consistent and we avoid possible similar bugs when health bonuses vs easy/hard AI, or Hold The Line are applied on the Quad.

