### PR TITLE
Fix: Scaffolds Delete Money Crates

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -220,6 +220,8 @@ Object SalvageCrate
 
 End
 
+; Patch104p @bugfix commy2 01/10/2021 Fix scaffolds delete crates.
+
 ; -----------------------------------------------------------------------------
 
 Object 1000DollarCrate
@@ -237,7 +239,7 @@ Object 1000DollarCrate
   TransportSlotCount = 1
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
     MoneyProvided = 1000
@@ -281,7 +283,7 @@ Object 2500DollarCrate
   TransportSlotCount = 1
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide     ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
     MoneyProvided = 2500
@@ -318,7 +320,7 @@ Object SmallLevelUpCrate
   EditorSorting   = MISC_MAN_MADE
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = VeterancyCrateCollide       ModuleTag_02
     ForbiddenKindOf = PROJECTILE
     EffectRange = 100
@@ -346,7 +348,7 @@ Object MediumLevelUpCrate
   EditorSorting   = MISC_MAN_MADE
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = VeterancyCrateCollide       ModuleTag_02
     ForbiddenKindOf = PROJECTILE
     ;ExecuteFX = FX_CratePickup
@@ -375,7 +377,7 @@ Object 2FreeCrusadersCrate
 
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = UnitCrateCollide ModuleTag_02
     ForbiddenKindOf = PROJECTILE
     ;ExecuteFX = FX_CratePickup
@@ -411,7 +413,7 @@ Object 100DollarCrate
   TransportSlotCount = 1
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
     MoneyProvided = 100
@@ -455,7 +457,7 @@ Object 200DollarCrate
   TransportSlotCount = 1
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
     MoneyProvided = 200
@@ -498,7 +500,7 @@ Object 100DollarCrateForBuildings
   TransportSlotCount = 1
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
     MoneyProvided = 100
@@ -544,7 +546,7 @@ Object SupplyDropZoneCrate
   TransportSlotCount = 1
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
     MoneyProvided = 250
@@ -589,7 +591,7 @@ Object 1500DollarCrate
   TransportSlotCount = 1
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE CRATE
+  KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
     MoneyProvided = 1500


### PR DESCRIPTION
- ref TheSuperHackers/GeneralsGameCode#23

This PR makes scaffolds not delete money crates.

This does not affect scrap boxes from GLA.