### PR TITLE
Fix: Boss General Infantry Issues

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -180,7 +180,7 @@ https://github.com/commy2/zerohour/issues/41  [DONE]                  Base Defen
 https://github.com/commy2/zerohour/issues/38  [DONE][NPROJEC!]        Detached Floating Object Orbits Avenger Model When Moving
 https://github.com/commy2/zerohour/issues/37  [DONE][NPROJEC!]        Tomahawk Launchers Have Reversed Order For Battle And Scout Drone Upgrade
 https://github.com/commy2/zerohour/issues/36  [MAYBE][NPROJECT]       Boss Helix Inconsistencies
-https://github.com/commy2/zerohour/issues/35  [MAYBE][NPROJECT]       Boss Infantry Inconsistencies
+https://github.com/commy2/zerohour/issues/35  [DONE][NPROJECT]        Boss Infantry Inconsistencies
 https://github.com/commy2/zerohour/issues/34  [MAYBE][NPROJECT]       Boss Avenger Inconsistencies
 https://github.com/commy2/zerohour/issues/33  [MAYBE][NPROJECT]       Air Force General Avenger Receives 30% More Damage From Jet Missiles
 https://github.com/commy2/zerohour/issues/32  [MAYBE][NPROJECT]       Non-vanilla USA Avengers Benefit From Composite Armor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17391,7 +17391,7 @@ Object Boss_InfantryPathfinder
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY STEALTH_GARRISON SCORE
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY STEALTH_GARRISON SCORE CANNOT_RETALIATE ; Patch104p @bugfix commy2 3/10/2021 Fix unit would retaliate unlike other Pathfinders.
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 120.0
@@ -17799,9 +17799,11 @@ Object Boss_InfantryBlackLotus
   RadarPriority = UNIT
   KindOf = PRELOAD SELECTABLE CAN_ATTACK CAN_CAST_REFLECTIONS INFANTRY SCORE HERO CANNOT_RETALIATE
 
+  ; Patch104p @bugfix commy2 3/10/2021 Fix unit has less health than other faction Lotus'.
+
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 150.0
-    InitialHealth   = 150.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior                = ArmorUpgrade ModuleTag_Armor01
@@ -18529,11 +18531,13 @@ Object Boss_InfantryHacker
     TriggeredBy           = Upgrade_AmericaChemicalSuits
   End
 
+  ; Patch104p @bugfix commy2 3/10/2021 Fix unit would hack faster than other Hackers inside the Internet Center.
+
   Behavior = HackInternetAIUpdate ModuleTag_03
     UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
     PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
     CashUpdateDelay     = 2000
-    CashUpdateDelayFast = 1500  ; Fast speed used inside a container (can only hack inside an Internet Center)
+    CashUpdateDelayFast = 1800  ; Fast speed used inside a container (can only hack inside an Internet Center)
     RegularCashAmount   = 5
     VeteranCashAmount   = 6
     EliteCashAmount     = 8
@@ -18912,7 +18916,7 @@ Object Boss_InfantryJarmenKell
   End
 
   VisionRange         = 200
-  ShroudClearingRange = 300
+  ShroudClearingRange = 400 ; Patch104p @bugfix commy2 3/10/2021 Fix unit would clear less fog than other Jarmens.
   Prerequisites
     Object = Boss_Barracks
     Object = Boss_ScudStorm


### PR DESCRIPTION
ZH 1.04:

- The Boss Generals Pathfinders will retaliate if the option is enabled, unlike every other Pathfinder.
- The Boss Generals Hackers hack 25% faster inside Internet Centers instead of 10% faster as other (non-Super Hacker) Hackers. (Note: The Boss General has no Internet Center)
- The Boss Generals Black Lotus has 25% less health than other Black Lotus' (Lotuses?).
- The Boss Generals Jarmen Kell has 25% less fog vision than other Jarmen Kells.
