### PR TITLE
Fix: Boss General Base Defense Issues

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -165,7 +165,7 @@ https://github.com/commy2/zerohour/issues/56  [DONE][NPROJEC!]        Saboteur B
 https://github.com/commy2/zerohour/issues/55  [DONE][NPROJEC!]        Vanilla GLA Combat Bike Has Duplicated Death Scream
 https://github.com/commy2/zerohour/issues/54  [DONE][NPROJEC!]        Vanilla GLA Hijacker And Saboteur Can Ride Toxin Generals Combat Bike
 https://github.com/commy2/zerohour/issues/53  [MAYBE]                 Veteran Quad Cannons Deal Less Damage When Scrapped
-https://github.com/commy2/zerohour/issues/52  [MAYBE][NPROJECT]       Boss Base Defense Inconsistencies
+https://github.com/commy2/zerohour/issues/52  [DONE][NPROJECT]        Boss Base Defense Inconsistencies
 https://github.com/commy2/zerohour/issues/51  [DONE][NPROJEC!]        Demo General Worker On Bike Missing Demo Generals Bike Destruction Effect
 https://github.com/commy2/zerohour/issues/50  [DONE][NPROJEC!]        Demo General Vehicle Destruction Effect Glitches
 https://github.com/commy2/zerohour/issues/49  [DONE][NPROJEC!]        Demo General Infantry Play Terrorist Sound Effect When Killed

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -8265,6 +8265,11 @@ Object Boss_SpeakerTower
   ; *** ART Parameters ***
   SelectPortrait         = SNPropSpeaker_L
   ButtonImage            = SNPropSpeaker
+
+  ; Patch104p @bugfix commy2 3/10/2021 Add missing upgrade icon for Subliminal Messaging.
+
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -9308,7 +9313,10 @@ Object Boss_TunnelNetwork
   End
   BuildCost        = 800
   RefundValue      = 100 ; With nothing (or zero) listed, we sell for half price.
-  BuildTime        = 5.0           ; in seconds
+
+  ; Patch104p @bugfix commy2 3/10/2021 Fix structure builds 6 times faster than other Tunnels.
+
+  BuildTime        = 15.0           ; in seconds
   EnergyProduction = 0
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
@@ -9412,7 +9420,7 @@ Object Boss_TunnelNetwork
   ;Kris: Cut camo-netting from Boss General
   ;Behavior = StealthUpdate ModuleTag_17
   ;  StealthDelay                = 2500 ; msec
-  ;  StealthForbiddenConditions  = ATTACKING USING_ABILITY
+  ;  StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE
   ;  MoveThresholdSpeed          = 3
   ;  InnateStealth               = No ;Requires upgrade first
   ;  OrderIdleEnemiesToAttackMeUponReveal  = Yes
@@ -13217,9 +13225,18 @@ Object Boss_Bunker
 
   ; *** ENGINEERING Parameters ***
   KindOf            = PRELOAD STRUCTURE SELECTABLE STICK_TO_TERRAIN_SLOPE IMMOBILE SCORE FS_BASE_DEFENSE GARRISONABLE_UNTIL_DESTROYED IMMUNE_TO_CAPTURE
+
   Body              = StructureBody ModuleTag_05
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
+
+    ; Patch104p @bugfix commy2 3/10/2021 Fix structure could not be disabled by Microwave tank.
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 1200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
 ;  Behavior               = FXListDie ModuleTag_07
 ;    DeathFX         = FX_SmallStructureDeath


### PR DESCRIPTION
ZH 1.04:

- The Boss Generals Propaganda Tower has no upgrade icon for Subliminal Messaging.
- The Boss Generals Tunnel Network is constructed 6 times faster than GLA faction Tunnels (3 times less build-time plus power).
- The Boss Generals Bunker is immune to Microwave tanks.
