### PR TITLE
Fix: Boss General Sentry Drone Issues

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -147,7 +147,7 @@ https://github.com/commy2/zerohour/issues/74  [DONE][NPROJEC!]        Avenger Tu
 https://github.com/commy2/zerohour/issues/73  [DONE][NPROJECT]        Avenger Turret Guard Range
 https://github.com/commy2/zerohour/issues/72  [DONE][NPROJEC!]        Non-Vanilla USA Microwave Tanks Use Humvee Move Start Sounds
 https://github.com/commy2/zerohour/issues/71  [DONE][NPROJEC!]        Some Paladins Missing Hellfire Drone Upgrade Icon
-https://github.com/commy2/zerohour/issues/70  [MAYBE][NPROJECT]       Boss Sentry Drone Inconsistencies
+https://github.com/commy2/zerohour/issues/70  [DONE][NPROJECT]        Boss Sentry Drone Inconsistencies
 https://github.com/commy2/zerohour/issues/69  [DONE][NPROJEC!]        Damaged And Non-Vanilla USA Sentry Drones Missing Their Move Start Sounds
 https://github.com/commy2/zerohour/issues/68  [DONE]                  Spy Drone Seleced By Q-Shortcut
 https://github.com/commy2/zerohour/issues/67  [DONE][NPROJEC!]        Super Weapon And Laser General Vehicle Drone Upgrade Incompatibility

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19719,7 +19719,7 @@ End
 ; - unit was using HumveeArmor type
 ; - unit would not get health bonus from Drone Armor
 ; - unit could not be disabled by ECM tank
-; - unit had less fog clearing range than other Sentry Drones
+; - unit had less guard mode range than other Sentry Drones
 ; - unit had less stealth detection range than other Sentry Drones
 ; - unit would attack while stealthed unlike other Sentry Drones
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19715,6 +19715,14 @@ End
 
 
 
+; Patch104p @bugfix commy2 3/10/2021 Fix the following issues with the Boss General Sentry Drone:
+; - unit was using HumveeArmor type
+; - unit would not get health bonus from Drone Armor
+; - unit could not be disabled by ECM tank
+; - unit had less fog clearing range than other Sentry Drones
+; - unit had less stealth detection range than other Sentry Drones
+; - unit would attack while stealthed unlike other Sentry Drones
+
 ;------------------------------------------------------------------------------
 ;Sentry Drone
 Object Boss_VehicleSentryDrone
@@ -19724,7 +19732,7 @@ Object Boss_VehicleSentryDrone
   ButtonImage            = SAsentry
 
   UpgradeCameo1 = Upgrade_AmericaSentryDroneGun
-  ;UpgradeCameo2 = NONE
+  UpgradeCameo2 = Upgrade_AmericaDroneArmor
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -19794,12 +19802,12 @@ Object Boss_VehicleSentryDrone
   End
   ArmorSet
     Conditions      = None
-    Armor           = HumveeArmor
+    Armor           = SentryDroneArmor
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 800
   BuildTime       = 10.0          ;in seconds
-  VisionRange     = 180
+  VisionRange     = 200
   ShroudClearingRange = 350
   Prerequisites
     Object = Boss_WarFactory
@@ -19843,6 +19851,18 @@ Object Boss_VehicleSentryDrone
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 300.0
     InitialHealth   = 300.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 480
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 50
+  End
+
+  Behavior = MaxHealthUpgrade ModuleTag_99
+    TriggeredBy = Upgrade_AmericaDroneArmor
+    AddMaxHealth = 75.0
+    ChangeType = ADD_CURRENT_HEALTH_TOO
   End
   Behavior = DeployStyleAIUpdate ModuleTag_04
     Turret
@@ -19859,7 +19879,7 @@ Object Boss_VehicleSentryDrone
       MinIdleScanAngle      = 0       ; in degrees off the natural turret angle
       MaxIdleScanAngle      = 360     ; in degrees off the natural turret angle
     End
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed ; Means "Yes when idle, even if I am stealthed"
+    AutoAcquireEnemiesWhenIdle = Yes ;Stealthed ; Means "Yes when idle, even if I am stealthed"
     PackTime = 1000
     UnpackTime = 1000
     TurretsFunctionOnlyWhenDeployed = Yes
@@ -19915,8 +19935,8 @@ Object Boss_VehicleSentryDrone
     AflameDamageDelay = 500       ; this often.
   End
   Behavior = StealthDetectorUpdate ModuleTag_12
-    DetectionRate             = 900   ; how often to rescan for stealthed things in my sight (msec)
-    ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
+    DetectionRate            = 900   ; how often to rescan for stealthed things in my sight (msec)
+    DetectionRange           = 225 ;Dustin, enable this for independant balancing!
   End
   Geometry = BOX
   GeometryMajorRadius = 9.0


### PR DESCRIPTION
ZH 1.04:

- The Sentry Drone works slightly different than the other Sentry Drones:
-- uses `HumveeArmor` type instead of the `SentryDroneArmor`
-- does not get extra health from `DroneArmor` upgrade
-- is immune to ECMs (missing jamming logic)
-- has 10% less vision range compared to all other Sentry Drones (smaller Guard Mode area)
-- uses default stealth detection range
-- automatically attacks even when stealthed