### PR TITLE
Fix: Boss General Avenger Issues

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -181,7 +181,7 @@ https://github.com/commy2/zerohour/issues/38  [DONE][NPROJEC!]        Detached F
 https://github.com/commy2/zerohour/issues/37  [DONE][NPROJEC!]        Tomahawk Launchers Have Reversed Order For Battle And Scout Drone Upgrade
 https://github.com/commy2/zerohour/issues/36  [MAYBE][NPROJECT]       Boss Helix Inconsistencies
 https://github.com/commy2/zerohour/issues/35  [MAYBE][NPROJECT]       Boss Infantry Inconsistencies
-https://github.com/commy2/zerohour/issues/34  [MAYBE][NPROJECT]       Boss Avenger Inconsistencies
+https://github.com/commy2/zerohour/issues/34  [DONE][NPROJECT]        Boss Avenger Inconsistencies
 https://github.com/commy2/zerohour/issues/33  [MAYBE][NPROJECT]       Air Force General Avenger Receives 30% More Damage From Jet Missiles
 https://github.com/commy2/zerohour/issues/32  [MAYBE][NPROJECT]       Non-vanilla USA Avengers Benefit From Composite Armor
 https://github.com/commy2/zerohour/issues/31  [DONE]                  Some Avengers Can Retaliate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19960,6 +19960,16 @@ End
 
 
 
+; Patch104p @bugfix commy2 3/10/2021 Fix the following issues with the Boss General Avenger:
+; - unit would display team color wrong (always red team)
+; - unit would show up wrong when disguised with Bomb Truck
+; - unit was missing upgrade icon for Hellfire Drones
+; - unit was using TankArmor type, had more health than regular Avengers against ground units, but be more vilnerable to air units
+; - unit cannot promote at all
+; - unit cannot be ordered to target air units
+; - unit second PDL uses different scan rate, thus attempts to zap the same missiles as the first PDL
+; - unit was useing the move sounds of Paladin instead of Humvee
+
 ;------------------------------------------------------------------------------
 Object Boss_TankAvenger
 
@@ -19969,24 +19979,37 @@ Object Boss_TankAvenger
 
   UpgradeCameo1 = Upgrade_AmericaBattleDrone
   UpgradeCameo2 = Upgrade_AmericaScoutDrone
-  UpgradeCameo3 = Upgrade_AmericaAdvancedTraining
-  UpgradeCameo4 = Upgrade_AmericaCompositeArmor
-  UpgradeCameo5 = Upgrade_AmericaHallfireDrone
+  UpgradeCameo3 = Upgrade_AmericaHellfireDrone
+  UpgradeCameo4 = Upgrade_AmericaAdvancedTraining
+  ;UpgradeCameo5 = Upgrade_AmericaCompositeArmor
 
   Draw = W3DOverlordTruckDraw ModuleTag_01
+    OkToChangeModelColor  = Yes
     ExtraPublicBone = TurretFX03
     ExtraPublicBone = LazerSpot01
     ExtraPublicBone = LazerSpot02
     DefaultConditionState
       Model               = AVAVNGER
+      HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
     ConditionState        = REALLYDAMAGED
       Model               = AVAVNGER_D
+      HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
     ConditionState        = RUBBLE
+      Model               = AVAVNGER_D1
+    End
+
+    ;When a bombtruck disguises as an avenger, show the turret!
+    ConditionState        = DISGUISED
+      Model               = AVAVNGER
+      ShowSubObject       = TURRET01
+    End
+    ConditionState        = REALLYDAMAGED DISGUISED
       Model               = AVAVNGER_D
+      ShowSubObject       = TURRET01  ;Hide controlled turret
     End
 
     TrackMarks = EXTireTrack.tga
@@ -20012,10 +20035,11 @@ Object Boss_TankAvenger
   WeaponSet
     Conditions = None
     Weapon = PRIMARY AvengerTargetDesignator
+    Weapon = SECONDARY AvengerAirLaserDummy
   End
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AvengerArmor
     DamageFX        = TankDamageFX
   End
   BuildCost       = 2000
@@ -20029,7 +20053,7 @@ Object Boss_TankAvenger
   ExperienceValue        = 100 100 200 400 ;Experience point value at each level
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
 
-  IsTrainable     = No
+  IsTrainable     = Yes
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet      = AmericaTankAvengerCommandSet
@@ -20038,9 +20062,10 @@ Object Boss_TankAvenger
   VoiceSelect = AvengerVoiceSelect
   VoiceMove = AvengerVoiceMove
   VoiceGuard = AvengerVoiceMove
-  VoiceAttack = AvengerVoiceAttack
-  SoundMoveStart = PaladinTankMoveStart
-  SoundMoveStartDamaged = PaladinTankMoveStart
+  VoiceAttack = AvengerVoicePaint
+  VoiceAttackAir = AvengerVoiceAttack
+  SoundMoveStart = HumveeMoveStart
+  SoundMoveStartDamaged = HumveeMoveStart
 
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
@@ -20057,8 +20082,8 @@ Object Boss_TankAvenger
   KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS VEHICLE SCORE CANNOT_RETALIATE  ; Patch104p @bugfix commy2 03/09/2021 This Avenger would retaliate unlike the normal USA Avenger.
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 500.0
-    InitialHealth   = 500.0
+    MaxHealth       = 300.0
+    InitialHealth   = 300.0
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
@@ -20109,7 +20134,7 @@ Object Boss_TankAvenger
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_Two
     WeaponTemplate        = AvengerPointDefenseLaserTwo
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
-    ScanRate              = 0
+    ScanRate              = 100
     ScanRange             = 200.0
     PredictTargetVelocityFactor = 1.0
   End


### PR DESCRIPTION
ZH 1.04:

- The Boss Avenger is wonky compared to other Avengers:
-- unit would display team color wrong (always red team)
-- a Bomb Truck disguised as this unit would show up wrong (without turret)
-- unit was missing upgrade icon for Hellfire Drones
-- unit was using `TankArmor` type, had more health than regular Avengers against ground units, but be more vulnerable to air units
-- unit cannot promote at all
-- unit cannot be ordered to target air units
-- unit second PDL uses different scan rate, thus attempts to zap the same missiles as the first PDL
-- unit was uses the move sounds of Paladin instead of Humvee