### PR TITLE
Fix: Boss General King Raptor Issues

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -132,7 +132,7 @@ https://github.com/commy2/zerohour/issues/90  [NOTRELEVANT][NPROJECT] Jarmen Kel
 https://github.com/commy2/zerohour/issues/89  [DONE][NPROJEC!]        Non-Vanilla USA Fire Bases Use Patriot Sound Effect
 https://github.com/commy2/zerohour/issues/88  [MAYBE][NPROJECT]       Air Force General Chinook And Combat Chinook Have Different PDL Scan Ranges
 https://github.com/commy2/zerohour/issues/87  [DONE][NPROJEC!]        Some Chinooks Collect Slower Than Others
-https://github.com/commy2/zerohour/issues/86  [MAYBE][NPROJECT]       Boss King Raptor Inconsistencies
+https://github.com/commy2/zerohour/issues/86  [DONE][NPROJECT]        Boss King Raptor Inconsistencies
 https://github.com/commy2/zerohour/issues/85  [MAYBE][NPROJECT]       King Raptor Missing Armor Bonus From Countermeasures Upgrade
 https://github.com/commy2/zerohour/issues/84  [MAYBE]                 Air Force General MOAB B2-Bomber Lacks Point Defense Laser
 https://github.com/commy2/zerohour/issues/83  [MAYBE]                 Some Airplane Countermeasures Evasion Rates Are 50% Instead Of 30%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15853,7 +15853,7 @@ End
 
 
 
-; Patch104p @bugfix commy2 3/10/2021 Fix the following issues with the Boss General Avenger:
+; Patch104p @bugfix commy2 3/10/2021 Fix the following issues with the Boss General King Raptor:
 ; - unit would use normal Raptor voice lines
 ; - unit was incompatible with Countermeasures upgrade
 ; - unit had less guard mode range than other (King) Raptors

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15853,6 +15853,11 @@ End
 
 
 
+; Patch104p @bugfix commy2 3/10/2021 Fix the following issues with the Boss General Avenger:
+; - unit would use normal Raptor voice lines
+; - unit was incompatible with Countermeasures upgrade
+; - unit had less guard mode range than other (King) Raptors
+
 ;------------------------------------------------------------------------------
 Object Boss_JetRaptor
 
@@ -15862,7 +15867,7 @@ Object Boss_JetRaptor
 
   UpgradeCameo1 = Upgrade_AmericaLaserMissiles
   UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
-  ;UpgradeCameo3 = NONE
+  UpgradeCameo3 = Upgrade_AmericaCountermeasures
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
@@ -15948,7 +15953,7 @@ Object Boss_JetRaptor
   EditorSorting           = VEHICLE
   Side                    = Boss
   TransportSlotCount      = 0 ;how many "slots" we take in a transport (0 == not transportable)
-  VisionRange             = 180.0
+  VisionRange             = 200.0
   ShroudClearingRange     = 400
   Prerequisites
     Object                = Boss_Airfield
@@ -15963,6 +15968,11 @@ Object Boss_JetRaptor
     Armor                 = AirplaneArmor
     DamageFX              = None
   End
+  ArmorSet
+    Conditions            = PLAYER_UPGRADE
+    Armor                 = AirplaneArmor ;CountermeasuresAirplaneArmor ; uncomment if we ever feel like fixing the AFG KRaptor ~commy2
+    DamageFX              = None
+  End
 
   BuildCost               = 1100
   BuildTime               = 20
@@ -15974,7 +15984,7 @@ Object Boss_JetRaptor
   CommandSet              = AmericaJetRaptorCommandSet
 
   ; *** AUDIO Parameters ***
-  VoiceSelect            = RaptorVoiceSelect
+  VoiceSelect            = KingRaptorVoiceSelect
   VoiceMove              = RaptorVoiceMove
   VoiceAttack            = RaptorVoiceAttack
   VoiceAttackAir         = RaptorVoiceAttackAir
@@ -15984,7 +15994,7 @@ Object Boss_JetRaptor
   ; SoundMoveLoop          = RaptorAmbientLoop  ; don't want sound while sitting at airfield
   ; SoundAmbient           = NoSound
   UnitSpecificSounds
-    VoiceCreate          = RaptorVoiceCreate
+    VoiceCreate          = KingRaptorVoiceCreate
     SoundEject           = PilotSoundEject
     VoiceEject           = PilotVoiceEject
     Afterburner          = RaptorAfterburner
@@ -16067,11 +16077,29 @@ Object Boss_JetRaptor
   End
   Behavior = StealthDetectorUpdate ModuleTag_24
     DetectionRate   = 500   ; how often to rescan for stealthed things in my sight (msec)
-    ;DetectionRange = ??? ;Dustin, enable this for independant balancing!
+    ;DetectionRange = 250 ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
+  Behavior                = ArmorUpgrade ModuleTag_Armor25
+    TriggeredBy           = Upgrade_AmericaCountermeasures
+  End
+
+  Behavior                = CountermeasuresBehavior ModuleTag_26
+    TriggeredBy           = Upgrade_AmericaCountermeasures
+    FlareTemplateName     = CountermeasureFlare
+    FlareBoneBaseName     = Flare ; Name of the base flare bone (Flare01, Flare02, Flare03)
+    VolleySize            = 4     ; Number of flares launched per volley (requires bones)
+    VolleyArcAngle        = 90.0  ; Max angle of flare relative to forward direction (with VolleySize of 1, flare will always goes straight back).
+    VolleyVelocityFactor  = 2.0   ; Shoots out flares at a stronger velocity with a higher value.
+    DelayBetweenVolleys   = 1000  ; Time between flare volleys
+    NumberOfVolleys       = 5     ; Number of times the volleys will fire before reloading
+    ReloadTime            = 0  ; After all volleys launched, then reloading must occur. If 0, then reloading occurs at airstrip only.
+    EvasionRate           = 30%   ; With active flares, the specified percentage will be diverted.
+    ReactionLaunchLatency = 100   ; Reaction between getting shot at and the firing of the first volley of countermeasures.
+    MissileDecoyDelay     = 200   ; A reported missile that has been determined to hit a decoy will wait this long before acquiring countermeasures.
+  End
 
   Geometry                 = Box
   GeometryIsSmall          = Yes


### PR DESCRIPTION
ZH 1.04:

- Unexplainable Boss King Raptor vs AFG King Raptor differences:
-- uses voice lines for normal Raptor exclusively, not King Raptor
-- does not get flares from `Countermeasures` upgrade
-- has 10% less vision range compared to all other (King) Raptors (smaller Guard Mode area)