### PR TITLE
Fix: Boss General Helix Issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15279,6 +15279,12 @@ End
 
 
 
+; Patch104p @bugfix commy2 3/10/2021 Fix the following issues with the Boss General Helix:
+; - unit had 50% more guard mode range than other Helixes
+; - unit used Chinook build cost and build-time instead of the expected values from the regular China faction
+; - unit used Chinook rotor blade sound effects when shot down and crashing
+; - unit used Dragon tank Fire Storm voice line when ordered to drop Napalm Bomb
+
 ;----------------------------------------------------------------------------------------------------------
 Object Boss_VehicleHelix
 
@@ -15351,10 +15357,10 @@ Object Boss_VehicleHelix
   EditorSorting       = VEHICLE
   Side                = Boss
   TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)
-  VisionRange         = 300.0
+  VisionRange         = 200.0
   ShroudClearingRange = 600
-  BuildCost           = 1200
-  BuildTime           = 10.0          ;in seconds
+  BuildCost           = 1500
+  BuildTime           = 20.0          ;in seconds
   Prerequisites
     Object = Boss_Airfield
   End
@@ -15444,7 +15450,7 @@ Object Boss_VehicleHelix
     SpiralOrbitForwardSpeed         = 110.0           ; bigger # = larger spiral
     SpiralOrbitForwardSpeedDamping  = .9999           ; smaller #'s = slow down faster
     MaxBraking                      = 210   ; max braking we can use during death spiral (lower num = wilder spiral)
-    SoundDeathLoop                  = ComancheDamagedLoop
+    SoundDeathLoop                  = HelixDamagedLoop
     MinSelfSpin                     = 40                     ; in degrees per second
     MaxSelfSpin                     = 120                     ; in degrees per second
     SelfSpinUpdateDelay             = 300                     ; in milliseconds
@@ -15549,7 +15555,7 @@ Object Boss_VehicleHelix
     SpecialPowerTemplate = SpecialAbilityHelixNapalmBomb
     UpdateModuleStartsAttack = Yes
     StartsPaused              = Yes; so the UnpauseSpecialPowerUpgrade, below can turn it on
-    InitiateSound             = DragonTankVoiceFireStorm ;;;; should get a new voice,. here
+    InitiateSound             = HelixVoiceAttack
   End
   Behavior = SpecialAbilityUpdate ModuleTag_33
     SpecialPowerTemplate = SpecialAbilityHelixNapalmBomb
@@ -15563,7 +15569,7 @@ Object Boss_VehicleHelix
     UnpackTime              = 500     ;slight delay to drop bomb
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
-    UnpackSound               = DragonTankVoiceFireStorm ;;;; should get a new voice,. here
+    UnpackSound               = NoSound
     LoseStealthOnTrigger      = No
     ApproachRequiresLOS       = No ; we are a helicopter, we can see everything
     NeedToFaceTarget          = No ; can drop the bomb at any angle to target


### PR DESCRIPTION
ZH 1.04:

- The Boss Helix is only halfway implemented it seems:
-- speaks like a Dragon Tank when dropping Napalm Bombs
-- uses Chinook rotor blade effect when crashing, even though the other Helixes have their own
-- uses cost and build-time copy pasted from Chinook
-- uses 50% more guard mode range