### PR TITLE
Fix: Tank And Nuke Outpost Use Dummy Weapon When Empty

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4733,7 +4733,11 @@ Object Nuke_ChinaVehicleListeningOutpost
   EditorSorting   = VEHICLE
   TransportSlotCount = 8                 ;Just enough to fit into a Chinook.
   WeaponSet
-    Conditions = None
+    Conditions          = None
+    Weapon              = PRIMARY     NONE
+  End
+  WeaponSet
+    Conditions          = PLAYER_UPGRADE
     Weapon              = PRIMARY     ListeningOutpostUpgradedDummyWeapon
   End
   ArmorSet
@@ -4843,6 +4847,7 @@ Object Nuke_ChinaVehicleListeningOutpost
     ExitDelay         = 250
     NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
     GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting
+    ArmedRidersUpgradeMyWeaponSet = Yes
   End
 
   Behavior = SlowDeathBehavior ModuleTag_07

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4871,8 +4871,12 @@ Object Tank_ChinaVehicleListeningOutpost
   EditorSorting   = VEHICLE
   TransportSlotCount = 8                 ;Just enough to fit into a Chinook.
   WeaponSet
-    Conditions = None
-    Weapon = PRIMARY ListeningOutpostUpgradedDummyWeapon
+    Conditions          = None
+    Weapon              = PRIMARY     NONE
+  End
+  WeaponSet
+    Conditions          = PLAYER_UPGRADE
+    Weapon              = PRIMARY     ListeningOutpostUpgradedDummyWeapon
   End
   ArmorSet
     Conditions      = None
@@ -4980,6 +4984,7 @@ Object Tank_ChinaVehicleListeningOutpost
     ExitDelay         = 250
     NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
     GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting
+    ArmedRidersUpgradeMyWeaponSet = Yes
   End
 
   Behavior = SlowDeathBehavior ModuleTag_07


### PR DESCRIPTION
main branch as of today

- The Tank and Nuke Outposts can be given attack orders when they are empty, while the China and Infantry Outposts can not.

after patch:

- None of the Outposts can be given an attack order while empty.

Continuation of #4