### PR TITLE
Fix: GLA02 Campaign Stealth General Base Defense Issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -1,3 +1,9 @@
+; Patch104p @bugfix commy2 07/10/2021 Fix issues with GLA02 campaign Stealth General:
+; - Tunnel Network is immune to Microwave Tanks.
+; - Tunnel Network is build in 10 seconds instead of 30 seconds like other Tunnels.
+; - Stinger Site is build in 50 seconds instead of 30 seconds like other Stinger Sites.
+; - Demo Trap plays an effect when damaged, unlike other Demo Traps.
+
 ;------------------------------------------------------------------------------
 Object GC_Slth_GLACommandCenter
 
@@ -2562,7 +2568,7 @@ Object GC_Slth_GLAStingerSite
     Object            = GC_Slth_GLABarracks
   End
   BuildCost           = 900
-  BuildTime           = 25.0           ; in seconds
+  BuildTime           = 15.0           ; in seconds
   EnergyProduction    = 0
   VisionRange         = 600.0           ; Shroud clearing distance
   ShroudClearingRange = 400
@@ -3078,7 +3084,7 @@ Object GC_Slth_GLATunnelNetwork
   End
   BuildCost        = 800
   RefundValue      = 100 ; With nothing (or zero) listed, we sell for half price.
-  BuildTime        = 5.0           ; in seconds
+  BuildTime        = 15.0           ; in seconds
   EnergyProduction = 0
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
@@ -3112,6 +3118,12 @@ Object GC_Slth_GLATunnelNetwork
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 1200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
 
   Behavior = StealthDetectorUpdate ModuleTag_13
@@ -5686,8 +5698,8 @@ Object GC_Slth_GLADemoTrap
 
   ; *** AUDIO Parameters ***
   VoiceSelect = UndergroundGeneratorSelect
-  SoundOnDamaged        = BuildingDamagedStateLight
-  SoundOnReallyDamaged  = BuildingDestroy
+  SoundOnDamaged        = NoSound
+  SoundOnReallyDamaged  = NoSound
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop


### PR DESCRIPTION
ZH 1.04

- The GLA02 Stealth General's Tunnel Network is build in 10 seconds.
- The GLA02 Stealth General's Stinger Site is build in 50 seconds.
- The GLA02 Stealth General's Tunnel Network is immune to Microwave Tanks.
- The GLA02 Stealth General's Demo Trap plays an effect when damaged.
