### PR TITLE
Fix: USA05 Campaign Toxin General Base Defense Issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5984,10 +5984,10 @@ End
 CommandButton GC_Chem_Command_ConstructGLATunnelNetwork
   Command       = DOZER_CONSTRUCT
   Object        = GC_Chem_GLATunnelNetwork
-  TextLabel     = CONTROLBAR:ConstructGLATunnelNetwork
-  ButtonImage   = SUTunnel
+  TextLabel     = CONTROLBAR:Chem_ConstructGLATunnelNetwork
+  ButtonImage   = SUToxicTunnel
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildTunnelNetwork
+  DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildTunnelNetwork
 End
 
 CommandButton GC_Chem_Command_ConstructGLADemoTrap

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1,10 +1,21 @@
+; Patch104p @bugfix commy2 07/10/2021 Fix issues with USA05 campaign Toxin General:
+; - Tunnel Network has the name, button and tooltips of a normal Tunnel Network.
+; - Tunnel Network is immune to Microwave Tanks.
+; - Tunnel Network is build in 10 seconds instead of 30 seconds like other Tunnels.
+; - Stinger Site is build in 50 seconds instead of 30 seconds like other Stinger Sites.
+; - Stinger Site missiles cannot be deflected by an ECM-tank.
+; - Tunnel Network and Stinger Site have unusable buttons to upgrade Camo-Netting.
+; - Demo Trap explodes twice.
+; - Demo Trap plays an effect when damaged, unlike other Demo Traps.
+; - Demo Trap is missing the upgrade icon for Anthrax Gamma.
+
 ;This file is for Chemical Generals Challenge GLA Buildings
 ;----------------------------------------------------------------------
 Object GC_Chem_GLATunnelNetwork
 
   ; *** ART Parameters ***
   SelectPortrait         = SUToxicTunnel_L
-  ButtonImage            = SUTunnel
+  ButtonImage            = SUToxicTunnel
   UpgradeCameo1          = Chem_Upgrade_GLAAnthraxGamma
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -363,7 +374,7 @@ Object GC_Chem_GLATunnelNetwork
   PlacementViewAngle = -135
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:TunnelNetwork
+  DisplayName      = OBJECT:Chem_TunnelNetwork
   Side = GLAToxinGeneral
   EditorSorting    = STRUCTURE
   Prerequisites
@@ -371,7 +382,7 @@ Object GC_Chem_GLATunnelNetwork
   End
   BuildCost        = 800
   RefundValue      = 100 ; With nothing (or zero) listed, we sell for half price.
-  BuildTime        = 5.0           ; in seconds
+  BuildTime        = 15.0           ; in seconds
   EnergyProduction = 0
   VisionRange     = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
@@ -389,7 +400,7 @@ Object GC_Chem_GLATunnelNetwork
     Weapon            = PRIMARY     Chem_TunnelNetworkGunGamma
   End
 
-  CommandSet       = GLATunnelNetworkCommandSet
+  CommandSet       = Chem_GLATunnelNetworkCommandSet
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -410,6 +421,12 @@ Object GC_Chem_GLATunnelNetwork
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 1200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
   Behavior = WeaponSetUpgrade ModuleTag_08
     TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
@@ -899,7 +916,7 @@ Object GC_Chem_GLAStingerSite
     Object            = GC_Chem_GLABarracks
   End
   BuildCost           = 900
-  BuildTime           = 25.0           ; in seconds
+  BuildTime           = 15.0           ; in seconds
   EnergyProduction    = 0
   VisionRange         = 600.0           ; Shroud clearing distance
   ShroudClearingRange = 400
@@ -908,7 +925,7 @@ Object GC_Chem_GLAStingerSite
     Armor             = StingerSiteArmor
     DamageFX          = StructureDamageFXNoShake
   End
-  CommandSet          = GLAStingerSiteCommandSet
+  CommandSet          = Chem_GLAStingerSiteCommandSet
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -972,7 +989,7 @@ Object GC_Chem_GLAStingerSite
   ;Kris: Cut camo-netting from Demo General
   ;Behavior = StealthUpdate ModuleTag_13
   ;  StealthDelay                = 2500 ; msec
-  ;  StealthForbiddenConditions  = ATTACKING USING_ABILITY NO_BLACK_MARKET
+  ;  StealthForbiddenConditions  = ATTACKING USING_ABILITY NO_BLACK_MARKET TAKING_DAMAGE
   ;  MoveThresholdSpeed          = 3
   ;  InnateStealth               = No ;Requires upgrade first
   ;  OrderIdleEnemiesToAttackMeUponReveal  = Yes
@@ -1015,6 +1032,8 @@ Object GC_Chem_GLADemoTrap
   ; *** ART Parameters ***
   SelectPortrait         = SSHideBomb
   ButtonImage            = SSHideBomb
+  UpgradeCameo1          = Chem_Upgrade_GLAAnthraxGamma
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     DefaultConditionState
@@ -1119,8 +1138,8 @@ Object GC_Chem_GLADemoTrap
 
   ; *** AUDIO Parameters ***
   VoiceSelect = UndergroundGeneratorSelect
-  SoundOnDamaged        = BuildingDamagedStateLight
-  SoundOnReallyDamaged  = BuildingDestroy
+  SoundOnDamaged        = NoSound
+  SoundOnReallyDamaged  = NoSound
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
@@ -1156,11 +1175,23 @@ Object GC_Chem_GLADemoTrap
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    ExemptStatus = UNDER_CONSTRUCTION
+    ExemptStatus = UNDER_CONSTRUCTION STATUS_RIDER1
     DestructionDelay = 1000
     FX = INITIAL FX_GLADemoTrapWarning
-    Weapon = INITIAL DemoTrapDetonationWeapon
-    Weapon = FINAL GC_Chem_SuicideDynamitePackGamma
+    Weapon = FINAL GC_Chem_DemoTrapDetonationWeaponBeta
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_05Anthrax
+    ExemptStatus = UNDER_CONSTRUCTION
+    RequiredStatus = STATUS_RIDER1
+    DestructionDelay = 1000
+    FX = INITIAL FX_GLADemoTrapWarning
+    Weapon = FINAL GC_Chem_DemoTrapDetonationWeaponGamma
+  End
+
+  Behavior = StatusBitsUpgrade ModuleTag_05Upgrade
+    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma
+    StatusToSet = STATUS_RIDER1
   End
 
   Behavior = FlammableUpdate ModuleTag_07

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -5,8 +5,11 @@ Object GC_Chem_StingerMissile
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
-    ConditionState = NONE
+    DefaultConditionState
       Model = UVRockBug_m
+    End
+    ConditionState = JAMMED
+      ParticleSysBone = None SparksMedium
     End
   End
 
@@ -26,6 +29,13 @@ Object GC_Chem_StingerMissile
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    ; A projectile is not disabled, but instead loses target and scatters
+    SubdualDamageCap = 200
+    SubdualDamageHealRate = 100000
+    SubdualDamageHealAmount = 50
   End
 
 ; ---- begin Projectile death behaviors

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -5136,6 +5136,50 @@ End
 ;------------------------------------------------------------------------------
 ; CHEMICAL GENERAL
 ;------------------------------------------------------------------------------
+Weapon GC_Chem_DemoTrapDetonationWeaponBeta
+  PrimaryDamage = 500.0           ;was 150.0
+  PrimaryDamageRadius = 18.0      ;was 6.0
+  SecondaryDamage = 300.0         ;was 30.0
+  SecondaryDamageRadius = 50.0    ;was 25.0
+  AttackRange = 5.0       ; must be very close to use this weapon!
+  DamageType = EXPLOSION
+  DeathType = EXPLODED
+  WeaponSpeed = 99999.0
+  ProjectileObject = NONE
+  DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?
+  RadiusDamageAffects = SELF SUICIDE ALLIES ENEMIES NEUTRALS NOT_SIMILAR
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+  AutoReloadsClip = No
+  FireFX = WeaponFX_DemoTrapDetonation
+  FireSound = CarBomberDie
+  FireOCL = OCL_PoisonFieldUpgradedMedium
+End
+
+;------------------------------------------------------------------------------
+Weapon GC_Chem_DemoTrapDetonationWeaponGamma
+  PrimaryDamage = 600.0           ;was 150.0
+  PrimaryDamageRadius = 18.0      ;was 6.0
+  SecondaryDamage = 300.0         ;was 30.0
+  SecondaryDamageRadius = 50.0    ;was 25.0
+  AttackRange = 5.0       ; must be very close to use this weapon!
+  DamageType = EXPLOSION
+  DeathType = EXPLODED
+  WeaponSpeed = 99999.0
+  ProjectileObject = NONE
+  DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?
+  RadiusDamageAffects = SELF SUICIDE ALLIES ENEMIES NEUTRALS NOT_SIMILAR
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+  AutoReloadsClip = No
+  FireFX = WeaponFX_DemoTrapDetonation
+  FireSound = CarBomberDie
+  FireOCL = OCL_PoisonFieldGammaMedium
+End
+
+;------------------------------------------------------------------------------
 Weapon GC_Chem_StingerMissileWeaponBeta
   PrimaryDamage = 20.0
   PrimaryDamageRadius = 5.0


### PR DESCRIPTION
ZH 1.04

- The USA05 Toxin General's Tunnel Network has the button of a normal Tunnel Network.
- The USA05 Toxin General's Tunnel Network has the name and tooltips of a normal Tunnel Network.
- The USA05 Toxin General's Tunnel Network is build in 10 seconds.
- The USA05 Toxin General's Stinger Site is build in 50 seconds.
- The USA05 Toxin General's Stinger Site missiles cannot be deflected by an ECM.
- The USA05 Toxin General's Tunnel Network and Stinger Site have un-usable buttons to upgrade Camo-Netting.
- The USA05 Toxin General's Tunnel Network is immune to Microwave Tanks.
- The USA05 Toxin General's Demo Trap explodes twice.
- The USA05 Toxin General's Demo Trap is missing the upgrade icon for Anthrax Gamma.
- The USA05 Toxin General's Demo Trap plays an effect when damaged.
