### PR TITLE
Fix: GLA02 Campaign Stealth General Building Issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1672,7 +1672,6 @@ End
 
 CommandSet GC_Slth_GLAScudStormCommandSet
   1  = Command_ScudStorm
-  12 = Command_UpgradeGLACamoNetting
   14 = Command_Sell
 End
 
@@ -1683,7 +1682,6 @@ CommandSet GC_Slth_GLABlackMarketCommandSet
   4  = Command_UpgradeGLABuggyAmmo
   5  = Command_UpgradeGLARadarVanScan
   6  = Command_UpgradeGLAWorkerShoes
-  12 = Command_UpgradeGLACamoNetting
   14 = Command_Sell
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -1,9 +1,22 @@
+; Patch104p @bugfix commy2 07/10/2021 Fix issues with GLA02 campaign Stealth General:
+; - Different buildings behave inconsistently when stealthed.
+; - Some buildings are incompatible with Fortified Structures.
+; - All buildings are immune to Microwave tanks.
+; - Barracks, Supply Stash, Black Market have half the health of the regular versions.
+; - Supply Stash is build in 30 seconds instead of 20 seconds like other Supply Stashes.
+; - Arms Dealer is build in 50 seconds instead of 30 seconds like other Arms Dealers.
+; - Black Market is build in 90 seconds instead of 60 seconds like other Black Markets.
+; - Black Market has an unusable button to upgrade Camo-Netting, despite already being camouflaged.
+; - Supply Stash is classified as power plant instead of as supply dock.
+; - Palace does use its day model during the night.
+
 ;------------------------------------------------------------------------------
 Object GC_Slth_GLACommandCenter
 
   ; *** ART Parameters ***
   SelectPortrait         = SUHeadquarters_L
   ButtonImage            = SUHeadquarters
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
 
   ; ----- The actual command center
   Draw                   = W3DModelDraw ModuleTag_01
@@ -31,21 +44,21 @@ Object GC_Slth_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED
-      Model                = UBCmdHQEG
+      Model                = UBCmdHQSE
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG.UBCmdHQEG
+      Animation            = UBCmdHQSE.UBCmdHQSE
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED
-      Model                = UBCmdHQEG_D
+      Model                = UBCmdHQSE_D
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_D.UBCmdHQEG_D
+      Animation            = UBCmdHQSE_D.UBCmdHQSE_D
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED
-      Model                = UBCmdHQEG_E
+      Model                = UBCmdHQSE_E
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_E.UBCmdHQEG_E
+      Animation            = UBCmdHQSE_E.UBCmdHQSE_E
       AnimationMode        = LOOP
     End
 
@@ -69,21 +82,21 @@ Object GC_Slth_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT
-      Model                = UBCmdHQEG_N
+      Model                = UBCmdHQSE_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_N.UBCmdHQEG_N
+      Animation            = UBCmdHQSE_N.UBCmdHQSE_N
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_DN
+      Model                = UBCmdHQSE_DN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DN.UBCmdHQEG_DN
+      Animation            = UBCmdHQSE_DN.UBCmdHQSE_DN
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_EN
+      Model                = UBCmdHQSE_EN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_EN.UBCmdHQEG_EN
+      Animation            = UBCmdHQSE_EN.UBCmdHQSE_EN
       AnimationMode        = LOOP
     End
 
@@ -107,21 +120,21 @@ Object GC_Slth_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED SNOW
-      Model                = UBCmdHQEG_S
+      Model                = UBCmdHQSE_S
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_S.UBCmdHQEG_S
+      Animation            = UBCmdHQSE_S.UBCmdHQSE_S
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_DS
+      Model                = UBCmdHQSE_DS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DS.UBCmdHQEG_DS
+      Animation            = UBCmdHQSE_DS.UBCmdHQSE_DS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_ES
+      Model                = UBCmdHQSE_ES
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ES.UBCmdHQEG_ES
+      Animation            = UBCmdHQSE_ES.UBCmdHQSE_ES
       AnimationMode        = LOOP
     End
 
@@ -145,21 +158,21 @@ Object GC_Slth_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_NS
+      Model                = UBCmdHQSE_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_NS.UBCmdHQEG_NS
+      Animation            = UBCmdHQSE_NS.UBCmdHQSE_NS
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_DNS
+      Model                = UBCmdHQSE_DNS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DNS.UBCmdHQEG_DNS
+      Animation            = UBCmdHQSE_DNS.UBCmdHQSE_DNS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_ENS
+      Model                = UBCmdHQSE_ENS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ENS.UBCmdHQEG_ENS
+      Animation            = UBCmdHQSE_ENS.UBCmdHQSE_ENS
       AnimationMode        = LOOP
     End
 
@@ -266,6 +279,18 @@ Object GC_Slth_GLACommandCenter
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
   End
 
@@ -560,6 +585,12 @@ Object GC_Slth_GLACommandCenter
     Armor             = StructureArmorTough
     DamageFX          = StructureDamageFXNoShake
   End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmorTough
+    DamageFX          = StructureDamageFXNoShake
+  End
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -578,6 +609,21 @@ Object GC_Slth_GLACommandCenter
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 5000.0
     InitialHealth     = 5000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 5200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
+  End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = GARRISONED
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
 
   Behavior = PreorderCreate ModuleTag_PreorderCreate
@@ -766,6 +812,8 @@ Object GC_Slth_GLASupplyStash
   ; *** ART Parameters ***
   SelectPortrait         = SUSupplyCenter_L
   ButtonImage            = SUSupplyCenter
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day
@@ -920,7 +968,7 @@ Object GC_Slth_GLASupplyStash
     ConditionState         = GARRISONED SNOW NIGHT
       Model                = UBSpplyEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBSpplyEG_S.UBSpplyEG_S
+      Animation            = UBSpplyEG_NS.UBSpplyEG_NS
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT
@@ -1038,6 +1086,18 @@ Object GC_Slth_GLASupplyStash
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
 
   End
@@ -1282,7 +1342,7 @@ Object GC_Slth_GLASupplyStash
   EditorSorting       = STRUCTURE
   BuildCost           = 1500
   RefundValue         = 650 ; With nothing (or zero) listed, we sell for half price.
-  BuildTime           = 15.0           ; in seconds
+  BuildTime           = 10.0           ; in seconds
   EnergyProduction    = 0
   CommandSet          = GC_Slth_GLASupplyStashCommandSet
   VisionRange         = 200.0           ; Shroud clearing distance
@@ -1290,6 +1350,11 @@ Object GC_Slth_GLASupplyStash
   ArmorSet
     Conditions        = None
     Armor             = StructureArmor
+    DamageFX          = StructureDamageFXNoShake
+  End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
@@ -1305,11 +1370,27 @@ Object GC_Slth_GLASupplyStash
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CASH_GENERATOR CAPTURABLE FS_POWER AUTO_RALLYPOINT MP_COUNT_FOR_VICTORY SCORE_CREATE CANNOT_BUILD_NEAR_SUPPLIES
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CASH_GENERATOR CAPTURABLE AUTO_RALLYPOINT MP_COUNT_FOR_VICTORY SCORE_CREATE CANNOT_BUILD_NEAR_SUPPLIES FS_SUPPLY_CENTER IGNORE_DOCKING_BONES
   Body                = StructureBody ModuleTag_04
-    MaxHealth       = 1000.0
-    InitialHealth   = 1000.0
+    MaxHealth       = 2000.0
+    InitialHealth   = 2000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 2200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = GARRISONED
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
   Behavior = SupplyCenterCreate ModuleTag_05
     ;nothing
   End
@@ -1461,6 +1542,8 @@ Object GC_Slth_GLABarracks
   ; *** ART Parameters ***
   SelectPortrait         = SUBarracks_L
   ButtonImage            = SUBarracks
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day
@@ -1741,6 +1824,18 @@ Object GC_Slth_GLABarracks
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
   End
   ; ------------ construction-zone fence -----------------
@@ -2024,9 +2119,16 @@ Object GC_Slth_GLABarracks
   RadarPriority   = STRUCTURE
   KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE HEAL_PAD CAPTURABLE FS_FACTORY AUTO_RALLYPOINT MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BARRACKS
   Body            = StructureBody ModuleTag_04
-    MaxHealth     = 500.0
-    InitialHealth = 500.0
+    MaxHealth     = 1000.0
+    InitialHealth = 1000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 1200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
+
   Behavior        = ArmorUpgrade ModuleTag_Armor01
     TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
@@ -2081,8 +2183,6 @@ Object GC_Slth_GLABarracks
 
   Behavior = StealthUpdate ModuleTag_17
     StealthDelay                = 2000 ; msec
-    StealthForbiddenConditions  = FIRING_PRIMARY
-    HintDetectableConditions    = IS_FIRING_WEAPON
     FriendlyOpacityMin          = 50.0%
     FriendlyOpacityMax          = 100.0%
     InnateStealth               = Yes
@@ -2632,8 +2732,9 @@ Object GC_Slth_GLAStingerSite
     StartsActive  = Yes
   End
   Behavior = StealthUpdate ModuleTag_13
-    StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY
+    StealthDelay                = 2000 ; msec
+    StealthForbiddenConditions  = FIRING_PRIMARY FIRING_SECONDARY
+    HintDetectableConditions    = IS_FIRING_WEAPON
     MoveThresholdSpeed          = 3
     FriendlyOpacityMin          = 50.0%
     FriendlyOpacityMax          = 100.0%
@@ -3170,8 +3271,9 @@ Object GC_Slth_GLATunnelNetwork
     AflameDamageDelay = 500       ; this often.
   End
   Behavior = StealthUpdate ModuleTag_17
-    StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY
+    StealthDelay                = 2000 ; msec
+    StealthForbiddenConditions  = FIRING_PRIMARY
+    HintDetectableConditions    = IS_FIRING_WEAPON
     MoveThresholdSpeed          = 3
     InnateStealth               = Yes ;Requires upgrade first
     FriendlyOpacityMin          = 50.0%
@@ -3255,6 +3357,7 @@ Object GC_Slth_GLAArmsDealer
   ; *** ART Parameters ***
   SelectPortrait         = SUArmsDealer_L
   ButtonImage            = SUArmsDealer
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
 
   ; ----------------- Main Building -------------------
   Draw = W3DModelDraw ModuleTag_01
@@ -3322,6 +3425,7 @@ Object GC_Slth_GLAArmsDealer
       AnimationMode        = LOOP
     End
 
+    ; snow
     ConditionState       = SNOW
       Model              = UBArmDeal_S
       Animation          = UBArmDeal_S.UBArmDeal_S
@@ -3403,7 +3507,7 @@ Object GC_Slth_GLAArmsDealer
       Animation       = UBArmDeal_EN.UBArmDeal_EN
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SmolderingSmoke
-     End
+    End
     ConditionState         = GARRISONED NIGHT
       Model                = UBArmDlEG_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
@@ -3442,7 +3546,7 @@ Object GC_Slth_GLAArmsDealer
       Animation       = UBArmDeal_ENS.UBArmDeal_ENS
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SmolderingSmoke
-     End
+    End
     ConditionState         = GARRISONED NIGHT SNOW
       Model                = UBArmDlEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
@@ -3564,6 +3668,18 @@ Object GC_Slth_GLAArmsDealer
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
 
 
@@ -3999,7 +4115,7 @@ Object GC_Slth_GLAArmsDealer
     Object = GC_Slth_GLASupplyStash
   End
   BuildCost        = 2500
-  BuildTime        = 25.0           ; in seconds
+  BuildTime        = 15.0           ; in seconds
   EnergyProduction = 0
   CommandSet       = GC_Slth_GLAArmsDealerCommandSet
   VisionRange     = 200.0           ; Shroud clearing distance
@@ -4031,7 +4147,14 @@ Object GC_Slth_GLAArmsDealer
   Body              = StructureBody ModuleTag_05
     MaxHealth       = 2000.0
     InitialHealth   = 2000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 2200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
+
   Behavior        = ArmorUpgrade ModuleTag_Armor01
     TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
@@ -4085,8 +4208,6 @@ Object GC_Slth_GLAArmsDealer
   End
   Behavior = StealthUpdate ModuleTag_15
     StealthDelay                = 2000 ; msec
-    StealthForbiddenConditions  = FIRING_PRIMARY
-    HintDetectableConditions    = IS_FIRING_WEAPON
     FriendlyOpacityMin          = 50.0%
     FriendlyOpacityMax          = 100.0%
     InnateStealth               = Yes
@@ -4178,6 +4299,8 @@ Object GC_Slth_GLAPalace
   ; *** ART Parameters ***
   SelectPortrait         = SUPalace_L
   ButtonImage            = SUPalace
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
 
@@ -4207,19 +4330,49 @@ Object GC_Slth_GLAPalace
       Animation            = UBPalace_G.UBPalace_G
       AnimationMode        = LOOP
     End
+    ConditionState         = USER_1
+      Model                = UBPalaceEG
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG.UBPalaceEG
+      AnimationMode        = LOOP
+    End
+    ConditionState         = USER_1 GARRISONED
+      Model                = UBPalaceEGX
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+       Animation            = UBPalaceEGX.UBPalaceEGX
+      AnimationMode        = LOOP
+    End
     ConditionState         = DAMAGED GARRISONED
       Model                = UBPalace_DG
       ParticleSysBone      = Smoke01 SmolderingSmoke
       Animation            = UBPalace_DG.UBPalace_DG
       AnimationMode        = LOOP
     End
-    ConditionState         = REALLYDAMAGED GARRISONED
-      Model                = UBPalace_EG
+    ConditionState         = DAMAGED USER_1
+      Model                = UBPalaceEG_D
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_EG.UBPalace_EG
+      Animation            = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 GARRISONED
+     Model                = UBPalaceEGX_D
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_D.UBPalaceEGX_D
       AnimationMode        = LOOP
     End
 
+    ConditionState         = REALLYDAMAGED GARRISONED
+      Model                = UBPalace_EG
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1
+      Model                = UBPalaceEG_E
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 GARRISONED
+      Model                = UBPalaceEGX_E
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
 
     ; day snow
     ConditionState         = SNOW
@@ -4246,59 +4399,121 @@ Object GC_Slth_GLAPalace
       Animation            = UBPalace_SG.UBPalace_SG
       AnimationMode        = LOOP
     End
+    ConditionState         = USER_1 SNOW
+      Model                = UBPalaceEG_S
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode        = LOOP
+    End
+    ConditionState         = USER_1 SNOW GARRISONED
+      Model                = UBPalaceEGX_S
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_S.UBPalaceEGX_S
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = DAMAGED GARRISONED SNOW
       Model                = UBPalace_DSG
       ParticleSysBone      = Smoke01 SmolderingSmoke
       Animation            = UBPalace_DSG.UBPalace_DSG
       AnimationMode        = LOOP
     End
+    ConditionState         = DAMAGED USER_1 SNOW
+      Model                = UBPalaceEG_DS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 SNOW GARRISONED
+      Model                = UBPalaceEGX_DS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_DSG.UBPalaceEGX_DS
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = REALLYDAMAGED GARRISONED SNOW
       Model                = UBPalace_ESG
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      ;Animation            = UBPalace_ESG.UBPalace_ESG
-      ;AnimationMode        = LOOP
     End
-
-
+    ConditionState         = REALLYDAMAGED USER_1 SNOW
+      Model                = UBPalaceEG_ES
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 GARRISONED SNOW
+      Model                = UBPalaceEGX_ES
+     ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
 
     ; night
     ConditionState         = NIGHT
-      Model                = UBPalace
+      Model                = UBPalace_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace.UBPalace
+      Animation            = UBPalace_N.UBPalace_N
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED NIGHT
-      Model                = UBPalace_D
+      Model                = UBPalace_DN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_D.UBPalace_D
+      Animation            = UBPalace_DN.UBPalace_DN
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED RUBBLE NIGHT
-      Model                = UBPalace_E
+      Model                = UBPalace_EN
       ParticleSysBone      = Smoke01 SmolderingSmoke
     End
 
 
     ConditionState         = GARRISONED NIGHT
-      Model                = UBPalace_G
+      Model                = UBPalace_NG
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_G.UBPalace_G
+      Animation            = UBPalace_NG.UBPalace_NG
       AnimationMode        = LOOP
     End
-    ConditionState         = DAMAGED GARRISONED NIGHT
-      Model                = UBPalace_DG
+    ConditionState         = USER_1 NIGHT
+      Model                = UBPalaceEG_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_DG.UBPalace_DG
+      Animation            = UBPalaceEG_N.UBPalaceEG_N
       AnimationMode        = LOOP
     End
-    ConditionState         = REALLYDAMAGED GARRISONED NIGHT
-      Model                = UBPalace_EG
+    ; commented out until we get the right state (garrison + elite guard)
+    ConditionState         = USER_1 NIGHT GARRISONED
+      Model                = UBPalaceEGX_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_EG.UBPalace_EG
+      Animation            = UBPalaceEGX_N.UBPalaceEGX_N
       AnimationMode        = LOOP
     End
 
+    ConditionState         = DAMAGED GARRISONED NIGHT
+      Model                = UBPalace_DGN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalace_DGN.UBPalace_DGN
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 NIGHT
+      Model                = UBPalaceEG_DN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 NIGHT GARRISONED
+      Model                = UBPalaceEGX_DN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_DN.UBPalaceEGX_DN
+      AnimationMode        = LOOP
+    End
+
+    ConditionState         = REALLYDAMAGED GARRISONED NIGHT
+      Model                = UBPalace_ENG
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 NIGHT
+      Model                = UBPalaceEG_EN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 NIGHT GARRISONED
+      Model                = UBPalaceEGX_EN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
 
     ; night snow
     ConditionState         = SNOW NIGHT
@@ -4325,17 +4540,49 @@ Object GC_Slth_GLAPalace
       Animation            = UBPalace_GNS.UBPalace_GNS
       AnimationMode        = LOOP
     End
+    ConditionState         = USER_1 SNOW NIGHT
+      Model                = UBPalaceEG_NS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode        = LOOP
+    End
+    ConditionState         = USER_1 SNOW NIGHT GARRISONED
+      Model                = UBPalaceEGX_NS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_NS.UBPalaceEGX_NS
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT
       Model                = UBPalace_DGNS
       ParticleSysBone      = Smoke01 SmolderingSmoke
       Animation            = UBPalace_DGNS.UBPalace_DGNS
       AnimationMode        = LOOP
     End
+    ConditionState         = DAMAGED USER_1 SNOW NIGHT
+      Model                = UBPalaceEG_DNS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 SNOW NIGHT GARRISONED
+      Model                = UBPalaceEGX_DNS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_DNS.UBPalaceEGX_DNS
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = REALLYDAMAGED GARRISONED SNOW NIGHT
       Model                = UBPalace_ENSG
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_ENSG.UBPalace_ENSG
-      AnimationMode        = LOOP
+    End
+    ConditionState         = REALLYDAMAGED USER_1 SNOW NIGHT
+      Model                = UBPalaceEG_ENS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 SNOW NIGHT GARRISONED
+      Model                = UBPalaceEGX_ENS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
     End
 
     ;**************************************************************************************************************************
@@ -4432,6 +4679,53 @@ Object GC_Slth_GLAPalace
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = AWAITING_CONSTRUCTION DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION REALLYDAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT REALLYDAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION SNOW USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION SNOW DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT SNOW USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT SNOW DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD USER_1
+    AliasConditionState  = SOLD DAMAGED USER_1
+    AliasConditionState  = SOLD REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT USER_1
+    AliasConditionState  = SOLD NIGHT DAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD SNOW USER_1
+    AliasConditionState  = SOLD SNOW DAMAGED USER_1
+    AliasConditionState  = SOLD SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT SNOW USER_1
+    AliasConditionState  = SOLD NIGHT SNOW DAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD USER_1
+    AliasConditionState  = GARRISONED SOLD DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD SNOW USER_1
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED USER_1
     ;**************************************************************************************************************************
 
   End
@@ -4689,6 +4983,11 @@ Object GC_Slth_GLAPalace
     Armor           = StructureArmor
     DamageFX        = StructureDamageFXNoShake
   End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmor
+    DamageFX          = StructureDamageFXNoShake
+  End
   CommandSet = GC_Slth_GLAPalaceCommandSet
   ExperienceValue     = 300 300 300 300  ; Experience point value at each level
 
@@ -4707,8 +5006,21 @@ Object GC_Slth_GLAPalace
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 3000.0
     InitialHealth   = 3000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 3200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
+  End
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
 
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = USER_1
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
   Behavior = ProductionUpdate ModuleTag_05
     ; nothing
   End
@@ -4751,7 +5063,7 @@ Object GC_Slth_GLAPalace
   End
   Behavior = StealthUpdate ModuleTag_13
     StealthDelay                = 2000 ; msec
-    StealthForbiddenConditions  = FIRING_PRIMARY
+    StealthForbiddenConditions  = RIDERS_ATTACKING
     HintDetectableConditions    = IS_FIRING_WEAPON
     FriendlyOpacityMin          = 50.0%
     FriendlyOpacityMax          = 100.0%
@@ -4832,6 +5144,8 @@ Object GC_Slth_GLABlackMarket
   ; *** ART Parameters ***
   SelectPortrait         = SUBlackMarket_L
   ButtonImage            = SUBlackMarket
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw                = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -5177,6 +5491,18 @@ Object GC_Slth_GLABlackMarket
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
 
   End
@@ -5422,7 +5748,7 @@ Object GC_Slth_GLABlackMarket
     Object = GC_Slth_GLAPalace
   End
   BuildCost           = 2500
-  BuildTime           = 45.0           ; in seconds
+  BuildTime           = 30.0           ; in seconds
   EnergyProduction    = 0
   CommandSet          = GC_Slth_GLABlackMarketCommandSet
   VisionRange         = 200.0           ; Shroud clearing distance
@@ -5452,9 +5778,16 @@ Object GC_Slth_GLABlackMarket
   RadarPriority       = STRUCTURE
   KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
   Body                = StructureBody ModuleTag_04
-    MaxHealth         = 500.0
-    InitialHealth     = 500.0
+    MaxHealth         = 1000.0
+    InitialHealth     = 1000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 1200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
+
   Behavior        = ArmorUpgrade ModuleTag_Armor01
     TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
@@ -5504,8 +5837,6 @@ Object GC_Slth_GLABlackMarket
   End
   Behavior = StealthUpdate ModuleTag_14
     StealthDelay                = 2000 ; msec
-    StealthForbiddenConditions  = FIRING_PRIMARY
-    HintDetectableConditions    = IS_FIRING_WEAPON
     FriendlyOpacityMin          = 50.0%
     FriendlyOpacityMax          = 100.0%
     InnateStealth               = Yes
@@ -7720,6 +8051,12 @@ Object GC_Slth_GLAScudStorm
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 4200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
   Behavior        = RebuildHoleExposeDie ModuleTag_08
     HoleName      = GC_Slth_GLAHoleScudStorm


### PR DESCRIPTION
ZH 1.04

- GLA02 Stealth General buildings generally behaves inconsistently when stealthed.
- Some GLA02 Stealth General's Buildings are incompatible with Fortified Structures.
- The GLA02 Stealth General's Buildings are immune to Microwave tanks.
- The GLA02 Stealth General's Barracks, Supply Stash, Black Market has half the health of the regular versions.
- The GLA02 Stealth General's Supply Stash is build in 30 seconds.
- The GLA02 Stealth General's Arms Dealer is build in 50 seconds.
- The GLA02 Stealth General's Black Market is build in 90 seconds.
- The GLA02 Stealth General's Black Market has an un-usable button to upgrade Camo-Netting, despite already being camouflaged.
- The GLA02 Stealth General's Supply Stash is classified as power plant instead of as supply dock.
- The GLA02 Stealth General's Palace does use its day model during the night.
