### PR TITLE
Fix: USA05 Campaign Toxin General Building Issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1484,7 +1484,7 @@ CommandSet GC_Chem_GLABarracksCommandSet
   ;4  = Command_ConstructGLAInfantryAngryMob
   5  = GC_Chem_Command_ConstructGLAInfantryHijacker
   6  = GC_Chem_Command_ConstructGLAInfantryJarmenKell
-  7  = Command_UpgradeGLARebelCaptureBuilding
+  11 = Command_UpgradeGLARebelCaptureBuilding
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
@@ -1515,11 +1515,13 @@ CommandSet GC_Chem_GLACommandCenterCommandSet
 End
 
 CommandSet GC_Chem_GLAArmsDealerCommandSet
-  1  = GC_Chem_Command_ConstructGLAVehicleRadarVan
-  2  = GC_Chem_Command_ConstructGLAVehicleQuadCannon
-  3  = GC_Chem_Command_ConstructGLAVehicleToxinTruck
-  4  = GC_Chem_Command_ConstructGLAVehicleBombTruck
-  5  = GC_Chem_Command_ConstructGLAVehicleScudLauncher
+  1  = GC_Chem_Command_ConstructGLATankScorpion
+  3  = GC_Chem_Command_ConstructGLAVehicleRadarVan
+  4  = GC_Chem_Command_ConstructGLAVehicleQuadCannon
+  5  = GC_Chem_Command_ConstructGLAVehicleToxinTruck
+  8  = GC_Chem_Command_ConstructGLAVehicleBombTruck
+  9  = GC_Chem_Command_ConstructGLAVehicleScudLauncher
+  10 = Command_UpgradeGLAScorpionRocket
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
@@ -1535,7 +1537,8 @@ CommandSet GC_Chem_GLABlackMarketCommandSet
   1  = Command_UpgradeGLAAPBullets
   2  = Command_UpgradeGLAAPRockets
   3  = Command_UpgradeGLAJunkRepair
-  4  = Command_UpgradeGLARadarVanScan
+  ;4  = Command_UpgradeGLABuggyAmmo
+  5  = Command_UpgradeGLARadarVanScan
   6  = Command_UpgradeGLAWorkerShoes
   14 = Command_Sell
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1,3 +1,16 @@
+; Patch104p @bugfix commy2 07/10/2021 Fix issues with USA05 campaign Toxin General:
+; - All buildings are incompatible with Fortified Structures.
+; - All buildings are immune to Microwave tanks.
+; - Barracks, Supply Stash, Black Market have half the health of the regular versions.
+; - Command Center does not grant Toxin Shells and Anthrax Beta.
+; - Supply Stash is build in 30 seconds instead of 20 seconds like other Supply Stashes.
+; - Arms Dealer is build in 50 seconds instead of 30 seconds like other Arms Dealers.
+; - Arms Dealer cannot build Scorpions and Scorpion Rockets.
+; - Black Market is build in 90 seconds instead of 60 seconds like other Black Markets.
+; - Supply Stash is classified as power plant instead of as supply dock.
+; - Palace does use its day model during the night.
+; - The buttons for Capture Building and Radar Van Scan are switched.
+
 ;This file is for Chemical Generals Challenge GLA Buildings
 ;----------------------------------------------------------------------
 Object GC_Chem_GLATunnelNetwork
@@ -1196,6 +1209,7 @@ Object GC_Chem_GLACommandCenter
   ; *** ART Parameters ***
   SelectPortrait         = SUHeadquarters_L
   ButtonImage            = SUHeadquarters
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
 
   ; ----- The actual command center
   Draw                   = W3DModelDraw ModuleTag_01
@@ -1223,21 +1237,21 @@ Object GC_Chem_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED
-      Model                = UBCmdHQEG
+      Model                = UBCmdHQCE
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG.UBCmdHQEG
+      Animation            = UBCmdHQCE.UBCmdHQCE
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED
-      Model                = UBCmdHQEG_D
+      Model                = UBCmdHQCE_D
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_D.UBCmdHQEG_D
+      Animation            = UBCmdHQCE_D.UBCmdHQCE_D
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED
-      Model                = UBCmdHQEG_E
+      Model                = UBCmdHQCE_E
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_E.UBCmdHQEG_E
+      Animation            = UBCmdHQCE_E.UBCmdHQCE_E
       AnimationMode        = LOOP
     End
 
@@ -1261,21 +1275,21 @@ Object GC_Chem_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT
-      Model                = UBCmdHQEG_N
+      Model                = UBCmdHQCE_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_N.UBCmdHQEG_N
+      Animation            = UBCmdHQCE_N.UBCmdHQCE_N
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_DN
+      Model                = UBCmdHQCE_DN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DN.UBCmdHQEG_DN
+      Animation            = UBCmdHQCE_DN.UBCmdHQCE_DN
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT
-      Model                = UBCmdHQEG_EN
+      Model                = UBCmdHQCE_EN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_EN.UBCmdHQEG_EN
+      Animation            = UBCmdHQCE_EN.UBCmdHQCE_EN
       AnimationMode        = LOOP
     End
 
@@ -1299,21 +1313,21 @@ Object GC_Chem_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED SNOW
-      Model                = UBCmdHQEG_S
+      Model                = UBCmdHQCE_S
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_S.UBCmdHQEG_S
+      Animation            = UBCmdHQCE_S.UBCmdHQCE_S
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_DS
+      Model                = UBCmdHQCE_DS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DS.UBCmdHQEG_DS
+      Animation            = UBCmdHQCE_DS.UBCmdHQCE_DS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED SNOW
-      Model                = UBCmdHQEG_ES
+      Model                = UBCmdHQCE_ES
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ES.UBCmdHQEG_ES
+      Animation            = UBCmdHQCE_ES.UBCmdHQCE_ES
       AnimationMode        = LOOP
     End
 
@@ -1337,21 +1351,21 @@ Object GC_Chem_GLACommandCenter
       AnimationMode      = LOOP
     End
     ConditionState         = GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_NS
+      Model                = UBCmdHQCE_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_NS.UBCmdHQEG_NS
+      Animation            = UBCmdHQCE_NS.UBCmdHQCE_NS
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_DNS
+      Model                = UBCmdHQCE_DNS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_DNS.UBCmdHQEG_DNS
+      Animation            = UBCmdHQCE_DNS.UBCmdHQCE_DNS
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED GARRISONED NIGHT SNOW
-      Model                = UBCmdHQEG_ENS
+      Model                = UBCmdHQCE_ENS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBCmdHQEG_ENS.UBCmdHQEG_ENS
+      Animation            = UBCmdHQCE_ENS.UBCmdHQCE_ENS
       AnimationMode        = LOOP
     End
 
@@ -1458,6 +1472,18 @@ Object GC_Chem_GLACommandCenter
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
   End
 
@@ -1752,6 +1778,11 @@ Object GC_Chem_GLACommandCenter
     Armor             = StructureArmorTough
     DamageFX          = StructureDamageFXNoShake
   End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmorTough
+    DamageFX          = StructureDamageFXNoShake
+  End
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -1770,6 +1801,21 @@ Object GC_Chem_GLACommandCenter
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 5000.0
     InitialHealth     = 5000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 5200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
+  End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = GARRISONED
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
 
   Behavior = PreorderCreate ModuleTag_PreorderCreate
@@ -1858,6 +1904,14 @@ Object GC_Chem_GLACommandCenter
     ReferenceObject      = GLASneakAttackTunnelNetwork ;So we know what the final product is for script placement calculations
   End
 
+  Behavior = GrantUpgradeCreate ModuleTag_22
+    UpgradeToGrant     = Upgrade_GLAToxinShells
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_23
+    UpgradeToGrant = Upgrade_GLAAnthraxBeta
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0
@@ -1918,6 +1972,8 @@ Object GC_Chem_GLABarracks
   ; *** ART Parameters ***
   SelectPortrait         = SUBarracks_L
   ButtonImage            = SUBarracks
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day
@@ -2215,6 +2271,18 @@ Object GC_Chem_GLABarracks
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
   End
   ; ------------ construction-zone fence -----------------
@@ -2473,6 +2541,11 @@ Object GC_Chem_GLABarracks
     Armor           = StructureArmor
     DamageFX        = StructureDamageFXNoShake
   End
+  ArmorSet
+    Conditions      = PLAYER_UPGRADE
+    Armor           = GLAUpgradedStructureArmor
+    DamageFX        = StructureDamageFXNoShake
+  End
   ExperienceValue     = 100 100 100 100  ; Experience point value at each level
 
   Prerequisites
@@ -2493,9 +2566,25 @@ Object GC_Chem_GLABarracks
   RadarPriority   = STRUCTURE
   KindOf          = PRELOAD STRUCTURE SELECTABLE IMMOBILE HEAL_PAD CAPTURABLE FS_FACTORY AUTO_RALLYPOINT MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BARRACKS
   Body            = StructureBody ModuleTag_04
-    MaxHealth     = 500.0
-    InitialHealth = 500.0
+    MaxHealth     = 1000.0
+    InitialHealth = 1000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 1200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = GARRISONED
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
@@ -2603,6 +2692,8 @@ Object GC_Chem_GLAPalace
   ; *** ART Parameters ***
   SelectPortrait         = SUPalace_L
   ButtonImage            = SUPalace
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
 
@@ -2632,19 +2723,49 @@ Object GC_Chem_GLAPalace
       Animation            = UBPalace_G.UBPalace_G
       AnimationMode        = LOOP
     End
+    ConditionState         = USER_1
+      Model                = UBPalaceEG
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG.UBPalaceEG
+      AnimationMode        = LOOP
+    End
+    ConditionState         = USER_1 GARRISONED
+      Model                = UBPalaceEGX
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+       Animation            = UBPalaceEGX.UBPalaceEGX
+      AnimationMode        = LOOP
+    End
     ConditionState         = DAMAGED GARRISONED
       Model                = UBPalace_DG
       ParticleSysBone      = Smoke01 SmolderingSmoke
       Animation            = UBPalace_DG.UBPalace_DG
       AnimationMode        = LOOP
     End
-    ConditionState         = REALLYDAMAGED GARRISONED
-      Model                = UBPalace_EG
+    ConditionState         = DAMAGED USER_1
+      Model                = UBPalaceEG_D
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_EG.UBPalace_EG
+      Animation            = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 GARRISONED
+     Model                = UBPalaceEGX_D
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_D.UBPalaceEGX_D
       AnimationMode        = LOOP
     End
 
+    ConditionState         = REALLYDAMAGED GARRISONED
+      Model                = UBPalace_EG
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1
+      Model                = UBPalaceEG_E
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 GARRISONED
+      Model                = UBPalaceEGX_E
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
 
     ; day snow
     ConditionState         = SNOW
@@ -2671,59 +2792,121 @@ Object GC_Chem_GLAPalace
       Animation            = UBPalace_SG.UBPalace_SG
       AnimationMode        = LOOP
     End
+    ConditionState         = USER_1 SNOW
+      Model                = UBPalaceEG_S
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode        = LOOP
+    End
+    ConditionState         = USER_1 SNOW GARRISONED
+      Model                = UBPalaceEGX_S
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_S.UBPalaceEGX_S
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = DAMAGED GARRISONED SNOW
       Model                = UBPalace_DSG
       ParticleSysBone      = Smoke01 SmolderingSmoke
       Animation            = UBPalace_DSG.UBPalace_DSG
       AnimationMode        = LOOP
     End
+    ConditionState         = DAMAGED USER_1 SNOW
+      Model                = UBPalaceEG_DS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 SNOW GARRISONED
+      Model                = UBPalaceEGX_DS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_DSG.UBPalaceEGX_DS
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = REALLYDAMAGED GARRISONED SNOW
       Model                = UBPalace_ESG
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      ;Animation            = UBPalace_ESG.UBPalace_ESG
-      ;AnimationMode        = LOOP
     End
-
-
+    ConditionState         = REALLYDAMAGED USER_1 SNOW
+      Model                = UBPalaceEG_ES
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 GARRISONED SNOW
+      Model                = UBPalaceEGX_ES
+     ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
 
     ; night
     ConditionState         = NIGHT
-      Model                = UBPalace
+      Model                = UBPalace_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace.UBPalace
+      Animation            = UBPalace_N.UBPalace_N
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED NIGHT
-      Model                = UBPalace_D
+      Model                = UBPalace_DN
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_D.UBPalace_D
+      Animation            = UBPalace_DN.UBPalace_DN
       AnimationMode        = LOOP
     End
     ConditionState         = REALLYDAMAGED RUBBLE NIGHT
-      Model                = UBPalace_E
+      Model                = UBPalace_EN
       ParticleSysBone      = Smoke01 SmolderingSmoke
     End
 
 
     ConditionState         = GARRISONED NIGHT
-      Model                = UBPalace_G
+      Model                = UBPalace_NG
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_G.UBPalace_G
+      Animation            = UBPalace_NG.UBPalace_NG
       AnimationMode        = LOOP
     End
-    ConditionState         = DAMAGED GARRISONED NIGHT
-      Model                = UBPalace_DG
+    ConditionState         = USER_1 NIGHT
+      Model                = UBPalaceEG_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_DG.UBPalace_DG
+      Animation            = UBPalaceEG_N.UBPalaceEG_N
       AnimationMode        = LOOP
     End
-    ConditionState         = REALLYDAMAGED GARRISONED NIGHT
-      Model                = UBPalace_EG
+    ; commented out until we get the right state (garrison + elite guard)
+    ConditionState         = USER_1 NIGHT GARRISONED
+      Model                = UBPalaceEGX_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_EG.UBPalace_EG
+      Animation            = UBPalaceEGX_N.UBPalaceEGX_N
       AnimationMode        = LOOP
     End
 
+    ConditionState         = DAMAGED GARRISONED NIGHT
+      Model                = UBPalace_DGN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalace_DGN.UBPalace_DGN
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 NIGHT
+      Model                = UBPalaceEG_DN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 NIGHT GARRISONED
+      Model                = UBPalaceEGX_DN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_DN.UBPalaceEGX_DN
+      AnimationMode        = LOOP
+    End
+
+    ConditionState         = REALLYDAMAGED GARRISONED NIGHT
+      Model                = UBPalace_ENG
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 NIGHT
+      Model                = UBPalaceEG_EN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 NIGHT GARRISONED
+      Model                = UBPalaceEGX_EN
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
 
     ; night snow
     ConditionState         = SNOW NIGHT
@@ -2750,17 +2933,49 @@ Object GC_Chem_GLAPalace
       Animation            = UBPalace_GNS.UBPalace_GNS
       AnimationMode        = LOOP
     End
+    ConditionState         = USER_1 SNOW NIGHT
+      Model                = UBPalaceEG_NS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode        = LOOP
+    End
+    ConditionState         = USER_1 SNOW NIGHT GARRISONED
+      Model                = UBPalaceEGX_NS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_NS.UBPalaceEGX_NS
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT
       Model                = UBPalace_DGNS
       ParticleSysBone      = Smoke01 SmolderingSmoke
       Animation            = UBPalace_DGNS.UBPalace_DGNS
       AnimationMode        = LOOP
     End
+    ConditionState         = DAMAGED USER_1 SNOW NIGHT
+      Model                = UBPalaceEG_DNS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode        = LOOP
+    End
+    ConditionState         = DAMAGED USER_1 SNOW NIGHT GARRISONED
+      Model                = UBPalaceEGX_DNS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+      Animation            = UBPalaceEGX_DNS.UBPalaceEGX_DNS
+      AnimationMode        = LOOP
+    End
+
     ConditionState         = REALLYDAMAGED GARRISONED SNOW NIGHT
       Model                = UBPalace_ENSG
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBPalace_ENSG.UBPalace_ENSG
-      AnimationMode        = LOOP
+    End
+    ConditionState         = REALLYDAMAGED USER_1 SNOW NIGHT
+      Model                = UBPalaceEG_ENS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
+    End
+    ConditionState         = REALLYDAMAGED USER_1 SNOW NIGHT GARRISONED
+      Model                = UBPalaceEGX_ENS
+      ParticleSysBone      = Smoke01 SmolderingSmoke
     End
 
     ;**************************************************************************************************************************
@@ -2857,6 +3072,53 @@ Object GC_Chem_GLAPalace
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = AWAITING_CONSTRUCTION DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION REALLYDAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT REALLYDAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION SNOW USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION SNOW DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT SNOW USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT SNOW DAMAGED USER_1
+    AliasConditionState  = AWAITING_CONSTRUCTION NIGHT SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD USER_1
+    AliasConditionState  = SOLD DAMAGED USER_1
+    AliasConditionState  = SOLD REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT USER_1
+    AliasConditionState  = SOLD NIGHT DAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD SNOW USER_1
+    AliasConditionState  = SOLD SNOW DAMAGED USER_1
+    AliasConditionState  = SOLD SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT SNOW USER_1
+    AliasConditionState  = SOLD NIGHT SNOW DAMAGED USER_1
+    AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD USER_1
+    AliasConditionState  = GARRISONED SOLD DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD SNOW USER_1
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED USER_1
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED USER_1
     ;**************************************************************************************************************************
 
   End
@@ -3114,6 +3376,11 @@ Object GC_Chem_GLAPalace
     Armor           = StructureArmor
     DamageFX        = StructureDamageFXNoShake
   End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmor
+    DamageFX          = StructureDamageFXNoShake
+  End
   CommandSet = GC_Chem_GLAPalaceCommandSet
   ExperienceValue     = 300 300 300 300  ; Experience point value at each level
 
@@ -3132,6 +3399,21 @@ Object GC_Chem_GLAPalace
   Body            = StructureBody ModuleTag_04
     MaxHealth       = 3000.0
     InitialHealth   = 3000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 3200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
+  End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = USER_1
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
 
   Behavior = ProductionUpdate ModuleTag_05
@@ -3228,6 +3510,7 @@ Object GC_Chem_GLAArmsDealer
   ; *** ART Parameters ***
   SelectPortrait         = SUArmsDealer_L
   ButtonImage            = SUArmsDealer
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
 
   ; ----------------- Main Building -------------------
   Draw = W3DModelDraw ModuleTag_01
@@ -3273,6 +3556,7 @@ Object GC_Chem_GLAArmsDealer
       AnimationMode        = LOOP
     End
 
+    ; snow
     ConditionState       = SNOW
       Model              = UBArmDeal_S
       Animation          = UBArmDeal_S.UBArmDeal_S
@@ -3332,7 +3616,7 @@ Object GC_Chem_GLAArmsDealer
       Animation       = UBArmDeal_EN.UBArmDeal_EN
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SmolderingSmoke
-     End
+    End
     ConditionState         = GARRISONED NIGHT
       Model                = UBArmDlEG_N
       ParticleSysBone      = Smoke01 SmolderingSmoke
@@ -3371,7 +3655,7 @@ Object GC_Chem_GLAArmsDealer
       Animation       = UBArmDeal_ENS.UBArmDeal_ENS
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SmolderingSmoke
-     End
+    End
     ConditionState         = GARRISONED NIGHT SNOW
       Model                = UBArmDlEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
@@ -3493,6 +3777,18 @@ Object GC_Chem_GLAArmsDealer
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
 
 
@@ -3928,7 +4224,7 @@ Object GC_Chem_GLAArmsDealer
     Object = GC_Chem_GLASupplyStash
   End
   BuildCost        = 2500
-  BuildTime        = 25.0           ; in seconds
+  BuildTime        = 15.0           ; in seconds
   EnergyProduction = 0
   CommandSet       = GC_Chem_GLAArmsDealerCommandSet
   VisionRange     = 200.0           ; Shroud clearing distance
@@ -3938,6 +4234,12 @@ Object GC_Chem_GLAArmsDealer
     Armor               = StructureArmor
     DamageFX            = StructureDamageFXNoShake
   End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmor
+    DamageFX          = StructureDamageFXNoShake
+  End
+
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   ; *** AUDIO Parameters ***
@@ -3955,6 +4257,21 @@ Object GC_Chem_GLAArmsDealer
   Body              = StructureBody ModuleTag_05
     MaxHealth       = 2000.0
     InitialHealth   = 2000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 2200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
+  End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = GARRISONED
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
 
   Behavior               = RebuildHoleExposeDie ModuleTag_06
@@ -4062,6 +4379,8 @@ Object GC_Chem_GLASupplyStash
   ; *** ART Parameters ***
   SelectPortrait         = SUSupplyCenter_L
   ButtonImage            = SUSupplyCenter
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day
@@ -4216,7 +4535,7 @@ Object GC_Chem_GLASupplyStash
     ConditionState         = GARRISONED SNOW NIGHT
       Model                = UBSpplyEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBSpplyEG_S.UBSpplyEG_S
+      Animation            = UBSpplyEG_NS.UBSpplyEG_NS
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT
@@ -4334,6 +4653,18 @@ Object GC_Chem_GLASupplyStash
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
 
   End
@@ -4578,7 +4909,7 @@ Object GC_Chem_GLASupplyStash
   EditorSorting       = STRUCTURE
   BuildCost           = 1500
   RefundValue         = 650 ; With nothing (or zero) listed, we sell for half price.
-  BuildTime           = 15.0           ; in seconds
+  BuildTime           = 10.0           ; in seconds
   EnergyProduction    = 0
   CommandSet          = GC_Chem_GLASupplyStashCommandSet
   VisionRange         = 200.0           ; Shroud clearing distance
@@ -4586,6 +4917,11 @@ Object GC_Chem_GLASupplyStash
   ArmorSet
     Conditions        = None
     Armor             = StructureArmor
+    DamageFX          = StructureDamageFXNoShake
+  End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
@@ -4601,11 +4937,27 @@ Object GC_Chem_GLASupplyStash
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CASH_GENERATOR CAPTURABLE FS_POWER AUTO_RALLYPOINT MP_COUNT_FOR_VICTORY SCORE_CREATE CANNOT_BUILD_NEAR_SUPPLIES
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CASH_GENERATOR CAPTURABLE AUTO_RALLYPOINT MP_COUNT_FOR_VICTORY SCORE_CREATE CANNOT_BUILD_NEAR_SUPPLIES FS_SUPPLY_CENTER IGNORE_DOCKING_BONES
   Body                = StructureBody ModuleTag_04
-    MaxHealth       = 1000.0
-    InitialHealth   = 1000.0
+    MaxHealth       = 2000.0
+    InitialHealth   = 2000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 2200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = GARRISONED
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
   Behavior = SupplyCenterCreate ModuleTag_05
     ;nothing
   End
@@ -4726,6 +5078,8 @@ Object GC_Chem_GLABlackMarket
   ; *** ART Parameters ***
   SelectPortrait         = SUBlackMarket_L
   ButtonImage            = SUBlackMarket
+  UpgradeCameo1          = Upgrade_GLAFortifiedStructure
+
   Draw                = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -5071,6 +5425,18 @@ Object GC_Chem_GLABlackMarket
     AliasConditionState  = SOLD NIGHT SNOW
     AliasConditionState  = SOLD NIGHT SNOW DAMAGED
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD
+    AliasConditionState  = GARRISONED SOLD DAMAGED
+    AliasConditionState  = GARRISONED SOLD REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT
+    AliasConditionState  = GARRISONED SOLD NIGHT DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW
+    AliasConditionState  = GARRISONED SOLD SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD SNOW REALLYDAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW DAMAGED
+    AliasConditionState  = GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
     ;**************************************************************************************************************************
 
   End
@@ -5316,7 +5682,7 @@ Object GC_Chem_GLABlackMarket
     Object = GC_Chem_GLAPalace
   End
   BuildCost           = 2500
-  BuildTime           = 45.0           ; in seconds
+  BuildTime           = 30.0           ; in seconds
   EnergyProduction    = 0
   CommandSet          = GC_Chem_GLABlackMarketCommandSet
   VisionRange         = 200.0           ; Shroud clearing distance
@@ -5324,6 +5690,11 @@ Object GC_Chem_GLABlackMarket
   ArmorSet
     Conditions        = None
     Armor             = StructureArmor
+    DamageFX          = StructureDamageFXNoShake
+  End
+  ArmorSet
+    Conditions        = PLAYER_UPGRADE
+    Armor             = GLAUpgradedStructureArmor
     DamageFX          = StructureDamageFXNoShake
   End
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
@@ -5341,8 +5712,23 @@ Object GC_Chem_GLABlackMarket
   RadarPriority       = STRUCTURE
   KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
   Body                = StructureBody ModuleTag_04
-    MaxHealth         = 500.0
-    InitialHealth     = 500.0
+    MaxHealth         = 1000.0
+    InitialHealth     = 1000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 1200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
+  End
+
+  Behavior        = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
+  End
+
+  Behavior        = ModelConditionUpgrade ModuleTag_Armor01Visual
+    ConditionFlag = GARRISONED
+    TriggeredBy   = Upgrade_GLAFortifiedStructure
   End
 
   Behavior = AutoDepositUpdate ModuleTag_05
@@ -7378,6 +7764,12 @@ Object GC_Chem_GLAScudStorm
   Body            = StructureBody ModuleTag_07
     MaxHealth       = 4000.0
     InitialHealth   = 4000.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 4200
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 100
   End
   Behavior        = RebuildHoleExposeDie ModuleTag_08
     HoleName      = GLAHoleScudStorm


### PR DESCRIPTION
ZH 1.04

- The USA05 Toxin General's Buildings are incompatible with Fortified Structures.
- The USA05 Toxin General's Buildings are immune to Microwave tanks.
- The USA05 Toxin General's Barracks, Supply Stash, Black Market has half the health of the regular versions.
- The USA05 Toxin General's Command Center does not grant Toxin Shells and Anthrx Beta.
- The USA05 Toxin General's Supply Stash is build in 30 seconds.
- The USA05 Toxin General's Arms Dealer is build in 50 seconds.
- The USA05 Toxin General's Arms Dealer cannot build Scorpions and Scorpion Rockets.
- The USA05 Toxin General's Black Market is build in 90 seconds.
- The USA05 Toxin General's Supply Stash is classified as power plant instead of as supply dock.
- The USA05 Toxin General's Palace does use its day model during the night.
- The button for Capture Building and Radar Van Scan are moved.
