### PR TITLE
Fix: GLA02 Campaign Stealth General Infantry Issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -1,3 +1,16 @@
+; Patch104p @bugfix commy2 07/10/2021 Fix issues with GLA02 campaign Stealth General:
+; - Different infantry units behave inconsistently when stealthed.
+; - Worker builds in 10 seconds instead of 6 seconds like other Workers.
+; - Rebel Booby Trap attack is not functional.
+; - Hijacker does not enter vehicles in guard mode.
+; - Sniper benefits from Advanced Training.
+; - Sniper does not benefit from AP Bullets.
+; - Sniper will retaliate if the option is enabled.
+; - Sniper screams like a USA unit when poisoned.
+; - Jarmen Kell has 25% less vision range than other Jarmens.
+; - Jarmen Kell will automatically engage enemies, even when stealthed.
+; - Jarmen Kell will retaliate if the option is enabled.
+
 ;------------------------------------------------------------------------------
 Object GC_Slth_GLAInfantryWorker
 
@@ -231,7 +244,7 @@ Object GC_Slth_GLAInfantryWorker
  ;  Object = GLABarracks GLASupplyStash ;commented out, or else you can't build from Con Yard as Dozer.
  ;End
   BuildCost = 200
-  BuildTime = 5.0          ;in seconds
+  BuildTime = 3.0          ;in seconds
   CrushableLevel         = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GC_Slth_GLAWorkerCommandSet
 
@@ -568,18 +581,6 @@ Object GC_Slth_GLAInfantryStingerSoldier
     ;nothing
   End
 
-  Behavior = StealthUpdate ModuleTag_10
-    StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY
-    MoveThresholdSpeed          = 3
-    InnateStealth               = No ;Requires upgrade first
-    OrderIdleEnemiesToAttackMeUponReveal  = Yes
-  End
-  Behavior = StealthUpgrade ModuleTag_11
-    TriggeredBy = Upgrade_GLACamoNetting
-  End
-
-
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
     DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -POISONED -POISONED_BETA -POISONED_GAMMA
@@ -639,7 +640,7 @@ Object GC_Slth_GLAInfantryStingerSoldier
   End
   Behavior = StealthUpdate ModuleTag_15
     StealthDelay                = 2000 ; msec
-    StealthForbiddenConditions  = FIRING_PRIMARY
+    StealthForbiddenConditions  = FIRING_PRIMARY FIRING_SECONDARY
     HintDetectableConditions    = IS_FIRING_WEAPON
     FriendlyOpacityMin          = 50.0%
     FriendlyOpacityMax          = 100.0%
@@ -1001,6 +1002,7 @@ Object GC_Slth_GLAInfantryJarmenKell
       AnimationSpeedFactorRange = 1.5 1.5
     End
     AliasConditionState = FIRING_B
+    AliasConditionState = FIRING_C
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
       Animation         = UIHERO_SKL.UIHERO_STA
@@ -1008,8 +1010,10 @@ Object GC_Slth_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = BETWEEN_FIRING_SHOTS_C
     AliasConditionState = RELOADING_A
     AliasConditionState = RELOADING_B
+    AliasConditionState = RELOADING_C
 
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -1018,6 +1022,7 @@ Object GC_Slth_GLAInfantryJarmenKell
       AnimationSpeedFactorRange = 1.5 1.5
     End
     AliasConditionState = FIRING_B REALLYDAMAGED
+    AliasConditionState = FIRING_C REALLYDAMAGED
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -1026,8 +1031,10 @@ Object GC_Slth_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
+    AliasConditionState = BETWEEN_FIRING_SHOTS_C REALLYDAMAGED
     AliasConditionState = RELOADING_A REALLYDAMAGED
     AliasConditionState = RELOADING_B REALLYDAMAGED
+    AliasConditionState = RELOADING_C REALLYDAMAGED
 
     TransitionState     = TRANS_FiringA TRANS_FiringAInjured
       Animation         = UIHERO_SKL.UIHERO_IATAHIT
@@ -1044,10 +1051,13 @@ Object GC_Slth_GLAInfantryJarmenKell
     End
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING FIRING_B
+    AliasConditionState = MOVING FIRING_C
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_C
     AliasConditionState = MOVING RELOADING_A
     AliasConditionState = MOVING RELOADING_B
+    AliasConditionState = MOVING RELOADING_C
 
     ConditionState      = MOVING REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IRNA 30
@@ -1058,10 +1068,13 @@ Object GC_Slth_GLAInfantryJarmenKell
     End
     AliasConditionState = MOVING FIRING_A REALLYDAMAGED
     AliasConditionState = MOVING FIRING_B REALLYDAMAGED
+    AliasConditionState = MOVING FIRING_C REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B REALLYDAMAGED
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_C REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_A REALLYDAMAGED
     AliasConditionState = MOVING RELOADING_B REALLYDAMAGED
+    AliasConditionState = MOVING RELOADING_C REALLYDAMAGED
 
     ; --- cheering
     ConditionState      = SPECIAL_CHEERING
@@ -1159,7 +1172,7 @@ Object GC_Slth_GLAInfantryJarmenKell
     DamageFX        = InfantryDamageFX
   End
   VisionRange         = 200
-  ShroudClearingRange = 300
+  ShroudClearingRange = 400
   Prerequisites
     Object = GC_Slth_GLABarracks
     Object = GC_Slth_GLAPalace
@@ -1194,7 +1207,7 @@ Object GC_Slth_GLAInfantryJarmenKell
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY SALVAGER STEALTH_GARRISON SCORE HERO
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY SALVAGER STEALTH_GARRISON SCORE HERO CANNOT_RETALIATE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0
@@ -1202,7 +1215,7 @@ Object GC_Slth_GLAInfantryJarmenKell
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
-    AutoAcquireEnemiesWhenIdle = Yes Stealthed
+    AutoAcquireEnemiesWhenIdle = Yes
   End
   Locomotor = SET_NORMAL JarmenKellLocomotor
 
@@ -1324,8 +1337,8 @@ Object GC_Slth_GLAInfantrySniper
   SelectPortrait         = SAPathfinder1_L
   ButtonImage            = SAPathfinder1
 
-  ;UpgradeCameo1 = Upgrade_AmericaAdvancedTraining
-  ;UpgradeCameo2 = Upgrade_AmericaChemicalSuits
+  UpgradeCameo1 = Upgrade_GLAAPBullets
+  ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
@@ -1476,7 +1489,7 @@ Object GC_Slth_GLAInfantrySniper
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY STEALTH_GARRISON SCORE
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY STEALTH_GARRISON SCORE CANNOT_RETALIATE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 120.0
@@ -1497,9 +1510,8 @@ Object GC_Slth_GLAInfantrySniper
 
   Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
 
-  Behavior = ExperienceScalarUpgrade ModuleTag_05
-    TriggeredBy = Upgrade_AmericaAdvancedTraining
-    AddXPScalar = 1.0 ;Increases experience gained by an additional 100%
+  Behavior = WeaponBonusUpgrade ModuleTag_05
+    TriggeredBy = Upgrade_GLAAPBullets
   End
 
   Behavior = PhysicsBehavior ModuleTag_06
@@ -1512,12 +1524,11 @@ Object GC_Slth_GLAInfantrySniper
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
   Behavior = StealthUpdate ModuleTag_09
-    StealthDelay                = 0           ; msec
-    StealthForbiddenConditions  = MOVING ; stays stealthy while attacking
-    FriendlyOpacityMin          = 30.0%
-    FriendlyOpacityMax          = 80.0%
-    PulseFrequency              = 500   ; msec
-    MoveThresholdSpeed          = 3
+    StealthDelay                = 2000           ; msec
+    StealthForbiddenConditions  = FIRING_PRIMARY
+    HintDetectableConditions    = IS_FIRING_WEAPON
+    FriendlyOpacityMin          = 50.0%
+    FriendlyOpacityMax          = 100.0%
     InnateStealth               = Yes
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
@@ -1556,19 +1567,19 @@ Object GC_Slth_GLAInfantrySniper
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireUSA
+    FX                  = INITIAL FX_DieByFireGLA
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
     DeathTypes          = NONE +POISONED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinUSA
+    FX                  = INITIAL FX_DieByToxinGLA
     OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06 ; don't forget to give it a new, unique module tag
     DeathTypes          = NONE +POISONED_BETA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinUSA
+    FX                  = INITIAL FX_DieByToxinGLA
     OCL                 = INITIAL OCL_ToxicInfantryBeta ;you'll have to create this OCL and make it use the blue guys instead of green ones
   End
   Behavior = SlowDeathBehavior ModuleTag_Death07
@@ -1645,7 +1656,7 @@ Object GC_Slth_GLAInfantryRebel
   UpgradeCameo1 = Upgrade_GLAAPBullets
   ;UpgradeCameo2 = Upgrade_GLACamouflage
   UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
-  ;UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
+  UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
   ;UpgradeCameo5 = NONE
 
   Draw = W3DModelDraw ModuleTag_01
@@ -1867,13 +1878,6 @@ Object GC_Slth_GLAInfantryRebel
   Behavior = PhysicsBehavior ModuleTag_05
     Mass = 5.0
   End
-  Behavior = StealthUpdate ModuleTag_07
-    StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY
-    MoveThresholdSpeed          = 3
-    InnateStealth               = No ;Requires upgrade first
-    OrderIdleEnemiesToAttackMeUponReveal  = Yes
-  End
 
   Behavior = WeaponBonusUpgrade ModuleTag_09
     TriggeredBy = Upgrade_GLAAPBullets
@@ -1963,12 +1967,34 @@ Object GC_Slth_GLAInfantryRebel
 
   Behavior = StealthUpdate ModuleTag_20
     StealthDelay                = 2000 ; msec
-    StealthForbiddenConditions  = FIRING_PRIMARY
+    StealthForbiddenConditions  = FIRING_PRIMARY USING_ABILITY
     HintDetectableConditions    = IS_FIRING_WEAPON
     FriendlyOpacityMin          = 50.0%
     FriendlyOpacityMax          = 100.0%
     InnateStealth               = Yes
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
+  End
+
+  Behavior = SpecialAbility ModuleTag_21
+    SpecialPowerTemplate = SpecialAbilityBoobyTrap
+    UpdateModuleStartsAttack = Yes
+    StartsPaused              = Yes
+    InitiateSound = RebelVoiceBoobyTrapInstall
+  End
+  Behavior = SpecialAbilityUpdate ModuleTag_22
+    SpecialPowerTemplate = SpecialAbilityBoobyTrap
+    StartAbilityRange = 5.0
+    PreparationTime = 0
+    SpecialObject = BoobyTrap
+    MaxSpecialObjects = 100
+    SpecialObjectsPersistWhenOwnerDies = Yes
+    SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
+; Not implemented    UniqueSpecialObjectTargets = Yes        ;This prevents multiple charges placed on the same object.
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_23
+    SpecialPowerTemplate = SpecialAbilityBoobyTrap
+    TriggeredBy = Upgrade_GLAInfantryRebelBoobyTrapAttack
   End
 
   Geometry = CYLINDER
@@ -2238,9 +2264,12 @@ Object GC_Slth_GLAInfantryTerrorist
     PoisonDuration = 3000       ; ... for this long after last hit by poison damage
   End
   Behavior = StealthUpdate ModuleTag_15
-    StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY
-    InnateStealth               = Yes ;Requires upgrade first
+    StealthDelay                = 2000 ; msec
+    StealthForbiddenConditions  = FIRING_PRIMARY
+    HintDetectableConditions    = IS_FIRING_WEAPON
+    FriendlyOpacityMin          = 50.0%
+    FriendlyOpacityMax          = 100.0%
+    InnateStealth               = Yes
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
 
@@ -2403,14 +2432,18 @@ Object GC_Slth_GLAInfantryHijacker
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
+  EnterGuard = Yes
+  HijackGuard = Yes
   KindOf = PRELOAD SELECTABLE CAN_CAST_REFLECTIONS INFANTRY SALVAGER SCORE STEALTH_GARRISON
   ;STEALTH_GARRISON Added per Dustin, 12/14--ML
 
 
   Behavior = StealthUpdate ModuleTag_02
     StealthDelay                = 1500
-    StealthForbiddenConditions  = ATTACKING ;MOVING
+    StealthForbiddenConditions  = NONE
     ;MoveThresholdSpeed          = 3
+    FriendlyOpacityMin          = 50.0%
+    FriendlyOpacityMax          = 100.0%
     InnateStealth               = Yes
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End


### PR DESCRIPTION
ZH 1.04

- GLA02 Stealth General Infantry generally behaves inconsistently when stealthed.
- The GLA02 Stealth General's Worker builds in 10 seconds.
- The GLA02 Stealth General's Rebel Booby Trap attack is not functional.
- The GLA02 Stealth General's Hijacker does not enter vehicles in guard mode.
- The GLA02 Stealth General's Sniper benefits from Advanced Training.
- The GLA02 Stealth General's Sniper does not benefit from AP Bullets.
- The GLA02 Stealth General's Sniper will retaliate if the option is enabled.
- The GLA02 Stealth General's Sniper screams like a USA unit when poisoned.
- The GLA02 Stealth General's Jarmen Kell has 25% less vision range.
- The GLA02 Stealth General's Jarmen Kell will automatically engage enemies, even when stealthed.
- The GLA02 Stealth General's Jarmen Kell will retaliate if the option is enabled.
