### PR TITLE
Fix: USA05 Campaign Toxin General Infantry Issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5939,10 +5939,10 @@ End
 CommandButton GC_Chem_Command_ConstructGLAInfantryRebel
   Command       = UNIT_BUILD
   Object        = GC_Chem_GLAInfantryRebel
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryRebel
+  TextLabel     = CONTROLBAR:Chem_ConstructGLAInfantryRebel
   ButtonImage   = SUToxinRebel
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildRebel
+  DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildRebel
 End
 
 CommandButton GC_Chem_Command_ConstructGLAInfantryRPGTrooper
@@ -6142,10 +6142,10 @@ End
 CommandButton GC_Chem_Command_ConstructGLAInfantryTerrorist
   Command       = UNIT_BUILD
   Object        = GC_Chem_GLAInfantryTerrorist
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryTerrorist
+  TextLabel     = CONTROLBAR:Chem_ConstructGLAInfantryTerrorist
   ButtonImage   = SUTerrorist
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildTerrorist
+  DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildTerrorist
 End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1465,15 +1465,15 @@ END
 
 CommandSet GC_Chem_GLAWorkerCommandSet
   1  = GC_Chem_Command_ConstructGLASupplyStash
-  2  = GC_Chem_Command_ConstructGLAPalace
+  2  = GC_Chem_Command_ConstructGLADemoTrap
   3  = GC_Chem_Command_ConstructGLABarracks
-  4  = GC_Chem_Command_ConstructGLABlackMarket
+  4  = GC_Chem_Command_ConstructGLAPalace
   5  = GC_Chem_Command_ConstructGLAStingerSite
-  6  = GC_Chem_Command_ConstructGLAScudStorm
+  6  = GC_Chem_Command_ConstructGLABlackMarket
   7  = GC_Chem_Command_ConstructGLATunnelNetwork
+  8  = GC_Chem_Command_ConstructGLAScudStorm
   9  = GC_Chem_Command_ConstructGLAArmsDealer
  10  = GC_Chem_Command_ConstructGLACommandCenter
- 11 = GC_Chem_Command_ConstructGLADemoTrap
  14  = Command_DisarmMinesAtPosition
 End
 
@@ -1484,6 +1484,7 @@ CommandSet GC_Chem_GLABarracksCommandSet
   ;4  = Command_ConstructGLAInfantryAngryMob
   5  = GC_Chem_Command_ConstructGLAInfantryHijacker
   6  = GC_Chem_Command_ConstructGLAInfantryJarmenKell
+  8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -1587,13 +1588,13 @@ END
 
 CommandSet GC_Slth_GLAWorkerCommandSet
   1  = GC_Slth_Command_ConstructGLASupplyStash
-  2  = GC_Slth_Command_ConstructGLAPalace
+  2  = GC_Slth_Command_ConstructGLADemoTrap
   3  = GC_Slth_Command_ConstructGLABarracks
-  4  = GC_Slth_Command_ConstructGLABlackMarket
+  4  = GC_Slth_Command_ConstructGLAPalace
   5  = GC_Slth_Command_ConstructGLAStingerSite
-  6  = GC_Slth_Command_ConstructGLAScudStorm
+  6  = GC_Slth_Command_ConstructGLABlackMarket
   7  = GC_Slth_Command_ConstructGLATunnelNetwork
-  8  = GC_Slth_Command_ConstructGLADemoTrap
+  8  = GC_Slth_Command_ConstructGLAScudStorm
   9  = GC_Slth_Command_ConstructGLAArmsDealer
  10  = GC_Slth_Command_ConstructGLACommandCenter
  14  = Command_DisarmMinesAtPosition

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1,3 +1,22 @@
+; Patch104p @bugfix commy2 07/10/2021 Fix issues with USA05 campaign Toxin General:
+; - Worker builds in 10 seconds instead of 6 seconds like other Workers.
+; - Worker command button order differs from other GLA sub-factions.
+; - Worker has no upgrade icon for Worker Shoes.
+; - Worker does not get faster with the Worker Shoes upgrade.
+; - Toxin Rebel uses the model of the normal Rebel when capturing buildings.
+; - Toxin Rebel has the name and tooltips of a normal Rebel.
+; - Toxin Rebel has the voice set of a normal Rebel.
+; - Toxin Rebel Booby Trap attack is not functional.
+; - Toxin Tunnel Defender has a broken animation for firing at airborne targets.
+; - Toxin Tunnel Defender the name and tooltips of a normal Tunnel Defender.
+; - Toxin Tunnel Defender has the voice set of a normal Tunnel Defender.
+; - Terrorist has no upgrade icon for Anthrax Gamma.
+; - Terrorist has the name and tooltips of a normal Terrorist.
+; - Hijacker does not enter vehicles in guard mode.
+; - Jarmen Kell cannot snipe infantry.
+; - Jarmen Kell has 25% less vision range than other Jarmens.
+; - Jarmen Kell will retaliate if the option is enabled.
+
 ;  This file is just for the Chemical Generals Challenge GLA Units
 ;------------------------------------------------------------------------------
 Object GC_Chem_StingerMissile
@@ -356,7 +375,7 @@ Object GC_Chem_GLAInfantryRebel
   UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
   UpgradeCameo2 = Upgrade_GLACamouflage
   UpgradeCameo3 = Upgrade_InfantryCaptureBuilding
-  ;UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
+  UpgradeCameo4 = Upgrade_GLAInfantryRebelBoobyTrapAttack
   ;UpgradeCameo5 = NONE
 
 
@@ -443,7 +462,7 @@ Object GC_Chem_GLAInfantryRebel
 
     ; ---- firing
     ConditionState = USING_WEAPON_A
-      Animation = UIRGrd_SKL.UIRGrd_ATA
+      Animation = UIRGrd_SKL.UIRGrd_ATA3
       AnimationMode = LOOP
       TransitionKey = TRANS_Firing
     End
@@ -484,14 +503,14 @@ Object GC_Chem_GLAInfantryRebel
     ; ------- Bldg-capture
 
     ConditionState = UNPACKING
-      Model             = UIRGrd_F_SKN
+      Model             = UIRGrdTOXF_SKN
       Animation         = UIRGrd_F_SKL.UIRGrd_F_FDP1
       AnimationMode     = ONCE
     End
     AliasConditionState = UNPACKING REALLYDAMAGED
 
     ConditionState = RAISING_FLAG
-      Model             = UIRGrd_F_SKN
+      Model             = UIRGrdTOXF_SKN
       Animation         = UIRGrd_F_SKL.UIRGrd_F_FDP2
       AnimationMode     = ONCE
       TransitionKey     = TRANS_Raising
@@ -499,7 +518,7 @@ Object GC_Chem_GLAInfantryRebel
     AliasConditionState = RAISING_FLAG REALLYDAMAGED
 
     ConditionState = PACKING
-      Model             = UIRGrd_F_SKN
+      Model             = UIRGrdTOXF_SKN
       Animation         = UIRGrd_F_SKL.UIRGrd_F_FDP1
       AnimationMode     = ONCE_BACKWARDS
       Flags             = START_FRAME_LAST
@@ -508,7 +527,7 @@ Object GC_Chem_GLAInfantryRebel
     AliasConditionState = PACKING REALLYDAMAGED
 
     TransitionState = TRANS_Raising TRANS_Packing
-      Model             = UIRGrd_F_SKN
+      Model             = UIRGrdTOXF_SKN
       Animation         = UIRGrd_F_SKL.UIRGrd_F_FDP2
       AnimationMode     = ONCE_BACKWARDS
       Flags             = START_FRAME_LAST
@@ -517,7 +536,7 @@ Object GC_Chem_GLAInfantryRebel
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Rebel
+  DisplayName         = OBJECT:Chem_Rebel
   Side                = GLAToxinGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -551,16 +570,16 @@ Object GC_Chem_GLAInfantryRebel
   CommandSet          = GLAInfantryRebelCommandSet
 
   ; *** AUDIO Parameters ***
-  VoiceSelect = RebelVoiceSelect
+  VoiceSelect = ToxinRebelVoiceSelect
   VoiceMove = RebelVoiceMove
   VoiceGuard = RebelVoiceMove
-  VoiceAttack = RebelVoiceAttack
+  VoiceAttack = ToxinRebelVoiceAttack
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
   VoiceFear = RebelVoiceFear
   VoiceTaskComplete = RebelVoiceCaptureComplete
   UnitSpecificSounds
-    VoiceCreate = RebelVoiceCreate
+    VoiceCreate = ToxinRebelVoiceCreate
     VoiceSubdue = RebelVoiceSubdue
     VoiceGarrison = RebelVoiceGarrison
     VoiceEnter = RebelVoiceMove
@@ -696,6 +715,27 @@ Object GC_Chem_GLAInfantryRebel
     TriggeredBy = Upgrade_InfantryCaptureBuilding
   End
 
+  Behavior = SpecialAbility ModuleTag_20
+    SpecialPowerTemplate = SpecialAbilityBoobyTrap
+    UpdateModuleStartsAttack = Yes
+    StartsPaused              = Yes
+    InitiateSound = RebelVoiceBoobyTrapInstall
+  End
+  Behavior = SpecialAbilityUpdate ModuleTag_21
+    SpecialPowerTemplate = SpecialAbilityBoobyTrap
+    StartAbilityRange = 5.0
+    PreparationTime = 0
+    SpecialObject = BoobyTrap
+    MaxSpecialObjects = 100
+    SpecialObjectsPersistWhenOwnerDies = Yes
+    SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
+; Not implemented    UniqueSpecialObjectTargets = Yes        ;This prevents multiple charges placed on the same object.
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_22
+    SpecialPowerTemplate = SpecialAbilityBoobyTrap
+    TriggeredBy = Upgrade_GLAInfantryRebelBoobyTrapAttack
+  End
 
   Geometry = CYLINDER
   GeometryMajorRadius = 10.0
@@ -736,6 +776,9 @@ Object GC_Chem_GLAInfantryTunnelDefender
       WeaponMuzzleFlash = PRIMARY MuzzleFX
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponLaunchBone = PRIMARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX      ;Fixes shooting at the hip.
+      WeaponFireFXBone = SECONDARY Muzzle         ;Fixes shooting at the hip.
+      WeaponLaunchBone = SECONDARY Muzzle         ;Fixes shooting at the hip.
     End
 
     ConditionState = MOVING
@@ -783,6 +826,7 @@ Object GC_Chem_GLAInfantryTunnelDefender
       AnimationMode = ONCE
       TransitionKey = TRANS_START_FIRING
     End
+    AliasConditionState = FIRING_B
     ConditionState = BETWEEN_FIRING_SHOTS_A
       Animation = UITunF_SKL.UITunF_STA
       AnimationMode = ONCE
@@ -793,7 +837,9 @@ Object GC_Chem_GLAInfantryTunnelDefender
       ; switching to us, if possible".
       WaitForStateToFinishIfPossible = TRANS_START_FIRING
     End
+    AliasConditionState = BETWEEN_FIRING_SHOTS_B
     AliasConditionState = RELOADING_A
+    AliasConditionState = RELOADING_B
 
     ConditionState = SPECIAL_CHEERING
       Animation = UITUNF_SKL.UITUNF_CHA
@@ -841,14 +887,14 @@ Object GC_Chem_GLAInfantryTunnelDefender
   CommandSet      = GLAInfantryTunnelDefenderCommandSet
 
   ; *** AUDIO Parameters ***
-  VoiceSelect = RPGTrooperVoiceSelect
+  VoiceSelect = ToxinRPGTrooperVoiceSelect
   VoiceMove = RPGTrooperVoiceMove
   VoiceGuard = RPGTrooperVoiceMove
-  VoiceAttack = RPGTrooperVoiceAttack
-  VoiceAttackAir = RPGTrooperVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  VoiceAttack = ToxinRPGTrooperVoiceAttack
+  VoiceAttackAir = ToxinRPGTrooperVoiceAttack  ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   VoiceFear = RPGTrooperVoiceFear
   UnitSpecificSounds
-    VoiceCreate          = RPGTrooperVoiceCreate
+    VoiceCreate          = ToxinRPGTrooperVoiceCreate
     VoiceGarrison = RPGTrooperVoiceGarrison
     VoiceEnter = RPGTrooperVoiceMove
     VoiceEnterHostile = RPGTrooperVoiceMove
@@ -1047,6 +1093,13 @@ Object GC_Chem_GLAInfantryWorker
   ; *** ART Parameters ***
   SelectPortrait         = SUWorker_L
   ButtonImage            = SUWorker
+
+  UpgradeCameo1 = Upgrade_GLAWorkerShoes
+  ;UpgradeCameo2 = NONE
+  ;UpgradeCameo3 = NONE
+  ;UpgradeCameo4 = NONE
+  ;UpgradeCameo5 = NONE
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     DefaultConditionState
@@ -1231,7 +1284,7 @@ Object GC_Chem_GLAInfantryWorker
   VisionRange = 100
   ShroudClearingRange = 200
   BuildCost = 200
-  BuildTime = 5.0          ;in seconds
+  BuildTime = 3.0          ;in seconds
   CrushableLevel         = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GC_Chem_GLAWorkerCommandSet
   ; *** AUDIO Parameters ***
@@ -1278,12 +1331,16 @@ Object GC_Chem_GLAInfantryWorker
     AutoAcquireEnemiesWhenIdle    = Yes
   End
   Locomotor = SET_NORMAL FastHumanLocomotor
+  Locomotor = SET_NORMAL_UPGRADED WorkerShoesLocomotor
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
+  End
+  Behavior = LocomotorSetUpgrade ModuleTag_07
+    TriggeredBy = Upgrade_GLAWorkerShoes
   End
 
 ; --- begin Death modules ---
@@ -2995,6 +3052,8 @@ Object GC_Chem_GLAInfantryHijacker
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
+  EnterGuard = Yes
+  HijackGuard = Yes
   KindOf = PRELOAD SELECTABLE CAN_CAST_REFLECTIONS INFANTRY SALVAGER SCORE STEALTH_GARRISON
   ;STEALTH_GARRISON Added per Dustin, 12/14--ML
 
@@ -3311,7 +3370,6 @@ Object GC_Chem_GLAInfantryJarmenKell
     Conditions = None
     Weapon = PRIMARY GLAJarmenKellRifle
     Weapon = SECONDARY GLAJarmenKellVehiclePilotSniperRifle
-    AutoChooseSources = PRIMARY NONE
     AutoChooseSources = SECONDARY NONE
   End
 ;  WeaponSet
@@ -3325,7 +3383,7 @@ Object GC_Chem_GLAInfantryJarmenKell
     DamageFX        = InfantryDamageFX
   End
   VisionRange         = 200
-  ShroudClearingRange = 300
+  ShroudClearingRange = 400
   Prerequisites
     Object = GC_Chem_GLABarracks
     Object = GC_Chem_GLAPalace
@@ -3360,7 +3418,7 @@ Object GC_Chem_GLAInfantryJarmenKell
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY SALVAGER STEALTH_GARRISON SCORE HERO
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY SALVAGER STEALTH_GARRISON SCORE HERO CANNOT_RETALIATE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0
@@ -3484,7 +3542,7 @@ Object GC_Chem_GLAInfantryTerrorist
   SelectPortrait         = SUTerrorist_L
   ButtonImage            = SUTerrorist
 
-  ;UpgradeCameo1 = NONE
+  UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
   ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
@@ -3591,7 +3649,7 @@ Object GC_Chem_GLAInfantryTerrorist
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Terrorist
+  DisplayName      = OBJECT:Chem_Terrorist
   Side = GLAToxinGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
ZH 1.04

- The USA05 Toxin General's Worker builds in 10 seconds.
- The USA05 Toxin General's Worker's command button order differs from other GLA sub-factions.
- The USA05 Toxin General's Worker has no upgrade icon for Worker Shoes.
- The USA05 Toxin General's Worker does not get faster with the Worker Shoes upgrade.
- The USA05 Toxin General's Toxin Rebel uses the model of the normal Rebel when capturing buildings.
- The USA05 Toxin General's Toxin Rebel has the name and tooltips of a normal Rebel.
- The USA05 Toxin General's Toxin Rebel has the voice set of a normal Rebel.
- The USA05 Toxin General's Toxin Rebel Booby Trap attack is not functional.
- The USA05 Toxin General's Toxin Tunnel Defender has a broken animation for firing at airborne targets.
- The USA05 Toxin General's Toxin Tunnel Defender the name and tooltips of a normal Tunnel Defender.
- The USA05 Toxin General's Toxin Tunnel Defender has the voice set of a normal Tunnel Defender.
- The USA05 Toxin General's Terrorist has no upgrade icon for Anthrax Gamma.
- The USA05 Toxin General's Terrorist has the name and tooltips of a normal Terrorist.
- The USA05 Toxin General's Hijacker does not enter vehicles in guard mode.
- The USA05 Toxin General's Jarmen Kell cannot snipe infantry.
- The USA05 Toxin General's Jarmen Kell has 25% less vision range.
- The USA05 Toxin General's Jarmen Kell will retaliate if the option is enabled.

