### PR TITLE
Fix: Grant Faction Inherent Upgrades By Dummy Instead Of By Building

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -1033,15 +1033,6 @@ Object Chem_GLACommandCenter
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
   End
 
-;Toxin General gets these for free.
-  Behavior = GrantUpgradeCreate ModuleTag_23
-    UpgradeToGrant     = Upgrade_GLAToxinShells
-  End
-
-  Behavior = GrantUpgradeCreate ModuleTag_24
-    UpgradeToGrant = Upgrade_GLAAnthraxBeta
-  End
-
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1169,12 +1169,6 @@ Object Demo_GLACommandCenter
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
   End
 
-; DemoGen gets free booby trap power.
-  Behavior = GrantUpgradeCreate ModuleTag_23
-    UpgradeToGrant           = Upgrade_GLAInfantryRebelBoobyTrapAttack
-    ExemptStatus      = UNDER_CONSTRUCTION
-  End
-
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1948,14 +1948,6 @@ Object GC_Chem_GLACommandCenter
     ReferenceObject      = GLASneakAttackTunnelNetwork ;So we know what the final product is for script placement calculations
   End
 
-  Behavior = GrantUpgradeCreate ModuleTag_22
-    UpgradeToGrant     = Upgrade_GLAToxinShells
-  End
-
-  Behavior = GrantUpgradeCreate ModuleTag_23
-    UpgradeToGrant = Upgrade_GLAAnthraxBeta
-  End
-
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -4281,11 +4281,6 @@ Object Infa_ChinaCommandCenter
     OCLAdjustPositionToPassable = Yes ;Like RA2, shift target to passable cell so we don't land in water and on cliffs.
   End
 
-  Behavior = GrantUpgradeCreate ModuleTag_28
-    UpgradeToGrant           = Upgrade_Nationalism
-    ExemptStatus      = UNDER_CONSTRUCTION
-  End
-
   Behavior           = OCLSpecialPower ModuleTag_29
     SpecialPowerTemplate = Early_SuperweaponFrenzy
     UpgradeOCL           = Early_SCIENCE_Frenzy3 SUPERWEAPON_Frenzy3
@@ -9803,11 +9798,6 @@ Object Infa_ChinaBarracks
     TriggeredBy = Upgrade_ChinaEMPMines
   End
 
-  Behavior = GrantUpgradeCreate ModuleTag_27
-    UpgradeToGrant           = Upgrade_Nationalism
-    ExemptStatus      = UNDER_CONSTRUCTION
-  End
-
   Geometry            = BOX
   GeometryMajorRadius = 36.0
   GeometryMinorRadius = 44.0
@@ -10856,11 +10846,6 @@ Object Infa_ChinaWarFactory
   End
   Behavior = ArmorUpgrade ModuleTag_26
     TriggeredBy = Upgrade_ChinaEMPMines
-  End
-
-  Behavior = GrantUpgradeCreate ModuleTag_27
-    UpgradeToGrant           = Upgrade_Nationalism
-    ExemptStatus      = UNDER_CONSTRUCTION
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -12812,9 +12812,6 @@ Object Slth_GLAInfantryRebel
   Behavior = WeaponBonusUpgrade ModuleTag_09
     TriggeredBy = Upgrade_GLAAPBullets
   End
-  Behavior = GrantUpgradeCreate ModuleTag_10
-    UpgradeToGrant = Upgrade_GLACamouflage
-  End
 
   Behavior = SquishCollide ModuleTag_11
     ;nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2912,3 +2912,107 @@ Object CashBountyDummy
     Bounty                  = 20%
   End
 End
+
+;------------------------------------------------------------------------------
+Object ChinaNationalism_UpgradeDummy
+  EditorSorting   = SYSTEM
+  KindOf          = INERT
+
+  Body = ActiveBody ModuleTag_01
+    MaxHealth        = 1.0
+    InitialHealth    = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0
+    MaxLifetime = 0
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_28
+    UpgradeToGrant           = Upgrade_Nationalism
+    ExemptStatus      = UNDER_CONSTRUCTION
+  End
+End
+
+;------------------------------------------------------------------------------
+Object GLAToxinShells_UpgradeDummy
+  EditorSorting   = SYSTEM
+  KindOf          = INERT
+
+  Body = ActiveBody ModuleTag_01
+    MaxHealth        = 1.0
+    InitialHealth    = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0
+    MaxLifetime = 0
+  End
+
+;Toxin General gets these for free.
+  Behavior = GrantUpgradeCreate ModuleTag_23
+    UpgradeToGrant     = Upgrade_GLAToxinShells
+  End
+End
+
+;------------------------------------------------------------------------------
+Object GLAAnthraxBeta_UpgradeDummy
+  EditorSorting   = SYSTEM
+  KindOf          = INERT
+
+  Body = ActiveBody ModuleTag_01
+    MaxHealth        = 1.0
+    InitialHealth    = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0
+    MaxLifetime = 0
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_24
+    UpgradeToGrant = Upgrade_GLAAnthraxBeta
+  End
+End
+
+;------------------------------------------------------------------------------
+Object GLACamouflage_UpgradeDummy
+  EditorSorting   = SYSTEM
+  KindOf          = INERT
+
+  Body = ActiveBody ModuleTag_01
+    MaxHealth        = 1.0
+    InitialHealth    = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0
+    MaxLifetime = 0
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_10
+    UpgradeToGrant = Upgrade_GLACamouflage
+  End
+End
+
+;------------------------------------------------------------------------------
+Object GLAInfantryRebelBoobyTrapAttack_UpgradeDummy
+  EditorSorting   = SYSTEM
+  KindOf          = INERT
+
+  Body = ActiveBody ModuleTag_01
+    MaxHealth        = 1.0
+    InitialHealth    = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0
+    MaxLifetime = 0
+  End
+
+; DemoGen gets free booby trap power.
+  Behavior = GrantUpgradeCreate ModuleTag_23
+    UpgradeToGrant           = Upgrade_GLAInfantryRebelBoobyTrapAttack
+    ExemptStatus      = UNDER_CONSTRUCTION
+  End
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -298,6 +298,7 @@ PlayerTemplate FactionChinaInfantryGeneral
   DisplayName       = INI:FactionChinaInfantryGeneral
   StartingBuilding  = Infa_ChinaCommandCenter
   StartingUnit0     = Infa_ChinaVehicleDozer
+  StartingUnit1     = ChinaNationalism_UpgradeDummy
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China
@@ -368,6 +369,8 @@ PlayerTemplate FactionGLAToxinGeneral
   DisplayName       = INI:FactionGLAToxinGeneral
   StartingBuilding  = Chem_GLACommandCenter
   StartingUnit0     = Chem_GLAInfantryWorker
+  StartingUnit1     = GLAToxinShells_UpgradeDummy
+  StartingUnit2     = GLAAnthraxBeta_UpgradeDummy
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -403,6 +406,7 @@ PlayerTemplate FactionGLADemolitionGeneral
   DisplayName       = INI:FactionGLADemolitionGeneral
   StartingBuilding  = Demo_GLACommandCenter
   StartingUnit0     = Demo_GLAInfantryWorker
+  StartingUnit1     = GLAInfantryRebelBoobyTrapAttack_UpgradeDummy
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -438,6 +442,7 @@ PlayerTemplate FactionGLAStealthGeneral
   DisplayName       = INI:FactionGLAStealthGeneral
   StartingBuilding  = Slth_GLACommandCenter
   StartingUnit0     = Slth_GLAInfantryWorker
+  StartingUnit1     = GLACamouflage_UpgradeDummy
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA


### PR DESCRIPTION
ZH 1.04


https://user-images.githubusercontent.com/6576312/136674410-5018de82-8676-4226-9e5c-ab0c7167615e.mp4


- Building an Infantry General Command Center, Barracks or War Factory grants Nationalism upgrade.
- Building a Tox Command Center grants Toxin Shells and Anthrax Beta upgrades.
- Building a Demo Command Center grants Booby Traps upgrade.
- Building a Stealthed Rebel grants Camouflage upgrade.

After patch:

- Only Infantry General spawns with Nationalism.
- Only Tox General spawns with Toxin Shells and Anthrax Beta.
- Only Demo General spawns with Booby Traps.
- Only Stealth General spawns with Camouflage upgrade.

