### PR TITLE
Fix: Fake Supply Stash Animation After Fortified Structures Upgrade On Snowy Night Maps

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -7712,7 +7712,7 @@ Object Chem_FakeGLASupplyStash
     ConditionState         = GARRISONED SNOW NIGHT
       Model                = UBSpplyEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBSpplyEG_S.UBSpplyEG_S
+      Animation            = UBSpplyEG_NS.UBSpplyEG_NS  ; Patch104p @bugfix commy2 10/10/2021 Fix fake using different animation than real building.
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -7627,7 +7627,7 @@ Object Demo_FakeGLASupplyStash
     ConditionState         = GARRISONED SNOW NIGHT
       Model                = UBSpplyEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBSpplyEG_S.UBSpplyEG_S
+      Animation            = UBSpplyEG_NS.UBSpplyEG_NS  ; Patch104p @bugfix commy2 10/10/2021 Fix fake using different animation than real building.
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -21198,7 +21198,7 @@ Object FakeGLASupplyStash
     ConditionState         = GARRISONED SNOW NIGHT
       Model                = UBSpplyEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBSpplyEG_S.UBSpplyEG_S
+      Animation            = UBSpplyEG_NS.UBSpplyEG_NS  ; Patch104p @bugfix commy2 10/10/2021 Fix fake using different animation than real building.
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -8308,7 +8308,7 @@ Object Slth_FakeGLASupplyStash
     ConditionState         = GARRISONED SNOW NIGHT
       Model                = UBSpplyEG_NS
       ParticleSysBone      = Smoke01 SmolderingSmoke
-      Animation            = UBSpplyEG_S.UBSpplyEG_S
+      Animation            = UBSpplyEG_NS.UBSpplyEG_NS  ; Patch104p @bugfix commy2 10/10/2021 Fix fake using different animation than real building.
       AnimationMode        = LOOP
     End
     ConditionState         = DAMAGED GARRISONED SNOW NIGHT


### PR DESCRIPTION
ref: #469

I can't make out any difference between the animations of fake and real with my eyes. However, this change is free.