### PR TITLE
Fix: Stealth General Saboteur Cannot Disable Internet Centers And Destroy Fake Buildings

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16165,6 +16165,9 @@ Object Demo_GLAInfantrySaboteur
     BuildingPickup = Yes
     SabotageDuration = 30000
   End
+
+  ; Patch104p @balance 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
+
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16165,6 +16165,13 @@ Object Demo_GLAInfantrySaboteur
     BuildingPickup = Yes
     SabotageDuration = 30000
   End
+  Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
+    BuildingPickup = Yes
+  End
+  Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
+    BuildingPickup = Yes
+    SabotageDuration = 15000
+  End
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16166,7 +16166,7 @@ Object Demo_GLAInfantrySaboteur
     SabotageDuration = 30000
   End
 
-  ; Patch104p @balance 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
+  ; Patch104p @bugfix commy2 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
 
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -16471,6 +16471,13 @@ Object Slth_GLAInfantrySaboteur
     BuildingPickup = Yes
     SabotageDuration = 30000
   End
+  Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
+    BuildingPickup = Yes
+  End
+  Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
+    BuildingPickup = Yes
+    SabotageDuration = 15000
+  End
 
   ; Patch104p @bugfix hanfield 28/08/2021 Replaced FX_RebelDie with FX_SaboteurDie.
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -16472,7 +16472,7 @@ Object Slth_GLAInfantrySaboteur
     SabotageDuration = 30000
   End
 
-  ; Patch104p @balance 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
+  ; Patch104p @bugfix commy2 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
 
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -16471,6 +16471,9 @@ Object Slth_GLAInfantrySaboteur
     BuildingPickup = Yes
     SabotageDuration = 30000
   End
+
+  ; Patch104p @balance 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
+
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes
   End


### PR DESCRIPTION
- ref #455

ZH 1.04

- The Stealth Generals Saboteur cannot enter Internet Centers. The normal GLA Saboteur can enter Internet Centers and will disable them by doing so for 15 seconds.
- The Stealth Generals Saboteur cannot enter Fake Buildings. The normal GLA Saboteur however can: the fake building will be destroyed by that.
- Since the Stealth Generals Saboteur cannot enter Fake Buildings, the cursor that appears when hovering above an enemies GLA Barracks, Arms Dealer, Supply Stash or Command Center can be abused to tell apart real and fake buildings.

After patch:

- Both the normal and the Stealth Saboteur can enter Internet Centers and Fake buildings.
