### PR TITLE
Change: Let Saboteurs Enter Supply Drop Zones And Black Markets (Steal $1000)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -2403,7 +2403,10 @@ Object Chem_GLABlackMarket
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
+
+  ; Patch104p @bugfix 10/10/2021 Add FS_SUPPLY_DROPZONE to let Saboteurs enter the building and steal cash.
+
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET FS_SUPPLY_DROPZONE
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 1000.0
     InitialHealth     = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -2536,7 +2536,10 @@ Object Demo_GLABlackMarket
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
+
+  ; Patch104p @bugfix 10/10/2021 Add FS_SUPPLY_DROPZONE to let Saboteurs enter the building and steal cash.
+
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET FS_SUPPLY_DROPZONE
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 1000.0
     InitialHealth     = 1000.0
@@ -16147,10 +16150,13 @@ Object Demo_GLAInfantrySaboteur
     BuildingPickup = Yes
     SabotagePowerDuration = 30000
   End
-  ;Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
-  ;  BuildingPickup  = Yes
-  ;  StealCashAmount = 800
-  ;End
+
+  ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
+
+  Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
+    BuildingPickup  = Yes
+    StealCashAmount = 1000
+  End
   Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
     BuildingPickup = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -10325,7 +10325,10 @@ Object GLABlackMarket
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
+
+  ; Patch104p @bugfix 10/10/2021 Add FS_SUPPLY_DROPZONE to let Saboteurs enter the building and steal cash.
+
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET FS_SUPPLY_DROPZONE
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 1000.0
     InitialHealth     = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -5739,7 +5739,10 @@ Object GC_Chem_GLABlackMarket
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
+
+  ; Patch104p @bugfix 10/10/2021 Add FS_SUPPLY_DROPZONE to let Saboteurs enter the building and steal cash.
+
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET FS_SUPPLY_DROPZONE
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 1000.0
     InitialHealth     = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -5786,7 +5786,10 @@ Object GC_Slth_GLABlackMarket
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
+
+  ; Patch104p @bugfix 10/10/2021 Add FS_SUPPLY_DROPZONE to let Saboteurs enter the building and steal cash.
+
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET FS_SUPPLY_DROPZONE
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 1000.0
     InitialHealth     = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -4035,10 +4035,13 @@ Object GLAInfantrySaboteur
     BuildingPickup = Yes
     SabotagePowerDuration = 30000
   End
-  ;Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
-  ;  BuildingPickup  = Yes
-  ;  StealCashAmount = 800
-  ;End
+
+  ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets. Prevents ability to tell apart fake and real Black Markets by cursor.
+
+  Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
+    BuildingPickup  = Yes
+    StealCashAmount = 1000
+  End
   Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
     BuildingPickup = Yes
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -2422,7 +2422,10 @@ Object Slth_GLABlackMarket
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET
+
+  ; Patch104p @bugfix 10/10/2021 Add FS_SUPPLY_DROPZONE to let Saboteurs enter the building and steal cash.
+
+  KindOf              = PRELOAD STRUCTURE SELECTABLE IMMOBILE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY SCORE_CREATE FS_BLACK_MARKET FS_SUPPLY_DROPZONE
   Body                = StructureBody ModuleTag_04
     MaxHealth         = 1000.0
     InitialHealth     = 1000.0
@@ -16453,10 +16456,13 @@ Object Slth_GLAInfantrySaboteur
     BuildingPickup = Yes
     SabotagePowerDuration = 30000
   End
-  ;Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
-  ;  BuildingPickup  = Yes
-  ;  StealCashAmount = 800
-  ;End
+
+  ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
+
+  Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
+    BuildingPickup  = Yes
+    StealCashAmount = 1000
+  End
   Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
     BuildingPickup = Yes
   End


### PR DESCRIPTION
- ref #455
- works best with: #544

ZH 1.04

- Saboteurs cannot enter Supply Drop Zones and Black Markets (among other buildings).
- Since vanilla GLA Saboteurs can enter Fake buildings, including Fake Black Markets, but cannot enter Black Markets, hovering with the cursor above enemy Black Markets can be used to tell fake and real ones apart.

After patch:

- All Saboteurs can enter Supply Drop Zones and Black Markets. They steal $1000 if they do so, similar to how they steal $1000 when entering a Supply Center or Supply Stash.
- The cursor can no longer be abused to tell apart real and fake Black Markets.

Sadly, the best way to fix the Saboteur cursor scouting bug is by doing this game design change. I think it's fine in this case, because Saboteurs are kind of lame, and them not being able to enter secondary eco stinks. I realize however that this is a highly controversial change.

Technical aspects: `FS_SUPPLY_DROPZONE` KindOf is safe to use here. It is only used by the engine to validate targets for the `SabotageSupplyDropzoneCrateCollide` module. 

<details><summary>chatlog with hanfi about FS_SUPPLY_DROPZONE</summary>

```
commy2
Where in engine is FS_SUPPLY_DROPZONE used?
I assume it is related to SabotageSupplyDropzoneCrateCollide. However, my question is if there're any other things that this is used for?

hanfield
only there

commy2
Splendid.
Where is FS_BLACK_MARKET used then? There does not seem to be a related SabotageXXX module.

hanfield
stealthupdate
BlackMarketCheckDelay
combined with NO_BLACK_MARKET forbiddenstealthcondition

commy2
BlackMarketCheckDelay does not seem to be used in 1.04.

hanfield
it works
but it's not used

commy2
Thank you.
Seems interesting. NO_BLACK_MARKET and FS_BLACK_MARKET.
```

</details>