### PR TITLE
Fix: Some Civilian Buildings Invisible On Snowy Maps

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
@@ -18624,63 +18624,65 @@ Object CivilianHighrise01
       AnimationMode = LOOP
     End
 
-    ; Snow
-    ConditionState = SNOW
-      Model         = CBHigh01_S
-    End
-    ConditionState = DAMAGED SNOW
-      Model         = CBHigh01_DS
-    End
-    ConditionState = REALLYDAMAGED SNOW
-      Model         = CBHigh01_ES
-    End
-    ConditionState = RUBBLE SNOW
-      Model         = CBHigh01_ES
-    End
-    ConditionState = POST_COLLAPSE SNOW
-      Model         = CBHigh01_RS
-    End
+    ; Patch104p @bugfix commy2 13/10/2021 Remove references to non-existing SNOW models. Game falls back to non-snow version.
 
-    ; snow garrisoned
-    ConditionState = GARRISONED SNOW
-      Model         = CBHigh01_SG
-      Animation     = CBHigh01_SG.CBHigh01_SG
-      AnimationMode = LOOP
-    End
-    ConditionState = DAMAGED GARRISONED SNOW
-      Model         = CBHigh01_DSG
-      Animation     = CBHigh01_DSG.CBHigh01_DSG
-      AnimationMode = LOOP
-    End
+    ;; Snow
+    ;ConditionState = SNOW
+    ;  Model         = CBHigh01_S
+    ;End
+    ;ConditionState = DAMAGED SNOW
+    ;  Model         = CBHigh01_DS
+    ;End
+    ;ConditionState = REALLYDAMAGED SNOW
+    ;  Model         = CBHigh01_ES
+    ;End
+    ;ConditionState = RUBBLE SNOW
+    ;  Model         = CBHigh01_ES
+    ;End
+    ;ConditionState = POST_COLLAPSE SNOW
+    ;  Model         = CBHigh01_RS
+    ;End
 
-    ; night snow
-    ConditionState = NIGHT SNOW
-      Model         = CBHigh01_SN
-    End
-    ConditionState = DAMAGED NIGHT SNOW
-      Model         = CBHigh01_DSN
-    End
-    ConditionState = REALLYDAMAGED NIGHT SNOW
-      Model         = CBHigh01_ESN
-    End
-    ConditionState = RUBBLE NIGHT SNOW
-      Model         = CBHigh01_ESN
-    End
-    ConditionState = POST_COLLAPSE SNOW NIGHT
-      Model         = CBHigh01_RSN
-    End
+    ;; snow garrisoned
+    ;ConditionState = GARRISONED SNOW
+    ;  Model         = CBHigh01_SG
+    ;  Animation     = CBHigh01_SG.CBHigh01_SG
+    ;  AnimationMode = LOOP
+    ;End
+    ;ConditionState = DAMAGED GARRISONED SNOW
+    ;  Model         = CBHigh01_DSG
+    ;  Animation     = CBHigh01_DSG.CBHigh01_DSG
+    ;  AnimationMode = LOOP
+    ;End
 
-    ; night garrisoned snow
-    ConditionState = NIGHT GARRISONED SNOW
-      Model         = CBHigh01_SNG
-      Animation     = CBHigh01_SNG.CBHigh01_SNG
-      AnimationMode = LOOP
-    End
-    ConditionState = DAMAGED NIGHT GARRISONED SNOW
-      Model         = CBHigh01_DSNG
-      Animation     = CBHigh01_DSNG.CBHigh01_DSNG
-      AnimationMode = LOOP
-    End
+    ;; night snow
+    ;ConditionState = NIGHT SNOW
+    ;  Model         = CBHigh01_SN
+    ;End
+    ;ConditionState = DAMAGED NIGHT SNOW
+    ;  Model         = CBHigh01_DSN
+    ;End
+    ;ConditionState = REALLYDAMAGED NIGHT SNOW
+    ;  Model         = CBHigh01_ESN
+    ;End
+    ;ConditionState = RUBBLE NIGHT SNOW
+    ;  Model         = CBHigh01_ESN
+    ;End
+    ;ConditionState = POST_COLLAPSE SNOW NIGHT
+    ;  Model         = CBHigh01_RSN
+    ;End
+
+    ;; night garrisoned snow
+    ;ConditionState = NIGHT GARRISONED SNOW
+    ;  Model         = CBHigh01_SNG
+    ;  Animation     = CBHigh01_SNG.CBHigh01_SNG
+    ;  AnimationMode = LOOP
+    ;End
+    ;ConditionState = DAMAGED NIGHT GARRISONED SNOW
+    ;  Model         = CBHigh01_DSNG
+    ;  Animation     = CBHigh01_DSNG.CBHigh01_DSNG
+    ;  AnimationMode = LOOP
+    ;End
   End
 
   ; *** AUDIO Parameters ***
@@ -18827,63 +18829,65 @@ Object CivilianHighrise02
       AnimationMode = LOOP
     End
 
-    ; Snow
-    ConditionState = SNOW
-      Model         = CBHigh02_S
-    End
-    ConditionState = DAMAGED SNOW
-      Model         = CBHigh02_DS
-    End
-    ConditionState = REALLYDAMAGED SNOW
-      Model         = CBHigh02_ES
-    End
-    ConditionState = RUBBLE SNOW
-      Model         = CBHigh02_ES
-    End
-    ConditionState = POST_COLLAPSE SNOW
-      Model         = CBHigh02_RS
-    End
+    ; Patch104p @bugfix commy2 13/10/2021 Remove references to non-existing SNOW models. Game falls back to non-snow version.
 
-    ; snow garrisoned
-    ConditionState = GARRISONED SNOW
-      Model         = CBHigh02_SG
-      Animation     = CBHigh02_SG.CBHigh02_SG
-      AnimationMode = LOOP
-    End
-    ConditionState = DAMAGED GARRISONED SNOW
-      Model         = CBHigh02_DSG
-      Animation     = CBHigh02_DSG.CBHigh02_DSG
-      AnimationMode = LOOP
-    End
+    ;; Snow
+    ;ConditionState = SNOW
+    ;  Model         = CBHigh02_S
+    ;End
+    ;ConditionState = DAMAGED SNOW
+    ;  Model         = CBHigh02_DS
+    ;End
+    ;ConditionState = REALLYDAMAGED SNOW
+    ;  Model         = CBHigh02_ES
+    ;End
+    ;ConditionState = RUBBLE SNOW
+    ;  Model         = CBHigh02_ES
+    ;End
+    ;ConditionState = POST_COLLAPSE SNOW
+    ;  Model         = CBHigh02_RS
+    ;End
 
-    ; night snow
-    ConditionState = NIGHT SNOW
-      Model         = CBHigh02_SN
-    End
-    ConditionState = DAMAGED NIGHT SNOW
-      Model         = CBHigh02_DSN
-    End
-    ConditionState = REALLYDAMAGED NIGHT SNOW
-      Model         = CBHigh02_ESN
-    End
-    ConditionState = RUBBLE NIGHT SNOW
-      Model         = CBHigh02_ESN
-    End
-    ConditionState = POST_COLLAPSE SNOW NIGHT
-      Model         = CBHigh02_RSN
-    End
+    ;; snow garrisoned
+    ;ConditionState = GARRISONED SNOW
+    ;  Model         = CBHigh02_SG
+    ;  Animation     = CBHigh02_SG.CBHigh02_SG
+    ;  AnimationMode = LOOP
+    ;End
+    ;ConditionState = DAMAGED GARRISONED SNOW
+    ;  Model         = CBHigh02_DSG
+    ;  Animation     = CBHigh02_DSG.CBHigh02_DSG
+    ;  AnimationMode = LOOP
+    ;End
 
-    ; night garrisoned snow
-    ConditionState = NIGHT GARRISONED SNOW
-      Model         = CBHigh02_SNG
-      Animation     = CBHigh02_SNG.CBHigh02_SNG
-      AnimationMode = LOOP
-    End
-    ConditionState = DAMAGED NIGHT GARRISONED SNOW
-      Model         = CBHigh02_DSNG
-      Animation     = CBHigh02_DSNG.CBHigh02_DSNG
-      AnimationMode = LOOP
-    End
+    ;; night snow
+    ;ConditionState = NIGHT SNOW
+    ;  Model         = CBHigh02_SN
+    ;End
+    ;ConditionState = DAMAGED NIGHT SNOW
+    ;  Model         = CBHigh02_DSN
+    ;End
+    ;ConditionState = REALLYDAMAGED NIGHT SNOW
+    ;  Model         = CBHigh02_ESN
+    ;End
+    ;ConditionState = RUBBLE NIGHT SNOW
+    ;  Model         = CBHigh02_ESN
+    ;End
+    ;ConditionState = POST_COLLAPSE SNOW NIGHT
+    ;  Model         = CBHigh02_RSN
+    ;End
+
+    ;; night garrisoned snow
+    ;ConditionState = NIGHT GARRISONED SNOW
+    ;  Model         = CBHigh02_SNG
+    ;  Animation     = CBHigh02_SNG.CBHigh02_SNG
+    ;  AnimationMode = LOOP
+    ;End
+    ;ConditionState = DAMAGED NIGHT GARRISONED SNOW
+    ;  Model         = CBHigh02_DSNG
+    ;  Animation     = CBHigh02_DSNG.CBHigh02_DSNG
+    ;  AnimationMode = LOOP
+    ;End
   End
 
   ; *** AUDIO Parameters ***


### PR DESCRIPTION
- fix #421

Models referenced in class don't exist. This comments out those models, which makes the game fall back to the approriate day or night models. Lots of buildings don't feature snow models, so they will not stick out or anything.