### PR TITLE
Fix: Demo General Advanced Demo Trap Uses Model Of Normal Demo Trap When Build Or Sold

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4716,6 +4716,9 @@ Object Demo_GLADemoTrap
   ; *** ART Parameters ***
   SelectPortrait         = SUAdvDeTrap_L
   ButtonImage            = SUAdvDeTrap
+
+  ; Patch104p @bugfix commy2 15/10/2021 Fix model when build or sold.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     DefaultConditionState
@@ -4738,7 +4741,7 @@ Object Demo_GLADemoTrap
     ;This block handles every possible case with construction process, selling process, awaiting construction, and sold states
     ;for this draw module
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model              = EXHideBomb
+      Model              = EXHideBombD
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT
@@ -4746,7 +4749,7 @@ Object Demo_GLADemoTrap
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
-      Model              = EXHideBomb
+      Model              = EXHideBombD
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED NIGHT
@@ -4754,7 +4757,7 @@ Object Demo_GLADemoTrap
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED NIGHT SNOW
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED
-      Model              = EXHideBomb
+      Model              = EXHideBombD
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED NIGHT


### PR DESCRIPTION
ZH 1.04

https://user-images.githubusercontent.com/6576312/137545835-7d5e9bb4-1c48-4bac-8283-cff53395d6ec.mp4

After patch:

https://user-images.githubusercontent.com/6576312/137546948-846e0829-ff0c-47f9-a9bf-06971759b3c5.mp4

