### PR TITLE
Fix: Broken Demo Bike Model When Dropped By Reinforcement Pad

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17349,6 +17349,19 @@ Object Demo_GLAVehicleCombatBike
       ParticleSysBone     = SMOKE CombatBikeSmokeHeavy
     End
 
+    ; Patch104p @bugfix commy2 16/10/2021 Fix model when dropped from Reinforcement Pad.
+
+    ConditionState = PARACHUTING
+      Model = UVComBike
+      ShowSubObject = BOMBBIKE
+    End
+
+    ConditionState = PARACHUTING REALLYDAMAGED
+      Model = UVComBike_d
+      ShowSubObject = BOMBBIKE
+    End
+    AliasConditionState PARACHUTING DYING
+
     TrackMarks = EXTireTrack03.tga
 
     Dust                        = CombatBikeDust
@@ -17615,6 +17628,19 @@ Object Demo_GLAVehicleCombatBike
       Model = None
     End
     AliasConditionState TOPPLED MOVING
+
+    ; Patch104p @bugfix commy2 16/10/2021 Fix model when dropped from Reinforcement Pad.
+
+    ConditionState = PARACHUTING
+      Model = UITer_Local_SKN
+      Animation           = UITer_Local_SKL.UITER_Local_A5
+      AnimationMode = LOOP
+    End
+    AliasConditionState PARACHUTING MOVING
+    AliasConditionState PARACHUTING MOVING CENTER_TO_LEFT
+    AliasConditionState PARACHUTING MOVING LEFT_TO_CENTER
+    AliasConditionState PARACHUTING MOVING CENTER_TO_RIGHT
+    AliasConditionState PARACHUTING MOVING RIGHT_TO_CENTER
   End
 
   ; ***DESIGN parameters ***


### PR DESCRIPTION
Version 1.04 of triple A title funded by EA:

https://user-images.githubusercontent.com/6576312/137585499-53b8a6c2-cd6f-40f0-b6bd-15a3e92d474a.mp4

This patch (by me done for free):

https://user-images.githubusercontent.com/6576312/137585519-1dbb4e8c-4968-42c8-bf72-4d4e322ec322.mp4

