### PR TITLE
Fix: Reinforcement Pad Is Deleted When Destroyed; It And Repair Bay Do Not Leave Ruins Like Other Tech Buildings

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -447,8 +447,10 @@ Object TechReinforcementPad
     FactionOCL   = Faction:FactionBossGeneral        OCL:OCL_BossGen_ReinforcementPadCHIVehicle
   End
 
-  Behavior = DestroyDie ModuleTag_06
-  End
+  ; Patch104p @bugfix commy2 16/10/2021 Fix building disappears when destroyed instead of leaving ruin.
+
+  ;Behavior = DestroyDie ModuleTag_06
+  ;End
 
   Behavior            = DefaultProductionExitUpdate ModuleTag_07
     NaturalRallyPoint = X: 0.0  Y:-60.0  Z:0.0 ;NaturalRallyPointX must always match GeometryMajorRadius! -ML
@@ -655,8 +657,11 @@ Object TechRepairPad
     NumberApproachPositions = 5
   End
 
-  Behavior  = DestroyDie ModuleTag_06
-  End
+  ; Patch104p @bugfix commy2 16/10/2021 Fix building disappears when destroyed instead of leaving ruin.
+
+  ;Behavior  = DestroyDie ModuleTag_06
+  ;End
+
   Behavior                  = CreateObjectDie ModuleTag_08
     CreationList       = OCL_LargeStructureDebris
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -274,6 +274,9 @@ Object TechReinforcementPad
   ; *** ART Parameters ***
   SelectPortrait         = LandingPad_L
   ButtonImage            = LandingPad
+
+  ; Patch104p @bugfix commy2 16/10/2021 Fix building does not use rubble model.
+
   Draw                 = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ConditionState       = NONE
@@ -290,10 +293,17 @@ Object TechReinforcementPad
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE
+    ConditionState     = REALLYDAMAGED
       Model              = ZBLndBay_E
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBLndBay_E.ZBLndBay_E
+      AnimationMode      = LOOP
+    End
+
+    ConditionState     = RUBBLE
+      Model              = ZBLndBay_R
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBLndBay_R.ZBLndBay_R
       AnimationMode      = LOOP
     End
 
@@ -311,10 +321,17 @@ Object TechReinforcementPad
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE NIGHT
+    ConditionState     = REALLYDAMAGED NIGHT
       Model              = ZBLndBay_E
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBLndBay_E.ZBLndBay_E
+      AnimationMode      = LOOP
+    End
+
+    ConditionState     = RUBBLE NIGHT
+      Model              = ZBLndBay_R
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBLndBay_R.ZBLndBay_R
       AnimationMode      = LOOP
     End
 
@@ -335,10 +352,17 @@ Object TechReinforcementPad
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE SNOW
+    ConditionState     = REALLYDAMAGED SNOW
       Model              = ZBLndBay_ES
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBLndBay_ES.ZBLndBay_ES
+      AnimationMode      = LOOP
+    End
+
+    ConditionState     = RUBBLE SNOW
+      Model              = ZBLndBay_RS
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBLndBay_RS.ZBLndBay_RS
       AnimationMode      = LOOP
     End
 
@@ -358,10 +382,17 @@ Object TechReinforcementPad
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE NIGHT SNOW
+    ConditionState     = REALLYDAMAGED NIGHT SNOW
       Model              = ZBLndBay_ES
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBLndBay_ES.ZBLndBay_ES
+      AnimationMode      = LOOP
+    End
+
+    ConditionState     = RUBBLE NIGHT SNOW
+      Model              = ZBLndBay_RS
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBLndBay_RS.ZBLndBay_RS
       AnimationMode      = LOOP
     End
   End
@@ -702,6 +733,9 @@ Object TechRepairbay
   ; *** ART Parameters ***
   SelectPortrait         = RepairBay_L
   ButtonImage            = RepairBay
+
+  ; Patch104p @bugfix commy2 16/10/2021 Fix building does not use rubble model.
+
   Draw                 = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ConditionState       = NONE
@@ -718,10 +752,17 @@ Object TechRepairbay
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE
+    ConditionState     = REALLYDAMAGED
       Model              = ZBRprBay_E
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBRprBay_E.ZBRprBay_E
+      AnimationMode      = LOOP
+    End
+
+    ConditionState     = RUBBLE
+      Model              = ZBRprBay_R
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBRprBay_R.ZBRprBay_R
       AnimationMode      = LOOP
     End
 
@@ -739,10 +780,17 @@ Object TechRepairbay
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE NIGHT
+    ConditionState     = REALLYDAMAGED NIGHT
       Model              = ZBRprBay_E
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBRprBay_E.ZBRprBay_E
+      AnimationMode      = LOOP
+    End
+
+    ConditionState     = RUBBLE NIGHT
+      Model              = ZBRprBay_R
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBRprBay_R.ZBRprBay_R
       AnimationMode      = LOOP
     End
 
@@ -763,10 +811,17 @@ Object TechRepairbay
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE SNOW
+    ConditionState     = REALLYDAMAGED SNOW
       Model              = ZBRprBay_ES
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBRprBay_ES.ZBRprBay_ES
+      AnimationMode      = LOOP
+    End
+
+    ConditionState     = RUBBLE SNOW
+      Model              = ZBRprBay_RS
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBRprBay_RS.ZBRprBay_RS
       AnimationMode      = LOOP
     End
 
@@ -786,13 +841,19 @@ Object TechRepairbay
       AnimationMode      = LOOP
     End
 
-    ConditionState     = REALLYDAMAGED RUBBLE NIGHT SNOW
+    ConditionState     = REALLYDAMAGED NIGHT SNOW
       Model              = ZBRprBay_ES
       ;ParticleSysBone    = Flare01 LandingZoneSmoke
       Animation          = ZBRprBay_ES.ZBRprBay_ES
       AnimationMode      = LOOP
     End
 
+    ConditionState     = RUBBLE NIGHT SNOW
+      Model              = ZBRprBay_RS
+      ;ParticleSysBone    = Flare01 LandingZoneSmoke
+      Animation          = ZBRprBay_RS.ZBRprBay_RS
+      AnimationMode      = LOOP
+    End
   End
     ; ========================= Flag Model ===============================
   Draw = W3DModelDraw ModuleTag_02


### PR DESCRIPTION
ZH 1.04

https://user-images.githubusercontent.com/6576312/137589619-70d8d766-8cd6-4f1e-91bd-de8a5875df6d.mp4

After patch:

https://user-images.githubusercontent.com/6576312/137589641-214469a1-08aa-471a-91bd-892b0bc27c76.mp4

---

This happens because while all tech buildings have a `KeepObjectDie` module that is supposed to spawn a ruin, the Reinforcement Pad only has a conflicting `DestroyDie` module as well that deletes the building when destroyed.

This also applies to the unused Repair Pad (not to be confused with the Repair Station), which is also fixed by this PR.