### PR TITLE
Change: Tank Nuke Cannon and Inferno Cannon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -7840,7 +7840,23 @@ CommandButton Tank_Command_ConstructChinaAirfield
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildAirField
 End
 
+CommandButton Tank_Command_ConstructChinaVehicleInfernoCannon
+  Command       = UNIT_BUILD
+  Object        = Tank_ChinaVehicleInfernoCannon
+  TextLabel     = CONTROLBAR:ConstructChinaVehicleInfernoCannon
+  ButtonImage   = SNInferno
+  ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipChinaBuildInfernoCannon
+End
 
+CommandButton Tank_Command_ConstructChinaVehicleNukeLauncher
+  Command       = UNIT_BUILD
+  Object        = Tank_ChinaVehicleNukeLauncher
+  TextLabel     = CONTROLBAR:ConstructChinaVehicleNukeLauncher
+  ButtonImage   = SNNukeCannon
+  ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipChinaBuildNukeLauncher
+End
 
 CommandButton Tank_Command_ConstructChinaTankDragon
   Command       = UNIT_BUILD

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -7840,7 +7840,7 @@ CommandButton Tank_Command_ConstructChinaAirfield
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildAirField
 End
 
-CommandButton Tank_Command_ConstructChinaVehicleInfernoCannon
+CommandButton Tank_Command_ConstructChinaVehicleInfernoCannon ; Patch104p Jundiyy 17.10.2021 Added to allow Tank General to build it's Inferno Cannon.
   Command       = UNIT_BUILD
   Object        = Tank_ChinaVehicleInfernoCannon
   TextLabel     = CONTROLBAR:ConstructChinaVehicleInfernoCannon
@@ -7849,7 +7849,7 @@ CommandButton Tank_Command_ConstructChinaVehicleInfernoCannon
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildInfernoCannon
 End
 
-CommandButton Tank_Command_ConstructChinaVehicleNukeLauncher
+CommandButton Tank_Command_ConstructChinaVehicleNukeLauncher ; Patch104p Jundiyy 17.10.2021 Added to allow Tank General to build it's Nuke Cannon.
   Command       = UNIT_BUILD
   Object        = Tank_ChinaVehicleNukeLauncher
   TextLabel     = CONTROLBAR:ConstructChinaVehicleNukeLauncher

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16640,3 +16640,484 @@ Object Tank_ChinaCommandCenter
 
 End
 
+;------------------------------------------------------------------------------
+;Also called NukeCannon
+Object Tank_ChinaVehicleNukeLauncher
+
+  ; *** ART Parameters ***
+  SelectPortrait         = SNNukeCannon_L
+  ButtonImage            = SNNukeCannon
+
+  UpgradeCameo1 = Upgrade_ChinaNeutronShells
+  ;UpgradeCameo2 = NONE
+  ;UpgradeCameo3 = NONE
+  ;UpgradeCameo4 = NONE
+  ;UpgradeCameo5 = NONE
+
+  Draw = W3DTankDraw ModuleTag_01
+
+    InitialRecoilSpeed   = 120
+    MaxRecoilDistance    = 8
+    RecoilSettleSpeed    = 6
+
+    OkToChangeModelColor = Yes
+
+    ExtraPublicBone = Turret01
+
+    DefaultConditionState
+      Model                           = NVNukeCn
+      WeaponLaunchBone                = PRIMARY Muzzle
+      WeaponMuzzleFlash               = PRIMARY MuzzleFX
+      WeaponFireFXBone                = PRIMARY Muzzle
+      WeaponRecoilBone                = PRIMARY Barrel
+      WeaponLaunchBone                = SECONDARY Muzzle
+      WeaponMuzzleFlash               = SECONDARY MuzzleFX
+      WeaponFireFXBone                = SECONDARY Muzzle
+      WeaponRecoilBone                = SECONDARY Barrel
+      HideSubObject                   = TURRET01      ;Hide controlled turret
+      ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
+      Turret                          = Turret01
+      TurretPitch                     = TurretEL
+    End
+
+    ConditionState                    = RUBBLE
+      Model                           = NVNukeCn_D1
+      WeaponLaunchBone                = PRIMARY Muzzle
+      WeaponMuzzleFlash               = PRIMARY MuzzleFX
+      WeaponRecoilBone                = PRIMARY Barrel
+      WeaponLaunchBone                = SECONDARY Muzzle
+      WeaponMuzzleFlash               = SECONDARY MuzzleFX
+      WeaponRecoilBone                = SECONDARY Barrel
+      HideSubObject                   = TURRET01      ;Hide controlled turret
+      ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
+      Turret                          = Turret01
+      TurretPitch                     = TurretEL
+    End
+
+    ;*** PACKED STATE -- ready to move ***
+    ConditionState    = MOVING
+      Animation       = NVNukeCn.NVNukeCn
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_FIRST
+    End
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
+    AliasConditionState = BETWEEN_FIRING_SHOTS_A
+    ;***
+    ConditionState    = REALLYDAMAGED MOVING
+      Model           = NVNukeCn_D
+      Animation       = NVNukeCn_D.NVNukeCn_D
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_FIRST
+    End
+    AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
+
+
+    ;*** UNPACKING STATE  -- preparing to fire ***
+    ConditionState    = UNPACKING
+      Animation       = NVNukeCn.NVNukeCn
+      AnimationMode   = ONCE
+    End
+    AliasConditionState = UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    ;***
+    ConditionState    = REALLYDAMAGED UNPACKING
+      Model           = NVNukeCn_D
+      Animation       = NVNukeCn_D.NVNukeCn_D
+      AnimationMode   = ONCE
+    End
+    AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+
+    ;*** PACKING STATE -- preparing to move ***
+    ConditionState    = PACKING
+      Animation       = NVNukeCn.NVNukeCn
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+
+    AliasConditionState = PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    ;***
+    ConditionState    = REALLYDAMAGED PACKING
+      Model           = NVNukeCn_D
+      Animation       = NVNukeCn_D.NVNukeCn_D
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+    AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+
+    ;*** DEPLOYED STATE -- ready to fire ***
+    ConditionState  = DEPLOYED
+      Animation       = NVNukeCn.NVNukeCn
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_LAST
+      TransitionKey   = TRANS_FIRING_A
+      HideSubObject   = TURRETFRONT TURRETBACK   ;Hide pack/unpack animated turret
+      ShowSubObject   = TURRET01      ;Show controlled turret
+    End
+    AliasConditionState = DEPLOYED FIRING_A
+    AliasConditionState = DEPLOYED BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = DEPLOYED RELOADING_A
+    AliasConditionState = DEPLOYED MOVING
+
+    ConditionState  = DEPLOYED REALLYDAMAGED
+      Model           = NVNukeCn_D
+      Animation       = NVNukeCn_D.NVNukeCn_D
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_LAST
+      TransitionKey   = TRANS_FIRING_A
+      HideSubObject   = TURRETFRONT TURRETBACK  ;Hide pack/unpack animated turret
+      ShowSubObject   = TURRET01      ;Show controlled turret
+    End
+    AliasConditionState = DEPLOYED REALLYDAMAGED FIRING_A
+    AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
+    AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+
+    TrackMarks              = EXTnkTrack.tga
+    TreadAnimationRate      = 4.0  ; amount of tread texture to move per second
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName      = OBJECT:NukeLauncher
+  Side = ChinaTankGeneral
+  EditorSorting   = VEHICLE
+  TransportSlotCount = 10                 ;how many "slots" we take in a transport (0 == not transportable)
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
+  WeaponSet
+    Conditions = None
+    Weapon = PRIMARY NukeCannonGun
+  End
+  WeaponSet
+    Conditions = PLAYER_UPGRADE
+    Weapon = PRIMARY NukeCannonGun
+    Weapon = SECONDARY NukeCannonNeutronWeapon
+    AutoChooseSources = PRIMARY FROM_PLAYER FROM_SCRIPT FROM_AI
+    AutoChooseSources = SECONDARY FROM_SCRIPT FROM_AI
+    ShareWeaponReloadTime = Yes
+  End
+
+
+  ArmorSet
+    Conditions      = None
+    Armor           = TankArmor
+    DamageFX        = TankDamageFX
+  End
+  BuildCost       = 1600
+  BuildTime       = 18.0          ;in seconds
+  VisionRange     = 180
+  ShroudClearingRange = 350
+  Prerequisites
+    Object = Tank_ChinaWarFactory
+    Object = Tank_ChinaPropagandaCenter
+    Object = TechWarFactory
+  End
+
+  ExperienceValue = 50 100 200 400    ;Experience point value at each level
+  ExperienceRequired = 0 400 600 1000  ;Experience points needed to gain each level
+  IsTrainable = Yes             ;Can gain experience
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CommandSet    = ChinaVehicleNukeCannonCommandSet
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect           = NukeCannonVoiceSelect
+  VoiceMove             = NukeCannonVoiceMove
+  VoiceGuard            = NukeCannonVoiceMove
+  VoiceAttack           = NukeCannonVoiceAttack
+  SoundMoveStart        = NukeCannonMoveStart
+  SoundMoveStartDamaged = NukeCannonMoveStart
+  UnitSpecificSounds
+    ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
+    VoiceCreate         = NukeCannonVoiceCreate
+    TurretMoveStart     = NoSound
+    TurretMoveLoop      = NukeCannonTurretMoveLoop
+    VoiceEnter          = NukeCannonVoiceMove
+    Deploy              = NukeCannonDeploy
+    Undeploy            = NukeCannonUnDeploy
+  End
+
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = UNIT
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK CAN_CAST_REFLECTIONS VEHICLE SCORE
+
+  Body = ActiveBody ModuleTag_02
+    MaxHealth       = 240.0
+    InitialHealth   = 240.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 480
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 50
+  End
+
+  Behavior = VeterancyGainCreate ModuleTag_03
+    StartingLevel = VETERAN
+    ScienceRequired = SCIENCE_ArtilleryTraining
+  End
+
+  Behavior = DeployStyleAIUpdate ModuleTag_04
+    Turret
+      TurretTurnRate        = 80
+      TurretPitchRate       = 80
+      FirePitch             = 0            ; Instead of aiming pitchwise at the target, it will aim here
+      AllowsPitch           = Yes
+      RecenterTime          = 5000         ; how long to wait during idle before recentering
+      ControlledWeaponSlots = PRIMARY SECONDARY
+      NaturalTurretAngle    = 0
+      InitiallyDisabled     = Yes
+    End
+    AutoAcquireEnemiesWhenIdle = No NotWhileAttacking ; Patch104p @bugfix commy2 10/09/2021 Fix Nuke Cannon changing to nearest target while unpacking.
+    PackTime = 3333
+    UnpackTime = 3333
+    TurretsFunctionOnlyWhenDeployed = Yes
+    TurretsMustCenterBeforePacking = Yes
+    ManualDeployAnimations = Yes
+  End
+
+  Locomotor = SET_NORMAL ChinaNukeCannonLocomotor
+  Behavior = PhysicsBehavior ModuleTag_05
+    Mass = 50.0
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_06
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    DestructionDelay  = 500
+    DestructionDelayVariance  = 100
+    FX  = INITIAL  FX_BattleMasterExplosionOneFinal
+    OCL = INITIAL  OCL_RadiationFieldSmall
+    OCL = MIDPOINT OCL_ChinaVehicleNukeCannonDie
+    OCL = FINAL    OCL_RadiationFieldSmall
+    FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
+  End
+
+  ; A crushing defeat
+  Behavior = FXListDie ModuleTag_07
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    DeathFX = FX_CarCrush
+  End
+  Behavior = CreateObjectDie ModuleTag_08
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_CrusaderTank_CrushEffect
+  End
+  Behavior = CreateCrateDie ModuleTag_09
+    CrateData = SalvageCrateData
+    ;CrateData = EliteTankCrateData
+    ;CrateData = HeroicTankCrateData
+  End
+
+  Behavior                 = TransitionDamageFX ModuleTag_10
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_NukeCannonDamageTransition
+  End
+
+  Behavior = DestroyDie ModuleTag_11
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
+  Behavior = FlammableUpdate ModuleTag_21
+    AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
+    AflameDamageAmount = 3       ; taking this much damage...
+    AflameDamageDelay = 500       ; this often.
+  End
+
+  Behavior = ProductionUpdate ModuleTag_12
+    MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
+  End
+
+  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
+
+  Behavior = WeaponSetUpgrade ModuleTag_13
+    TriggeredBy = Upgrade_ChinaNeutronShells
+  End
+
+  Geometry = BOX
+  GeometryMajorRadius = 32.0
+  GeometryMinorRadius = 10.0
+  GeometryHeight = 17.0
+  GeometryIsSmall = No
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 45  ; minimum elevation angle above horizon. Used to limit shadow length
+
+End
+
+;------------------------------------------------------------------------------
+Object Tank_ChinaVehicleInfernoCannon
+
+  ; *** ART Parameters ***
+  SelectPortrait         = SNInferno_L
+  ButtonImage            = SNInferno
+
+  UpgradeCameo1 = Upgrade_ChinaBlackNapalm
+  ;UpgradeCameo2 = NONE
+  ;UpgradeCameo3 = NONE
+  ;UpgradeCameo4 = NONE
+  ;UpgradeCameo5 = NONE
+
+  Draw                    = W3DTankDraw ModuleTag_01
+    OkToChangeModelColor  = Yes
+    ConditionState        = NONE
+      Model               = NVInferno
+      Turret              = Turret
+      TurretPitch         = TurretEL
+      WeaponFireFXBone    = PRIMARY Muzzle
+      WeaponRecoilBone    = PRIMARY Barrel
+      WeaponMuzzleFlash   = PRIMARY MuzzleFX
+      WeaponLaunchBone = PRIMARY Muzzle
+    End
+
+    ConditionState        = RUBBLE REALLYDAMAGED
+      Model               = NVInferno_D
+      Turret              = Turret
+      TurretPitch         = TurretEL
+      WeaponFireFXBone    = PRIMARY Muzzle
+      WeaponRecoilBone    = PRIMARY Barrel
+      WeaponMuzzleFlash   = PRIMARY MuzzleFX
+      WeaponLaunchBone = PRIMARY Muzzle
+    End
+
+    TrackMarks           = EXTnkTrack.tga
+    TreadAnimationRate      = 2.0  ; amount of tread texture to move per second
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName        = OBJECT:InfernoCannon
+  Side               = ChinaTankGeneral
+  EditorSorting      = VEHICLE
+  TransportSlotCount = 3                 ;how many "slots" we take in a transport (0 == not transportable)
+  WeaponSet
+    Conditions       = None
+    Weapon           = PRIMARY InfernoCannonGun
+  End
+  WeaponSet
+    Conditions       = PLAYER_UPGRADE
+    Weapon           = PRIMARY InfernoCannonGunUpgraded
+  End
+  ArmorSet
+    Conditions      = None
+    Armor           = TankArmor
+    DamageFX        = TankDamageFX
+  End
+  BuildCost          = 900
+  BuildTime          = 14.0          ;in seconds
+  VisionRange        = 180
+  ShroudClearingRange = 300
+  Prerequisites
+    Object = Tank_ChinaWarFactory
+    Object = Tank_ChinaPropagandaCenter
+    Object = TechWarFactory
+  End
+
+  ExperienceValue = 50 50 100 150    ;Experience point value at each level
+  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
+  IsTrainable = Yes             ;Can gain experience
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CommandSet      = ChinaVehicleInfernoCannonCommandSet
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect       = InfernoCannonVoiceSelect
+  VoiceMove         = InfernoCannonVoiceMove
+  VoiceGuard        = InfernoCannonVoiceMove
+  VoiceAttack       = InfernoCannonVoiceAttack
+  SoundMoveStart    = InfernoCannonMoveStart
+  SoundMoveStartDamaged = InfernoCannonMoveStart
+  UnitSpecificSounds
+    ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
+    VoiceCreate     = InfernoCannonVoiceCreate
+    TurretMoveStart = NoSound
+    TurretMoveLoop  = NoSound
+    VoiceCrush          = InfernoCannonVoiceCrush
+    VoiceEnter         = InfernoCannonVoiceMove
+  End
+
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority     = UNIT
+  KindOf            = PRELOAD SELECTABLE CAN_ATTACK CAN_CAST_REFLECTIONS VEHICLE SCORE
+
+  Body              = ActiveBody ModuleTag_02
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 240
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 50
+  End
+
+  Behavior = VeterancyGainCreate ModuleTag_03
+    StartingLevel = VETERAN
+    ScienceRequired = SCIENCE_ArtilleryTraining
+  End
+
+  Behavior = AIUpdateInterface ModuleTag_04
+    Turret
+      TurretTurnRate = 100
+      TurretPitchRate = 100
+      AllowsPitch = Yes
+      FirePitch = 45
+      ControlledWeaponSlots = PRIMARY
+    End
+    AutoAcquireEnemiesWhenIdle = No NotWhileAttacking
+  End
+  Locomotor = SET_NORMAL InfernoLocomotor
+  Behavior = PhysicsBehavior ModuleTag_05
+    Mass = 50.0
+  End
+
+  ; A crushing defeat
+  Behavior               = FXListDie ModuleTag_06
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    DeathFX         = FX_CarCrush
+  End
+  Behavior               = CreateObjectDie ModuleTag_07
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList    = OCL_CrusaderTank_CrushEffect
+  End
+  Behavior = SlowDeathBehavior ModuleTag_08
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 50
+    DestructionDelay = 2000
+    DestructionDelayVariance = 300
+    FX  = INITIAL  FX_CrusaderCatchFire
+    FX  = FINAL    FX_GenericTankDeathExplosion
+    OCL = FINAL    OCL_InfernoCannonDeathEffect
+  End
+
+  Behavior                 = TransitionDamageFX ModuleTag_09
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
+    ReallyDamagedFXList1 = Loc: X:-7 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
+
+  Behavior         = CreateCrateDie ModuleTag_10
+    CrateData = SalvageCrateData
+    ;CrateData = EliteTankCrateData
+    ;CrateData = HeroicTankCrateData
+  End
+
+  Behavior      = WeaponSetUpgrade ModuleTag_11
+    TriggeredBy = Upgrade_ChinaBlackNapalm
+  End
+
+  Behavior = FlammableUpdate ModuleTag_21
+    AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
+    AflameDamageAmount = 3       ; taking this much damage...
+    AflameDamageDelay = 500       ; this often.
+  End
+
+  Behavior = DestroyDie ModuleTag_22
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
+  Geometry            = BOX
+  GeometryMajorRadius = 15.0
+  GeometryMinorRadius = 10.0
+  GeometryHeight      = 15.0
+  GeometryIsSmall     = Yes
+  Shadow              = SHADOW_VOLUME
+  ShadowSizeX = 45  ; minimum elevation angle above horizon. Used to limit shadow length
+
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16782,8 +16782,6 @@ Object Tank_ChinaVehicleNukeLauncher
   EditorSorting   = VEHICLE
   TransportSlotCount = 10                 ;how many "slots" we take in a transport (0 == not transportable)
 
-  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
-
   WeaponSet
     Conditions = None
     Weapon = PRIMARY NukeCannonGun
@@ -16810,7 +16808,6 @@ Object Tank_ChinaVehicleNukeLauncher
   Prerequisites
     Object = Tank_ChinaWarFactory
     Object = Tank_ChinaPropagandaCenter
-    Object = TechWarFactory ;Needed to prevernt Command Button exploit.
   End
 
   ExperienceValue = 50 100 200 400    ;Experience point value at each level
@@ -16869,7 +16866,7 @@ Object Tank_ChinaVehicleNukeLauncher
       NaturalTurretAngle    = 0
       InitiallyDisabled     = Yes
     End
-    AutoAcquireEnemiesWhenIdle = No NotWhileAttacking ; Patch104p @bugfix commy2 10/09/2021 Fix Nuke Cannon changing to nearest target while unpacking.
+    AutoAcquireEnemiesWhenIdle = No NotWhileAttacking
     PackTime = 3333
     UnpackTime = 3333
     TurretsFunctionOnlyWhenDeployed = Yes
@@ -16926,8 +16923,6 @@ Object Tank_ChinaVehicleNukeLauncher
   Behavior = ProductionUpdate ModuleTag_12
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
   End
-
-  ; Patch104p @bugfix commy2 09/09/2021 Prevent exploit that allows Neutron Shells without upgrade.
 
   Behavior = WeaponSetUpgrade ModuleTag_13
     TriggeredBy = Upgrade_ChinaNeutronShells
@@ -17008,7 +17003,6 @@ Object Tank_ChinaVehicleInfernoCannon
   Prerequisites
     Object = Tank_ChinaWarFactory
     Object = Tank_ChinaPropagandaCenter
-    Object = TechWarFactory ;Needed to prevent Command Button exploit.
   End
 
   ExperienceValue = 50 50 100 150    ;Experience point value at each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16641,6 +16641,7 @@ Object Tank_ChinaCommandCenter
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p Jundiyy 17.10.2021 added Nuke Cannon to Tank General to allow it to be added to fun maps.
 ;Also called NukeCannon
 Object Tank_ChinaVehicleNukeLauncher
 
@@ -16809,7 +16810,7 @@ Object Tank_ChinaVehicleNukeLauncher
   Prerequisites
     Object = Tank_ChinaWarFactory
     Object = Tank_ChinaPropagandaCenter
-    Object = TechWarFactory
+    Object = TechWarFactory ;Needed to prevernt Command Button exploit.
   End
 
   ExperienceValue = 50 100 200 400    ;Experience point value at each level
@@ -16943,6 +16944,7 @@ Object Tank_ChinaVehicleNukeLauncher
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p Jundiyy 17.10.2021 added Inferno Cannon to Tank General to allow it to be added to fun maps.
 Object Tank_ChinaVehicleInfernoCannon
 
   ; *** ART Parameters ***
@@ -17006,7 +17008,7 @@ Object Tank_ChinaVehicleInfernoCannon
   Prerequisites
     Object = Tank_ChinaWarFactory
     Object = Tank_ChinaPropagandaCenter
-    Object = TechWarFactory
+    Object = TechWarFactory ;Needed to prevent Command Button exploit.
   End
 
   ExperienceValue = 50 50 100 150    ;Experience point value at each level


### PR DESCRIPTION
Mappers can now add Nuke Cannons and Inferno Cannons to the Tank General War Factory.

First they must use the CommandButton script to add these units to the War Factory, then they must also place down a TechWarFactory per player (off map is fine) and script them so they are given to each player. 

The second route is to add the CommandButtons scripts then add scripts to ignore prerequisites.