### PR TITLE
Fix: Frenzy-Scan Bug

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -212,7 +212,7 @@ https://github.com/commy2/zerohour/issues/7   [DONE][NPROJEC!]        Mini-Gunne
 https://github.com/commy2/zerohour/issues/6   [DONE][NPROJEC!]        Mini-Gunner Has Broken Sound And Fire Animation When Aiming At Airborne Targets
 https://github.com/commy2/zerohour/issues/5   [DONE][NPROJEC!]        Heroic Pathfinders And Jarmen Kell Don't Use Red Tracers
 https://github.com/commy2/zerohour/issues/4   [DONE][NPROJEC!]        Vet 3 Jarmen Kell Has Tracer For Sniper Attack But Not For Normal Attack
-https://github.com/commy2/zerohour/issues/3   [MAYBE]                 Frenzy-Scan Bug
+https://github.com/commy2/zerohour/issues/3   [DONE]                  Frenzy-Scan Bug
 https://github.com/commy2/zerohour/issues/2   [DONE][NPROJEC!]        Microwave-Supply Drop Zone-Bug
 https://github.com/commy2/zerohour/issues/1   [DONE][NPROJEC!]        Scud-Bug
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -265,6 +265,8 @@ SpecialPower SuperweaponArtilleryBarrage
   AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.
 End
 
+; Patch104p @bugfix commy2 23/10/2021 Fix Frenzy special power revealed map.
+
 ;-----------------------------------------------------------------------------
 SpecialPower SuperweaponFrenzy
   Enum                = SPECIAL_FRENZY
@@ -273,8 +275,6 @@ SpecialPower SuperweaponFrenzy
 ;  InitiateSound       = FireArtilleryCannonSound
   PublicTimer         = No
   SharedSyncedTimer   = Yes
-  ViewObjectDuration  = 30000
-  ViewObjectRange     = 250
   RadiusCursorRadius  = 200
   InitiateAtLocationSound = FrenzyActivate
   ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
@@ -289,8 +289,6 @@ SpecialPower Early_SuperweaponFrenzy
   InitiateAtLocationSound = FrenzyActivate
   PublicTimer         = No
   SharedSyncedTimer   = Yes
-  ViewObjectDuration  = 30000
-  ViewObjectRange     = 250
   RadiusCursorRadius  = 200
   ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
   AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.


### PR DESCRIPTION
ZH 1.04:

- Frenzy can be used to reveal the map. Especially relevant to Infantry General, since he gets Frenzy 1 at rank 1.

After this patch:

- Frenzy will no longer reveal the map where used.

See discussion in close #591