### PR TITLE
Fix: Cash Bounty Granted By Command Center Scaffold

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1354,6 +1354,8 @@ Object Boss_CommandCenter
     ReferenceObject      = GLASneakAttackTunnelNetwork ;So we know what the final product is for script placement calculations
   End
 
+  ; Patch104p @bugfix commy2 23/10/2021 Fix Command Center scaffold unlocks Cash Bounty.
+
   Behavior = CashBountyPower ModuleTag_96
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1357,14 +1357,35 @@ Object Boss_CommandCenter
   Behavior = CashBountyPower ModuleTag_96
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_97
     SpecialPowerTemplate    = SpecialAbilityCashBounty2
     Bounty                  = 10%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_98
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+    StartsPaused            = Yes ; Unpaused by upgrade module
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause1
+    SpecialPowerTemplate = SpecialAbilityCashBounty1
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause2
+    SpecialPowerTemplate = SpecialAbilityCashBounty2
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause3
+    SpecialPowerTemplate = SpecialAbilityCashBounty3
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_CashBountyUpauseTrigger
+    UpgradeToGrant = Upgrade_AmericaRadar
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = FlammableUpdate ModuleTag_23

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -991,6 +991,7 @@ Object Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @bugfix commy2 23/10/2021 Fix Command Center scaffold unlocks Cash Bounty.
 
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -995,14 +995,35 @@ Object Chem_GLACommandCenter
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_16
     SpecialPowerTemplate    = SpecialAbilityCashBounty2
     Bounty                  = 10%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+    StartsPaused            = Yes ; Unpaused by upgrade module
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause1
+    SpecialPowerTemplate = SpecialAbilityCashBounty1
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause2
+    SpecialPowerTemplate = SpecialAbilityCashBounty2
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause3
+    SpecialPowerTemplate = SpecialAbilityCashBounty3
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_CashBountyUpauseTrigger
+    UpgradeToGrant = Upgrade_AmericaRadar
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1131,14 +1131,35 @@ Object Demo_GLACommandCenter
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_16
     SpecialPowerTemplate    = SpecialAbilityCashBounty2
     Bounty                  = 10%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+    StartsPaused            = Yes ; Unpaused by upgrade module
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause1
+    SpecialPowerTemplate = SpecialAbilityCashBounty1
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause2
+    SpecialPowerTemplate = SpecialAbilityCashBounty2
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause3
+    SpecialPowerTemplate = SpecialAbilityCashBounty3
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_CashBountyUpauseTrigger
+    UpgradeToGrant = Upgrade_AmericaRadar
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1127,6 +1127,7 @@ Object Demo_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @bugfix commy2 23/10/2021 Fix Command Center scaffold unlocks Cash Bounty.
 
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -2169,6 +2169,7 @@ Object GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @bugfix commy2 23/10/2021 Fix Command Center scaffold unlocks Cash Bounty.
 
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -2173,14 +2173,35 @@ Object GLACommandCenter
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_16
     SpecialPowerTemplate    = SpecialAbilityCashBounty2
     Bounty                  = 10%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+    StartsPaused            = Yes ; Unpaused by upgrade module
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause1
+    SpecialPowerTemplate = SpecialAbilityCashBounty1
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause2
+    SpecialPowerTemplate = SpecialAbilityCashBounty2
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause3
+    SpecialPowerTemplate = SpecialAbilityCashBounty3
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_CashBountyUpauseTrigger
+    UpgradeToGrant = Upgrade_AmericaRadar
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1902,14 +1902,35 @@ Object GC_Chem_GLACommandCenter
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_16
     SpecialPowerTemplate    = SpecialAbilityCashBounty2
     Bounty                  = 10%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+    StartsPaused            = Yes ; Unpaused by upgrade module
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause1
+    SpecialPowerTemplate = SpecialAbilityCashBounty1
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause2
+    SpecialPowerTemplate = SpecialAbilityCashBounty2
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause3
+    SpecialPowerTemplate = SpecialAbilityCashBounty3
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_CashBountyUpauseTrigger
+    UpgradeToGrant = Upgrade_AmericaRadar
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1899,6 +1899,8 @@ Object GC_Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @bugfix commy2 23/10/2021 Fix Command Center scaffold unlocks Cash Bounty.
+
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -697,14 +697,35 @@ Object GC_Slth_GLACommandCenter
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_16
     SpecialPowerTemplate    = SpecialAbilityCashBounty2
     Bounty                  = 10%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+    StartsPaused            = Yes ; Unpaused by upgrade module
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause1
+    SpecialPowerTemplate = SpecialAbilityCashBounty1
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause2
+    SpecialPowerTemplate = SpecialAbilityCashBounty2
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause3
+    SpecialPowerTemplate = SpecialAbilityCashBounty3
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_CashBountyUpauseTrigger
+    UpgradeToGrant = Upgrade_AmericaRadar
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -693,6 +693,7 @@ Object GC_Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @bugfix commy2 23/10/2021 Fix Command Center scaffold unlocks Cash Bounty.
 
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -997,14 +997,35 @@ Object Slth_GLACommandCenter
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1
     Bounty                  = 5%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_16
     SpecialPowerTemplate    = SpecialAbilityCashBounty2
     Bounty                  = 10%
+    StartsPaused            = Yes ; Unpaused by upgrade module
   End
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+    StartsPaused            = Yes ; Unpaused by upgrade module
+  End
+
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause1
+    SpecialPowerTemplate = SpecialAbilityCashBounty1
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause2
+    SpecialPowerTemplate = SpecialAbilityCashBounty2
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+  Behavior = UnpauseSpecialPowerUpgrade ModuleTag_CashBountyUpause3
+    SpecialPowerTemplate = SpecialAbilityCashBounty3
+    TriggeredBy = Upgrade_AmericaRadar
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_CashBountyUpauseTrigger
+    UpgradeToGrant = Upgrade_AmericaRadar
+    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -993,6 +993,7 @@ Object Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @bugfix commy2 23/10/2021 Fix Command Center scaffold unlocks Cash Bounty.
 
   Behavior = CashBountyPower ModuleTag_15
     SpecialPowerTemplate    = SpecialAbilityCashBounty1


### PR DESCRIPTION
- may fix #590

This needs to be thoroughly tested first. It would be very sweet if this worked, since this is the least hacky implementation.