### PR TITLE
Fix: Cash Bounty Granted By Command Center Scaffold, Method 1

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1354,19 +1354,6 @@ Object Boss_CommandCenter
     ReferenceObject      = GLASneakAttackTunnelNetwork ;So we know what the final product is for script placement calculations
   End
 
-  Behavior = CashBountyPower ModuleTag_96
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_97
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_98
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
-  End
-
   Behavior = FlammableUpdate ModuleTag_23
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -991,20 +991,6 @@ Object Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
-  End
-
   Behavior = FlammableUpdate ModuleTag_19
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1127,20 +1127,6 @@ Object Demo_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
-  End
-
   Behavior = FlammableUpdate ModuleTag_19
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -2169,20 +2169,6 @@ Object GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
-  End
-
   Behavior = FlammableUpdate ModuleTag_19
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1899,19 +1899,6 @@ Object GC_Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
-  End
-
   Behavior = FlammableUpdate ModuleTag_19
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -693,20 +693,6 @@ Object GC_Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
-  End
-
   Behavior = FlammableUpdate ModuleTag_19
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -993,20 +993,6 @@ Object Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
-  End
-
   Behavior = FlammableUpdate ModuleTag_19
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2878,3 +2878,32 @@ Object DummyWeaponProjectile
   GeometryMajorRadius = 2.0
 
 End
+
+; Patch104p @bugfix commy2 24/10/2021 Logic that grants player Cash Bounty.
+
+;------------------------------------------------------------------------------
+Object CashBountyDummy
+
+  ; ***DESIGN parameters ***
+  EditorSorting   = SYSTEM
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
+
+  ; *** ENGINEERING Parameters ***
+  Body = HighlanderBody ModuleTag_01
+    MaxHealth = 1.0
+    InitialHealth = 1.0
+  End
+
+  Behavior = CashBountyPower ModuleTag_15
+    SpecialPowerTemplate    = SpecialAbilityCashBounty1
+    Bounty                  = 5%
+  End
+  Behavior = CashBountyPower ModuleTag_16
+    SpecialPowerTemplate    = SpecialAbilityCashBounty2
+    Bounty                  = 10%
+  End
+  Behavior = CashBountyPower ModuleTag_17
+    SpecialPowerTemplate    = SpecialAbilityCashBounty3
+    Bounty                  = 20%
+  End
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -127,6 +127,7 @@ PlayerTemplate FactionGLA
   DisplayName       = INI:FactionGLA
   StartingBuilding  = GLACommandCenter
   StartingUnit0     = GLAInfantryWorker
+  StartingUnit1     = CashBountyDummy
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -368,6 +369,7 @@ PlayerTemplate FactionGLAToxinGeneral
   DisplayName       = INI:FactionGLAToxinGeneral
   StartingBuilding  = Chem_GLACommandCenter
   StartingUnit0     = Chem_GLAInfantryWorker
+  StartingUnit1     = CashBountyDummy
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -403,6 +405,7 @@ PlayerTemplate FactionGLADemolitionGeneral
   DisplayName       = INI:FactionGLADemolitionGeneral
   StartingBuilding  = Demo_GLACommandCenter
   StartingUnit0     = Demo_GLAInfantryWorker
+  StartingUnit1     = CashBountyDummy
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -438,6 +441,7 @@ PlayerTemplate FactionGLAStealthGeneral
   DisplayName       = INI:FactionGLAStealthGeneral
   StartingBuilding  = Slth_GLACommandCenter
   StartingUnit0     = Slth_GLAInfantryWorker
+  StartingUnit1     = CashBountyDummy
   ScoreScreenImage  = GLA_ScoreScreen
   LoadScreenImage   = SUFactionLogoPage_GLA
   LoadScreenMusic   = Load_GLA
@@ -472,6 +476,7 @@ PlayerTemplate FactionBossGeneral
   DisplayName       = INI:FactionBossGeneral
   StartingBuilding  = Boss_CommandCenter
   StartingUnit0     = Boss_VehicleDozer
+  StartingUnit1     = CashBountyDummy
   ScoreScreenImage  = China_ScoreScreen
   LoadScreenImage   = SNFactionLogoPage_China
   LoadScreenMusic   = Load_China


### PR DESCRIPTION
- fix #590
- alternative to close #595

This change makes it such that an xGLA (or Boss General) player does not need a Command Center (scaffold) at all to unlock Cash Bounty. The Cash Bounty will be available as soon as the generals promotion is picked.