### PR TITLE
Add: Production Door Logic For Propaganda Center

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1089,6 +1089,7 @@ CommandSet ChinaPropagandaCenterCommandSet
   1  = Command_UpgradeChinaNationalism
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeChinaMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -1096,6 +1097,7 @@ CommandSet ChinaPropagandaCenterCommandSetUpgrade
   1  = Command_UpgradeChinaNationalism
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeEMPMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -3192,6 +3194,7 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSet
   2  = Nuke_Command_UpgradeChinaIsotopeStability
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeChinaMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -3200,6 +3203,7 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
   2  = Nuke_Command_UpgradeChinaIsotopeStability
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeEMPMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -3927,6 +3931,7 @@ CommandSet Infa_ChinaPropagandaCenterCommandSet
   ;2  = Command_UpgradeAmericaChemicalSuits
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeChinaMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -3935,6 +3940,7 @@ CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
   ;2  = Command_UpgradeAmericaChemicalSuits
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeEMPMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -4651,6 +4657,7 @@ CommandSet Tank_ChinaPropagandaCenterCommandSet ;DO NOT CHANGE THIS COMMAND SET 
   2  = Tank_Command_UpgradeChinaAutoLoader
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeChinaMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -4659,6 +4666,7 @@ CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade ;DO NOT CHANGE THIS COMMA
   2  = Tank_Command_UpgradeChinaAutoLoader
   3  = Command_UpgradeChinaSubliminalMessaging
  12  = Command_UpgradeEMPMines
+ 13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -31672,7 +31672,7 @@ Object ChinaPropagandaCenter
 
   ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
   RadarPriority     = STRUCTURE
-  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
+  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH FS_FACTORY AUTO_RALLYPOINT
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0
     InitialHealth = 1000.0
@@ -31684,7 +31684,15 @@ Object ChinaPropagandaCenter
     SubdualDamageHealAmount = 100
   End
   Behavior = ProductionUpdate ModuleTag_10
-    ;<NO DATA>
+    NumDoorAnimations            = 1
+    DoorOpeningTime              = 3000  ;in mSeconds
+    DoorWaitOpenTime             = 2000  ;in mSeconds
+    DoorCloseTime                = 2000  ;in mSeconds
+    ConstructionCompleteDuration = 1500  ;in mSeconds
+  End
+  Behavior = DefaultProductionExitUpdate ModuleTag_11
+    UnitCreatePoint   = X: 0.0 Y:45.0 Z:0.0
+    NaturalRallyPoint = X:57.0 Y:45.0 Z:0.0
   End
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -11687,7 +11687,7 @@ Object Infa_ChinaPropagandaCenter
 
   ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
   RadarPriority     = STRUCTURE
-  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
+  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH FS_FACTORY AUTO_RALLYPOINT
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0
     InitialHealth = 1000.0
@@ -11699,7 +11699,15 @@ Object Infa_ChinaPropagandaCenter
     SubdualDamageHealAmount = 100
   End
   Behavior = ProductionUpdate ModuleTag_10
-    ;<NO DATA>
+    NumDoorAnimations            = 1
+    DoorOpeningTime              = 3000  ;in mSeconds
+    DoorWaitOpenTime             = 2000  ;in mSeconds
+    DoorCloseTime                = 2000  ;in mSeconds
+    ConstructionCompleteDuration = 1500  ;in mSeconds
+  End
+  Behavior = DefaultProductionExitUpdate ModuleTag_11
+    UnitCreatePoint   = X: 0.0 Y:45.0 Z:0.0
+    NaturalRallyPoint = X:57.0 Y:45.0 Z:0.0
   End
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -14273,7 +14273,7 @@ Object Nuke_ChinaPropagandaCenter
 
   ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
   RadarPriority     = STRUCTURE
-  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
+  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH FS_FACTORY AUTO_RALLYPOINT
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0
     InitialHealth = 1000.0
@@ -14285,7 +14285,15 @@ Object Nuke_ChinaPropagandaCenter
     SubdualDamageHealAmount = 100
   End
   Behavior = ProductionUpdate ModuleTag_10
-    ;<NO DATA>
+    NumDoorAnimations            = 1
+    DoorOpeningTime              = 3000  ;in mSeconds
+    DoorWaitOpenTime             = 2000  ;in mSeconds
+    DoorCloseTime                = 2000  ;in mSeconds
+    ConstructionCompleteDuration = 1500  ;in mSeconds
+  End
+  Behavior = DefaultProductionExitUpdate ModuleTag_11
+    UnitCreatePoint   = X: 0.0 Y:45.0 Z:0.0
+    NaturalRallyPoint = X:57.0 Y:45.0 Z:0.0
   End
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -13274,7 +13274,7 @@ Object Tank_ChinaPropagandaCenter
 
   ; Patch104p @bugfix hanfield 01/09/2021 Added missing RadarPriority = STRUCTURE parameter.
   RadarPriority     = STRUCTURE
-  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH
+  KindOf = PRELOAD STRUCTURE SELECTABLE IMMOBILE SCORE CAPTURABLE FS_TECHNOLOGY MP_COUNT_FOR_VICTORY FS_ADVANCED_TECH FS_FACTORY AUTO_RALLYPOINT
   Body            = StructureBody ModuleTag_07
     MaxHealth     = 1000.0
     InitialHealth = 1000.0
@@ -13286,7 +13286,15 @@ Object Tank_ChinaPropagandaCenter
     SubdualDamageHealAmount = 100
   End
   Behavior = ProductionUpdate ModuleTag_10
-    ;<NO DATA>
+    NumDoorAnimations            = 1
+    DoorOpeningTime              = 3000  ;in mSeconds
+    DoorWaitOpenTime             = 2000  ;in mSeconds
+    DoorCloseTime                = 2000  ;in mSeconds
+    ConstructionCompleteDuration = 1500  ;in mSeconds
+  End
+  Behavior = DefaultProductionExitUpdate ModuleTag_11
+    UnitCreatePoint   = X: 0.0 Y:45.0 Z:0.0
+    NaturalRallyPoint = X:57.0 Y:45.0 Z:0.0
   End
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>


### PR DESCRIPTION
This patch will:

- enable Propaganda Centers to produce units, including a door animation for when they're ready
- add rallypoints to Propaganda Centers
- make Propaganda Centers hackable by Saboteurs*

* untested

I don't think we want this in the patch tbh. This could serve as a documention for map makers to add this though. Everything here should be possible to do via map.ini.

