### PR TITLE
Add: Functional Speaker Tower For Propaganda Center

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -6702,6 +6702,24 @@ FXList FX_PropagandaTowerSubliminalPulse
 End
 
 ; ----------------------------------------------
+FXList FX_PropagandaCenterPropagandaPulse
+  ParticleSystem
+    Name = SonicRange
+    Offset = X:-18.6 Y:-48.7 Z:45.0
+    OrientToObject = Yes
+  End
+End
+
+; ----------------------------------------------
+FXList FX_PropagandaCenterSubliminalPulse
+  ParticleSystem
+    Name = SonicRangeUpgraded
+    Offset = X:-18.6 Y:-48.7 Z:45.0
+    OrientToObject = Yes
+  End
+End
+
+; ----------------------------------------------
 ; Patch104p @bugfix Stubbjax 06/09/2021 New Listening Outpost Propaganda effects to fix alignment
 FXList FX_ListeningOutpostPropagandaPulse
   ParticleSystem

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -30868,6 +30868,9 @@ Object ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -31701,6 +31704,16 @@ Object ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -10883,6 +10883,9 @@ Object Infa_ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -11716,6 +11719,16 @@ Object Infa_ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -13469,6 +13469,9 @@ Object Nuke_ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -14302,6 +14305,16 @@ Object Nuke_ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -12470,6 +12470,9 @@ Object Tank_ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -13303,6 +13306,16 @@ Object Tank_ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17


### PR DESCRIPTION
Adds functional speaker tower to Propaganda Centers.

Big change. Doubt we want this in the base game. But I'll document it for map makers:

<details><summary>map script</summary>

```map.ini
FXList FX_PropagandaCenterPropagandaPulse
  ParticleSystem
    Name = SonicRange
    Offset = X:-18.6 Y:-48.7 Z:45.0
    OrientToObject = Yes
  End
End

FXList FX_PropagandaCenterSubliminalPulse
  ParticleSystem
    Name = SonicRangeUpgraded
    Offset = X:-18.6 Y:-48.7 Z:45.0
    OrientToObject = Yes
  End
End

Object ChinaPropagandaCenter
  UpgradeCameo1 = Upgrade_ChinaSubliminalMessaging

  AddModule
    Behavior        = PropagandaTowerBehavior ModuleTag_16
      Radius                = 150.0
      DelayBetweenUpdates   = 2000 ; in milliseconds
      HealPercentEachSecond = 2%   ; get this % of max health every second
      PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
      UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
      UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
      UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
    End
  End
End

Object Infa_ChinaPropagandaCenter
  UpgradeCameo1 = Upgrade_ChinaSubliminalMessaging

  AddModule
    Behavior        = PropagandaTowerBehavior ModuleTag_16
      Radius                = 150.0
      DelayBetweenUpdates   = 2000 ; in milliseconds
      HealPercentEachSecond = 2%   ; get this % of max health every second
      PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
      UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
      UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
      UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
    End
  End
End

Object Nuke_ChinaPropagandaCenter
  UpgradeCameo1 = Upgrade_ChinaSubliminalMessaging

  AddModule
    Behavior        = PropagandaTowerBehavior ModuleTag_16
      Radius                = 150.0
      DelayBetweenUpdates   = 2000 ; in milliseconds
      HealPercentEachSecond = 2%   ; get this % of max health every second
      PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
      UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
      UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
      UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
    End
  End
End

Object Tank_ChinaPropagandaCenter
  UpgradeCameo1 = Upgrade_ChinaSubliminalMessaging

  AddModule
    Behavior        = PropagandaTowerBehavior ModuleTag_16
      Radius                = 150.0
      DelayBetweenUpdates   = 2000 ; in milliseconds
      HealPercentEachSecond = 2%   ; get this % of max health every second
      PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
      UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
      UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
      UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
    End
  End
End
```

</details>