### PR TITLE
Fix: PORTABLE_STRUCTURE objects no longer block building construction

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1339,7 +1339,8 @@ Object AirF_SpectreGunshipHowitzer
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -7026,7 +7027,8 @@ Object AirF_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -365,7 +365,8 @@ Object SpectreGunshipGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -435,7 +436,8 @@ Object SpectreGunshipHowitzer
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2356,7 +2356,8 @@ Object AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack i
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -422,7 +422,8 @@ Object ChinaHelixGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
 
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
@@ -524,7 +525,8 @@ Object ChinaHelixPropagandaTower
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -625,7 +627,8 @@ Object ChinaHelixBattleBunker
   ; *** ENGINEERING Parameters ***
 
   ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
+  ;                                       Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -555,7 +555,8 @@ Object ChinaTankOverlordGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -659,7 +660,8 @@ Object ChinaTankOverlordPropagandaTower
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -765,7 +767,8 @@ Object ChinaTankOverlordBattleBunker
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
+  ;                            04/11/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16145,7 +16145,8 @@ Object Infa_ChinaHelixBattleBunker
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
+  ;                                       Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -367,7 +367,8 @@ Object Lazr_SpectreGunshipGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -437,7 +438,8 @@ Object Lazr_SpectreGunshipHowitzer
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -6734,7 +6736,8 @@ Object Lazr_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -700,7 +700,8 @@ Object Nuke_ChinaHelixGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
 
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
@@ -808,7 +809,8 @@ Object Nuke_ChinaHelixPropagandaTower
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -913,7 +915,8 @@ Object Nuke_ChinaHelixBattleBunker
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
+  ;                            24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -17010,7 +17013,8 @@ Object Nuke_ChinaTankOverlordGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -17114,7 +17118,8 @@ Object Nuke_ChinaTankOverlordPropagandaTower
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -17219,7 +17224,8 @@ Object Nuke_ChinaTankOverlordBattleBunker
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
+  ;                                       Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -842,7 +842,8 @@ Object SupW_SpectreGunshipGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -912,7 +913,8 @@ Object SupW_SpectreGunshipHowitzer
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -7202,7 +7204,8 @@ Object SupW_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -429,7 +429,8 @@ Object Tank_ChinaHelixGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
 
   Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
@@ -536,7 +537,8 @@ Object Tank_ChinaHelixPropagandaTower
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -642,7 +644,8 @@ Object Tank_ChinaHelixBattleBunker
   ; *** ENGINEERING Parameters ***
 
   ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
+  ;                                       Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -3296,7 +3299,8 @@ Object Tank_ChinaTankOverlordGattlingCannon
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -3405,7 +3409,8 @@ Object Tank_ChinaTankOverlordPropagandaTower
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI
+  ; Patch104p @bugfix hanfield 24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CAN_ATTACK CLICK_THROUGH IGNORED_IN_GUI INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
@@ -3515,7 +3520,8 @@ Object Tank_ChinaTankOverlordBattleBunker
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @bugfix hanfield 01/09/2021 Added CAN_ATTACK KINDOF to let Frenzy affect the Battle Bunker.
-  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK
+  ;                            24/12/2021 Added INERT KINDOF to prevent addon from blocking construction.
+  KindOf            = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI CAN_ATTACK INERT
     Body            = StructureBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0


### PR DESCRIPTION
Adding ``INERT`` KINDOF to these objects ensures they no longer block scaffold placement.