### PR TITLE
Fix: Non-Vanilla China ECM Tanks Automatically Engage Enemy Vehicles

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -3072,7 +3072,9 @@ Object Infa_ChinaTankECM
       MinIdleScanAngle      = 180    ; in degrees off the natural turret angle
       MaxIdleScanAngle      = 180    ; in degrees off the natural turret angle
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+
+    ; Patch104p @bugfix commy2 24/12/2021 Fix non vanilla China ECM auto-attack enemies when idle.
+    AutoAcquireEnemiesWhenIdle = No
   End
   Locomotor       = SET_NORMAL GattlingTankLocomotor
   Behavior          = PhysicsBehavior ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4574,7 +4574,9 @@ Object Nuke_ChinaTankECM
       MinIdleScanAngle      = 180    ; in degrees off the natural turret angle
       MaxIdleScanAngle      = 180    ; in degrees off the natural turret angle
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+
+    ; Patch104p @bugfix commy2 24/12/2021 Fix non vanilla China ECM auto-attack enemies when idle.
+    AutoAcquireEnemiesWhenIdle = No
   End
   Locomotor       = SET_NORMAL GattlingTankLocomotor
   Behavior          = PhysicsBehavior ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4713,7 +4713,9 @@ Object Tank_ChinaTankECM
       MinIdleScanAngle      = 180    ; in degrees off the natural turret angle
       MaxIdleScanAngle      = 180    ; in degrees off the natural turret angle
     End
-    AutoAcquireEnemiesWhenIdle = Yes
+
+    ; Patch104p @bugfix commy2 24/12/2021 Fix non vanilla China ECM auto-attack enemies when idle.
+    AutoAcquireEnemiesWhenIdle = No
   End
   Locomotor       = SET_NORMAL GattlingTankLocomotor
   Behavior          = PhysicsBehavior ModuleTag_04


### PR DESCRIPTION
ZH 1.04

- The Infantry, Tank and Nuke General's ECM tanks automatically start firing at vehicles, thus turning off their missile deflection. This does not apply to the vanilla China ECM tank.

After patch

- None of the ECM tanks automatically engage enemies when idle. All ECM behave the same.