### PR TITLE
Fix: Flashbangs Can Damage Stinger Troopers

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -105,7 +105,7 @@ https://github.com/commy2/zerohour/issues/117 [DONE][NPROJEC!]        Some Rebel
 https://github.com/commy2/zerohour/issues/116 [DONE][NPROJECT]        Tactical Nuke Mig Upgrade Not Buildable While Low On Power
 https://github.com/commy2/zerohour/issues/115 [DONE][NPROJEC!]        Early And Nuke Carpet Bomber Unavailable While Controlling Mixed Sub Faction Command Centers
 https://github.com/commy2/zerohour/issues/114 [DONE][NPROJEC!]        Hitting Battle Bus In Hull Mode Causes Screen Shake
-https://github.com/commy2/zerohour/issues/113 [MAYBE][NPROJECT]       Flashbangs Cannot Target Stinger Sites
+https://github.com/commy2/zerohour/issues/113 [DONE][NPROJECT]        Flashbangs Cannot Target Stinger Sites
 https://github.com/commy2/zerohour/issues/112 [DONE][NPROJEC!]        Stealth Fake Arms Dealer Missing Camo Netting Upgrade Icon
 https://github.com/commy2/zerohour/issues/111 [DONE][NPROJEC!]        Stealth General Saboteur Uses Rebel Death Scream
 https://github.com/commy2/zerohour/issues/110 [DONE][NPROJEC!]        Anthrax Beta And Gamma Upgrade Icons Missing From Many Objects

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -6081,8 +6081,9 @@ Object Chem_GLAStingerSite
     InitialHealth      = 1000.0
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +SURRENDER
-    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON +SURRENDER; Take no damage if no one to pass this to
+    ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -5971,8 +5971,9 @@ Object Demo_GLAStingerSite
     InitialHealth      = 1000.0
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +SURRENDER
-    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON +SURRENDER; Take no damage if no one to pass this to
+    ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -17158,8 +17158,9 @@ Object GLAStingerSite
     InitialHealth      = 1000.0
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +SURRENDER +MICROWAVE
-    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON +SURRENDER; Take no damage if no one to pass this to
+    ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +MICROWAVE
+    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
@@ -33429,8 +33430,9 @@ Object GLAStingerSiteNoHole
     InitialHealth      = 1000.0
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +SURRENDER
-    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON +SURRENDER; Take no damage if no one to pass this to
+    ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -957,8 +957,9 @@ Object GC_Chem_GLAStingerSite
     InitialHealth      = 1000.0
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +SURRENDER
-    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON +SURRENDER; Take no damage if no one to pass this to
+    ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -2709,8 +2709,9 @@ Object GC_Slth_GLAStingerSite
     InitialHealth      = 1000.0
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +SURRENDER
-    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON +SURRENDER; Take no damage if no one to pass this to
+    ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -6654,8 +6654,9 @@ Object Slth_GLAStingerSite
     InitialHealth      = 1000.0
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +SURRENDER
-    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON +SURRENDER; Take no damage if no one to pass this to
+    ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.


### PR DESCRIPTION
- alternative to pull #297

Instead of making Stinger Sites an eligible target for Rangers in Flashbang mode, this makes the Stinger Troopers immune to Flashbangs.

### Original

- Stinger Sites cannot be targeted by Flashbangs. However, Flashbangs force-fired on the ground next to the Stinger Site can damage Stinger Troopers.

### Patched

- Flashbang grenades from USA Rangers no longer damage Stinger Soldiers.


