### PR TITLE
Change: Disable Suicide Button on Demo GLA Combat Bike

### DIFF
--- a/Patch104pZH/Design/Changes/game_fixes.md
+++ b/Patch104pZH/Design/Changes/game_fixes.md
@@ -137,7 +137,8 @@
 |   |   | [#331](https://github.com/xezon/GeneralsGamePatch/pull/331) | Fixed issue where Stealth GLA could not build Hijacker with VGLA Barracks                                             |
 |   |   | [#331](https://github.com/xezon/GeneralsGamePatch/pull/331) | Fixed issue where Nuke China could not build Nuke Cannon in VChina and Infantry China Warfactories                    |
 |   |   | [#331](https://github.com/xezon/GeneralsGamePatch/pull/331) | Fixed issue where Airforce USA could not build Stealth Fighters in non-Airforce Airfields                             |
-| C |   | [#345](https://github.com/xezon/GeneralsGamePatch/pull/345) | Fixed non-functional suicide button on Demo GLA Demo Combat Cycle                                                     |
+|   |   | [#345](https://github.com/xezon/GeneralsGamePatch/pull/345) | Fixed wrong suicide button on Demo GLA Demo Combat Cycle                                                              |
+|   |   | [#680](https://github.com/xezon/GeneralsGamePatch/pull/680) | Disabled suicide button on Demo GLA Combat Cycle                                                                      |
 |   |   | [#351](https://github.com/xezon/GeneralsGamePatch/pull/351) | Fixed missing Radar icon on China Command Center                                                                      |
 |   |   | [#352](https://github.com/xezon/GeneralsGamePatch/pull/352) | Added Supply Lines Upgrade icon to USA Chinooks                                                                       |
 |   |   | [#352](https://github.com/xezon/GeneralsGamePatch/pull/352) | Removed Supply Lines Upgrade icon from USA Supply Center                                                              |

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2194,10 +2194,12 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @tweak xezon 10/07/2022 Disable suicide on Demo Bikes as per original game design.
+
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
   1  = Command_ScuttleCombatBike
   11 = Command_AttackMove
-  12 = Demo_Command_TertiarySuicide
+  ;12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2206,7 +2208,7 @@ CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
   1  = Command_ScuttleCombatBike
   2  = Command_GLAInfantryJarmenKellSnipeVehicleAttack
   11 = Command_AttackMove
-  12 = Demo_Command_TertiarySuicide
+  ;12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -2513,10 +2515,12 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   14 = Command_Stop
 End
 
+; Patch104p @tweak xezon 10/07/2022 Disable suicide on Demo Bikes as per original game design
+
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
   1  = Command_ScuttleCombatBike
   11 = Command_AttackMove
-  12 = Demo_Command_TertiarySuicide
+  ;12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
   14 = Command_Stop
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17707,35 +17707,36 @@ Object Demo_GLAVehicleCombatBike
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
 
   ; Patch104p @bugfix commy2 13/09/2021 Fix permanently disabled Suicide ability button.
+  ; Patch104p @tweak xezon 10/07/2022 Disable suicide on Demo Bikes as per original game design.
 
   WeaponSet
     Conditions = None
     Weapon = PRIMARY None
     Weapon = SECONDARY None
-    Weapon = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
+    ;Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    ;AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     Conditions = WEAPON_RIDER2
     Weapon = PRIMARY GLARebelBikerMachineGun
     Weapon = SECONDARY None
-    Weapon = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
+    ;Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    ;AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     Conditions = WEAPON_RIDER3
     Weapon = PRIMARY DEMO_TunnelDefenderBikerRocketWeapon
     Weapon = SECONDARY None
-    Weapon = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
+    ;Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    ;AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     Conditions = WEAPON_RIDER4
     Weapon = PRIMARY GLABikerKellSniperRifle
     Weapon = SECONDARY GLAJarmenKellVehiclePilotSniperRifle
-    Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    ;Weapon = TERTIARY TerroristSuicideNotARealWeapon
     AutoChooseSources = SECONDARY NONE
-    AutoChooseSources = TERTIARY NONE
+    ;AutoChooseSources = TERTIARY NONE
   End
   WeaponSet
     ;Kill himself so we can use FireWeaponWhenDead to fire the real weapon -- and use UNRESISTABLE
@@ -17743,8 +17744,8 @@ Object Demo_GLAVehicleCombatBike
     Conditions = WEAPON_RIDER5
     Weapon = PRIMARY TerroristSuicideWeapon
     Weapon = SECONDARY None
-    Weapon = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
+    ;Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    ;AutoChooseSources = TERTIARY NONE
   End
   ArmorSet
     Conditions      = None


### PR DESCRIPTION
  - fix: GLA Demo Combat Bike no longer shows the deactivated suicide button before acquiring the Demolition Upgrade.

1. **CommandSet.ini:**
    - For the `Demo_GLAVehicleCombatBikeDefaultCommandSet` and `Demo_GLAVehicleCombatBikeJarmenKellCommandSet`, the `Demo_Command_TertiarySuicide` command has been commented out.

2. **DemoGeneral.ini:**
    - For the `Demo_GLAVehicleCombatBike` object, several weapon sets have had their `TERTIARY` Suicide weapon commands commented out.
