### PR TITLE
Fix: Toxin terrorist suicide extra damage and glitches before Anthrax Gamma upgrade

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13031,6 +13031,8 @@ Object Chem_GLAInfantryTerrorist
     FlingPitchVariance  = 10
     OCL                 = INITIAL Chem_PoisonFieldGammaLarge
   End
+  
+  ; Patch104p @bugfix xezon 16/07/2022 Paste death types from other Terrorists to avoid Toxin Terrorists exploding by all kinds of deaths.
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
@@ -13052,12 +13054,14 @@ Object Chem_GLAInfantryTerrorist
     TriggeredBy   = Upgrade_GLAAnthraxBeta
     RequiresAllTriggers = Yes ;TriggeredBy is an AND, not an OR like it normally is
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_93
     DeathWeapon   = Chem_SuicideWeapon
     StartsActive  = Yes ; @bugfix commy2 22/09/2021 Fix Toxin Terrorist creates no poison cloud when used by other factions.
     ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
+    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
   End
 
 ; Units that can gain experience can't have GrantUpgradeCreate or they crash savegames.
@@ -16714,6 +16718,7 @@ Object Chem_GLAVehicleCombatBike
     TriggeredBy   = Upgrade_GLAAnthraxBeta
     RequiresAllTriggers = Yes ;TriggeredBy is an AND, not an OR like it normally is
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_93
@@ -16721,6 +16726,7 @@ Object Chem_GLAVehicleCombatBike
     DeathWeapon   = Chem_SuicideWeapon
     StartsActive  = Yes ; @bugfix commy2 22/09/2021 Fix Toxin Terrorist creates no poison cloud when used by other factions.
     ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
+    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
   End
 
 ; Units that can gain experience can't have GrantUpgradeCreate or they crash savegames.


### PR DESCRIPTION
Toxin Terrorists now no longer kill each other with odd chain reactions at "random" occurrences. They will also apply less damage than before, same damage as regular GLA Terrorists.

* Fixes #30

