### PR TITLE
Change: Separate crushable death from suicide death for all GLA Terrorists and apply a bit of damage when crushing them

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -22292,7 +22292,14 @@ Object Boss_VehicleCombatBikeTerrorist
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13037,7 +13037,13 @@ Object Chem_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag91
@@ -16699,7 +16705,14 @@ Object Chem_GLAVehicleCombatBike
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus  = STATUS_RIDER5
+    DeathWeapon   = CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag91

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13545,7 +13545,13 @@ Object Demo_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death08
     DeathWeapon   = Demo_SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = Demo_CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
   End
 
 
@@ -17996,8 +18002,17 @@ Object Demo_GLAVehicleCombatBike
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
     ConflictsWith = Demo_Upgrade_SuicideBomb
+  End
+
+  ;Terrorist without suicide bomb upgrade crushed
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    ConflictsWith  = Demo_Upgrade_SuicideBomb
   End
 
   ;Non-terrorist with suicide bomb upgrade (fire)
@@ -18006,9 +18021,9 @@ Object Demo_GLAVehicleCombatBike
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
-    RequiresAllTriggers = Yes;
-    DeathTypes = ALL -SUICIDED
-  End;
+    RequiresAllTriggers = Yes
+    DeathTypes = ALL -SUICIDED -CRUSHED -SPLATTED -LASERED
+  End
 
   ;Non-terrorist with suicide bomb upgrade (no fire)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -18016,9 +18031,19 @@ Object Demo_GLAVehicleCombatBike
     DeathWeapon   = Demo_SuicideDynamitePack
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
-    RequiresAllTriggers = Yes;
+    RequiresAllTriggers = Yes
     DeathTypes = NONE +SUICIDED
-  End;
+  End
+  
+  ;Non-terroris with suicide bomb upgrade crushed
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p_2
+    ExemptStatus        = STATUS_RIDER5
+    DeathWeapon         = CrushedDynamitePack_Patch104p
+    StartsActive        = No
+    TriggeredBy         = Demo_Upgrade_SuicideBomb
+    RequiresAllTriggers = Yes
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+  End
 
   ;Terrorist with suicide bomb upgrade (fire)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag997
@@ -18026,9 +18051,9 @@ Object Demo_GLAVehicleCombatBike
     DeathWeapon    = Demo_TerroristOnCombatBikeSuicideDynamitePackPlusFire
     StartsActive   = No
     TriggeredBy    = Demo_Upgrade_SuicideBomb
-    RequiresAllTriggers = Yes;
-    DeathTypes     = ALL -SUICIDED
-  End;
+    RequiresAllTriggers = Yes
+    DeathTypes     = ALL -SUICIDED -CRUSHED -SPLATTED -LASERED
+  End
 
   ;Terrorist with suicide bomb upgrade (no fire)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag996
@@ -18038,7 +18063,17 @@ Object Demo_GLAVehicleCombatBike
     TriggeredBy    = Demo_Upgrade_SuicideBomb
     RequiresAllTriggers = Yes;
     DeathTypes     = NONE +SUICIDED
-  End;
+  End
+
+  ;Terroris with suicide bomb upgrade crushed
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p_3
+    RequiredStatus      = STATUS_RIDER5
+    DeathWeapon         = CrushedBikeBomb_Patch104p
+    StartsActive        = No
+    TriggeredBy         = Demo_Upgrade_SuicideBomb
+    RequiresAllTriggers = Yes
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+  End
 
   Geometry = BOX
   GeometryMajorRadius = 11.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -3890,14 +3890,29 @@ Object GC_Chem_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = GC_Chem_SuicideDynamitePackBeta
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
   End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+  End
+  
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death05
     DeathWeapon   = GC_Chem_SuicideDynamitePackGamma
     StartsActive  = No                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
-    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p_2
+    DeathWeapon   = CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
 
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2269,11 +2269,19 @@ Object GC_Slth_GLAInfantryTerrorist
     FlingPitch          = 60
     FlingPitchVariance  = 10
   End
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
   End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+  End
+
 ; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_14
@@ -5099,7 +5107,14 @@ Object GC_Slth_GLAVehicleCombatBike
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19
@@ -6016,7 +6031,14 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19
@@ -6933,7 +6955,14 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -1511,7 +1511,14 @@ Object CINE_GLAVehicleCombatBike
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes                      ; turned on by upgrade
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = SuicideBikeBomb ; Retain 1.04 damage for Cinematics
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19
@@ -5676,11 +5683,19 @@ Object CINE_GLAInfantryTerrorist
     FlingPitch          = 60
     FlingPitchVariance  = 10
   End
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
   End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = SuicideBikeBomb ; Retain 1.04 damage for Cinematics
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+  End
+
 ; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_14
@@ -7572,7 +7587,13 @@ Object CINE_CheeringTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = SuicideBikeBomb ; Retain 1.04 damage for Cinematics
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
   End
 ; --- end Death modules ---
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1447,11 +1447,19 @@ Object GLAInfantryTerrorist
     FlingPitch          = 60
     FlingPitchVariance  = 10
   End
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
   End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+  End
+  
 ; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -1384,7 +1384,14 @@ Object GLAVehicleCombatBike
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19
@@ -2312,7 +2319,14 @@ Object GLAVehicleCombatBikeRocket
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19
@@ -3228,7 +3242,14 @@ Object GLAVehicleCombatBikeTerrorist
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14018,10 +14018,17 @@ Object Slth_GLAInfantryTerrorist
     FlingPitch          = 60
     FlingPitchVariance  = 10
   End
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
-    DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    DeathWeapon   = CrushedDynamitePack_Patch104p
+    StartsActive  = Yes
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
   End
 ; --- end Death modules ---
 
@@ -18161,7 +18168,14 @@ Object Slth_GLAVehicleCombatBike
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon     = SuicideBikeBomb
     StartsActive    = Yes
-    DeathTypes      = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
+  End
+  
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
+    RequiredStatus = STATUS_RIDER5
+    DeathWeapon    = CrushedBikeBomb_Patch104p
+    StartsActive   = Yes
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
   End
 
   Behavior = StealthUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2303,10 +2303,52 @@ Weapon SuicideDynamitePack
 End
 
 ;------------------------------------------------------------------------------
+Weapon CrushedDynamitePack_Patch104p
+  PrimaryDamage = 100.0
+  PrimaryDamageRadius = 18.0
+  SecondaryDamage = 40.0
+  SecondaryDamageRadius = 50.0
+  AttackRange = 5.0       ; must be very close to use this weapon!
+  DamageType = EXPLOSION
+  DeathType = SUICIDED
+  WeaponSpeed = 99999.0
+  ProjectileObject = NONE
+  DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?
+  RadiusDamageAffects = SELF SUICIDE ALLIES ENEMIES NEUTRALS NOT_SIMILAR
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+  AutoReloadsClip = No
+  FireFX = WeaponFX_SuicideDynamitePackDetonation
+  FireSound = CarBomberDie
+End
+
+;------------------------------------------------------------------------------
 Weapon SuicideBikeBomb
   PrimaryDamage = 700.0
   PrimaryDamageRadius = 20.0
   SecondaryDamage = 100.0
+  SecondaryDamageRadius = 50.0
+  AttackRange = 5.0       ; must be very close to use this weapon!
+  DamageType = EXPLOSION
+  DeathType = SUICIDED
+  WeaponSpeed = 99999.0
+  ProjectileObject = NONE
+  DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?
+  RadiusDamageAffects = SELF SUICIDE ALLIES ENEMIES NEUTRALS NOT_SIMILAR
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+  AutoReloadsClip = No
+  FireFX = WeaponFX_SuicideDynamitePackDetonation
+  FireSound = CarBomberDie
+End
+
+;------------------------------------------------------------------------------
+Weapon CrushedBikeBomb_Patch104p
+  PrimaryDamage = 280.0
+  PrimaryDamageRadius = 20.0
+  SecondaryDamage = 80.0
   SecondaryDamageRadius = 50.0
   AttackRange = 5.0       ; must be very close to use this weapon!
   DamageType = EXPLOSION
@@ -6768,6 +6810,26 @@ Weapon Demo_SuicideDynamitePack
   FireSound = CarBomberDie
 End
 
+;------------------------------------------------------------------------------
+Weapon Demo_CrushedDynamitePack_Patch104p
+  PrimaryDamage = 140.0
+  PrimaryDamageRadius = 18.0
+  SecondaryDamage = 56.0
+  SecondaryDamageRadius = 50.0
+  AttackRange = 5.0       ; must be very close to use this weapon!
+  DamageType = EXPLOSION
+  DeathType = SUICIDED
+  WeaponSpeed = 99999.0
+  ProjectileObject = NONE
+  DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?
+  RadiusDamageAffects = SELF SUICIDE ENEMIES NEUTRALS NOT_SIMILAR ;ALLIES
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+  AutoReloadsClip = No
+  FireFX = WeaponFX_DemoSuicideDynamitePackDetonation
+  FireSound = CarBomberDie
+End
 
 ;------------------------------------------------------------------------------
 Weapon Demo_SuicideDynamitePackPlusFire
@@ -7970,6 +8032,7 @@ Weapon Chem_ScudStormWeapon
   ProjectileCollidesWith = STRUCTURES
 End
 
+; Patch104p @bugfix 16/07/2022 Set all PrimaryDamage values from 200 to 0 in poison puddle weapons.
 
 ;------------------------------------------------------------------------------
 Weapon Chem_SuicideWeaponGamma ; No extra damage, just lays down a damage field

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2304,11 +2304,11 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon CrushedDynamitePack_Patch104p
-  PrimaryDamage = 100.0
+  PrimaryDamage = 110.0             ; Damage of 108 is just enough to kill a Vet 1 Technical on crushing 2 Terrorists.
   PrimaryDamageRadius = 18.0
-  SecondaryDamage = 40.0
+  SecondaryDamage = 66.0            ; 0.6 times as much as PrimaryDamage
   SecondaryDamageRadius = 50.0
-  AttackRange = 5.0       ; must be very close to use this weapon!
+  AttackRange = 5.0                 ; must be very close to use this weapon!
   DamageType = EXPLOSION
   DeathType = SUICIDED
   WeaponSpeed = 99999.0
@@ -2346,11 +2346,11 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon CrushedBikeBomb_Patch104p
-  PrimaryDamage = 280.0
+  PrimaryDamage = 308.0             ; 2 times as much as Demo_CrushedDynamitePack_Patch104p
   PrimaryDamageRadius = 20.0
-  SecondaryDamage = 80.0
+  SecondaryDamage = 185.0           ; 0.6 times as much as PrimaryDamage
   SecondaryDamageRadius = 50.0
-  AttackRange = 5.0       ; must be very close to use this weapon!
+  AttackRange = 5.0                 ; must be very close to use this weapon!
   DamageType = EXPLOSION
   DeathType = SUICIDED
   WeaponSpeed = 99999.0
@@ -6812,11 +6812,11 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Demo_CrushedDynamitePack_Patch104p
-  PrimaryDamage = 140.0
+  PrimaryDamage = 154.0             ; 1.4 times as much as CrushedDynamitePack_Patch104p
   PrimaryDamageRadius = 18.0
-  SecondaryDamage = 56.0
+  SecondaryDamage = 92.0            ; 0.6 times as much as PrimaryDamage
   SecondaryDamageRadius = 50.0
-  AttackRange = 5.0       ; must be very close to use this weapon!
+  AttackRange = 5.0                 ; must be very close to use this weapon!
   DamageType = EXPLOSION
   DeathType = SUICIDED
   WeaponSpeed = 99999.0


### PR DESCRIPTION
Fixes #503

All GLA Terrorists can now be crushed. Before only Demo Terrorists could be crushed, without receiving any damage. All other Terrorist variants applied full damage on crush. Now all Terrorists from all factions will apply a bit of damage to their surroundings when crushed. This weak damage is also applied when lasered by small lasers, such as USA Paladin and USA Laser Crusader (#2081).

Some practical scenarios - assuming full health on Victim unit:

| Pristine victim unit | dies on                     |
|----------------------|-----------------------------|
| China Overlord       | 4 crushed Demo Terror Bikes |
| China Truck          | 2 crushed Normal Terrorists |
| China Dozer          | 3 crushed Normal Terrorists |
| GLA Vet 1 Technical  | 2 crushed Normal Terrorists |
| GLA Vet 2 Technical  | 3 crushed Normal Terrorists |
| USA Vet 2 Humvee     | 3 crushed Normal Terrorists |
| USA Vet 3 Humvee     | 4 crushed Normal Terrorists |
| China Vet 1 Gattling | 3 crushed Normal Terrorists |
| China Vet 2 Gattling | 4 crushed Normal Terrorists |
| GLA Quad Cannon      | 3 crushed Normal Terrorists |
| GLA Rocket Buggy     | 2 crushed Normal Terrorists |
| USA Tomahawk         | 2 crushed Normal Terrorists |
| China Dragon Tank    | 3 crushed Normal Terrorists |
| GLA Scorpion Tank    | 4 crushed Normal Terrorists |

The Demo Terrorist deals 1.4 times more damage on crush than other Terrorists. It kills a Buggy on 1 crush, but a Technical barely survives 1 crush.

1 Technical crushing 2 Terrorists should be enough to save big buildings from dying.

5 Normal Terrorists would deal just 1720 DMG instead of 2500 DMG when crushed with 1 Technical.

5 Demo Terrorists would deal just 2408 DMG instead of 3500 DMG when crushed with 1 Technical.

# Rationale

Crushing Terrorists to stop them from killing important infrastructure is a rare skill and makes for epic moments when it happens. Originally it was possible to crush Demo Terrorists only because it was a glitch and not intentional.

The crush is now an explicit feature and combines the designs of the former Demo Terrorist and Regular Terrorist, where crushing micro is awarded with the chance to save a base from bigger destruction.

In turn, the game offers more control to affect the outcome of an event. And all Terrorist behave consistently, making it easier to understand and learn.