### PR TITLE
Fix: Remove 200 extra damage prior Gamma Upgrade from Toxin Terrorists

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7993,7 +7993,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_SuicideWeapon ; No extra damage, just lays down a damage field
-  PrimaryDamage = 200.0
+  PrimaryDamage = 0.0
   PrimaryDamageRadius = 10.0
   AttackRange = 100.0
   DamageType = EXPLOSION
@@ -8013,7 +8013,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_SuicideWeaponBeta ; No extra damage, just lays down a damage field
-  PrimaryDamage = 200.0
+  PrimaryDamage = 0.0
   PrimaryDamageRadius = 10.0
   AttackRange = 100.0
   DamageType = EXPLOSION


### PR DESCRIPTION
This change removes the 200 extra damage from the Toxin Terrorists before Gamma Upgrade.

* Fixes #31

| Object | Damage before Anthrax Gamma | Damage after Anthrax Gamma |
|--|--|--|
| Original regular Terrorist         | 500 | -   |
| Original Demo Terrorist            | 700 | -   |
| Original Toxin Terrorist           | 700 | 500 |
| **Patched Toxin Terrorist (this)** | 500 | 500 |