### PR TITLE
Change: USA Drop Zone Cargo Planes are no longer shot at automatically

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -14673,7 +14673,7 @@ Object AirF_AmericaSupplyDropZone
   ; Patch104p @performance hanfield xezon 19/07/2022
   ; Grant upgrade for the cargo planes to keep them safe from AI attacks
   Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
-    UpgradeToGrant = Upgrade_CostReduction
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -14669,6 +14669,12 @@ Object AirF_AmericaSupplyDropZone
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
     TriggeredBy = Upgrade_DummyUpgrade
   End
+  
+  ; Patch104p @performance hanfield xezon 19/07/2022
+  ; Grant upgrade for the cargo planes to keep them safe from AI attacks
+  Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
+    UpgradeToGrant = Upgrade_CostReduction
+  End
 
   Geometry            = BOX
   GeometryMajorRadius = 27.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -2574,3 +2574,241 @@ Object AmericaJetCargoPlane
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 End
+
+
+
+;------------------------------------------------------------------------------
+Object AmericaJetDropZoneCargoPlane_Patch104p
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model           = AVCargoPln
+      Animation       = AVCargoPln.AVCargoPln
+      AnimationMode   = LOOP
+      ParticleSysBone = Propeller01 JetBlackTrailThin
+      ParticleSysBone = Propeller02 JetBlackTrailThin
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = WingTip01 JetContrailThin
+      ParticleSysBone = WingTip02 JetContrailThin
+    End
+
+    ConditionState = DAMAGED
+      Model           = AVCargoPln_D
+      Animation       = AVCargoPln_D.AVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke02 JetFireLarge
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke02 JetSmokeLarge
+    End
+
+    ConditionState = REALLYDAMAGED
+      Model           = AVCargoPln_D
+      Animation       = AVCargoPln_D.AVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke02 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Smoke05 JetFireLarge
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke02 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = Smoke05 JetSmokeLarge
+    End
+
+    ConditionState = RUBBLE
+      Model           = AVCargoPln_D1
+      Animation       = AVCargoPln_D.AVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke06 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Smoke05 JetFireLarge
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke06 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = Smoke05 JetSmokeLarge
+    End
+
+    OkToChangeModelColor = Yes
+    ParticlesAttachedToAnimatedBones = Yes
+
+  End
+
+  Draw = W3DModelDraw ModuleTag_02
+    DefaultConditionState
+      Model           = AVCargoPln_A2
+      Animation       = AVCargoPln_A2.AVCargoPln_A2
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_OPENING
+      Model           = AVCargoPln_A2
+      Animation       = AVCargoPln_A2.AVCargoPln_A2
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_CLOSING
+      Model           = AVCargoPln_A2
+      Animation       = AVCargoPln_A2.AVCargoPln_A2
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName         = OBJECT:CargoPlane
+  EditorSorting       = VEHICLE
+  Side                = America
+  TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)
+  VisionRange         = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = AirplaneArmor
+    DamageFX        = TankDamageFX
+  End
+  ArmorSet
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
+  End
+  CommandSet        = Command_ScriptedTransportDrops
+
+  ; *** AUDIO Parameters ***
+  SoundAmbient = C130AmbientLoop
+  SoundAmbientRubble    = NoSound
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = LOCAL_UNIT_ONLY
+  KindOf = PRELOAD CAN_ATTACK CAN_CAST_REFLECTIONS VEHICLE TRANSPORT AIRCRAFT FORCEATTACKABLE IGNORED_IN_GUI EMP_HARDENED
+  Body = ActiveBody ModuleTag_03
+    MaxHealth       = 1000.0
+    InitialHealth   = 1000.0
+  End
+
+  ExperienceValue     = 40 40 40 40  ; Experience point value at each level
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 500.0
+  End
+
+  Behavior = StatusBitsUpgrade ModuleTag_IgnoreMe01
+    TriggeredBy   = Upgrade_CostReduction
+    StatusToSet   = NO_ATTACK_FROM_AI
+  End
+
+  ;SCRIPTED SUPPORT: These special powers are triggered directly
+  ;from the transport without creating a transport. This is done
+  ;via new code support and CreateLocation USE_OWNER_OBJECT --
+  ;which also prevents creating the payload transport.
+  Behavior    = OCLSpecialPower ModuleTag_05
+    SpecialPowerTemplate = SuperweaponDaisyCutter
+    OCL                  = SUPERWEAPON_DaisyCutter
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_06
+    SpecialPowerTemplate = SuperweaponParadropAmerica
+    UpgradeOCL           = SCIENCE_Paradrop3 SUPERWEAPON_Paradrop3
+    UpgradeOCL           = SCIENCE_Paradrop2 SUPERWEAPON_Paradrop2
+    OCL                  = SUPERWEAPON_Paradrop1
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_07
+    SpecialPowerTemplate = SuperweaponCarpetBomb
+    OCL                  = SUPERWEAPON_CarpetBomb
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_08
+    SpecialPowerTemplate = SuperweaponCrateDrop
+    OCL                  = SUPERWEAPON_CrateDrop
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+
+  Behavior = DeliverPayloadAIUpdate ModuleTag_09
+    DoorDelay         = 500
+    MaxAttempts       = 4
+    DropOffset        = X:0 Y:0 Z:-10
+    DropDelay         = 1000 ; time in between each item dropped (if more than one)
+    PutInContainer    = AmericaParachute
+    DeliveryDistance  = 150
+  End
+  Locomotor = SET_NORMAL B52Locomotor
+
+  Behavior = TransportContain ModuleTag_10
+    Slots = 100                     ; hey, it's a BIG transport
+    ScatterNearbyOnExit = No
+    OrientLikeContainerOnExit = Yes
+    KeepContainerVelocityOnExit = Yes
+    ExitPitchRate = 30
+    ExitBone = WeaponA01
+    AllowInsideKindOf  = INFANTRY VEHICLE PROJECTILE DOZER PARACHUTABLE
+    ;gs I added parachutable as a catch all to prevent making new kindofs (like CRATE)
+    DoorOpenTime = 0                ; this prevents the Contain module from messing with the doors, since we want DeliverPayload to handle 'em
+    NumberOfExitPaths = 0
+    DestroyRidersWhoAreNotFreeToExit = Yes  ; 'destroy' as opposed to 'kill'
+  End
+
+  Behavior                          = JetSlowDeathBehavior ModuleTag_11
+    DestructionDelay                = 2000
+    RollRate                        = 0.0
+    RollRateDelta                   = 100%      ;each frame, rollrate = rollrate * rollrateDelta
+    PitchRate                       = 0
+    FallHowFast                     = 25.0%    ;Bigger is faster (can be over 100%,it's a fraction of gravity)
+    FXInitialDeath                  = FX_JetBigDeathInitial
+    OCLInitialDeath                 = OCL_AmericaJetCargoDeathStart
+    DelaySecondaryFromInitialDeath  = 2000       ; in milliseconds     This guy won't hit the ground, so this time equals the above time
+    OCLSecondary                    = OCL_AmericaJetCargoHulkDeath
+    FXSecondary                     = FX_BigPlaneDeath
+;   FXFinalBlowUp                   = FX_JetDeathFinalBlowUp
+;   OCLFinalBlowUp                  = OCL_AuroraDeathFinalBlowUp
+;   DeathLoopSound                  = MICAL NEEDS TO MAKE ME
+  End
+
+;;;;;;;;  ClientUpdate         = AnimatedParticleSysBoneClientUpdate ModuleTag_12
+;;;;;;;;  End
+
+  Behavior                = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy           = Upgrade_AmericaCountermeasures
+  End
+
+  Behavior                = CountermeasuresBehavior ModuleTag_13
+    TriggeredBy           = Upgrade_AmericaCountermeasures
+    FlareTemplateName     = CountermeasureFlare
+    FlareBoneBaseName     = Flare ; Name of the base flare bone (Flare01, Flare02, Flare03)
+    VolleySize            = 4     ; Number of flares launched per volley (requires bones)
+    VolleyArcAngle        = 90.0  ; Max angle of flare relative to forward direction (with VolleySize of 1, flare will always goes straight back).
+    VolleyVelocityFactor  = 2.0   ; Shoots out flares at a stronger velocity with a higher value.
+    DelayBetweenVolleys   = 1000  ; Time between flare volleys
+    NumberOfVolleys       = 5     ; Number of times the volleys will fire before reloading
+    ReloadTime            = 0     ; After all volleys launched, then reloading must occur. If 0, then reloading occurs at airstrip only.
+    EvasionRate           = 30%   ; With active flares, the specified percentage will be diverted.
+    ReactionLaunchLatency = 0     ; Reaction between getting shot at and the firing of the first volley of countermeasures.
+    MissileDecoyDelay     = 200   ; A reported missile that has been determined to hit a decoy will wait this long before acquiring countermeasures.
+  End
+
+  Behavior = TransitionDamageFX ModuleTag_17
+    DamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+  End
+
+  Geometry = Box
+  GeometryIsSmall = No
+  GeometryMajorRadius = 40.0
+  GeometryMinorRadius = 10.0
+  GeometryHeight = 10.0
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -2702,7 +2702,7 @@ Object AmericaJetDropZoneCargoPlane_Patch104p
   End
 
   Behavior = StatusBitsUpgrade ModuleTag_IgnoreMe01
-    TriggeredBy   = Upgrade_CostReduction
+    TriggeredBy   = Upgrade_GlobalDummy
     StatusToSet   = NO_ATTACK_FROM_AI
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
@@ -25408,10 +25408,10 @@ Object TechOilRefinery
   End
 
   Behavior         = GrantUpgradeCreate ModuleTag_04
-    UpgradeToGrant = Upgrade_CostReduction
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
   Behavior       = CostModifierUpgrade ModuleTag_05
-    TriggeredBy  = Upgrade_CostReduction
+    TriggeredBy  = Upgrade_GlobalDummy
     EffectKindOf = VEHICLE
     Percentage   = -10%
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -20422,6 +20422,12 @@ Object AmericaSupplyDropZone
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
     TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
   End
+  
+  ; Patch104p @performance hanfield xezon 19/07/2022
+  ; Grant upgrade for the cargo planes to keep them safe from AI attacks
+  Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
+    UpgradeToGrant = Upgrade_CostReduction
+  End
 
   Geometry            = BOX
   GeometryMajorRadius = 27.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -20426,7 +20426,7 @@ Object AmericaSupplyDropZone
   ; Patch104p @performance hanfield xezon 19/07/2022
   ; Grant upgrade for the cargo planes to keep them safe from AI attacks
   Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
-    UpgradeToGrant = Upgrade_CostReduction
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14354,6 +14354,12 @@ Object Lazr_AmericaSupplyDropZone
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
     TriggeredBy = Upgrade_DummyUpgrade
   End
+  
+  ; Patch104p @performance hanfield xezon 19/07/2022
+  ; Grant upgrade for the cargo planes to keep them safe from AI attacks
+  Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
+    UpgradeToGrant = Upgrade_CostReduction
+  End
 
   Geometry            = BOX
   GeometryMajorRadius = 27.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14358,7 +14358,7 @@ Object Lazr_AmericaSupplyDropZone
   ; Patch104p @performance hanfield xezon 19/07/2022
   ; Grant upgrade for the cargo planes to keep them safe from AI attacks
   Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
-    UpgradeToGrant = Upgrade_CostReduction
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13783,6 +13783,12 @@ Object SupW_AmericaSupplyDropZone
     TriggeredBy = Upgrade_DummyUpgrade
   End
 
+  ; Patch104p @performance hanfield xezon 19/07/2022
+  ; Grant upgrade for the cargo planes to keep them safe from AI attacks
+  Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
+    UpgradeToGrant = Upgrade_CostReduction
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 27.0
   GeometryMinorRadius = 27.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13786,7 +13786,7 @@ Object SupW_AmericaSupplyDropZone
   ; Patch104p @performance hanfield xezon 19/07/2022
   ; Grant upgrade for the cargo planes to keep them safe from AI attacks
   Behavior         = GrantUpgradeCreate ModuleTag_For_AmericaJetDropZoneCargoPlane_Patch104p
-    UpgradeToGrant = Upgrade_CostReduction
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3014,6 +3014,10 @@ Object AmericaStartingThings
     MaxDelay = 50
     OCL      = OCL_AmericaVehicleDozer
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3035,6 +3039,10 @@ Object SupW_AmericaStartingThings
     MinDelay = 50
     MaxDelay = 50
     OCL      = OCL_SupW_AmericaVehicleDozer
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 End
 
@@ -3058,6 +3066,10 @@ Object Lazr_AmericaStartingThings
     MaxDelay = 50
     OCL      = OCL_Lazr_AmericaVehicleDozer
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3079,6 +3091,10 @@ Object AirF_AmericaStartingThings
     MinDelay = 50
     MaxDelay = 50
     OCL      = OCL_AirF_AmericaVehicleDozer
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 End
 
@@ -3102,6 +3118,10 @@ Object ChinaStartingThings
     MaxDelay = 50
     OCL      = OCL_ChinaVehicleDozer
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3123,6 +3143,10 @@ Object Tank_ChinaStartingThings
     MinDelay = 50
     MaxDelay = 50
     OCL      = OCL_Tank_ChinaVehicleDozer
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 End
 
@@ -3151,6 +3175,10 @@ Object Infa_ChinaStartingThings
     UpgradeToGrant           = Upgrade_Nationalism
     ExemptStatus      = UNDER_CONSTRUCTION
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3173,6 +3201,10 @@ Object Nuke_ChinaStartingThings
     MaxDelay = 50
     OCL      = OCL_Nuke_ChinaVehicleDozer
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3194,6 +3226,10 @@ Object GLAStartingThings
     MinDelay = 50
     MaxDelay = 50
     OCL      = OCL_GLAInfantryWorker
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 End
 
@@ -3226,6 +3262,10 @@ Object Chem_GLAStartingThings
   Behavior = GrantUpgradeCreate ModuleTag_24
     UpgradeToGrant = Upgrade_GLAAnthraxBeta
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3254,6 +3294,10 @@ Object Demo_GLAStartingThings
     UpgradeToGrant           = Upgrade_GLAInfantryRebelBoobyTrapAttack
     ExemptStatus      = UNDER_CONSTRUCTION
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3280,6 +3324,10 @@ Object Slth_GLAStartingThings
   Behavior = GrantUpgradeCreate ModuleTag_10
     UpgradeToGrant = Upgrade_GLACamouflage
   End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
+  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3301,5 +3349,9 @@ Object Boss_StartingThings
     MinDelay = 50
     MaxDelay = 50
     OCL      = OCL_Boss_VehicleDozer
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_GlobalDummy
+    UpgradeToGrant = Upgrade_GlobalDummy
   End
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5956,9 +5956,12 @@ End
 
 ; -----------------------------------------------------------------------------
 ; -----------------------------------------------------------------------------
+
+; Patch104p @performance xezon 19/07/2022 Use a friendly plane that is not auto attacked for drop zone money supplies.
+
 ObjectCreationList OCL_AmericaSupplyDropZoneCrateDrop
   DeliverPayload
-    Transport = AmericaJetCargoPlane
+    Transport = AmericaJetDropZoneCargoPlane_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -639,11 +639,14 @@ Upgrade Upgrade_ChinaOverlordBattleBunker
 End
 
 ;Even tho there is no radar upgrade, this is necessary to give the player free radar, or so I have gathered.  - CLH
-Upgrade Upgrade_CostReduction
-  DisplayName        = UPGRADE:CostReduction
-  ;Type               = OBJECT ; Patch104p Upgrade is repurposed as global upgrade for other unrelated functionalities
-  BuildTime          = 10.0
-  BuildCost          = 500
+; Patch104p @tweak former Upgrade_CostReduction is repurposed as global upgrade for more functionalities
+Upgrade Upgrade_GlobalDummy
+  ;DisplayName        = UPGRADE:CostReduction
+  ;Type               = OBJECT 
+  ;BuildTime          = 10.0
+  ;BuildCost          = 500
+  BuildTime          = 0.0
+  BuildCost          = 0
 End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -641,7 +641,7 @@ End
 ;Even tho there is no radar upgrade, this is necessary to give the player free radar, or so I have gathered.  - CLH
 Upgrade Upgrade_CostReduction
   DisplayName        = UPGRADE:CostReduction
-  Type               = OBJECT
+  ;Type               = OBJECT ; Patch104p Upgrade is repurposed as global upgrade for other unrelated functionalities
   BuildTime          = 10.0
   BuildCost          = 500
 End


### PR DESCRIPTION
A solution for
* #79

Cargo Planes from Drop Zones are no longer auto attacked. Player must Force Fire on the plane to attack it. Consequences:

* Gets rid of attack notification spams on Radar and Voice
* Improves performance in spam/AOD games where many planes no longer draw fire
* Mig, Raptor, etc will no longer auto attack Cargo Planes on Guard Mode
* Cargo Planes will fly the same route, so enemy player knows USA has a Drop Zone where it comes from
* Cargo Planes can be attacked manually to prevent the money drop
* USA Faction loses its free cannon fodder unit