### PR TITLE
Remove SCORE KindOf and UNIT RadarPriority from harmless Cargo Planes

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -2574,3 +2574,241 @@ Object AmericaJetCargoPlane
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 End
+
+
+
+; Patch104p: Adds plane same as AmericaJetCargoPlane, but intended for reoccuring harmless events, such as Drop Zone and Vehicle Reinforcement supplies, not Generals Powers.
+; xezon 20/07/2022 Remove SCORE KindOf to exclude this plane from score numbers (Score Screen, Replay)
+; xezon 20/07/2022 Change RadarPriority from UNIT to LOCAL_UNIT_ONLY to not show plane to enemies on Radar.
+
+;------------------------------------------------------------------------------
+Object AmericaJetCargoPlane_Harmless_Patch104p
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model            = AVCargoPln
+      Animation       = AVCargoPln.AVCargoPln
+      AnimationMode   = LOOP
+      ParticleSysBone = Propeller01 JetBlackTrailThin
+      ParticleSysBone = Propeller02 JetBlackTrailThin
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = WingTip01 JetContrailThin
+      ParticleSysBone = WingTip02 JetContrailThin
+    End
+
+    ConditionState = DAMAGED
+      Model           = AVCargoPln_D
+      Animation       = AVCargoPln_D.AVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke02 JetFireLarge
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke02 JetSmokeLarge
+    End
+
+    ConditionState = REALLYDAMAGED
+      Model           = AVCargoPln_D
+      Animation       = AVCargoPln_D.AVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke02 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Smoke05 JetFireLarge
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke02 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = Smoke05 JetSmokeLarge
+    End
+
+    ConditionState = RUBBLE
+      Model           = AVCargoPln_D1
+      Animation       = AVCargoPln_D.AVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke06 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Smoke05 JetFireLarge
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke06 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = Smoke05 JetSmokeLarge
+    End
+
+    OkToChangeModelColor = Yes
+  ParticlesAttachedToAnimatedBones = Yes
+
+  End
+
+  Draw = W3DModelDraw ModuleTag_02
+    DefaultConditionState
+      Model           = AVCargoPln_A2
+      Animation       = AVCargoPln_A2.AVCargoPln_A2
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_OPENING
+      Model           = AVCargoPln_A2
+      Animation       = AVCargoPln_A2.AVCargoPln_A2
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_CLOSING
+      Model           = AVCargoPln_A2
+      Animation       = AVCargoPln_A2.AVCargoPln_A2
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName         = OBJECT:CargoPlane
+  EditorSorting       = VEHICLE
+  Side                = America
+  TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)
+  VisionRange         = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = AirplaneArmor
+    DamageFX        = TankDamageFX
+  End
+  ArmorSet
+    Conditions      = PLAYER_UPGRADE
+    Armor           = CountermeasuresAirplaneArmor
+    DamageFX        = TankDamageFX  ; Patch104p @bugfix commy2 12/09/2021 Fix hit effect disappearing after Countermeasures upgrade.
+  End
+  CommandSet        = Command_ScriptedTransportDrops
+
+  ; *** AUDIO Parameters ***
+  SoundAmbient = C130AmbientLoop
+  SoundAmbientRubble    = NoSound
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = LOCAL_UNIT_ONLY
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS CAN_ATTACK VEHICLE TRANSPORT AIRCRAFT FORCEATTACKABLE IGNORED_IN_GUI EMP_HARDENED
+  Body = ActiveBody ModuleTag_03
+    MaxHealth       = 1000.0
+    InitialHealth   = 1000.0
+  End
+
+  ExperienceValue     = 40 40 40 40  ; Experience point value at each level
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 500.0
+  End
+
+  ;SCRIPTED SUPPORT: These special powers are triggered directly
+  ;from the transport without creating a transport. This is done
+  ;via new code support and CreateLocation USE_OWNER_OBJECT --
+  ;which also prevents creating the payload transport.
+  Behavior    = OCLSpecialPower ModuleTag_05
+    SpecialPowerTemplate = SuperweaponDaisyCutter ;@@KRIS@@
+    OCL                  = SUPERWEAPON_DaisyCutter
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_06
+    SpecialPowerTemplate = SuperweaponParadropAmerica
+    UpgradeOCL           = SCIENCE_Paradrop3 SUPERWEAPON_Paradrop3
+    UpgradeOCL           = SCIENCE_Paradrop2 SUPERWEAPON_Paradrop2
+    OCL                  = SUPERWEAPON_Paradrop1
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_07
+    SpecialPowerTemplate = SuperweaponCarpetBomb
+    OCL                  = SUPERWEAPON_CarpetBomb
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_08
+    SpecialPowerTemplate = SuperweaponCrateDrop
+    OCL                  = SUPERWEAPON_CrateDrop
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+
+  Behavior = DeliverPayloadAIUpdate ModuleTag_09
+    DoorDelay         = 500
+    MaxAttempts       = 4
+    DropOffset        = X:0 Y:0 Z:-10
+    DropDelay         = 1000 ; time in between each item dropped (if more than one)
+    PutInContainer    = AmericaParachute
+    DeliveryDistance  = 150
+  End
+  Locomotor = SET_NORMAL B52Locomotor
+
+  Behavior = TransportContain ModuleTag_10
+    Slots = 100                     ; hey, it's a BIG transport
+    ScatterNearbyOnExit = No
+    OrientLikeContainerOnExit = Yes
+    KeepContainerVelocityOnExit = Yes
+    ExitPitchRate = 30
+    ExitBone = WeaponA01
+    AllowInsideKindOf  = INFANTRY VEHICLE PROJECTILE DOZER PARACHUTABLE
+    ;gs I added parachutable as a catch all to prevent making new kindofs (like CRATE)
+    DoorOpenTime = 0                ; this prevents the Contain module from messing with the doors, since we want DeliverPayload to handle 'em
+    NumberOfExitPaths = 0
+    DestroyRidersWhoAreNotFreeToExit = Yes  ; 'destroy' as opposed to 'kill'
+  End
+
+  Behavior                          = JetSlowDeathBehavior ModuleTag_11
+    DestructionDelay                = 2000
+    RollRate                        = 0.0
+    RollRateDelta                   = 100%      ;each frame, rollrate = rollrate * rollrateDelta
+    PitchRate                       = 0
+    FallHowFast                     = 25.0%    ;Bigger is faster (can be over 100%,it's a fraction of gravity)
+    FXInitialDeath                  = FX_JetBigDeathInitial
+    OCLInitialDeath                 = OCL_AmericaJetCargoDeathStart
+    DelaySecondaryFromInitialDeath  = 2000       ; in milliseconds     This guy won't hit the ground, so this time equals the above time
+    OCLSecondary                    = OCL_AmericaJetCargoHulkDeath
+    FXSecondary                     = FX_BigPlaneDeath
+;   FXFinalBlowUp                   = FX_JetDeathFinalBlowUp
+;   OCLFinalBlowUp                  = OCL_AuroraDeathFinalBlowUp
+;   DeathLoopSound                  = MICAL NEEDS TO MAKE ME
+  End
+
+;;;;;;;;  ClientUpdate         = AnimatedParticleSysBoneClientUpdate ModuleTag_12
+;;;;;;;;  End
+
+  Behavior                = ArmorUpgrade ModuleTag_Armor01
+    TriggeredBy           = Upgrade_AmericaCountermeasures
+  End
+
+  Behavior                = CountermeasuresBehavior ModuleTag_13
+    TriggeredBy           = Upgrade_AmericaCountermeasures
+    FlareTemplateName     = CountermeasureFlare
+    FlareBoneBaseName     = Flare ; Name of the base flare bone (Flare01, Flare02, Flare03)
+    VolleySize            = 4     ; Number of flares launched per volley (requires bones)
+    VolleyArcAngle        = 90.0  ; Max angle of flare relative to forward direction (with VolleySize of 1, flare will always goes straight back).
+    VolleyVelocityFactor  = 2.0   ; Shoots out flares at a stronger velocity with a higher value.
+    DelayBetweenVolleys   = 1000  ; Time between flare volleys
+    NumberOfVolleys       = 5     ; Number of times the volleys will fire before reloading
+    ReloadTime            = 0     ; After all volleys launched, then reloading must occur. If 0, then reloading occurs at airstrip only.
+    EvasionRate           = 30%   ; With active flares, the specified percentage will be diverted.
+    ReactionLaunchLatency = 0     ; Reaction between getting shot at and the firing of the first volley of countermeasures.
+    MissileDecoyDelay     = 200   ; A reported missile that has been determined to hit a decoy will wait this long before acquiring countermeasures.
+  End
+
+  Behavior = TransitionDamageFX ModuleTag_17
+    DamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+  End
+
+
+  Geometry = Box
+  GeometryIsSmall = No
+  GeometryMajorRadius = 40.0
+  GeometryMinorRadius = 10.0
+  GeometryHeight = 10.0
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -1072,3 +1072,218 @@ Object ChinaJetCargoPlane
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End
+
+
+
+; Patch104p: Adds plane same as ChinaJetCargoPlane, but intended for reoccuring harmless events, such as Drop Zone and Vehicle Reinforcement supplies, not Generals Powers.
+; xezon 20/07/2022 Remove SCORE KindOf to exclude this plane from score numbers (Score Screen, Replay)
+; xezon 20/07/2022 Change RadarPriority from UNIT to LOCAL_UNIT_ONLY to not show plane to enemies on Radar.
+
+;------------------------------------------------------------------------------
+Object ChinaJetCargoPlane_Harmless_Patch104p
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model           = NVCargoPln
+      Animation       = NVCargoPln.NVCargoPln
+      AnimationMode   = LOOP
+      ParticleSysBone = Propeller01 JetBlackTrailThin
+      ParticleSysBone = Propeller02 JetBlackTrailThin
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = WingTip01 JetContrailThin
+      ParticleSysBone = WingTip02 JetContrailThin
+    End
+    ConditionState = DAMAGED
+      Model           = NVCargoPln_D
+      Animation       = NVCargoPln_D.NVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Propeller01 JetBlackTrailThin
+      ParticleSysBone = Propeller02 JetBlackTrailThin
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = WingTip01 JetContrailThin
+      ParticleSysBone = WingTip02 JetContrailThin
+    End
+    ConditionState = REALLYDAMAGED
+      Model           = NVCargoPln_D
+      Animation       = NVCargoPln_D.NVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Smoke04 JetFireLarge
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = Smoke04 JetSmokeLarge
+      ParticleSysBone = WingTip01 JetContrailThin
+      ParticleSysBone = WingTip02 JetContrailThin
+    End
+    ConditionState = RUBBLE
+      Model           = NVCargoPln_D1
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke06 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Smoke04 JetFireLarge
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke06 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = Smoke04 JetSmokeLarge
+    End
+
+    OkToChangeModelColor = Yes
+      ParticlesAttachedToAnimatedBones = Yes
+
+  End
+
+  Draw = W3DModelDraw ModuleTag_02
+    DefaultConditionState
+      Model           = NVCargoPln_A2
+      Animation       = NVCargoPln_A2.NVCargoPln_A2
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_OPENING
+      Model           = NVCargoPln_A2
+      Animation       = NVCargoPln_A2.NVCargoPln_A2
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_CLOSING
+      Model           = NVCargoPln_A2
+      Animation       = NVCargoPln_A2.NVCargoPln_A2
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+
+  ; ***DESIGN parameters ***
+  DisplayName         = OBJECT:CargoPlane
+  EditorSorting       = VEHICLE
+  Side                = China
+  TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)
+  VisionRange         = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = AirplaneArmor
+    DamageFX        = None
+  End
+  CommandSet        = Command_ScriptedTransportDrops
+
+  ; *** AUDIO Parameters ***
+  SoundAmbient = C130AmbientLoop
+  SoundAmbientRubble    = NoSound
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = LOCAL_UNIT_ONLY
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE TRANSPORT AIRCRAFT FORCEATTACKABLE IGNORED_IN_GUI CAN_ATTACK EMP_HARDENED
+  Body = ActiveBody ModuleTag_03
+    MaxHealth       = 1000.0
+    InitialHealth   = 1000.0
+  End
+
+  ExperienceValue     = 40 40 40 40  ; Experience point value at each level
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 500.0
+  End
+
+  Behavior = DeliverPayloadAIUpdate ModuleTag_05
+    DoorDelay = 500
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 300 ;500 ; time in between each item dropped (if more than one)
+    PutInContainer = AmericaParachute
+    DeliveryDistance = 150
+  End
+  Locomotor = SET_NORMAL B52Locomotor
+
+  Behavior = TransportContain ModuleTag_06
+    Slots = 100                     ; hey, it's a BIG transport
+    ScatterNearbyOnExit = No
+    OrientLikeContainerOnExit = Yes
+    KeepContainerVelocityOnExit = Yes
+    ExitPitchRate = 30
+    ExitBone = WeaponA01
+    AllowInsideKindOf  = INFANTRY VEHICLE PROJECTILE DOZER PARACHUTABLE
+    DoorOpenTime = 0                ; this prevents the Contain module from messing with the doors, since we want DeliverPayload to handle 'em
+    NumberOfExitPaths = 0
+    DestroyRidersWhoAreNotFreeToExit = Yes  ; 'destroy' as opposed to 'kill'
+  End
+
+  ;SCRIPTED SUPPORT: These special powers are triggered directly
+  ;from the transport without creating a transport. This is done
+  ;via new code support and CreateLocation USE_OWNER_OBJECT --
+  ;which also prevents creating the payload transport.
+  Behavior    = OCLSpecialPower ModuleTag_07
+    SpecialPowerTemplate = SuperweaponDaisyCutter ;@@KRIS@@
+    OCL                  = SUPERWEAPON_DaisyCutter
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_08
+    SpecialPowerTemplate = SuperweaponParadropAmerica
+    UpgradeOCL           = SCIENCE_Paradrop3 SUPERWEAPON_Paradrop3
+    UpgradeOCL           = SCIENCE_Paradrop2 SUPERWEAPON_Paradrop2
+    OCL                  = SUPERWEAPON_Paradrop1
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_09
+    SpecialPowerTemplate = SuperweaponCarpetBomb
+    OCL                  = SUPERWEAPON_CarpetBomb
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_10
+    SpecialPowerTemplate = SuperweaponClusterMines
+    OCL                  = SUPERWEAPON_ClusterMines
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_11
+    SpecialPowerTemplate = SuperweaponEMPPulse
+    OCL                  = SUPERWEAPON_EMPPulse
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+
+  Behavior                          = JetSlowDeathBehavior ModuleTag_12
+    DestructionDelay                = 2000
+    RollRate                        = 0.0
+    RollRateDelta                   = 100%      ;each frame, rollrate = rollrate * rollrateDelta
+    PitchRate                       = 0
+    FallHowFast                     = 25.0%    ;Bigger is faster (can be over 100%,it's a fraction of gravity)
+    FXInitialDeath                  = FX_JetBigDeathInitial
+    OCLInitialDeath                 = OCL_AmericaJetCargoDeathStart
+    DelaySecondaryFromInitialDeath  = 2000       ; in milliseconds     This guy won't hit the ground, so this time equals the above time
+    OCLSecondary                    = OCL_AmericaJetCargoHulkDeath
+    FXSecondary                     = FX_BigPlaneDeath
+  End
+
+;;;;;;;;  ClientUpdate         = AnimatedParticleSysBoneClientUpdate ModuleTag_13
+;;;;;;;;  End
+
+  Behavior = TransitionDamageFX ModuleTag_14
+    DamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+  End
+
+  Geometry = Box
+  GeometryIsSmall = No
+  GeometryMajorRadius = 40.0
+  GeometryMinorRadius = 10.0
+  GeometryHeight = 10.0
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
+
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAAir.ini
@@ -185,3 +185,196 @@ Object GLAJetCargoPlane
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End
+
+
+
+; Patch104p: Adds plane same as GLAJetCargoPlane, but intended for reoccuring harmless events, such as Drop Zone and Vehicle Reinforcement supplies, not Generals Powers.
+; xezon 20/07/2022 Remove SCORE KindOf to exclude this plane from score numbers (Score Screen, Replay)
+; xezon 20/07/2022 Change RadarPriority from UNIT to LOCAL_UNIT_ONLY to not show plane to enemies on Radar.
+
+;------------------------------------------------------------------------------
+Object GLAJetCargoPlane_Harmless_Patch104p
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+  ParticlesAttachedToAnimatedBones = Yes
+    DefaultConditionState
+      Model           = UVCargoPln
+      Animation       = UVCargoPln.UVCargoPln
+      AnimationMode   = LOOP
+      ParticleSysBone = Engine01 JetBlackTrail
+      ParticleSysBone = Engine02 JetBlackTrail
+      ParticleSysBone = Engine03 JetBlackTrail
+      ParticleSysBone = Engine04 JetBlackTrail
+    End
+    ConditionState = DAMAGED
+      Model           = UVCargoPln_D
+      Animation       = UVCargoPln_D.UVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke02 JetFireLarge
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke02 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+    End
+    ConditionState = REALLYDAMAGED
+      Model           = UVCargoPln_D
+      Animation       = UVCargoPln_D.UVCargoPln_D
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke02 JetFireLarge
+      ParticleSysBone = Propeller03 JetBlackTrailThin
+      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke02 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+    End
+    ConditionState = RUBBLE
+      Model           = UVCargoPln_D1
+      ParticleSysBone = Smoke01 JetFireLarge
+      ParticleSysBone = Smoke02 JetFireLarge
+      ParticleSysBone = Smoke03 JetFireLarge
+      ParticleSysBone = Smoke04 JetFireLarge
+      ParticleSysBone = Smoke01 JetSmokeLarge
+      ParticleSysBone = Smoke02 JetSmokeLarge
+      ParticleSysBone = Smoke03 JetSmokeLarge
+      ParticleSysBone = Smoke04 JetSmokeLarge
+    End
+
+    OkToChangeModelColor = Yes
+  End
+
+  Draw = W3DModelDraw ModuleTag_02
+    DefaultConditionState
+      Model           = UVCargoPln_A2
+      Animation       = UVCargoPln_A2.UVCargoPln_A2
+      AnimationMode   = MANUAL
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_OPENING
+      Model           = UVCargoPln_A2
+      Animation       = UVCargoPln_A2.UVCargoPln_A2
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
+    End
+    ConditionState = DOOR_1_CLOSING
+      Model           = UVCargoPln_A2
+      Animation       = UVCargoPln_A2.UVCargoPln_A2
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName         = OBJECT:CargoPlane
+  EditorSorting       = VEHICLE
+  Side                = GLA
+  TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)
+  VisionRange         = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = AirplaneArmor
+    DamageFX        = None
+  End
+  CommandSet          = Command_ScriptedTransportDrops
+
+  ; *** AUDIO Parameters ***
+  SoundAmbient = C130AmbientLoop
+  SoundAmbientRubble    = NoSound
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = LOCAL_UNIT_ONLY
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS CAN_ATTACK VEHICLE TRANSPORT AIRCRAFT FORCEATTACKABLE IGNORED_IN_GUI EMP_HARDENED
+  Body = ActiveBody ModuleTag_03
+    MaxHealth       = 1000.0
+    InitialHealth   = 1000.0
+  End
+
+  ExperienceValue     = 40 40 40 40  ; Experience point value at each level
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 500.0
+  End
+
+  Behavior = DeliverPayloadAIUpdate ModuleTag_05
+    DoorDelay = 500
+    MaxAttempts = 4
+    DropOffset = X:0 Y:0 Z:-10
+    DropDelay = 300 ;500 ; time in between each item dropped (if more than one)
+    PutInContainer = AmericaParachute
+    DeliveryDistance = 150
+  End
+  Locomotor = SET_NORMAL B52Locomotor
+
+  Behavior = TransportContain ModuleTag_06
+    Slots = 100                     ; hey, it's a BIG transport
+    ScatterNearbyOnExit = No
+    OrientLikeContainerOnExit = Yes
+    KeepContainerVelocityOnExit = Yes
+    ExitPitchRate = 30
+    ExitBone = WeaponA01
+    AllowInsideKindOf  = INFANTRY VEHICLE PROJECTILE DOZER PARACHUTABLE FORCEATTACKABLE
+    DoorOpenTime = 0                ; this prevents the Contain module from messing with the doors, since we want DeliverPayload to handle 'em
+    NumberOfExitPaths = 0
+    DestroyRidersWhoAreNotFreeToExit = Yes  ; 'destroy' as opposed to 'kill'
+  End
+
+  ;SCRIPTED SUPPORT: These special powers are triggered directly
+  ;from the transport without creating a transport. This is done
+  ;via new code support and CreateLocation USE_OWNER_OBJECT --
+  ;which also prevents creating the payload transport.
+  Behavior    = OCLSpecialPower ModuleTag_07
+    SpecialPowerTemplate = SuperweaponDaisyCutter ;@@KRIS@@
+    OCL                  = SUPERWEAPON_DaisyCutter
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_08
+    SpecialPowerTemplate = SuperweaponParadropAmerica
+    UpgradeOCL           = SCIENCE_Paradrop3 SUPERWEAPON_Paradrop3
+    UpgradeOCL           = SCIENCE_Paradrop2 SUPERWEAPON_Paradrop2
+    OCL                  = SUPERWEAPON_Paradrop1
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+  Behavior    = OCLSpecialPower ModuleTag_09
+    SpecialPowerTemplate = SuperweaponCarpetBomb
+    OCL                  = SUPERWEAPON_CarpetBomb
+    CreateLocation       = USE_OWNER_OBJECT
+    ScriptedSpecialPowerOnly = Yes
+  End
+
+  Behavior                          = JetSlowDeathBehavior ModuleTag_10
+    DestructionDelay                = 2000
+    RollRate                        = 0.0
+    RollRateDelta                   = 100%      ;each frame, rollrate = rollrate * rollrateDelta
+    PitchRate                       = 0
+    FallHowFast                     = 25.0%    ;Bigger is faster (can be over 100%,it's a fraction of gravity)
+    FXInitialDeath                  = FX_JetBigDeathInitial
+    OCLInitialDeath                 = OCL_AmericaJetCargoDeathStart
+    DelaySecondaryFromInitialDeath  = 2000       ; in milliseconds     This guy won't hit the ground, so this time equals the above time
+    OCLSecondary                    = OCL_AmericaJetCargoHulkDeath
+    FXSecondary                     = FX_BigPlaneDeath
+  End
+
+;;;;;;;;  ClientUpdate         = AnimatedParticleSysBoneClientUpdate ModuleTag_11
+;;;;;;;;  End
+
+  Behavior = TransitionDamageFX ModuleTag_12
+    DamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_JetBigDamageTransition
+  End
+
+  Geometry = Box
+  GeometryIsSmall = No
+  GeometryMajorRadius = 40.0
+  GeometryMinorRadius = 10.0
+  GeometryHeight = 10.0
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
+
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5926,7 +5926,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_AmericaSupplyDropZoneCrateDrop
   DeliverPayload
-    Transport = AmericaJetCargoPlane
+    Transport = AmericaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7843,7 +7843,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_ReinforcementPadUSAVehicle
   DeliverPayload
-    Transport = AmericaJetCargoPlane
+    Transport = AmericaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7861,7 +7861,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_ReinforcementPadCHIVehicle
   DeliverPayload
-    Transport = ChinaJetCargoPlane
+    Transport = ChinaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7879,7 +7879,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_ReinforcementPadGLAVehicle
   DeliverPayload
-    Transport = GLAJetCargoPlane
+    Transport = GLAJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7897,7 +7897,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_SWGen_ReinforcementPadUSAVehicle
   DeliverPayload
-    Transport = AmericaJetCargoPlane
+    Transport = AmericaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7915,7 +7915,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_LGen_ReinforcementPadUSAVehicle
   DeliverPayload
-    Transport = AmericaJetCargoPlane
+    Transport = AmericaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7933,7 +7933,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_AFGen_ReinforcementPadUSAVehicle
   DeliverPayload
-    Transport = AmericaJetCargoPlane
+    Transport = AmericaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7951,7 +7951,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_InfGen_ReinforcementPadCHIVehicle
   DeliverPayload
-    Transport = ChinaJetCargoPlane
+    Transport = ChinaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7969,7 +7969,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_TnkGen_ReinforcementPadCHIVehicle
   DeliverPayload
-    Transport = ChinaJetCargoPlane
+    Transport = ChinaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -7987,7 +7987,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_NukeGen_ReinforcementPadCHIVehicle
   DeliverPayload
-    Transport = ChinaJetCargoPlane
+    Transport = ChinaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -8005,7 +8005,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_ToxGen_ReinforcementPadGLAVehicle
   DeliverPayload
-    Transport = GLAJetCargoPlane
+    Transport = GLAJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -8023,7 +8023,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_DemoGen_ReinforcementPadGLAVehicle
   DeliverPayload
-    Transport = GLAJetCargoPlane
+    Transport = GLAJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -8041,7 +8041,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_StlthGen_ReinforcementPadGLAVehicle
   DeliverPayload
-    Transport = GLAJetCargoPlane
+    Transport = GLAJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
@@ -8061,7 +8061,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_BossGen_ReinforcementPadCHIVehicle
   DeliverPayload
-    Transport = ChinaJetCargoPlane
+    Transport = ChinaJetCargoPlane_Harmless_Patch104p
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 4


### PR DESCRIPTION
This change
1) removes the score from harmless Cargo Planes
2) hides Cargo Plane on Radar for enemy player

I tested Score in Skirmish but was unable to reproduce Score points given for killing Cargo Planes. But according to the INI code it would give Score. I don't understand.

I am not convinced this change is necessary at all, but I put it here for further discussion.