### PR TITLE
Change: Streamline GLA Marauder EXP with China Battlemaster and USA Paladin

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19186,7 +19186,9 @@ Object Chem_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance xezon 21/07/2022 Marauder now gives as much EXP as Paladin and Battlemaster on HEROIC level.
+
+  ExperienceValue = 100 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20670,7 +20670,9 @@ Object Demo_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance xezon 21/07/2022 Marauder now gives as much EXP as Paladin and Battlemaster on HEROIC level.
+
+  ExperienceValue = 100 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6002,7 +6002,9 @@ Object GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance xezon 21/07/2022 Marauder now gives as much EXP as Paladin and Battlemaster on HEROIC level.
+
+  ExperienceValue = 100 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20719,7 +20719,9 @@ Object Slth_GLATankMarauder
     Science = SCIENCE_MarauderTank
   End
 
-  ExperienceValue = 100 100 200 300    ;Experience point value at each level
+  ; Patch104p @balance xezon 21/07/2022 Marauder now gives as much EXP as Paladin and Battlemaster on HEROIC level.
+
+  ExperienceValue = 100 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 200 300 600  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles


### PR DESCRIPTION
Reference:
* #719

### Before
```
GLATankMarauder
  ExperienceValue    = 100 100 200 300 ;Experience point value at each level
  ExperienceRequired = 0 200 300 600   ;Experience points needed to gain each level
```
### After
```
GLATankMarauder
  ExperienceValue    = 100 100 200 400 ;Experience point value at each level
  ExperienceRequired = 0 200 300 600   ;Experience points needed to gain each level
```
### Similar
```
ChinaTankBattleMaster
  ExperienceValue    = 100 100 200 400 ;Experience point value at each level
  ExperienceRequired = 0 200 300 600   ;Experience points needed to gain each level

AmericaTankPaladin
  ExperienceValue    = 100 100 200 400 ;Experience point value at each level
  ExperienceRequired = 0 200 300 600 ;Experience points needed to gain each level
```

3 Star Marauder, especially with 2 Scrap, is very strong. Killing it deserves no less reward than killing Paladin and Battlemaster.