### PR TITLE
Change: Increase required XP of GLA SCUD Launcher by 50% and decrease required XP of GLA Rocket Buggy by 25%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -21269,7 +21269,7 @@ Object Boss_VehicleRocketBuggy
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 200 400 800 to fit better into comparable setups in GLAVehicleScudLauncher, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable           = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -15682,7 +15682,7 @@ Object Chem_GLAVehicleRocketBuggy
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 200 400 800 to fit better into comparable setups in GLAVehicleScudLauncher, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable           = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -17952,7 +17952,7 @@ Object Chem_GLAVehicleScudLauncher
   End
 
   ExperienceValue = 50 50 100 150   ;Experience point value at each level
-  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 100 200 400 to fit better into comparable setups in GLAVehicleRocketBuggy, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16897,7 +16897,7 @@ Object Demo_GLAVehicleRocketBuggy
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 200 400 800 to fit better into comparable setups in GLAVehicleScudLauncher, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable           = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -19336,7 +19336,7 @@ Object Demo_GLAVehicleScudLauncher
   End
 
   ExperienceValue = 50 50 100 150   ;Experience point value at each level
-  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 100 200 400 to fit better into comparable setups in GLAVehicleRocketBuggy, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2899,7 +2899,7 @@ Object GC_Chem_GLAVehicleScudLauncher
   End
 
   ExperienceValue = 50 50 100 150   ;Experience point value at each level
-  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 100 200 400 to fit better into comparable setups in GLAVehicleRocketBuggy, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -380,7 +380,7 @@ Object GLAVehicleRocketBuggy
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 200 400 800 to fit better into comparable setups in GLAVehicleScudLauncher, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable           = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -4554,7 +4554,7 @@ Object GLAVehicleScudLauncher
   End
 
   ExperienceValue = 50 50 100 150   ;Experience point value at each level
-  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 100 200 400 to fit better into comparable setups in GLAVehicleRocketBuggy, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -6804,7 +6804,7 @@ Object GLAVehicleScudLauncherHiDef
   End
 
   ExperienceValue = 50 50 100 150   ;Experience point value at each level
-  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 100 200 400 to fit better into comparable setups in GLAVehicleRocketBuggy, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17173,7 +17173,7 @@ Object Slth_GLAVehicleRocketBuggy
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 200 400 800 to fit better into comparable setups in GLAVehicleScudLauncher, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable           = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -19481,7 +19481,7 @@ Object Slth_GLAVehicleScudLauncher
   End
 
   ExperienceValue = 50 50 100 150   ;Experience point value at each level
-  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired = 0 150 300 600 ; Patch104p @balance xezon 21/07/2022 From 0 100 200 400 to fit better into comparable setups in GLAVehicleRocketBuggy, ChinaVehicleNukeCannon, ChinaVehicleInfernoCannon
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles


### PR DESCRIPTION
Closes #719

## Original
```
Demo_GLAVehicleRocketBuggy
  ExperienceValue    = 50 50 100 150
  ExperienceRequired = 0 200 400 800

Demo_GLAVehicleScudLauncher
  ExperienceValue    = 50 50 100 150
  ExperienceRequired = 0 100 200 400
```

## Patched
```
Demo_GLAVehicleRocketBuggy
  ExperienceValue    = 50 50 100 150
  ExperienceRequired = 0 150 300 600

Demo_GLAVehicleScudLauncher
  ExperienceValue    = 50 50 100 150
  ExperienceRequired = 0 150 300 600
```

## Other long range units for reference
```
ChinaVehicleInfernoCannon
  ExperienceValue    = 50 50 100 150
  ExperienceRequired = 0 100 200 400

ChinaVehicleNukeCannon
  ExperienceValue    = 50 100 200 400
  ExperienceRequired = 0 400 600 1000

AmericaVehicleTomahawk
  ExperienceValue    = 50 50 100 150
  ExperienceRequired = 0 200 400 800
```

# Rationale

There is no reason that justifies such a relatively small XP requirement by SCUD Launcher and such a relatively large XP requirement by Rocket Buggy. SCUD Launcher can kill alot of units with one hit and level up relatively quickly. It is no rare occurance to have multiple 3 Star SCUD Launchers sitting in the Tunnel Network. Meanwhite, Rocket Buggys attack single targets only, so will require a lot more time to level up compared to SCUD Launcher. There is no justification for them to require 2 times as much XP. This change consolidates the XP by subtracting XP requirement away from Rocket Buggy and adding it to the SCUD Launcher. Therefore the total sum of Experience Required across both units is identical to the original distribution.