### PR TITLE
Change: Decrease China Mig reload time by 50% before Upgrade

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -4279,6 +4279,7 @@ Weapon MiGFirestormCreationWeapon
   FireOCL = OCL_MiGFirestorm
 End
 
+; Patch104p @balance commy2 24/07/2022 Decrease MIG reload time before upgrade.
 ;------------------------------------------------------------------------------
 Weapon NapalmMissileWeapon
   PrimaryDamage               = 75.0
@@ -4298,7 +4299,7 @@ Weapon NapalmMissileWeapon
   AcceptableAimDelta          = 30
   DelayBetweenShots           = 300             ; time between shots, msec
   ClipSize                    = 2                        ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 8000               ; how long to reload a Clip, msec
+  ClipReloadTime              = 4000               ; how long to reload a Clip, msec
   AutoReloadsClip             = RETURN_TO_BASE                 ; must return to base to reload this weapon
   AntiGround                  = Yes
   ProjectileDetonationFX      = WeaponFX_NapalmMissileDetonation
@@ -8169,6 +8170,7 @@ Weapon HelixNukeBombDetonationWeaponWithAnEvenLongerName
   DamageDealtAtSelfPosition   = Yes
 End
 
+; Patch104p @balance commy2 24/07/2022 Decrease MIG reload time before upgrade.
 ;------------------------------------------------------------------------------
 Weapon Nuke_MiGMissileWeapon
   PrimaryDamage               = 100.0
@@ -8188,7 +8190,7 @@ Weapon Nuke_MiGMissileWeapon
   AcceptableAimDelta          = 30
   DelayBetweenShots           = 300             ; time between shots, msec
   ClipSize                    = 2                        ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 8000               ; how long to reload a Clip, msec
+  ClipReloadTime              = 4000               ; how long to reload a Clip, msec
   AutoReloadsClip             = RETURN_TO_BASE                 ; must return to base to reload this weapon
   AntiGround                  = Yes
   ProjectileDetonationFX      = WeaponFX_JetMissileDetonation


### PR DESCRIPTION
Implementation of proposal made in https://github.com/TheSuperHackers/GeneralsGamePatch/issues/747.

This pull request decreases the reload time of non-Black Napalm MIGs from 8 seconds to 4 seconds. This also applies to Nuke MIGs before the Nuke Mig Upgrade. The reload time after both upgrades remains at 2 seconds.

## Plane Reload Times
| Object                                       | ReloadTime |
|----------------------------------------------|------------|
| Original China Mig                           | 8 seconds  |
| Patched China Mig (this)                     | 4 seconds  |
| Original China Mig + Black Napalm            | 2 seconds  |
| Original China Mig + Nuke Missile            | 2 seconds  |
| Original USA Raptor                          | 8 seconds  |
| Original USA Stealth Fighter                 | 8 seconds  |
| Original USA Stealth Fighter + Bunker Buster | 8 seconds  |
| Original USA Aurora                          | 5 seconds  |
| Original USA Alpha Aurora                    | 5 seconds  |
| Original USA King Raptor                     | 2 seconds  |
