### PR TITLE
Remove obsolete Chem_PoisonFieldGammaLarge OCL from Chem_GLAInfantryTerrorist

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13029,7 +13029,6 @@ Object Chem_GLAInfantryTerrorist
     FlingForceVariance  = 3
     FlingPitch          = 60
     FlingPitchVariance  = 10
-    OCL                 = INITIAL Chem_PoisonFieldGammaLarge
   End
   
   ; Patch104p @bugfix xezon 16/07/2022 Paste death types from other Terrorists to avoid Toxin Terrorists exploding by all kinds of deaths.


### PR DESCRIPTION
The OCL looks obsolete. Tests with and without this OCL yielded identical visual result.