### PR TITLE
Fix: Adds status requirement to Terrorist death weapons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13032,17 +13032,20 @@ Object Chem_GLAInfantryTerrorist
   End
   
   ; Patch104p @bugfix xezon 16/07/2022 Paste death types from other Terrorists to avoid Toxin Terrorists exploding by all kinds of deaths.
+  ; Patch104p @bugfix hanfield 27/07/2022 Exempt MASKED status to postpone death explosion until after passenger exit, if ever.
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
     DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End
   
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
     DeathWeapon   = CrushedDynamitePack_Patch104p
     StartsActive  = Yes
     DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus  = MASKED
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag91
@@ -13051,6 +13054,7 @@ Object Chem_GLAInfantryTerrorist
     TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
     RequiresAllTriggers = Yes;
     DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End;
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_92
@@ -13060,13 +13064,15 @@ Object Chem_GLAInfantryTerrorist
     RequiresAllTriggers = Yes ;TriggeredBy is an AND, not an OR like it normally is
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
     DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_93
     DeathWeapon   = Chem_SuicideWeapon
-    StartsActive  = Yes ; @bugfix commy2 22/09/2021 Fix Toxin Terrorist creates no poison cloud when used by other factions.
+    StartsActive  = Yes                     ; Patch104p @bugfix commy2 22/09/2021 Fix Toxin Terrorist creates no poison cloud when used by other factions.
     ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
     DeathTypes = NONE +SUICIDED +CRUSHED +SPLATTED +LASERED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End
 
 ; Units that can gain experience can't have GrantUpgradeCreate or they crash savegames.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13542,16 +13542,20 @@ Object Demo_GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix hanfield 27/07/2022 Exempt MASKED status to postpone death explosion until after passenger exit, if ever.
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death08
     DeathWeapon   = Demo_SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
     DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End
   
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
     DeathWeapon   = Demo_CrushedDynamitePack_Patch104p
     StartsActive  = Yes
     DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus  = MASKED
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -3887,10 +3887,14 @@ Object GC_Chem_GLAInfantryTerrorist
     FlingPitch          = 60
     FlingPitchVariance  = 10
   End
+
+  ; Patch104p @bugfix hanfield 27/07/2022 Exempt MASKED status to postpone death explosion until after passenger exit, if ever.
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = GC_Chem_SuicideDynamitePackBeta
     StartsActive  = Yes                      ; turned on by upgrade
     DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
   End
   
@@ -3898,6 +3902,7 @@ Object GC_Chem_GLAInfantryTerrorist
     DeathWeapon   = CrushedDynamitePack_Patch104p
     StartsActive  = Yes
     DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus  = MASKED
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
   End
   
@@ -3905,6 +3910,7 @@ Object GC_Chem_GLAInfantryTerrorist
     DeathWeapon   = GC_Chem_SuicideDynamitePackGamma
     StartsActive  = No                      ; turned on by upgrade
     DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
     TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
   
@@ -3912,6 +3918,7 @@ Object GC_Chem_GLAInfantryTerrorist
     DeathWeapon   = CrushedDynamitePack_Patch104p
     StartsActive  = Yes
     DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus  = MASKED
     TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2270,16 +2270,20 @@ Object GC_Slth_GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix hanfield 27/07/2022 Exempt MASKED status to postpone death explosion until after passenger exit, if ever.
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
     DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End
   
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
     DeathWeapon   = CrushedDynamitePack_Patch104p
     StartsActive  = Yes
     DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus  = MASKED
   End
 
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1448,16 +1448,20 @@ Object GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix hanfield 27/07/2022 Exempt MASKED status to postpone death explosion until after passenger exit, if ever.
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
     DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End
   
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
     DeathWeapon   = CrushedDynamitePack_Patch104p
     StartsActive  = Yes
     DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus  = MASKED
   End
   
 ; --- end Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14019,16 +14019,20 @@ Object Slth_GLAInfantryTerrorist
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix hanfield 27/07/2022 Exempt MASKED status to postpone death explosion until after passenger exit, if ever.
+
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death04
     DeathWeapon   = SuicideDynamitePack
     StartsActive  = Yes                      ; turned on by upgrade
     DeathTypes    = NONE +SUICIDED +BURNED +EXPLODED
+    ExemptStatus  = MASKED
   End
   
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_Patch104p
     DeathWeapon   = CrushedDynamitePack_Patch104p
     StartsActive  = Yes
     DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    ExemptStatus  = MASKED
   End
 ; --- end Death modules ---
 


### PR DESCRIPTION
- MASKED status is applied whenever a unit enters a container. With this status, the ``FireWeaponWhenDead`` modules will not activated whenever the MASKED status is active (inside a container/transport).