### PR TITLE
Change: Decrease ambient audio loop range of Helix helicopter to reasonable distance

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -6779,8 +6779,8 @@ AudioEvent HelixAmbientLoop
   VolumeShift = -10
   Volume = 85
   Limit = 3
-  MinRange = 150
-  MaxRange = 1000
+  MinRange = 116 ; Patch104p @tweak from 150 to streamline with Chinook at factor 1.16 (700/600)
+  MaxRange = 700 ; Patch104p @tweak from 1000 to streamline with Planes
   Priority = normal
   Type = world shrouded everyone
 End


### PR DESCRIPTION
This change reduces Helix sound ranges.

Related to
* TheSuperHackers/GeneralsGameCode#60

## Original Audio
```
Helix
  MinRange = 150
  MaxRange = 1000

Chinook
  MinRange = 100
  MaxRange = 600

Comanche
  MinRange = 100
  MaxRange = 600

Raptor
  MinRange = 75
  MaxRange = 700

Mig
  MinRange = 75
  MaxRange = 700
```

Helix at the bottom can be heard up to here.

![shot_20220727_182728_2](https://user-images.githubusercontent.com/4720891/181302920-c132ffd4-460b-4a62-8cb2-175351751ba6.jpg)


## Patched Audio
```
Helix
  MinRange = 116
  MaxRange = 700
```

Helix at the bottom can be heard up to here.

![shot_20220727_183327_1](https://user-images.githubusercontent.com/4720891/181303009-6e648b79-ee3d-428a-a1f6-935a12837c83.jpg)