### PR TITLE
Change: Decrease Tank China Hacker build cost from 780 to 625

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2454,7 +2454,7 @@ Object Tank_ChinaInfantryHacker
     Object = Tank_ChinaBarracks
     Object = Tank_ChinaPropagandaCenter
   End
-  BuildCost = 780
+  BuildCost = 625 ; Patch104p @balance from 780 to streamline price with all other faction Hackers
   BuildTime = 20.0          ;in seconds
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level


### PR DESCRIPTION
* Relates to #754

All China Hackers now cost the same. 4 Vet0 Regular Hackers valued at 2500 cash make as much income as as an equal value GLA Black Market.

# Rationale

Originally Tank General is the only faction that has a price penalty for its secondary income, while not even being the strongest faction to begin with. Tank General typically struggles in late game, due the absence of artillery tanks, expensive aircraft and expensive infantry. The price reduction of the Hacker to the regular China price alleviates some of the burden and makes investment into secondary economy more attractive.