### PR TITLE
Change: Decrease China Hacker build time from 20 to 15 seconds

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18542,7 +18542,7 @@ Object Boss_InfantryHacker
     Object = Boss_Barracks
   End
   BuildCost = 625
-  BuildTime = 20.0          ;in seconds
+  BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -1304,7 +1304,7 @@ Object ChinaInfantryHacker
     Object = ChinaPropagandaCenter
   End
   BuildCost = 625
-  BuildTime = 20.0          ;in seconds
+  BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1397,7 +1397,7 @@ Object Infa_ChinaInfantryHacker
     Object = Infa_ChinaPropagandaCenter
   End
   BuildCost = 625
-  BuildTime = 20.0          ;in seconds
+  BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2724,7 +2724,7 @@ Object Nuke_ChinaInfantryHacker
     Object = Nuke_ChinaPropagandaCenter
   End
   BuildCost = 625
-  BuildTime = 20.0          ;in seconds
+  BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2455,7 +2455,7 @@ Object Tank_ChinaInfantryHacker
     Object = Tank_ChinaPropagandaCenter
   End
   BuildCost = 625 ; Patch104p @balance from 780 to streamline price with all other faction Hackers
-  BuildTime = 20.0          ;in seconds
+  BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience


### PR DESCRIPTION
* Relates to #754

All China Hackers now build faster. 4 Hackers will build as fast as an identical value GLA Black Market (without Power) in 1 minute.

| Object of same value         | Build Time without Power | Build Time with Power |
|------------------------------|--------------------------|-----------------------|
| Original 1x USA Drop Zone    | 01:30                    | **00:45**             |
| Original 1x GLA Market       | **01:00**                | 00:30                 |
| Original 4x Hacker           | 02:40                    | **01:20**             |
| **Patched 4x Hacker (this)** | 02:00                    | **01:00**             |

# Rationale

Originally the China Hacker has the longest build time of all types of faction economies of identical value (and reward). 4 Hackers take 33% longer to build than 1 GLA Black Market and 78% longer to build than 1 USA Supply Drop Zone. Additionally Hackers also need to walk to scattered places to be somewhat safe. And require attention to start hacking after they reach their destination. This exacerbates the delay until they start collecting money, while the Black Market and Supply Drop Zone collect money passively right away. The build time adjustment helps reduce the discrepancy.

Hackers do however have the advantage of gaining veterancy, which allows them to out earn their Black Market and Supply Drop Zone counterparts by a maximum reward of +100%.