### PR TITLE
Change: Decrease China Hacker experience reward from 50 100 150 400 to 50 60 80 100

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18543,7 +18543,7 @@ Object Boss_InfantryHacker
   End
   BuildCost = 625
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
-  ExperienceValue = 50 100 150 400    ;Experience point value at each level
+  ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -1305,7 +1305,7 @@ Object ChinaInfantryHacker
   End
   BuildCost = 625
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
-  ExperienceValue = 50 100 150 400    ;Experience point value at each level
+  ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1398,7 +1398,7 @@ Object Infa_ChinaInfantryHacker
   End
   BuildCost = 625
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
-  ExperienceValue = 50 100 150 400    ;Experience point value at each level
+  ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2725,7 +2725,7 @@ Object Nuke_ChinaInfantryHacker
   End
   BuildCost = 625
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
-  ExperienceValue = 50 100 150 400    ;Experience point value at each level
+  ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2456,7 +2456,7 @@ Object Tank_ChinaInfantryHacker
   End
   BuildCost = 625 ; Patch104p @balance from 780 to streamline price with all other faction Hackers
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
-  ExperienceValue = 50 100 150 400    ;Experience point value at each level
+  ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
   ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
 


### PR DESCRIPTION
Related to
* #754

Fixes: #689

Significantly reduces enemy XP rewards for killed Hackers. Values 50 60 80 100 have been choosen because USA Drop Zone, worth 4 Hackers, gives 200 XP flat. And a Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable. Killing 4 Vet3 Hackers would give 400 XP, twice as much as a Drop Zone and Black Market.