### PR TITLE
Change: Decrease Regular China Hacker required experience from 0 100 300 500 to 0 100 250 400

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18544,7 +18544,7 @@ Object Boss_InfantryHacker
   BuildCost = 625
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
-  ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
+  ExperienceRequired = 0 100 250 400 ; Patch104p @balance from 0 100 300 500 to level up quicker. Reaches Vet2 100s slower than original Super Hacker (400s), but Vet3 at same time (800s)
   IsTrainable = Yes             ;Can gain experience
 
   CrushableLevel         = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -1306,7 +1306,7 @@ Object ChinaInfantryHacker
   BuildCost = 625
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
-  ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
+  ExperienceRequired = 0 100 250 400 ; Patch104p @balance from 0 100 300 500 to level up quicker. Reaches Vet2 100s slower than original Super Hacker (400s), but Vet3 at same time (800s)
   IsTrainable = Yes             ;Can gain experience
 
   CrushableLevel         = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2726,7 +2726,7 @@ Object Nuke_ChinaInfantryHacker
   BuildCost = 625
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
-  ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
+  ExperienceRequired = 0 100 250 400 ; Patch104p @balance from 0 100 300 500 to level up quicker. Reaches Vet2 100s slower than original Super Hacker (400s), but Vet3 at same time (800s)
   IsTrainable = Yes             ;Can gain experience
 
   CrushableLevel         = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2457,7 +2457,7 @@ Object Tank_ChinaInfantryHacker
   BuildCost = 625 ; Patch104p @balance from 780 to streamline price with all other faction Hackers
   BuildTime = 15.0 ; Patch104p @balance from 20.0 to equalize build time of 4 Hackers with build time of same value Black Market (01:00)
   ExperienceValue = 50 60 80 100 ; Patch104p @balance from 50 100 150 400. USA Drop Zone, equal cost to 4 Hackers, gives 200 XP flat. Vet 3 Hacker makes twice as much money as he started with, so a doubling of XP is reasonable.
-  ExperienceRequired = 0 100 300 500  ;Experience points needed to gain each level
+  ExperienceRequired = 0 100 250 400 ; Patch104p @balance from 0 100 300 500 to level up quicker. Reaches Vet2 100s slower than original Super Hacker (400s), but Vet3 at same time (800s)
   IsTrainable = Yes             ;Can gain experience
 
   CrushableLevel         = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles


### PR DESCRIPTION
Related to
* #754

Boosts level up times of Regular Hackers.

Table shows how many seconds it takes until hacker reached veteran level.

| Object | Vet1 (s) | Vet2 (s) | Vet3 (s) |
|--------|----------|----------|----------|
| Original Hacker | 200 | 600 | 1000 |
| Patched Hacker (this) | 200 | 500 | 800 |
| Original Super Hacker | 0 | 400 | 800 |
| Patched Super Hacker (this) | 0 | 400 | 800 |
