### PR TITLE
Change: Decrease Regular China Hacker hack interval in Internet Center from 1800 to 1600 ms

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18588,7 +18588,7 @@ Object Boss_InfantryHacker
     UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
     PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
     CashUpdateDelay     = 2000
-    CashUpdateDelayFast = 1800  ; Fast speed used inside a container (can only hack inside an Internet Center)
+    CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
     VeteranCashAmount   = 6
     EliteCashAmount     = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -1344,7 +1344,7 @@ Object ChinaInfantryHacker
     UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
     PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
     CashUpdateDelay     = 2000
-    CashUpdateDelayFast = 1800  ; Fast speed used inside a container (can only hack inside an Internet Center)
+    CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
     VeteranCashAmount   = 6
     EliteCashAmount     = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2764,7 +2764,7 @@ Object Nuke_ChinaInfantryHacker
     UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
     PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
     CashUpdateDelay     = 2000
-    CashUpdateDelayFast = 1800  ; Fast speed used inside a container (can only hack inside an Internet Center)
+    CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
     VeteranCashAmount   = 6
     EliteCashAmount     = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2495,7 +2495,7 @@ Object Tank_ChinaInfantryHacker
     UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
     PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
     CashUpdateDelay     = 2000
-    CashUpdateDelayFast = 1800  ; Fast speed used inside a container (can only hack inside an Internet Center)
+    CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
     VeteranCashAmount   = 6
     EliteCashAmount     = 8


### PR DESCRIPTION
* Relates to #754

Regular China Hackers now enjoy the same cash hack boost as the Super Hackers do. The increased hack speed will not just generate more cash in shorter time, but also reduce the level up time.

The Internet Center can be build just once per Player and fits 8 Hackers max.

## Considerations

The Internet Center costs 2500, as much as 4 Hackers. If a player went to invest the 7500 cash in 12 Hackers instead of the Internet Center and the 8 Hackers, then he would get a 20% better return on investment with just 12 Hackers over the patched Internet Center with 8 Hackers.

### No veteran

```
Internet Center    8 hackers * 1/1600 ms * 5 cash = 0.025 cash/ms
Solo              12 hackers * 1/2000 ms * 5 cash = 0.030 cash/ms
```

### Vet 1

```
Internet Center    8 hackers * 1/1600 ms * 6 cash = 0.030 cash/ms
Solo              12 hackers * 1/2000 ms * 6 cash = 0.036 cash/ms
```

### Vet 2

```
Internet Center    8 hackers * 1/1600 ms * 8 cash = 0.040 cash/ms
Solo              12 hackers * 1/2000 ms * 8 cash = 0.048 cash/ms
```

### Vet 3

```
Internet Center    8 hackers * 1/1600 ms * 10 cash = 0.050 cash/ms
Solo              12 hackers * 1/2000 ms * 10 cash = 0.060 cash/ms
```

Ignoring other perks of the Internet Center, the fair value for return on investment would be a hack interval of 1333 ms instead of 1600 ms.

# Rationale

The Internet Center is expected to be a worthwhile investment for China. It provides upgrades, protection for 8 Hackers and a hacking speed bonus. The original hack interval of 1800 over 2000 is not much. The decreased hack interval of 1600 makes the Internet Center more attractive and useful for China.