### PR TITLE
Change: Increase China Hacker movement speed by +25%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18596,7 +18596,8 @@ Object Boss_InfantryHacker
     XpPerCashUpdate     = 1
     PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
   End
-  Locomotor = SET_NORMAL BasicHumanLocomotor
+
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
 
   Behavior = SpecialAbility ModuleTag_04
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -1352,7 +1352,8 @@ Object ChinaInfantryHacker
     XpPerCashUpdate     = 1
     PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
   End
-  Locomotor = SET_NORMAL BasicHumanLocomotor
+
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
 
   Behavior = SpecialAbility ModuleTag_04
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1449,7 +1449,8 @@ Object Infa_ChinaInfantryHacker
     XpPerCashUpdate     = 1
     PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
   End
-  Locomotor = SET_NORMAL BasicHumanLocomotor
+
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
 
   Behavior = SpecialAbility ModuleTag_04
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2772,7 +2772,8 @@ Object Nuke_ChinaInfantryHacker
     XpPerCashUpdate     = 1
     PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
   End
-  Locomotor = SET_NORMAL BasicHumanLocomotor
+
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
 
   Behavior = SpecialAbility ModuleTag_04
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2503,7 +2503,8 @@ Object Tank_ChinaInfantryHacker
     XpPerCashUpdate     = 1
     PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
   End
-  Locomotor = SET_NORMAL BasicHumanLocomotor
+
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
 
   Behavior = SpecialAbility ModuleTag_04
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding


### PR DESCRIPTION
* Relates to #754

All China Hackers move as quick as a China Red Guard now. Black Lotus walks quicker than Hackers. Tank Hunter walks slower than Hackers.

## Original

https://user-images.githubusercontent.com/4720891/181492505-e361d842-a2db-480d-ae97-0141a51c9507.mp4

## Changed

https://user-images.githubusercontent.com/4720891/181492628-5651909a-533e-480a-b458-ee39c137052d.mp4

# Rationale

Originally the China Hacker walks as slow as the Tank Hunter, despite just carrying a military grade laptop with him. When built, he typically needs to move a bit first to reach his optimal hack location, unlike the GLA Black Market and USA Supply Drop Zone, which begin collecting money passively straight away. The increased movement speed allows hackers to move quicker into positon and also flee the scene quicker in case of danger.