### PR TITLE
Change: Decrease China Hackers pack and unpack times and time variations

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18585,8 +18585,8 @@ Object Boss_InfantryHacker
   ; Patch104p @bugfix commy2 3/10/2021 Fix unit would hack faster than other Hackers inside the Internet Center.
 
   Behavior = HackInternetAIUpdate ModuleTag_03
-    UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime          = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to 7300-PackUnpackVariationFactor*7300 to have smoother animations
+    PackTime            = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @balance from 5133 to 75% to allow for quicker Hacker evacuations
     CashUpdateDelay     = 2000
     CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
@@ -18594,7 +18594,7 @@ Object Boss_InfantryHacker
     EliteCashAmount     = 8
     HeroicCashAmount    = 10
     XpPerCashUpdate     = 1
-    PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
+    PackUnpackVariationFactor = 0.1 ;Adds + or - n% to pack and unpack time randomly. ; Patch104p @balance from 0.5 to allow for quicker Hacker evacuations
   End
 
   Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
@@ -18608,8 +18608,8 @@ Object Boss_InfantryHacker
   Behavior = SpecialAbilityUpdate ModuleTag_05
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding
     StartAbilityRange = 150.0
-    UnpackTime      = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime        = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime      = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to be consistent with Internet Hack time
+    PackTime        = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @tweak from 5133 to be consistent with Internet Hack time
     PreparationTime = 3000
 
     ;PersistentPrepTime = 500 ; old setting

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -1341,8 +1341,8 @@ Object ChinaInfantryHacker
   End
 
   Behavior = HackInternetAIUpdate ModuleTag_03
-    UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime          = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to 7300-PackUnpackVariationFactor*7300 to have smoother animations
+    PackTime            = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @balance from 5133 to 75% to allow for quicker Hacker evacuations
     CashUpdateDelay     = 2000
     CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
@@ -1350,7 +1350,7 @@ Object ChinaInfantryHacker
     EliteCashAmount     = 8
     HeroicCashAmount    = 10
     XpPerCashUpdate     = 1
-    PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
+    PackUnpackVariationFactor = 0.1 ;Adds + or - n% to pack and unpack time randomly. ; Patch104p @balance from 0.5 to allow for quicker Hacker evacuations
   End
 
   Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
@@ -1364,8 +1364,8 @@ Object ChinaInfantryHacker
   Behavior = SpecialAbilityUpdate ModuleTag_05
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding
     StartAbilityRange = 150.0
-    UnpackTime      = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime        = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime      = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to be consistent with Internet Hack time
+    PackTime        = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @tweak from 5133 to be consistent with Internet Hack time
     PreparationTime = 3000
 
     ;PersistentPrepTime = 500 ; old setting

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1438,8 +1438,8 @@ Object Infa_ChinaInfantryHacker
 
 
   Behavior = HackInternetAIUpdate ModuleTag_03
-    UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime          = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to 7300-PackUnpackVariationFactor*7300 to have smoother animations
+    PackTime            = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @balance from 5133 to 75% to allow for quicker Hacker evacuations
     CashUpdateDelay     = 2000
     CashUpdateDelayFast = 1600  ; Fast speed used inside a container (can only hack inside an Internet Center)
     RegularCashAmount   = 5
@@ -1447,7 +1447,7 @@ Object Infa_ChinaInfantryHacker
     EliteCashAmount     = 8
     HeroicCashAmount    = 10
     XpPerCashUpdate     = 1
-    PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
+    PackUnpackVariationFactor = 0.1 ;Adds + or - n% to pack and unpack time randomly. ; Patch104p @balance from 0.5 to allow for quicker Hacker evacuations
   End
 
   Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
@@ -1461,8 +1461,8 @@ Object Infa_ChinaInfantryHacker
   Behavior = SpecialAbilityUpdate ModuleTag_05
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding
     StartAbilityRange = 150.0
-    UnpackTime      = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime        = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime      = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to be consistent with Internet Hack time
+    PackTime        = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @tweak from 5133 to be consistent with Internet Hack time
     PreparationTime = 3000
 
     ;PersistentPrepTime = 500 ; old setting

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2761,8 +2761,8 @@ Object Nuke_ChinaInfantryHacker
   End
 
   Behavior = HackInternetAIUpdate ModuleTag_03
-    UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime          = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to 7300-PackUnpackVariationFactor*7300 to have smoother animations
+    PackTime            = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @balance from 5133 to 75% to allow for quicker Hacker evacuations
     CashUpdateDelay     = 2000
     CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
@@ -2770,7 +2770,7 @@ Object Nuke_ChinaInfantryHacker
     EliteCashAmount     = 8
     HeroicCashAmount    = 10
     XpPerCashUpdate     = 1
-    PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
+    PackUnpackVariationFactor = 0.1 ;Adds + or - n% to pack and unpack time randomly. ; Patch104p @balance from 0.5 to allow for quicker Hacker evacuations
   End
 
   Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
@@ -2784,8 +2784,8 @@ Object Nuke_ChinaInfantryHacker
   Behavior = SpecialAbilityUpdate ModuleTag_05
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding
     StartAbilityRange = 150.0
-    UnpackTime      = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime        = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime      = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to be consistent with Internet Hack time
+    PackTime        = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @tweak from 5133 to be consistent with Internet Hack time
     PreparationTime = 3000
 
     ;PersistentPrepTime = 500 ; old setting

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2492,8 +2492,8 @@ Object Tank_ChinaInfantryHacker
   End
 
   Behavior = HackInternetAIUpdate ModuleTag_03
-    UnpackTime          = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime            = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime          = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to 7300-PackUnpackVariationFactor*7300 to have smoother animations
+    PackTime            = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @balance from 5133 to 75% to allow for quicker Hacker evacuations
     CashUpdateDelay     = 2000
     CashUpdateDelayFast = 1600 ; Patch104p @balance from 1800 to streamline with Super Hacker Internet Center hack speed
     RegularCashAmount   = 5
@@ -2501,7 +2501,7 @@ Object Tank_ChinaInfantryHacker
     EliteCashAmount     = 8
     HeroicCashAmount    = 10
     XpPerCashUpdate     = 1
-    PackUnpackVariationFactor = 0.5 ;Adds + or - 20% to pack and unpack time randomly.
+    PackUnpackVariationFactor = 0.1 ;Adds + or - n% to pack and unpack time randomly. ; Patch104p @balance from 0.5 to allow for quicker Hacker evacuations
   End
 
   Locomotor = SET_NORMAL BasicHumanLocomotorPlus25 ; Patch104p @balance +25% movement speed to allow for quicker Hacker evacuations
@@ -2515,8 +2515,8 @@ Object Tank_ChinaInfantryHacker
   Behavior = SpecialAbilityUpdate ModuleTag_05
     SpecialPowerTemplate = SpecialAbilityHackerDisableBuilding
     StartAbilityRange = 150.0
-    UnpackTime      = 7300 ;animation time is 7300 (changing this will scale anim speed)
-    PackTime        = 5133 ;animation time is 5133 (changing this will scale anim speed)
+    UnpackTime      = 6570 ;animation time is 7300 (changing this will scale anim speed) ; Patch104p @tweak from 7300 to be consistent with Internet Hack time
+    PackTime        = 3850 ;animation time is 5133 (changing this will scale anim speed) ; Patch104p @tweak from 5133 to be consistent with Internet Hack time
     PreparationTime = 3000
 
     ;PersistentPrepTime = 500 ; old setting

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -3786,7 +3786,7 @@ End
 AudioEvent HackerCashPing
   Sounds      = ihaccasa ihaccasb
   VolumeShift = -5
-  Limit       = 2
+  Limit       = 1
   Volume      = 20
   Priority    = lowest
   Type        = world shrouded everyone


### PR DESCRIPTION
* Relates to #754

All China Hackers now unpack and pack their laptops quicker. The packing time variation has been significantly reduced from 100% to 20%. This adds more time consistency when packing and unpacking. The unpack base time has been just marginally tweaked to accommodate the pack variation for improved animation optics. The pack time has been reduced by 25%, allowing Hackers to flee the scene a bit quicker.

| Action                    | Min Time (ms) | Max Time (ms) | Average Time (ms) |
|---------------------------|---------------|---------------|-------------------|
| Original Unpack           | 3650          | 10950         | 7300              |
| Original Pack             | 2566          | 7700          | 5133              |
| **Patched Unpack (this)** | 5913          | 7227          | 6570 (-10%)       |
| **Patched Pack (this)**   | 3465          | 4235          | 3850 (-25%)       |

## Original

https://user-images.githubusercontent.com/4720891/181493444-4085847a-d4bd-47d8-a872-9b31174146d3.mp4

## Changed

https://user-images.githubusercontent.com/4720891/181493502-a16484f5-323a-4401-b0aa-21d7d2f52633.mp4

# Rationale

Originally the random time discrepancies for unpack and pack have a very wide margin, meaning some Hackers will pack quick while others take 3 times as long. The reduced random time margin helps making the pack times more predictable. The pack time on average is now 25 % quicker too, so Hackers can try flee the scene quicker in the case of approaching danger.