### PR TITLE
Change: Increase USA Paladin Composite Armor bonus to match with USA Crusader Tank bonus (200)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1823,6 +1823,15 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Paladin advantages over Crusader:
+;   +20 Health (500 vs 480)
+;   Low range Laser gun
+
+; Paladin disadvantages over Crusader:
+;   Requires 1x Level 1 Generals Promotion
+;   +200 cost (1100 vs 900)
+;   +2s build time (15.25 vs 13.25)
+
 Object AmericaTankPaladin
 
   ; *** ART Parameters ***
@@ -2044,9 +2053,11 @@ Object AmericaTankPaladin
     VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
+  ; Patch104p @bugfix xezon 28/07/2022 Match Paladin Composite Armor bonus with Crusader Tank bonus to guarantee it performs just a little bit better.
+
   Behavior = MaxHealthUpgrade ModuleTag_18
     TriggeredBy   = Upgrade_AmericaCompositeArmor
-    AddMaxHealth  = 100.0
+    AddMaxHealth  = 200.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 


### PR DESCRIPTION
* Fixes #645

The USA Paladin Tank now has the same Composite Armor bonus as Crusader Tank does.

## Stats

| Unit                                | Health | Composite Armor Bonus |
|-------------------------------------|--------|-----------------------|
| Original USA Crusader Tank          | 480    | 200 |
| Original USA Paladin Tank           | 500    | 100 |
| **Patched USA Paladin Tank (this)** | 500    | 200 |

### USA Paladin advantages over USA Crusader (in Patch):

* +20 Health (500 vs 480)
* Has low range Point Defense Laser gun

### USA Paladin disadvantages over USA Crusader (in Patch):

* Requires 1x Level 1 Generals Promotion
* +200 cost (1100 vs 900)
* +2s build time (15.25 vs 13.25)

# Rationale

The Paladin tank is better than a Crusader in that it starts with 20 extra health points (HP) (+4.2%) and a slow firing Point Defense Laser (PDL) that can target infantry besides neutralizing missiles.

In general, it is not worth the extra cost of 200 and build time of 2 seconds. After Composite Armor, it has much less HP than a Crusader to the point where the Crusader survives longer against 2 rocket infantries than a Paladin does despite the PDL.

To keep the Paladin worth the investment after Composite Armor upgrade, its Armor bonus is now equalized with the Armor bonus of the Crusader Tank.