### PR TITLE
Change: Add XP reward of 5 to China Outpost and China Troopcrawler

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -206,6 +206,10 @@ Object ChinaVehicleTroopCrawlerEmpty
   Prerequisites
     Object = ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = ChinaTroopCrawlerCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1107,6 +1107,10 @@ Object ChinaVehicleTroopCrawler
   Prerequisites
     Object = ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = ChinaTroopCrawlerCommandSet
@@ -2621,6 +2625,10 @@ Object ChinaVehicleListeningOutpost
   Prerequisites
     Object = ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = ChinaListeningOutpostCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15357,6 +15357,10 @@ Object Infa_ChinaVehicleTroopCrawler
   Prerequisites
     Object = Infa_ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = Infa_ChinaTroopCrawlerCommandSet
@@ -15650,6 +15654,10 @@ Object Infa_ChinaVehicleListeningOutpost
   Prerequisites
     Object = Infa_ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = Infa_ChinaListeningOutpostCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3253,6 +3253,10 @@ Object Nuke_ChinaVehicleTroopCrawler
   Prerequisites
     Object = Nuke_ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = ChinaTroopCrawlerCommandSet
@@ -4759,6 +4763,10 @@ Object Nuke_ChinaVehicleListeningOutpost
   Prerequisites
     Object = Nuke_ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = Nuke_ChinaListeningOutpostCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3879,6 +3879,10 @@ Object Tank_ChinaVehicleTroopCrawler
   Prerequisites
     Object = Tank_ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = ChinaTroopCrawlerCommandSet
@@ -4906,6 +4910,10 @@ Object Tank_ChinaVehicleListeningOutpost
   Prerequisites
     Object = Tank_ChinaWarFactory
   End
+
+  ExperienceValue        = 5 5 5 5  ; Patch104p @tweak from 0 to give small XP reward for killing
+  ExperienceRequired     = 0 0 0 0
+  IsTrainable            = No
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = ChinaListeningOutpostCommandSet


### PR DESCRIPTION
Fixes #549

## Original
China Outpost and Troopcrawler grant 0 XP points for kill.

## Patched
China Outpost and Troopcrawler grant 5 XP points for kill.
