### PR TITLE
Fix: Remove Demo GLA Terror Combat Bike suicide damage to allies before Demo Upgrade

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17999,15 +17999,17 @@ Object Demo_GLAVehicleCombatBike
 ;  End
 
   ; Patch104p @bugfix commy2 29/08/2021 Fix poison death not firing expected death weapons.
-  ; This made Bike deal no damage when killed by Anthrax Gamma poison.
+  ;   This made Bike deal no damage when killed by Anthrax Gamma poison.
+  ; Patch104p @bugfix xezon 29/07/2022 Replace SuicideBikeBomb with new bike bomb to exclude damage to ALLIES.
+  ;   This makes it consistent with Terrorist before/after Demo Upgrade and Terror Bike after Demo Upgrade
 
   ;Terrorist without suicide bomb upgrade
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death18
     RequiredStatus  = STATUS_RIDER5
-    DeathWeapon     = SuicideBikeBomb
+    DeathWeapon     = Demo_SuicideBikeBomb_Patch104p
     StartsActive    = Yes
     DeathTypes      = NONE +SUICIDED +BURNED +EXPLODED
-    ConflictsWith = Demo_Upgrade_SuicideBomb
+    ConflictsWith   = Demo_Upgrade_SuicideBomb
   End
 
   ;Terrorist without suicide bomb upgrade crushed

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2345,6 +2345,27 @@ Weapon SuicideBikeBomb
 End
 
 ;------------------------------------------------------------------------------
+Weapon Demo_SuicideBikeBomb_Patch104p
+  PrimaryDamage = 700.0
+  PrimaryDamageRadius = 20.0
+  SecondaryDamage = 100.0
+  SecondaryDamageRadius = 50.0
+  AttackRange = 5.0       ; must be very close to use this weapon!
+  DamageType = EXPLOSION
+  DeathType = SUICIDED
+  WeaponSpeed = 99999.0
+  ProjectileObject = NONE
+  DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?
+  RadiusDamageAffects = SELF SUICIDE ENEMIES NEUTRALS NOT_SIMILAR ;ALLIES
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+  AutoReloadsClip = No
+  FireFX = WeaponFX_SuicideDynamitePackDetonation
+  FireSound = CarBomberDie
+End
+
+;------------------------------------------------------------------------------
 Weapon CrushedBikeBomb_Patch104p
   PrimaryDamage = 308.0             ; 2 times as much as Demo_CrushedDynamitePack_Patch104p
   PrimaryDamageRadius = 20.0


### PR DESCRIPTION
* Fixes #775

Demo GLA Terror Combat Bike no longer damages allies before Demo Upgrade.

## Original

| Object | Damages ALLIES |
|--------|----------------|
| Demo Terrorist without Upgrade  |  |
| Demo Terrorist with Upgrade  |  |
| Demo Bike without Upgrade  | x  |
| Demo Bike with Upgrade  |  |
| Regular Terrorist  | x |
| Regular Terror Bike | x |
| Stealth Terror Bike | x |

## Patched

| Object | Damages ALLIES |
|--------|----------------|
| Demo Terrorist without Upgrade  |  |
| Demo Terrorist with Upgrade  |  |
| Demo Bike without Upgrade  |  |
| Demo Bike with Upgrade  |  |
| Regular Terrorist  | x |
| Regular Terror Bike | x |
| Stealth Terror Bike | x |

# Rationale

All Terrorists behave the same with Demo General. No inconsistencies.

## Proof of change

![shot_20220729_163451_2](https://user-images.githubusercontent.com/4720891/181784051-d8bbd5d4-5f2e-48e9-8b87-940c4ad4963d.jpg)
