### PR TITLE
Fix broken binary stream effect

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -298,7 +298,6 @@ End
 
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
-; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
 ; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
 ; Change Segments (20) to save as much as 60% performance impact.
 ; Change TilingScalar (0.25) to unstretch the texture.
@@ -306,16 +305,16 @@ End
 Object AirF_PatriotBinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream.tga
+    Texture = EXBinaryStream32.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2.75             ;The total width of beam
+    InnerBeamWidth = 5                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
     Segments = 5                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
+    TilingScalar = 0.66                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1,6 +1,5 @@
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
-; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
 ; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
 ; Change Segments (20) to save as much as 60% performance impact.
 ; Change TilingScalar (0.25) to unstretch the texture.
@@ -8,16 +7,16 @@
 Object Boss_PatriotBinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream.tga
+    Texture = EXBinaryStream32.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2.75             ;The total width of beam
+    InnerBeamWidth = 5                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
     Segments = 5                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
+    TilingScalar = 0.66                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -29520,7 +29520,6 @@ End
 
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
-; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
 ; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
 ; Change Segments (20) to save as much as 60% performance impact.
 ; Change TilingScalar (0.25) to unstretch the texture.
@@ -29528,16 +29527,16 @@ End
 Object PatriotBinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream.tga
+    Texture = EXBinaryStream32.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2.75             ;The total width of beam
+    InnerBeamWidth = 5                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
     Segments = 5                      ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
+    TilingScalar = 0.66                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4410,7 +4410,6 @@ End
 
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix xezon 12/09/2021 Fix expensive BinaryDataStream effect
-; Change Texture (EXBinaryStream32.tga) as it appears to benefit some systems.
 ; Change InnerBeamWidth (4) to reduce width of new textured stream effect.
 ; Change Segments (20) to save as much as 60% performance impact.
 ; Change TilingScalar (0.25) to unstretch the texture.
@@ -4418,16 +4417,16 @@ End
 Object BinaryDataStream
   ; *** ART Parameters ***
   Draw = W3DLaserDraw ModuleTag_01
-    Texture = EXBinaryStream.tga
+    Texture = EXBinaryStream32.tga
     NumBeams = 1                      ;Number of overlapping cylinders that make the beam. 1 beam will just use inner data. Current max: 10
-    InnerBeamWidth = 2.75             ;The total width of beam
+    InnerBeamWidth = 5                ;The total width of beam
     InnerColor = R:0 G:255 B:0 A:180  ;The inside color of the laser (hot)
     Tile = Yes                        ;The height of the texture will determine how many times to tile the texture to fit without scaling.
     ScrollRate = -0.25                 ;Scrolls the texture offset this fast -- towards(-) away(+)
     Segments = 10                     ;Number of segments -- more segments give smoother curve (but more joints) Current max: 20
     ArcHeight = 30.0                  ;The height of the arc
     SegmentOverlapRatio = 0.0000      ;This value overlaps(+) or separates(-) the segments by ratio
-    TilingScalar = 0.33                ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
+    TilingScalar = 0.66               ;Stretches tiling if value > 1.0, otherwise shrinks it (1.0 is natural)
  End
 
   KindOf = IMMOBILE


### PR DESCRIPTION
#336 broke binary effect on some installs.

Appears EXBinaryStream.tga does not exist on CD version. On First Decade it does.

![shot_20220730_093819_1](https://user-images.githubusercontent.com/4720891/181880645-ab0661d1-c7e1-45a4-891a-68f0ee1d2f43.jpg)