### PR TITLE
Fix: Sat Hack 1 Fails To Reveal Newly Built Command Centers

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -35110,11 +35110,9 @@ Object ChinaInternetCenter
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_15
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes        ; No SpecialPower module, turns self on and off on timers (No timers means always on)
-    SpyOnKindof   = COMMANDCENTER ; Defaults to ALL
-    TriggeredBy   = Upgrade_ChinaSatelliteHackOne
+  ; Patch104p @bugfix commy2 30/07/2022 Fix Sathack 1 does not reveal new Command Centers.
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = SatelliteHackOneDummyWeapon
   End
 
   Behavior         = SpyVisionUpdate ModuleTag_16

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -13822,11 +13822,9 @@ Object Infa_ChinaInternetCenter
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_15
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes        ; No SpecialPower module, turns self on and off on timers (No timers means always on)
-    SpyOnKindof   = COMMANDCENTER ; Defaults to ALL
-    TriggeredBy   = Upgrade_ChinaSatelliteHackOne
+  ; Patch104p @bugfix commy2 30/07/2022 Fix Sathack 1 does not reveal new Command Centers.
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = SatelliteHackOneDummyWeapon
   End
 
   Behavior         = SpyVisionUpdate ModuleTag_16

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16410,11 +16410,9 @@ Object Nuke_ChinaInternetCenter
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_15
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes        ; No SpecialPower module, turns self on and off on timers (No timers means always on)
-    SpyOnKindof   = COMMANDCENTER ; Defaults to ALL
-    TriggeredBy   = Upgrade_ChinaSatelliteHackOne
+  ; Patch104p @bugfix commy2 30/07/2022 Fix Sathack 1 does not reveal new Command Centers.
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = SatelliteHackOneDummyWeapon
   End
 
   Behavior         = SpyVisionUpdate ModuleTag_16

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2927,8 +2927,8 @@ Object SatelliteHackOneDummy
   End
 
   Behavior = LifetimeUpdate ModuleTag_02
-    MinLifetime = 250   ; min lifetime in msec
-    MaxLifetime = 250   ; max lifetime in msec
+    MinLifetime = 1000   ; min lifetime in msec
+    MaxLifetime = 1000   ; max lifetime in msec
   End
 
   Behavior         = SpyVisionUpdate ModuleTag_15

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2880,7 +2880,6 @@ Object DummyWeaponProjectile
 End
 
 ; Patch104p @bugfix commy2 24/10/2021 Logic that grants player Cash Bounty.
-
 ;------------------------------------------------------------------------------
 Object CashBountyDummy
 
@@ -2910,5 +2909,32 @@ Object CashBountyDummy
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+  End
+End
+
+; Patch104p @bugfix commy2 30/07/2022 Logic for Sathack 1 to reveal Command Centers.
+;------------------------------------------------------------------------------
+Object SatelliteHackOneDummy
+
+  ; ***DESIGN parameters ***
+  EditorSorting   = SYSTEM
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
+
+  ; *** ENGINEERING Parameters ***
+  Body = HighlanderBody ModuleTag_01
+    MaxHealth = 1.0
+    InitialHealth = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 250   ; min lifetime in msec
+    MaxLifetime = 250   ; max lifetime in msec
+  End
+
+  Behavior         = SpyVisionUpdate ModuleTag_15
+    NeedsUpgrade  = Yes
+    SelfPowered   = Yes        ; No SpecialPower module, turns self on and off on timers (No timers means always on)
+    SpyOnKindof   = COMMANDCENTER ; Defaults to ALL
+    TriggeredBy   = Upgrade_ChinaSatelliteHackOne
   End
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15415,11 +15415,9 @@ Object Tank_ChinaInternetCenter
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_15
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes        ; No SpecialPower module, turns self on and off on timers (No timers means always on)
-    SpyOnKindof   = COMMANDCENTER ; Defaults to ALL
-    TriggeredBy   = Upgrade_ChinaSatelliteHackOne
+  ; Patch104p @bugfix commy2 30/07/2022 Fix Sathack 1 does not reveal new Command Centers.
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = SatelliteHackOneDummyWeapon
   End
 
   Behavior         = SpyVisionUpdate ModuleTag_16

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -8537,6 +8537,15 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop3
 End
 
 
+; Patch104p @bugfix commy2 30/07/2022 Creates fresh Sathack 1 dummy object.
+; -----------------------------------------------------------------------------
+ObjectCreationList OCL_SatelliteHackOneDummy
+  CreateObject
+    ObjectNames = SatelliteHackOneDummy
+  End
+End
+
+
 
 ObjectCreationList GC_Slth_SUPERWEAPON_RebelAmbush1
   CreateObject
@@ -9136,7 +9145,6 @@ End
 
 
 ; Patch104p @bugfix commy2 29/08/2021 Creates dummies used to handle Demolitions upgrade with the Battle Bus.
-
 ; -----------------------------------------------------------------------------
 ; Demolitions General
 ; -----------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8712,6 +8712,6 @@ End
 ; Patch104p @bugfix commy2 24/10/2021 Spawns dummy object with sathack 1 logic over and over.
 ;------------------------------------------------------------------------------
 Weapon SatelliteHackOneDummyWeapon
-  DelayBetweenShots = 250                ; time between shots, msec
+  DelayBetweenShots = 1000                ; time between shots, msec
   FireOCL = OCL_SatelliteHackOneDummy
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8703,9 +8703,15 @@ Weapon Demo_ScudStormDeathWeapon
 End
 
 ; Patch104p @bugfix commy2 24/10/2021 Spawns temporary object with cash bounty logic over and over.
-
 ;------------------------------------------------------------------------------
 Weapon CashBountyDummyWeapon
   DelayBetweenShots = 250                ; time between shots, msec
   FireOCL = OCL_CashBountyDummy
+End
+
+; Patch104p @bugfix commy2 24/10/2021 Spawns dummy object with sathack 1 logic over and over.
+;------------------------------------------------------------------------------
+Weapon SatelliteHackOneDummyWeapon
+  DelayBetweenShots = 250                ; time between shots, msec
+  FireOCL = OCL_SatelliteHackOneDummy
 End


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/748

1.04:

- Satellite Hack 1 will only reveal Command Centers that existed when the upgrade was finished or the latest Internet Center was built. It will not reveal Command Centers that were built afterwards, until it is destroyed or sold and then rebuild.

This patch: The Internet Center will continously reveal new Command Centers as one may expect.