### PR TITLE
Change: Reduce China Black Lotus level up requirements by -82%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17824,9 +17824,10 @@ Object Boss_InfantryBlackLotus
   CommandSet            = ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+  ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
 
-  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
+  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = ChinaInfantryBlackLotusCommandSet
@@ -17953,7 +17954,7 @@ Object Boss_InfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -657,9 +657,10 @@ Object ChinaInfantryBlackLotus
   CommandSet            = ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+  ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
 
-  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
+  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = ChinaInfantryBlackLotusCommandSet
@@ -780,7 +781,7 @@ Object ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -734,9 +734,10 @@ Object Infa_ChinaInfantryBlackLotus
   MaxSimultaneousOfType = 1
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+  ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
 
-  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
+  ExperienceRequired    = 0 40 120 200 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Infa_ChinaInfantryBlackLotusCommandSet
@@ -857,7 +858,7 @@ Object Infa_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2079,9 +2079,10 @@ Object Nuke_ChinaInfantryBlackLotus
   CommandSet            = Nuke_ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+  ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
 
-  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
+  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Nuke_ChinaInfantryBlackLotusCommandSet
@@ -2202,7 +2203,7 @@ Object Nuke_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1810,9 +1810,10 @@ Object Tank_ChinaInfantryBlackLotus
   CommandSet            = Tank_ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
+  ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
 
-  ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
+  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Tank_ChinaInfantryBlackLotusCommandSet
@@ -1933,7 +1934,7 @@ Object Tank_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 


### PR DESCRIPTION
Related changes:
* #413
* #437

This change further decreases Black Lotus level up requirements by -60% (total -82%) for regular Black Lotus. Super Lotus is tweaked a bit differently, because it spawns at Level 1 already and has better range for Vehicle Hack. Super Lotus will require the same actions as regular Black Lotus does to gain Level 2.

Additionally the Cash Hack XP has been reduced from 20 to 10. This scaled better in comparison to Vehicle Hack XP (5) and Capture Build XP (20).

| Object                         | ExperienceRequired | req. Vehicle Hack count | req. Cash Hack count | req. Building Cap count |
|--------------------------------|-------------------:|------------------------:|---------------------:|------------------------:|
| Original Black Lotus           | 150 450 900        |                         | 08 23 45             | 08 23 45                |
| Patched Black Lotus (1)        | 100 200 400        | 20 40 80                | 05 10 20             | 05 10 20                |
| Patched Black Lotus (2) (this) | 040 080 160        | 08 16 32                | 04 08 16             | 02 04 08                |
| Patched Super Lotus (2) (this) | 040 120 200        | 00 16 32                | 00 08 16             | 00 04 08                |

# Rationale

## China Black Lotus estimated level up times

We do not have statistical data, so the best we can do is make a rough estimate for level up times. We assume in a match scenario a Black Lotus could perform a Vehicle Hack every 15 seconds, a Cash Hack every 25 seconds, a Building Capture every 40 seconds. A Vehicle Hack rewards 5 XP, a Cash Hack rewards 10 XP and a Building Capture rewards 20 XP.

Why these times?

A Vehicle Hack on its own already takes around 5 seconds to perform. Add some walking, fleeing and idle inbetween and 15 seconds do appear plausible.

A Cash Hack takes around 12 seconds to perform. Add some walking, fleeing and idle times inbetween and the estimated 25 seconds should be generous.

A Building Capture takes around 12 seconds to perform. Add some walking, fleeing and idle times inbetween and the estimated 40 seconds should be generous.

| Veterancy | ExperienceRequired | req. Vehicle Hack count | req. Vehicle Hack time     |
|-----------|-------------------:|------------------------:|---------------------------:|
| 1         | 100                | 20                      |  300 seconds (05:00)       |
| 2         | 200                | 40                      |  600 seconds (10:00)       |
| 3         | 400                | 80                      | 1200 seconds (20:00)       |

| Veterancy | ExperienceRequired | req. Cash Hack count    | req. Cash Hack time        |
|-----------|-------------------:|------------------------:|---------------------------:|
| 1         | 100                | 10                      |  300 seconds (05:00)       |
| 2         | 200                | 20                      |  600 seconds (10:00)       |
| 3         | 400                | 40                      | 1200 seconds (20:00)       |

| Veterancy | ExperienceRequired | req. Building Cap count | req. Building Cap time     |
|-----------|-------------------:|------------------------:|---------------------------:|
| 1         | 100                |  5                      |  200 seconds (03:20)       |
| 2         | 200                | 10                      |  400 seconds (06:40)       |
| 3         | 400                | 20                      |  800 seconds (13:20)       |

Given these 3 types of XP reward, we use the average time as our final result (rounded to 50):

| Veterancy | ExperienceRequired | required time        |
|-----------|-------------------:|---------------------:|
| 1         | 100                |  250 seconds (03:45) |
| 2         | 200                |  550 seconds (07:30) |
| 3         | 400                | 1050 seconds (15:00) |


## GLA Jarmen Kell estimated level up times

For Jarmen Kell we can also do a rough estimate. First we look at how much XP we can expect for standard Infantry kills.

| Object               | ExperienceValue |
|----------------------|----------------:|
| USA Ranger           | 20 20 40 60     |
| USA Missile Defender | 20 20 40 60     |
| China Red Guard      | 05 05 10 20     |
| China Tank Hunter    | 20 20 40 60     |
| GLA Rebel            | 15 15 30 40     |
| GLA Tunnel Defender  | 20 20 40 60     |

There is a wide range of values. For simplicity, we assume a Veterancy level of 2.25. This is arbitrary.

| Object               | ExperienceValue simplified |
|----------------------|---------------------------:|
| USA Ranger           | 25.00                      |
| USA Missile Defender | 25.00                      |
| China Red Guard      | 6.25                       |
| China Tank Hunter    | 25.00                      |
| GLA Rebel            | 18.75                      |
| GLA Tunnel Defender  | 25.00                      |

We average this XP reward to 125/6 = 21, round down to 20 for simplicity.

We estimate a Jarmen Kell can realistically kill a soldier every 10 seconds, if there are targets available. Typically Infantries come in blobs, so Jarmen Kell can kill some units, idle a bit and then kill more.

| Veterancy | ExperienceRequired | req. Infantry kills | req. kill time             |
|-----------|-------------------:|--------------------:|---------------------------:|
| 1         | 100                | 5                   |  50 seconds (00:50)        |
| 2         | 200                | 10                  | 100 seconds (01:40)        |
| 3         | 400                | 20                  | 200 seconds (03:20)        |


## USA Colonel Burton level up times

Burton is the most versatile hero unit to gain veterancy with. It can not just kill infantry as Jarmen Kell can, but can kill vehicles and structures as well. The gun has a lower firing range than the rifle of Jarmen Kell, so for starters we assume Burton takes longer to kill infantry. We can realistically estimate Burton to kill a soldier every 15 seconds.

| Veterancy | ExperienceRequired | req. Infantry kills | req. kill time             |
|-----------|-------------------:|--------------------:|---------------------------:|
| 1         | 200                | 10                  | 150 seconds (02:30)        |
| 2         | 300                | 15                  | 225 seconds (03:45)        |
| 3         | 600                | 30                  | 450 seconds (07:30)        |

Favorite vehicle targets of Colonel Burton are Artillery units such as Rocket Buggy, Inferno Cannon and Tomahawk. Additionally Burton likes to kill Migs and Raptors on Airfields. All these units give an XP reward of 50 50 100 150. For simplicity, we assume a vehicle veterancy level of 2.25, putting the vehicle XP reward at 62.5, or just 60 to keep it rounded. Realistically, we can assume Burton to kill Vehicles just as efficiently as Infantry, if the opportunity is presented. We therefore assume a vehicle kill every 15 seconds.

| Veterancy | ExperienceRequired | req. Vehicle kills | req. kill time             |
|-----------|-------------------:|-------------------:|---------------------------:|
| 1         | 200                | 3.3                |  50 seconds (00:50)        |
| 2         | 300                | 5                  |  75 seconds (01:15)        |
| 3         | 600                | 10                 | 150 seconds (02:30)        |

Favorite structure targets of Colonel Burton are Warfactories (200 XP), Tech Centers (around 250 XP) and Money houses (200 XP). These require just one demo charge to destroy and gain XP from. The rewarded XP is around 200 for most of the high value structures, so for simplicity we work with that value. It does take some 5 seconds or so to plant the demo charge and 10 seconds for the charge to explode. Adding a bit of walking and hiding to it, we can assume around 40 seconds per building kill, same as Lotus would require to capture enemy buildings.

| Veterancy | ExperienceRequired | req. Building kills | req. kill time             |
|-----------|-------------------:|--------------------:|---------------------------:|
| 1         | 200                | 1                   |  40 seconds (00:40)        |
| 2         | 300                | 1.5                 |  60 seconds (01:00)        |
| 3         | 600                | 3                   | 120 seconds (02:00)        |

To consolidate the Burton level up times, we simply add them and divide by the count.

| Veterancy | ExperienceRequired | required time              |
|-----------|-------------------:|---------------------------:|
| 1         | 200                |  80 seconds (01:20)        |
| 2         | 300                | 120 seconds (02:00)        |
| 3         | 600                | 240 seconds (04:00)        |

Colonel Burton has a very competitive level up time similar to Jarmen Kell.

## Conclusion

Given these estimations and calculations, we can assume that on average a Black Lotus will take 5.25 times as much time and effort as Jarmen Kell and 4.3 times as much time and effort as Colonel Burton does to reach the same veterancy level. Additionally it is very difficult to pull off Building Captures deep in the enemy base, whereas Jarmen Kell snipes and Burton kills can be performed at the front line in cover of friendly units and Tunnel Networks.

There is one big caveat though: Civilian building captures. Black Lotus can profit from capturing civilian buildings, such as Oil Derricks and Artillery Platforms. Especially at the start of the match, when nothing has yet been captured, Lotus can achieve a Level 1 or Level 2 promotion almost effortlessly. On some maps blessed with many structures, such as Oil Rampage, a Level 3 promotion may be possible very quickly. However, this will be almost always exclusive to the very first built Lotus.

Therefore a reduction in Black Lotus level up requirements appear reasonable. With this change, Black Lotus level up is 2.5 times better than before, and just 2.1 times worse than Jarmen Kell.