### PR TITLE
Fix: Missing particle effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -10336,7 +10336,7 @@ ParticleSystem ArmExplosionSmall01
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -17205,7 +17205,7 @@ ParticleSystem airCarrierHotPillarArms
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -18682,7 +18682,7 @@ ParticleSystem BuggyNewExplosionArms
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -20380,7 +20380,7 @@ ParticleSystem airCarrierJetExplosion1
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -20493,7 +20493,7 @@ ParticleSystem airCarrierJetExplosion2
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -20665,7 +20665,7 @@ ParticleSystem airCarrierJetExplosion3
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -24125,7 +24125,7 @@ ParticleSystem MammothTankExplosionArms
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -31214,7 +31214,7 @@ ParticleSystem FireBaseHowitzerPillarArms
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -32530,7 +32530,7 @@ ParticleSystem HotPillarArms
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -38674,7 +38674,7 @@ ParticleSystem airCarrierJet01Explosion
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -47951,7 +47951,7 @@ ParticleSystem BarrelExplosion
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -48575,7 +48575,7 @@ ParticleSystem airCarrierExplosion2
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -62208,7 +62208,7 @@ ParticleSystem SpectreHotPillarArms
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:3 G:0 B:0 0
+  Color1 = R:6 G:6 B:6 0 ; Patch104p @bugfix xezon 02/08/2022 From R:3 G:0 B:0 0 fixes broken effect in game
   Color2 = R:0 G:0 B:0 0
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0


### PR DESCRIPTION
Closes #543
Fixes #424

This change recovers 13 broken particles.

## Fixed with tweaking color values

airCarrierExplosion2
airCarrierHotPillarArms
airCarrierJet01Explosion
airCarrierJetExplosion1
airCarrierJetExplosion2
airCarrierJetExplosion3
ArmExplosionSmall01
BarrelExplosion
BuggyNewExplosionArms
FireBaseHowitzerPillarArms
HotPillarArms
MammothTankExplosionArms
SpectreHotPillarArms

## Original Zero Hour

https://user-images.githubusercontent.com/4720891/182839993-bd081f25-3129-4a0b-8b09-11006d3b2f9e.mp4

## Patched

https://user-images.githubusercontent.com/4720891/182840036-1a85e3d3-2a65-48b4-90c3-02cd067d698c.mp4
