### PR TITLE
Fix: Toxin Tractor Model Scrap Stages

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -17109,6 +17109,7 @@ Object Chem_GLAVehicleToxinTruck
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 05/08/2022 Fix scrap models.
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -17116,8 +17117,8 @@ Object Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk
       Turret = Turret
       TurretPitch = TurretEL
-      ShowSubObject = Turret
-      HideSubObject = TurretUP01 TurretUP02
+      ShowSubObject = Turret ToxTanks00 HouseColor01
+      HideSubObject = TurretUP01 TurretUP02 ToxTanks01 HouseColor02 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponA
       WeaponLaunchBone = PRIMARY WeaponA
       WeaponFireFXBone = SECONDARY Spigot
@@ -17154,8 +17155,8 @@ Object Chem_GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -17164,8 +17165,8 @@ Object Chem_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -17173,8 +17174,8 @@ Object Chem_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxGammaPuddleContinuous
@@ -17184,8 +17185,8 @@ Object Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -17197,8 +17198,8 @@ Object Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -17207,8 +17208,8 @@ Object Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxGammaPuddleContinuous
@@ -17218,8 +17219,8 @@ Object Chem_GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -17228,8 +17229,8 @@ Object Chem_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -17237,8 +17238,8 @@ Object Chem_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxGammaPuddleContinuous
@@ -17248,8 +17249,8 @@ Object Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -17261,8 +17262,8 @@ Object Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -17271,8 +17272,8 @@ Object Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxGammaPuddleContinuous

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -18463,6 +18463,7 @@ Object Demo_GLAVehicleToxinTruck
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 05/08/2022 Fix scrap models.
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -18470,8 +18471,8 @@ Object Demo_GLAVehicleToxinTruck
       Model = UVToxinTrk
       Turret = Turret
       TurretPitch = TurretEL
-      ShowSubObject = Turret
-      HideSubObject = TurretUP01 TurretUP02
+      ShowSubObject = Turret ToxTanks00 HouseColor01
+      HideSubObject = TurretUP01 TurretUP02 ToxTanks01 HouseColor02 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponA
       WeaponLaunchBone = PRIMARY WeaponA
       WeaponFireFXBone = SECONDARY Spigot
@@ -18508,8 +18509,8 @@ Object Demo_GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -18518,8 +18519,8 @@ Object Demo_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18527,8 +18528,8 @@ Object Demo_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -18538,8 +18539,8 @@ Object Demo_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -18551,8 +18552,8 @@ Object Demo_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18561,8 +18562,8 @@ Object Demo_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -18572,8 +18573,8 @@ Object Demo_GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -18582,8 +18583,8 @@ Object Demo_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18591,8 +18592,8 @@ Object Demo_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -18602,8 +18603,8 @@ Object Demo_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -18615,8 +18616,8 @@ Object Demo_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18625,8 +18626,8 @@ Object Demo_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1462,8 +1462,8 @@ Object GC_Chem_GLAVehicleToxinTruck
       Model = UVToxinTrk
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponFireFXBone = SECONDARY Spigot

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3609,6 +3609,7 @@ Object GLAVehicleToxinTruck
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 05/08/2022 Fix scrap models.
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -3616,8 +3617,8 @@ Object GLAVehicleToxinTruck
       Model = UVToxinTrk
       Turret = Turret
       TurretPitch = TurretEL
-      ShowSubObject = Turret
-      HideSubObject = TurretUP01 TurretUP02
+      ShowSubObject = Turret ToxTanks00 HouseColor01
+      HideSubObject = TurretUP01 TurretUP02 ToxTanks01 HouseColor02 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponA
       WeaponLaunchBone = PRIMARY WeaponA
       WeaponFireFXBone = SECONDARY Spigot
@@ -3654,8 +3655,8 @@ Object GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -3664,8 +3665,8 @@ Object GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
@@ -3673,8 +3674,8 @@ Object GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -3684,8 +3685,8 @@ Object GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -3697,8 +3698,8 @@ Object GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
@@ -3707,8 +3708,8 @@ Object GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -3718,8 +3719,8 @@ Object GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -3728,8 +3729,8 @@ Object GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
@@ -3737,8 +3738,8 @@ Object GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -3748,8 +3749,8 @@ Object GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -3761,8 +3762,8 @@ Object GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
@@ -3771,8 +3772,8 @@ Object GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18538,6 +18538,7 @@ Object Slth_GLAVehicleToxinTruck
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 05/08/2022 Fix scrap models.
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -18545,8 +18546,8 @@ Object Slth_GLAVehicleToxinTruck
       Model = UVToxinTrk
       Turret = Turret
       TurretPitch = TurretEL
-      ShowSubObject = Turret
-      HideSubObject = TurretUP01 TurretUP02
+      ShowSubObject = Turret ToxTanks00 HouseColor01
+      HideSubObject = TurretUP01 TurretUP02 ToxTanks01 HouseColor02 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponA
       WeaponLaunchBone = PRIMARY WeaponA
       WeaponFireFXBone = SECONDARY Spigot
@@ -18583,8 +18584,8 @@ Object Slth_GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -18593,8 +18594,8 @@ Object Slth_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18602,8 +18603,8 @@ Object Slth_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -18613,8 +18614,8 @@ Object Slth_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
     End
@@ -18626,8 +18627,8 @@ Object Slth_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18636,8 +18637,8 @@ Object Slth_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP01
       TurretPitch = TurretEL01
-      ShowSubObject = TurretUP01
-      HideSubObject = Turret TurretUP02
+      ShowSubObject = TurretUP01 ToxTanks01 HouseColor02
+      HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -18647,8 +18648,8 @@ Object Slth_GLAVehicleToxinTruck
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -18657,8 +18658,8 @@ Object Slth_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18666,8 +18667,8 @@ Object Slth_GLAVehicleToxinTruck
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
@@ -18677,8 +18678,8 @@ Object Slth_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
     End
@@ -18690,8 +18691,8 @@ Object Slth_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
@@ -18700,8 +18701,8 @@ Object Slth_GLAVehicleToxinTruck
       Model = UVToxinTrk_D
       Turret = TurretUP02
       TurretPitch = TurretEL02
-      ShowSubObject = TurretUP02
-      HideSubObject = TurretUP01 Turret
+      ShowSubObject = TurretUP02 ToxTanks03 HouseColor04
+      HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous


### PR DESCRIPTION
Enlima29 pointed this one out.

- fix: https://github.com/TheSuperHackers/GeneralsGamePatch/issues/814

1.04:

- Toxin Tractor only change their gun when scrapped up. Toxin Tractor also looks different than CCG Toxin Tractor even before scrapping up.

This patch:

- Toxin Tractor gets bigger side barrels when scrapping up once.
- Toxin Tractor gets back barrel when scrapped up twice.

![shot_20220805_142649_2](https://user-images.githubusercontent.com/6576312/183077959-0bf45bed-9892-4988-b7ee-8a75d508c3e1.jpg)
![shot_20220805_142709_3](https://user-images.githubusercontent.com/6576312/183077963-d5bfa95a-45e1-490c-a60c-7bd6f9449434.jpg)

- USA05 Toxin Tractor is visually unchanged, but I removed the sections that are covered by bigger model parts anyway to be in line with a regular twice scrapped Toxin Truck.