### PR TITLE
Change: Make Anthrax Bomb Use Color Of Anthrax Upgrade

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -6850,38 +6850,6 @@ End
 ; ----------------------------------------------
 ; weapon fx for Demo Anthrax Bomb
 ; ----------------------------------------------
-FXList Demo_FX_AnthraxBomb
-  ViewShake
-    Type = SUBTLE
-  End
-;  TerrainScorch
-;    Type = RANDOM
-;    Radius = 15
-;  End
-;  LightPulse
-;    Color = R:255 G:128 B:51
-;    Radius = 30
-;    IncreaseTime = 0
-;    DecreaseTime = 2333
-;  End
-  ParticleSystem
-    Name = Demo_AnthraxBombExplosion
-  End
-  ParticleSystem
-    Name = Demo_AnthraxBombSpray
-  End
-  ParticleSystem
-    Name = Demo_AnthraxBombLenzflare
-    Offset = X:0 Y:0 Z:2
-  End
-  Sound
-    Name = ExplosionAnthraxBomb
-  End
-End
-
-; ----------------------------------------------
-; weapon fx for Anthrax Bomb
-; ----------------------------------------------
 FXList FX_AnthraxBomb
   ViewShake
     Type = SUBTLE
@@ -6904,6 +6872,38 @@ FXList FX_AnthraxBomb
   End
   ParticleSystem
     Name = AnthraxBombLenzflare
+    Offset = X:0 Y:0 Z:2
+  End
+  Sound
+    Name = ExplosionAnthraxBomb
+  End
+End
+
+; ----------------------------------------------
+; weapon fx for Anthrax Bomb
+; ----------------------------------------------
+FXList FX_AnthraxBetaBomb
+  ViewShake
+    Type = SUBTLE
+  End
+;  TerrainScorch
+;    Type = RANDOM
+;    Radius = 15
+;  End
+;  LightPulse
+;    Color = R:255 G:128 B:51
+;    Radius = 30
+;    IncreaseTime = 0
+;    DecreaseTime = 2333
+;  End
+  ParticleSystem
+    Name = AnthraxBetaBombExplosion
+  End
+  ParticleSystem
+    Name = AnthraxBetaBombSpray
+  End
+  ParticleSystem
+    Name = AnthraxBetaBombLenzflare
     Offset = X:0 Y:0 Z:2
   End
   Sound

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -6848,7 +6848,7 @@ End
 
 ; Patch104p @bugfix commy2 31/07/2022 Effects list for green Anthrax Bomb.
 ; ----------------------------------------------
-; weapon fx for Demo Anthrax Bomb
+; weapon fx for Anthrax Bomb
 ; ----------------------------------------------
 FXList FX_AnthraxBomb
   ViewShake
@@ -6880,7 +6880,7 @@ FXList FX_AnthraxBomb
 End
 
 ; ----------------------------------------------
-; weapon fx for Anthrax Bomb
+; weapon fx for Anthrax Beta Bomb
 ; ----------------------------------------------
 FXList FX_AnthraxBetaBomb
   ViewShake

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1126,7 +1126,7 @@ Object Demo_GLACommandCenter
 
   Behavior           = OCLSpecialPower ModuleTag_13
     SpecialPowerTemplate = SuperweaponAnthraxBomb
-    OCL                  = Demo_SUPERWEAPON_AnthraxBomb ; Patch104p @bugfix commy2 31/07/2022 Fix Demo General now drops green instead of blue Anthrax Bomb.
+    OCL                  = SUPERWEAPON_AnthraxBomb
     CreateLocation       = CREATE_AT_EDGE_NEAR_SOURCE
   End
   Behavior           = OCLSpecialPower ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2091,7 +2091,7 @@ Object PoisonFieldUpgradedSmall
 
 End
 
-; Patch104p @bugfix commy2 31/07/2022 Green poison cloud created by Demo General Anthrax Bomb.
+; Patch104p @bugfix commy2 31/07/2022 Green poison cloud created by Anthrax Bomb without upgrades.
 ;------------------------------------------------------------------------------
 Object PoisonFieldAnthraxBomb
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2093,7 +2093,7 @@ End
 
 ; Patch104p @bugfix commy2 31/07/2022 Green poison cloud created by Demo General Anthrax Bomb.
 ;------------------------------------------------------------------------------
-Object Demo_PoisonFieldAnthraxBomb
+Object PoisonFieldAnthraxBomb
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -2119,7 +2119,7 @@ Object Demo_PoisonFieldAnthraxBomb
     InitialHealth    = 100.0
   End
   Behavior = FireWeaponUpdate ModuleTag_03
-    Weapon = Demo_AnthraxBombPoisonFieldWeapon
+    Weapon = AnthraxBombPoisonFieldWeapon
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -2146,7 +2146,7 @@ Object Demo_PoisonFieldAnthraxBomb
 End
 
 ;------------------------------------------------------------------------------
-Object PoisonFieldAnthraxBomb
+Object PoisonFieldAnthraxBetaBomb
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -2172,7 +2172,7 @@ Object PoisonFieldAnthraxBomb
     InitialHealth    = 120.0
   End
   Behavior = FireWeaponUpdate ModuleTag_03
-    Weapon = AnthraxBombPoisonFieldWeapon
+    Weapon = AnthraxBetaBombPoisonFieldWeapon
   End
 
   Behavior = LifetimeUpdate ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1540,104 +1540,6 @@ Object BlackMarketNuke
 
 End
 
-; Patch104p @bugfix commy2 31/07/2022 Green Anthrax Bomb for Demo General.
-;------------------------------------------------------------------------------
-Object Demo_AnthraxBomb
-
-  ; *** ART Parameters ***
-  Draw = W3DModelDraw ModuleTag_01
-    OkToChangeModelColor = Yes
-    DefaultConditionState
-      Model = AVBomber_B
-    End
-  End
-
-  ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:AnthraxBomb
-  Side                = GLADemolitionGeneral
-  EditorSorting       = SYSTEM
-  TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
-  VisionRange         = 300.0
-  ShroudClearingRange = 0
-  ArmorSet
-    Conditions      = None
-    Armor           = ProjectileArmor
-    DamageFX        = None
-  End
-
-  ; *** AUDIO Parameters ***
-  SoundFallingFromPlane = DaisyCutterWeapon
-
-  ; *** ENGINEERING Parameters ***
-  KindOf            = PROJECTILE
-  Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
-  End
-
-  Behavior = AIUpdateInterface ModuleTag_03
-  End
-  Locomotor = SET_NORMAL None
-
-  Behavior = PhysicsBehavior ModuleTag_04
-    Mass                  = 75.0
-    AerodynamicFriction   = 1  ; this is now friction-per-sec
-    ForwardFriction       = 33     ; this is now friction-per-sec
-    CenterOfMassOffset    = 2  ; Default of 0 means nothing tips as it falls.  Positive tips forward, negative tips back
-  End
-
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_05
-    DeathWeapon   = Demo_AnthraxBombWeapon
-    StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
-  End
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Beta
-    DeathWeapon   = AnthraxBombWeapon
-    StartsActive  = No                      ; turned on by upgrade
-    TriggeredBy   = Upgrade_GLAAnthraxBeta
-    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
-  End
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Gamma
-    DeathWeapon   = AnthraxGammaBombWeapon
-    StartsActive  = No                      ; turned on by upgrade
-    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
-  End
-
-  Behavior = HeightDieUpdate ModuleTag_06
-    TargetHeight = 40.0
-    TargetHeightIncludesStructures = No
-  End
-
-  Behavior = SpecialPowerCompletionDie ModuleTag_07
-    SpecialPowerTemplate = SuperweaponAnthraxBomb
-  End
-  Behavior = DestroyDie ModuleTag_08
-    ;nothing
-  End
-
-  Behavior = FXListDie ModuleTag_09
-    DeathFX = Demo_FX_AnthraxBomb
-    StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
-  End
-  Behavior = FXListDie ModuleTag_BetaFX
-    DeathFX = FX_AnthraxBomb
-    StartsActive  = No
-    TriggeredBy   = Upgrade_GLAAnthraxBeta
-    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
-  End
-  Behavior = FXListDie ModuleTag_GammaFX
-    DeathFX = FX_AnthraxGammaBomb
-    StartsActive  = No
-    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
-  End
-
-;  Geometry = Sphere
- ; GeometryIsSmall = Yes
-  ;GeometryMajorRadius = 12.0
-
-End
-
 ;------------------------------------------------------------------------------
 Object AnthraxBomb
 
@@ -1686,6 +1588,12 @@ Object AnthraxBomb
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_05
     DeathWeapon   = AnthraxBombWeapon
     StartsActive  = Yes
+    ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
+  End
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Beta
+    DeathWeapon   = AnthraxBetaBombWeapon
+    StartsActive  = No
+    TriggeredBy   = Upgrade_GLAAnthraxBeta
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Gamma
@@ -1709,12 +1617,18 @@ Object AnthraxBomb
   Behavior = FXListDie ModuleTag_09
     DeathFX = FX_AnthraxBomb
     StartsActive  = Yes
+    ConflictsWith = Upgrade_GLAAnthraxBeta Chem_Upgrade_GLAAnthraxGamma
+  End
+  Behavior = FXListDie ModuleTag_BetaFX
+    DeathFX = FX_AnthraxBetaBomb
+    StartsActive  = No
+    TriggeredBy   = Upgrade_GLAAnthraxBeta
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
   End
   Behavior = FXListDie ModuleTag_GammaFX
     DeathFX = FX_AnthraxGammaBomb
     StartsActive  = No
-    TriggeredBy = Chem_Upgrade_GLAAnthraxGamma
+    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
 
 ;  Geometry = Sphere
@@ -1768,9 +1682,15 @@ Object AnthraxBombGamma
     CenterOfMassOffset    = 2  ; Default of 0 means nothing tips as it falls.  Positive tips forward, negative tips back
   End
 
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_05
+    DeathWeapon   = AnthraxBetaBombWeapon
+    StartsActive  = Yes
+    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+  End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_Gamma
     DeathWeapon   = AnthraxGammaBombWeapon
-    StartsActive  = Yes
+    StartsActive  = No                      ; turned on by upgrade
+    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
 
   Behavior = HeightDieUpdate ModuleTag_06
@@ -1785,9 +1705,15 @@ Object AnthraxBombGamma
     ;nothing
   End
 
+  Behavior = FXListDie ModuleTag_BetaFX
+    DeathFX = FX_AnthraxBetaBomb
+    StartsActive  = Yes
+    ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
+  End
   Behavior = FXListDie ModuleTag_GammaFX
     DeathFX = FX_AnthraxGammaBomb
-    StartsActive  = Yes
+    StartsActive  = No
+    TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
 
 ;  Geometry = Sphere

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1705,6 +1705,9 @@ Object AnthraxBombGamma
     ;nothing
   End
 
+  ; Patch104p @bugfix commy2 05/08/2022 Object is named AnthraxBombGamma for backwards compatibility.
+  ; It is the AnthraxBomb version dropped by the Toxin General Command Center.
+  ; In this patch, that bomb will appear blue before the Anthrax Gamma upgrade.
   Behavior = FXListDie ModuleTag_BetaFX
     DeathFX = FX_AnthraxBetaBomb
     StartsActive  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -79,17 +79,17 @@ End
 
 ; Patch104p @bugfix commy2 31/07/2022 Creates green Anthrax Bomb poison cloud.
 ; ----------------------------------------------
-ObjectCreationList Demo_OCL_PoisonFieldAnthraxBomb
+ObjectCreationList OCL_PoisonFieldAnthraxBomb
  CreateObject
-   ObjectNames = Demo_PoisonFieldAnthraxBomb
+   ObjectNames = PoisonFieldAnthraxBomb
    Disposition = ON_GROUND_ALIGNED
  End
 End
 
 ; ----------------------------------------------
-ObjectCreationList OCL_PoisonFieldAnthraxBomb
+ObjectCreationList OCL_PoisonFieldAnthraxBetaBomb
  CreateObject
-   ObjectNames = PoisonFieldAnthraxBomb
+   ObjectNames = PoisonFieldAnthraxBetaBomb
    Disposition = ON_GROUND_ALIGNED
  End
 End
@@ -5260,29 +5260,6 @@ End
 ; The anthrax bomb doesn't have any art yet so right now it is going
 ; to use the daisy cutter animation/bomb stuff -- only because this is going
 ; to be a nuke dropped from a plane
-
-; Patch104p @bugfix commy2 31/07/2022 Summons cargo plane that drops Anthrax Bomb for Demo General.
-ObjectCreationList Demo_SUPERWEAPON_AnthraxBomb
-  DeliverPayload
-    Transport = GLAJetCargoPlane
-    StartAtPreferredHeight = Yes
-    StartAtMaxSpeed = Yes
-    MaxAttempts = 1
-    DropOffset = X:0 Y:0 Z:-10
-    Payload = Demo_AnthraxBomb
-    DeliveryDistance = 140
-    DeliveryDecalRadius = 200
-    DeliveryDecal
-      Texture           = SCCAnthraxBomb_GLA
-      Style             = SHADOW_ALPHA_DECAL
-      OpacityMin        = 25%
-      OpacityMax        = 50%
-      OpacityThrobTime  = 500
-      Color             = R:33 G:255 B:67 A:255
-      OnlyVisibleToOwningPlayer = Yes
-    End
-  End
-End
 
 ObjectCreationList SUPERWEAPON_AnthraxBomb
   DeliverPayload

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -3010,7 +3010,7 @@ ParticleSystem AircraftCarrierCatapultSteamParent
 End
 
 ; Patch104p @bugfix commy2 31/07/2022 Recoloured Anthrax Bomb effect in green.
-ParticleSystem Demo_AnthraxBombLenzflare
+ParticleSystem AnthraxBombLenzflare
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -3035,7 +3035,7 @@ ParticleSystem Demo_AnthraxBombLenzflare
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:128 G:255 B:0 0
+  Color1 = R:0 G:128 B:0 0
   Color2 = R:0 G:0 B:0 100
   Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
@@ -3065,7 +3065,7 @@ ParticleSystem Demo_AnthraxBombLenzflare
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AnthraxBombLenzflare
+ParticleSystem AnthraxBetaBombLenzflare
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -10425,7 +10425,7 @@ ParticleSystem BuggyNewExplosionFlameSlave
 End
 
 ; Patch104p @bugfix commy2 31/07/2022 Recoloured Anthrax Bomb effect in green.
-ParticleSystem Demo_AnthraxBombExplosion
+ParticleSystem AnthraxBombExplosion
   Priority = WEAPON_EXPLOSION
   IsOneShot = No
   Shader = ADDITIVE
@@ -10451,7 +10451,7 @@ ParticleSystem Demo_AnthraxBombExplosion
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
-  Color2 = R:0 G:255 B:0 10
+  Color2 = R:0 G:128 B:0 10
   Color3 = R:0 G:0 B:0 100
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
@@ -10480,7 +10480,7 @@ ParticleSystem Demo_AnthraxBombExplosion
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AnthraxBombExplosion
+ParticleSystem AnthraxBetaBombExplosion
   Priority = WEAPON_EXPLOSION
   IsOneShot = No
   Shader = ADDITIVE
@@ -54285,7 +54285,7 @@ ParticleSystem FallingShellsSpectreGattling
 End
 
 ; Patch104p @bugfix commy2 31/07/2022 Recoloured Anthrax Bomb effect in green.
-ParticleSystem Demo_AnthraxBombSpray
+ParticleSystem AnthraxBombSpray
   Priority = CRITICAL
   IsOneShot = No
   Shader = ALPHA
@@ -54342,7 +54342,7 @@ ParticleSystem Demo_AnthraxBombSpray
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AnthraxBombSpray
+ParticleSystem AnthraxBetaBombSpray
   Priority = CRITICAL
   IsOneShot = No
   Shader = ALPHA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1924,22 +1924,6 @@ End
 
 ; Patch104p @bugfix commy2 31/07/2022 Initial explosion for green Anthrax Bomb. Same damage and radius as blue and pink variants.
 ;--------------------------------------------------------------------------------
-Weapon Demo_AnthraxBombWeapon
-  PrimaryDamage       = 200.0
-  PrimaryDamageRadius = 100.0
-  AttackRange         = 100.0
-  DamageType          = EXPLOSION
-  DeathType           = EXPLODED
-  WeaponSpeed         = 99999.0
-  FireOCL             = Demo_OCL_PoisonFieldAnthraxBomb  ; So this weapon will do normal damage, and create this object
-  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots   = 0                   ; time between shots, msec
-  ClipSize            = 1                   ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime      = 0                   ; how long to reload a Clip, msec
-  AutoReloadsClip     = No
-End
-
-;--------------------------------------------------------------------------------
 Weapon AnthraxBombWeapon
   PrimaryDamage       = 200.0
   PrimaryDamageRadius = 100.0
@@ -1948,6 +1932,22 @@ Weapon AnthraxBombWeapon
   DeathType           = EXPLODED
   WeaponSpeed         = 99999.0
   FireOCL             = OCL_PoisonFieldAnthraxBomb  ; So this weapon will do normal damage, and create this object
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots   = 0                   ; time between shots, msec
+  ClipSize            = 1                   ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime      = 0                   ; how long to reload a Clip, msec
+  AutoReloadsClip     = No
+End
+
+;--------------------------------------------------------------------------------
+Weapon AnthraxBetaBombWeapon
+  PrimaryDamage       = 200.0
+  PrimaryDamageRadius = 100.0
+  AttackRange         = 100.0
+  DamageType          = EXPLOSION
+  DeathType           = EXPLODED
+  WeaponSpeed         = 99999.0
+  FireOCL             = OCL_PoisonFieldAnthraxBetaBomb  ; So this weapon will do normal damage, and create this object
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots   = 0                   ; time between shots, msec
   ClipSize            = 1                   ; how many shots in a Clip (0 == infinite)
@@ -3570,7 +3570,7 @@ End
 
 ; Patch104p @bugfix commy2 31/07/2022 Over time damage inside green Anthrax Bomb cloud. Same damage as blue and pink variants.
 ;------------------------------------------------------------------------------
-Weapon Demo_AnthraxBombPoisonFieldWeapon
+Weapon AnthraxBombPoisonFieldWeapon
   PrimaryDamage = 40.0
   PrimaryDamageRadius = 300.0
   AttackRange = 15.0
@@ -3587,7 +3587,7 @@ Weapon Demo_AnthraxBombPoisonFieldWeapon
 End
 
 ;------------------------------------------------------------------------------
-Weapon AnthraxBombPoisonFieldWeapon
+Weapon AnthraxBetaBombPoisonFieldWeapon
   PrimaryDamage = 40.0
   PrimaryDamageRadius = 300.0
   AttackRange = 15.0


### PR DESCRIPTION
- close https://github.com/TheSuperHackers/GeneralsGamePatch/issues/756

With patch, the colour of the Anthrax Bomb will match the current Anthrax upgrade:

- No upgrade: green
- Anthrax Beta, but not Anthrax Gamma: blue
- Anthrax Gamma: pink
- Tox Command Center always orders at least blue

This is a purely visual change.

I toned down the green effects to better match those which are shown for the blue and pink bombs in 1.04.