### PR TITLE
Make Dummy Upgrade Global

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -811,9 +811,9 @@ End
 ; Added a new dummy object-class upgrade for use in places where a local upgrade is required.
 ; 23/08/2021
 
+; @bugfix commy2 06/08/2022 Upgrade is now global.
 ;----------------------------
 Upgrade Upgrade_DummyUpgrade
-  Type               = OBJECT
   BuildTime          = 0.0
   BuildCost          = 0
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -807,7 +807,7 @@ Upgrade RocketBuggyToxinUpgrade
   BuildCost          = 1000
 End
 
-; @bugfix hanfield commy2 23/08/2021 Added a new global dummy upgrade for use in places where an upgrade is required.
+; Patch104p @bugfix hanfield commy2 23/08/2021 Added a new global dummy upgrade for use in places where an upgrade is required.
 ;----------------------------
 Upgrade Upgrade_DummyUpgrade
   BuildTime          = 0.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -807,11 +807,7 @@ Upgrade RocketBuggyToxinUpgrade
   BuildCost          = 1000
 End
 
-; @bugfix - hanfield
-; Added a new dummy object-class upgrade for use in places where a local upgrade is required.
-; 23/08/2021
-
-; @bugfix commy2 06/08/2022 Upgrade is now global.
+; @bugfix hanfield commy2 23/08/2021 Added a new global dummy upgrade for use in places where an upgrade is required.
 ;----------------------------
 Upgrade Upgrade_DummyUpgrade
   BuildTime          = 0.0


### PR DESCRIPTION
The current uses of the dummy upgrade don't require it to be `Type = Object`. If such a case were found, it could always utilize a upgrade like OverlordGatling or FakeBuildingsWorker.