### PR TITLE
Clean Up Dummy Upgrade Code

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -9833,7 +9833,6 @@ Object AirF_AmericaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
@@ -14663,7 +14662,6 @@ Object AirF_AmericaSupplyDropZone
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -9823,7 +9823,7 @@ Object AirF_AmericaPowerPlant
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
@@ -14652,7 +14652,7 @@ Object AirF_AmericaSupplyDropZone
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -9735,7 +9735,7 @@ Object AirF_AmericaPowerPlant
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021
@@ -14565,7 +14565,7 @@ Object AirF_AmericaSupplyDropZone
   EnergyProduction = -4
   ShroudClearingRange = 100
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 22/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -5105,7 +5105,7 @@ Object AmericaPowerPlant
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
@@ -19006,7 +19006,7 @@ Object ChinaPowerPlant
     TriggeredBy = Upgrade_ChinaMines
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
@@ -20404,7 +20404,7 @@ Object AmericaSupplyDropZone
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -5115,7 +5115,6 @@ Object AmericaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
@@ -19017,7 +19016,6 @@ Object ChinaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
@@ -20415,12 +20413,12 @@ Object AmericaSupplyDropZone
   ; 22/08/2021
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
-    UpgradeToGrant = Upgrade_ChinaOverlordGattlingCannon
+    UpgradeToGrant = Upgrade_DummyUpgrade
     ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
-    TriggeredBy = Upgrade_ChinaOverlordGattlingCannon
+    TriggeredBy = Upgrade_DummyUpgrade
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -5017,7 +5017,7 @@ Object AmericaPowerPlant
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021
@@ -18902,7 +18902,7 @@ Object ChinaPowerPlant
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021
@@ -19022,7 +19022,7 @@ Object ChinaPowerPlant
     TriggeredBy = Upgrade_DummyUpgrade
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
   ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
   ; 23/08/2021
@@ -20317,7 +20317,7 @@ Object AmericaSupplyDropZone
   EnergyProduction = -4
   ShroudClearingRange = 100
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 22/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -20414,7 +20414,6 @@ Object AmericaSupplyDropZone
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -8348,7 +8348,7 @@ Object Infa_ChinaPowerPlant
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021
@@ -8467,7 +8467,7 @@ Object Infa_ChinaPowerPlant
     TriggeredBy = Upgrade_DummyUpgrade
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
   ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
   ; 23/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -8461,7 +8461,6 @@ Object Infa_ChinaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -8451,7 +8451,7 @@ Object Infa_ChinaPowerPlant
     TriggeredBy = Upgrade_ChinaMines
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -9435,7 +9435,7 @@ Object Lazr_AmericaPowerPlant
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021
@@ -14250,7 +14250,7 @@ Object Lazr_AmericaSupplyDropZone
   EnergyProduction = -4
   ShroudClearingRange = 100
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 22/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -9523,7 +9523,7 @@ Object Lazr_AmericaPowerPlant
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
@@ -14337,7 +14337,7 @@ Object Lazr_AmericaSupplyDropZone
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -9533,7 +9533,6 @@ Object Lazr_AmericaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
@@ -14348,7 +14347,6 @@ Object Lazr_AmericaSupplyDropZone
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -10118,7 +10118,7 @@ Object Nuke_ChinaPowerPlant
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021
@@ -10237,7 +10237,7 @@ Object Nuke_ChinaPowerPlant
     TriggeredBy = Upgrade_DummyUpgrade
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
   ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
   ; 23/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -10231,7 +10231,6 @@ Object Nuke_ChinaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -10221,7 +10221,7 @@ Object Nuke_ChinaPowerPlant
     TriggeredBy = Upgrade_ChinaMines
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13776,7 +13776,6 @@ Object SupW_AmericaSupplyDropZone
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02
@@ -17505,7 +17504,6 @@ Object SupW_AmericaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13679,7 +13679,7 @@ Object SupW_AmericaSupplyDropZone
   EnergyProduction = -4
   ShroudClearingRange = 100
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 22/08/2021
@@ -17416,7 +17416,7 @@ Object SupW_AmericaPowerPlant
   VisionRange      = 200.0           ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13766,7 +13766,7 @@ Object SupW_AmericaSupplyDropZone
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.
@@ -17494,7 +17494,7 @@ Object SupW_AmericaPowerPlant
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -8136,7 +8136,6 @@ Object Tank_ChinaPowerPlant
 
   Behavior = GrantUpgradeCreate ModuleTag_MicrowaveTankFix01
     UpgradeToGrant = Upgrade_DummyUpgrade
-    ExemptStatus = UNDER_CONSTRUCTION
   End
 
   Behavior = ArmorUpgrade ModuleTag_MicrowaveTankFix02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -8126,7 +8126,7 @@ Object Tank_ChinaPowerPlant
     TriggeredBy = Upgrade_ChinaMines
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added two extra modules for Microwave Tank bug fix.
   ;
   ; MicrowaveTankFix01 grants a dummy object-class upgrade once the building is complete.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -8023,7 +8023,7 @@ Object Tank_ChinaPowerPlant
   VisionRange         = 200.0          ; Shroud clearing distance
   ShroudClearingRange = 200
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Added new default armorset that cannot be targeted or suffer SUBDUAL damage.
   ; This resolves the Microwave Tank exploit but does not prevent being properly disabled later.
   ; 23/08/2021
@@ -8142,7 +8142,7 @@ Object Tank_ChinaPowerPlant
     TriggeredBy = Upgrade_DummyUpgrade
   End
 
-  ; @bugfix - hanfield
+  ; Patch104p @bugfix - hanfield
   ; Replaced the ArmorUpgrade that was used to trigger EMP mine availability with WeaponSetUpgrade.
   ; This allows the player to research EMP mines while permitting the armorset-related bugfix.
   ; 23/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -811,9 +811,9 @@ End
 ; Added a new dummy object-class upgrade for use in places where a local upgrade is required.
 ; 23/08/2021
 
+; @bugfix commy2 06/08/2022 Upgrade is now global.
 ;----------------------------
 Upgrade Upgrade_DummyUpgrade
-  Type               = OBJECT
   BuildTime          = 0.0
   BuildCost          = 0
 End


### PR DESCRIPTION
- requires and forks https://github.com/TheSuperHackers/GeneralsGamePatch/pull/830

- Remove the superfluous `ExemptStatus`. `ExemptStatus` flag does nothing here. `GrantUpgradeCreate` is only triggered once the scaffold is completed (or the unit leaves a factory or the at the start of the map for preplaced objects).
- Use `Upgrade_DummyUpgrade` instead of `Upgrade_ChinaOverlordGattlingCannon` on the vUSA SDZ. This appears to be a minor mistake.

Despite this being a global upgrade, I left it so the buildings grant it. This helps for maps where the player does not chose their faction.

