### PR TITLE
Change: Add China Propaganda Center to Prerequisite of Internet Center

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -35045,7 +35045,7 @@ Object ChinaInternetCenter
   Side              = China
   EditorSorting     = STRUCTURE
   Prerequisites
-    Object            = ChinaWarFactory
+    Object            = ChinaWarFactory ChinaPropagandaCenter ; Patch104p @tweak from ChinaWarFactory to be consistent with Prerequisites of ChinaInfantryHacker
   End
   BuildCost         = 2500
   BuildTime         = 30.0           ; in seconds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -13753,7 +13753,7 @@ Object Infa_ChinaInternetCenter
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   Prerequisites
-    Object            = Infa_ChinaWarFactory
+    Object            = Infa_ChinaWarFactory Infa_ChinaPropagandaCenter ; Patch104p @tweak from Infa_ChinaWarFactory to be consistent with Prerequisites of ChinaInfantryHacker
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16364,7 +16364,7 @@ Object Nuke_ChinaInternetCenter
   ExperienceValue     = 200 200 200 200  ; Experience point value at each level
 
   Prerequisites
-    Object            = Nuke_ChinaWarFactory
+    Object            = Nuke_ChinaWarFactory Nuke_ChinaPropagandaCenter ; Patch104p @tweak from Nuke_ChinaWarFactory to be consistent with Prerequisites of ChinaInfantryHacker
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15370,7 +15370,7 @@ Object Tank_ChinaInternetCenter
 
 
   Prerequisites
-    Object            = Tank_ChinaWarFactory
+    Object            = Tank_ChinaWarFactory Tank_ChinaPropagandaCenter ; Patch104p @tweak from Tank_ChinaWarFactory to be consistent with Prerequisites of ChinaInfantryHacker
   End
 
   ;*******************************************************************************************************************


### PR DESCRIPTION
This change adds the Propaganda Center or Warfactory prerequisite to the Internet Center. Reason being, that Hackers also require the Propaganda Center. This makes the requirement more intuitive.

## Original

Internet Center requires Warfactory.

## Patched

Internet Center requires Warfactory OR Propaganda Center.