### PR TITLE
Change: Add Airfield or Warfactory Prerequisites to China Speaker Tower

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -8804,7 +8804,7 @@ Object Boss_SpeakerTower
     DamageFX          = StructureDamageFXNoShake
   End
   Prerequisites
-    Object            = Boss_Airfield
+    Object            = Boss_Airfield Boss_WarFactory ; Patch104p @balance from Boss_Airfield to make it much more accessible throughout the game
   End
   CommandSet          = ChinaSpeakerTowerCommandSet
   ExperienceValue     = 50 50 50 50  ; Experience point value at each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -15313,7 +15313,7 @@ Object ChinaSpeakerTower
     DamageFX          = StructureDamageFXNoShake
   End
   Prerequisites
-    Object            = ChinaPropagandaCenter
+    Object            = ChinaPropagandaCenter ChinaAirfield ChinaWarFactory ; Patch104p @balance from ChinaPropagandaCenter to make it much more accessible throughout the game
   End
   CommandSet          = ChinaSpeakerTowerCommandSet
   ExperienceValue     = 50 50 50 50  ; Experience point value at each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -7418,7 +7418,7 @@ Object Infa_ChinaSpeakerTower
     DamageFX          = StructureDamageFXNoShake
   End
   Prerequisites
-    Object            = Infa_ChinaPropagandaCenter
+    Object            = Infa_ChinaPropagandaCenter Infa_ChinaAirfield Infa_ChinaWarFactory ; Patch104p @balance from Infa_ChinaPropagandaCenter to make it much more accessible throughout the game
   End
   CommandSet          = ChinaSpeakerTowerCommandSet
   ExperienceValue     = 50 50 50 50  ; Experience point value at each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -9188,7 +9188,7 @@ Object Nuke_ChinaSpeakerTower
     DamageFX          = StructureDamageFXNoShake
   End
   Prerequisites
-    Object            = Nuke_ChinaPropagandaCenter
+    Object            = Nuke_ChinaPropagandaCenter Nuke_ChinaAirfield Nuke_ChinaWarFactory ; Patch104p @balance from Nuke_ChinaPropagandaCenter to make it much more accessible throughout the game
   End
   CommandSet          = ChinaSpeakerTowerCommandSet
   ExperienceValue     = 50 50 50 50  ; Experience point value at each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -7093,7 +7093,7 @@ Object Tank_ChinaSpeakerTower
     DamageFX          = StructureDamageFXNoShake
   End
   Prerequisites
-    Object            = Tank_ChinaPropagandaCenter
+    Object            = Tank_ChinaPropagandaCenter Tank_ChinaAirfield Tank_ChinaWarFactory ; Patch104p @balance from Tank_ChinaPropagandaCenter to make it much more accessible throughout the game
   End
   CommandSet          = ChinaSpeakerTowerCommandSet
   ExperienceValue     = 50 50 50 50  ; Experience point value at each level


### PR DESCRIPTION
Closes #818
* #818

Related:
* #745

This change adds the Airfield or Warfactory prerequisites to China Speaker Tower.

## Original

China Speaker Tower requires Propaganda Center.

## Patched

China Speaker Tower requires Propaganda Center OR Airfield OR Warfactory.

# Rationale

This will make the China Speaker Tower accessible in early game. It is mainly useful to establish a stronghold within the China home base to defend against enemy forces. It can also be used to repair Aircraft quicker near the Airfield. And it can be used for propaganda pushes, if China can protect a Dozer to build on the front lines.

A Speaker Tower gives twice the bonus that a propaganda unit gives (except Assault Troop Crawler).

## Reference Stats

| Stat   | Value |
|--------|-------|
| BuildCost | 500 |
| BuildTime | 10 |
| MaxHealth | 300 |
| EnergyProduction | -1 |
| Radius | 150 |
| HealPercentEachSecond | 2% |
| UpgradedHealPercentEachSecond | 4% |