### PR TITLE
Change: Turn Satellite Hack 2 Into Manually Activated Ability

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1298,6 +1298,27 @@ CommandButton Command_UpgradeChinaSatelliteHackTwo
   DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeSatelliteHackTwo
 End
 
+; Patch104p @balance commy2 06/08/2022 Buttons for manual Sathack 2 power.
+CommandButton Command_SatelliteHackTwo
+  Command           = SPECIAL_POWER
+  SpecialPower      = SuperweaponSatelliteHackTwo
+  Options           = NEED_SPECIAL_POWER_SCIENCE
+  TextLabel         = CONTROLBAR:SatelliteHackTwo
+  ButtonImage       = SNIntCntup02
+  ButtonBorderType  = ACTION
+  DescriptLabel     = CONTROLBAR:TooltipSatelliteHackTwo
+End
+
+CommandButton Command_SatelliteHackTwoFromShortcut
+  Command           = SPECIAL_POWER_FROM_SHORTCUT
+  SpecialPower      = SuperweaponSatelliteHackTwo
+  Options           = NEED_SPECIAL_POWER_SCIENCE
+  TextLabel         = CONTROLBAR:SatelliteHackTwoShortcut
+  ButtonImage       = SNIntCntup02
+  ButtonBorderType  = ACTION
+  DescriptLabel     = CONTROLBAR:TooltipSatelliteHackTwo
+End
+
 CommandButton Command_UpgradeChinaNationalism
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_Nationalism

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -959,6 +959,37 @@ CommandSet ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell
 End
 
+; Patch104p @balance commy2 06/08/2022 Sets with manual Sathack 2 button.
+CommandSet ChinaInternetCenterCommandSetThree
+  1 = Command_StructureExit
+  2 = Command_StructureExit
+  3 = Command_StructureExit
+  4 = Command_StructureExit
+  5 = Command_StructureExit
+  6 = Command_StructureExit
+  7 = Command_StructureExit
+  8 = Command_StructureExit
+  9 = Command_Evacuate
+  10 = Command_SatelliteHackTwo
+  12 = Command_UpgradeChinaMines
+  14 = Command_Sell
+End
+
+CommandSet ChinaInternetCenterCommandSetThreeUpgrade
+  1 = Command_StructureExit
+  2 = Command_StructureExit
+  3 = Command_StructureExit
+  4 = Command_StructureExit
+  5 = Command_StructureExit
+  6 = Command_StructureExit
+  7 = Command_StructureExit
+  8 = Command_StructureExit
+  9 = Command_Evacuate
+  10 = Command_SatelliteHackTwo
+  12 = Command_UpgradeEMPMines
+  14 = Command_Sell
+End
+
 
 
 CommandSet ChinaPowerPlantCommandSet
@@ -1373,6 +1404,7 @@ CommandSet SpecialPowerShortcutChina
   6 = Command_NeutronMissileFromShortcut
   7 = Early_Command_ChinaCarpetBombFromShortcut
   8 = Command_FrenzyFromShortcut
+  9 = Command_SatelliteHackTwoFromShortcut
 END
 
 
@@ -3054,6 +3086,7 @@ CommandSet Nuke_SpecialPowerShortcutChina
   5 = Command_EMPPulseFromShortcut
   6 = Command_NeutronMissileFromShortcut
   7 = Nuke_Command_ChinaCarpetBombFromShortcut
+  9 = Command_SatelliteHackTwoFromShortcut
   10 = Command_FrenzyFromShortcut
 END
 
@@ -3790,6 +3823,7 @@ CommandSet Infa_SpecialPowerShortcutChina
   6 = Command_NeutronMissileFromShortcut
   7 = Early_Command_ChinaCarpetBombFromShortcut
   8 = Early_Command_FrenzyFromShortcut
+  9 = Command_SatelliteHackTwoFromShortcut
 END
 
 
@@ -4030,6 +4064,37 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
   8 = Command_StructureExit
   9 = Command_Evacuate
   10 = Command_UpgradeChinaSatelliteHackTwo
+  12 = Command_UpgradeEMPMines
+  14 = Command_Sell
+End
+
+; Patch104p @balance commy2 06/08/2022 Sets with manual Sathack 2 button.
+CommandSet Infa_ChinaInternetCenterCommandSetThree
+  1 = Command_StructureExit
+  2 = Command_StructureExit
+  3 = Command_StructureExit
+  4 = Command_StructureExit
+  5 = Command_StructureExit
+  6 = Command_StructureExit
+  7 = Command_StructureExit
+  8 = Command_StructureExit
+  9 = Command_Evacuate
+  10 = Command_SatelliteHackTwo
+  12 = Command_UpgradeChinaMines
+  14 = Command_Sell
+End
+
+CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
+  1 = Command_StructureExit
+  2 = Command_StructureExit
+  3 = Command_StructureExit
+  4 = Command_StructureExit
+  5 = Command_StructureExit
+  6 = Command_StructureExit
+  7 = Command_StructureExit
+  8 = Command_StructureExit
+  9 = Command_Evacuate
+  10 = Command_SatelliteHackTwo
   12 = Command_UpgradeEMPMines
   14 = Command_Sell
 End
@@ -4556,6 +4621,7 @@ CommandSet Tank_SpecialPowerShortcutChina
   6 = Command_NeutronMissileFromShortcut
   7 = Command_ChinaCarpetBombFromShortcut
   8 = Command_FrenzyFromShortcut
+  9 = Command_SatelliteHackTwoFromShortcut
 End
 
 CommandSet Tank_ChinaDozerCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -35939,30 +35939,56 @@ Object ChinaInternetCenter
     Weapon = SatelliteHackOneDummyWeapon
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_16
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes         ; No SpecialPower module, turns self on and off on timers
-    SelfPoweredDuration = 20000
-    SelfPoweredInterval = 240000
-    TriggeredBy   = Upgrade_ChinaSatelliteHackTwo
+  ; Patch104p @balance commy2 06/08/2022 Turn Sathack 2 into manually activated power.
+  Behavior = SpyVisionSpecialPower ModuleTag_16
+    SpecialPowerTemplate     = SuperweaponSatelliteHackTwo
+    BaseDuration             = 20000 ;in milliseconds
+    BonusDurationPerCaptured = 0 ;in milliseconds
+    MaxDuration              = 20000 ;in milliseconds
+  End
+  Behavior = SpyVisionUpdate ModuleTag_17
+    ;<NO DATA>
+  End
+  Behavior = GrantScienceUpgrade ModuleTag_Unhide16
+    GrantScience         = SCIENCE_SatelliteHackTwo
+    TriggeredBy          = Upgrade_ChinaSatelliteHackTwo
   End
 
   Behavior = ArmorUpgrade ModuleTag_30
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  Behavior = CommandSetUpgrade ModuleTag_31
-    CommandSet = ChinaInternetCenterCommandSetOneUpgrade
-    TriggeredBy = Upgrade_ChinaMines
 
-    CommandSetAlt = ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaSatelliteHackOne
-  End
-  Behavior = CommandSetUpgrade ModuleTag_32
+  ; Patch104p @balance commy2 06/08/2022 Adjust command set logic for new Sathack 2 button.
+  ; Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_31
     CommandSet = ChinaInternetCenterCommandSetTwo
     TriggeredBy = Upgrade_ChinaSatelliteHackOne
-
-    CommandSetAlt = ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_32
+    CommandSet = ChinaInternetCenterCommandSetThree
+    TriggeredBy = Upgrade_ChinaSatelliteHackTwo
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Mines
+  Behavior = CommandSetUpgrade ModuleTag_33
+    CommandSet = ChinaInternetCenterCommandSetOneUpgrade
+    TriggeredBy = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaSatelliteHackOne
+  End
+  ; Mines + Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_34
+    CommandSet = ChinaInternetCenterCommandSetTwoUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackOne
+    RequiresAllTriggers = Yes
+    ConflictsWith = Upgrade_ChinaSatelliteHackTwo
+  End
+  ; Mines + Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_35
+    CommandSet = ChinaInternetCenterCommandSetThreeUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackTwo
+    RequiresAllTriggers = Yes
   End
 
   Behavior = ModelConditionUpgrade ModuleTag_18

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -13824,30 +13824,56 @@ Object Infa_ChinaInternetCenter
     Weapon = SatelliteHackOneDummyWeapon
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_16
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes         ; No SpecialPower module, turns self on and off on timers
-    SelfPoweredDuration = 20000
-    SelfPoweredInterval = 240000
-    TriggeredBy   = Upgrade_ChinaSatelliteHackTwo
+  ; Patch104p @balance commy2 06/08/2022 Turn Sathack 2 into manually activated power.
+  Behavior = SpyVisionSpecialPower ModuleTag_16
+    SpecialPowerTemplate     = SuperweaponSatelliteHackTwo
+    BaseDuration             = 20000 ;in milliseconds
+    BonusDurationPerCaptured = 0 ;in milliseconds
+    MaxDuration              = 20000 ;in milliseconds
+  End
+  Behavior = SpyVisionUpdate ModuleTag_17
+    ;<NO DATA>
+  End
+  Behavior = GrantScienceUpgrade ModuleTag_Unhide16
+    GrantScience         = SCIENCE_SatelliteHackTwo
+    TriggeredBy          = Upgrade_ChinaSatelliteHackTwo
   End
 
   Behavior = ArmorUpgrade ModuleTag_30
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  Behavior = CommandSetUpgrade ModuleTag_31
-    CommandSet = Infa_ChinaInternetCenterCommandSetOneUpgrade
-    TriggeredBy = Upgrade_ChinaMines
 
-    CommandSetAlt = Infa_ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaSatelliteHackOne
-  End
-  Behavior = CommandSetUpgrade ModuleTag_32
+  ; Patch104p @balance commy2 06/08/2022 Adjust command set logic for new Sathack 2 button.
+  ; Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_31
     CommandSet = Infa_ChinaInternetCenterCommandSetTwo
     TriggeredBy = Upgrade_ChinaSatelliteHackOne
-
-    CommandSetAlt = Infa_ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_32
+    CommandSet = Infa_ChinaInternetCenterCommandSetThree
+    TriggeredBy = Upgrade_ChinaSatelliteHackTwo
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Mines
+  Behavior = CommandSetUpgrade ModuleTag_33
+    CommandSet = Infa_ChinaInternetCenterCommandSetOneUpgrade
+    TriggeredBy = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaSatelliteHackOne
+  End
+  ; Mines + Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_34
+    CommandSet = Infa_ChinaInternetCenterCommandSetTwoUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackOne
+    RequiresAllTriggers = Yes
+    ConflictsWith = Upgrade_ChinaSatelliteHackTwo
+  End
+  ; Mines + Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_35
+    CommandSet = Infa_ChinaInternetCenterCommandSetThreeUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackTwo
+    RequiresAllTriggers = Yes
   End
 
   Behavior = ModelConditionUpgrade ModuleTag_18

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16435,30 +16435,56 @@ Object Nuke_ChinaInternetCenter
     Weapon = SatelliteHackOneDummyWeapon
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_16
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes         ; No SpecialPower module, turns self on and off on timers
-    SelfPoweredDuration = 20000
-    SelfPoweredInterval = 240000
-    TriggeredBy   = Upgrade_ChinaSatelliteHackTwo
+  ; Patch104p @balance commy2 06/08/2022 Turn Sathack 2 into manually activated power.
+  Behavior = SpyVisionSpecialPower ModuleTag_16
+    SpecialPowerTemplate     = SuperweaponSatelliteHackTwo
+    BaseDuration             = 20000 ;in milliseconds
+    BonusDurationPerCaptured = 0 ;in milliseconds
+    MaxDuration              = 20000 ;in milliseconds
+  End
+  Behavior = SpyVisionUpdate ModuleTag_17
+    ;<NO DATA>
+  End
+  Behavior = GrantScienceUpgrade ModuleTag_Unhide16
+    GrantScience         = SCIENCE_SatelliteHackTwo
+    TriggeredBy          = Upgrade_ChinaSatelliteHackTwo
   End
 
   Behavior = ArmorUpgrade ModuleTag_30
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  Behavior = CommandSetUpgrade ModuleTag_31
-    CommandSet = ChinaInternetCenterCommandSetOneUpgrade
-    TriggeredBy = Upgrade_ChinaMines
 
-    CommandSetAlt = ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaSatelliteHackOne
-  End
-  Behavior = CommandSetUpgrade ModuleTag_32
+  ; Patch104p @balance commy2 06/08/2022 Adjust command set logic for new Sathack 2 button.
+  ; Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_31
     CommandSet = ChinaInternetCenterCommandSetTwo
     TriggeredBy = Upgrade_ChinaSatelliteHackOne
-
-    CommandSetAlt = ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_32
+    CommandSet = ChinaInternetCenterCommandSetThree
+    TriggeredBy = Upgrade_ChinaSatelliteHackTwo
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Mines
+  Behavior = CommandSetUpgrade ModuleTag_33
+    CommandSet = ChinaInternetCenterCommandSetOneUpgrade
+    TriggeredBy = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaSatelliteHackOne
+  End
+  ; Mines + Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_34
+    CommandSet = ChinaInternetCenterCommandSetTwoUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackOne
+    RequiresAllTriggers = Yes
+    ConflictsWith = Upgrade_ChinaSatelliteHackTwo
+  End
+  ; Mines + Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_35
+    CommandSet = ChinaInternetCenterCommandSetThreeUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackTwo
+    RequiresAllTriggers = Yes
   End
 
   Behavior = ModelConditionUpgrade ModuleTag_18

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15440,30 +15440,56 @@ Object Tank_ChinaInternetCenter
     Weapon = SatelliteHackOneDummyWeapon
   End
 
-  Behavior         = SpyVisionUpdate ModuleTag_16
-    NeedsUpgrade  = Yes
-    SelfPowered   = Yes         ; No SpecialPower module, turns self on and off on timers
-    SelfPoweredDuration = 20000
-    SelfPoweredInterval = 240000
-    TriggeredBy   = Upgrade_ChinaSatelliteHackTwo
+  ; Patch104p @balance commy2 06/08/2022 Turn Sathack 2 into manually activated power.
+  Behavior = SpyVisionSpecialPower ModuleTag_16
+    SpecialPowerTemplate     = SuperweaponSatelliteHackTwo
+    BaseDuration             = 20000 ;in milliseconds
+    BonusDurationPerCaptured = 0 ;in milliseconds
+    MaxDuration              = 20000 ;in milliseconds
+  End
+  Behavior = SpyVisionUpdate ModuleTag_17
+    ;<NO DATA>
+  End
+  Behavior = GrantScienceUpgrade ModuleTag_Unhide16
+    GrantScience         = SCIENCE_SatelliteHackTwo
+    TriggeredBy          = Upgrade_ChinaSatelliteHackTwo
   End
 
   Behavior = ArmorUpgrade ModuleTag_30
     TriggeredBy = Upgrade_ChinaEMPMines
   End
-  Behavior = CommandSetUpgrade ModuleTag_31
-    CommandSet = ChinaInternetCenterCommandSetOneUpgrade
-    TriggeredBy = Upgrade_ChinaMines
 
-    CommandSetAlt = ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaSatelliteHackOne
-  End
-  Behavior = CommandSetUpgrade ModuleTag_32
+  ; Patch104p @balance commy2 06/08/2022 Adjust command set logic for new Sathack 2 button.
+  ; Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_31
     CommandSet = ChinaInternetCenterCommandSetTwo
     TriggeredBy = Upgrade_ChinaSatelliteHackOne
-
-    CommandSetAlt = ChinaInternetCenterCommandSetTwoUpgrade
-    TriggerAlt = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_32
+    CommandSet = ChinaInternetCenterCommandSetThree
+    TriggeredBy = Upgrade_ChinaSatelliteHackTwo
+    ConflictsWith = Upgrade_ChinaMines
+  End
+  ; Mines
+  Behavior = CommandSetUpgrade ModuleTag_33
+    CommandSet = ChinaInternetCenterCommandSetOneUpgrade
+    TriggeredBy = Upgrade_ChinaMines
+    ConflictsWith = Upgrade_ChinaSatelliteHackOne
+  End
+  ; Mines + Sathack 1
+  Behavior = CommandSetUpgrade ModuleTag_34
+    CommandSet = ChinaInternetCenterCommandSetTwoUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackOne
+    RequiresAllTriggers = Yes
+    ConflictsWith = Upgrade_ChinaSatelliteHackTwo
+  End
+  ; Mines + Sathack 2
+  Behavior = CommandSetUpgrade ModuleTag_35
+    CommandSet = ChinaInternetCenterCommandSetThreeUpgrade
+    TriggeredBy = Upgrade_ChinaMines Upgrade_ChinaSatelliteHackTwo
+    RequiresAllTriggers = Yes
   End
 
   Behavior = ModelConditionUpgrade ModuleTag_18

--- a/Patch104pZH/GameFilesEdited/Data/INI/Science.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Science.ini
@@ -838,3 +838,10 @@ Science AirF_SCIENCE_A10ThunderboltMissileStrike3
   DisplayName = SCIENCE:USAA10Strike3
   Description = CONTROLBAR:ToolTipUSAScienceA10Strike
 End
+
+; Patch104p @balance commy2 06/08/2022 Dummy science granted by Sathack 2 upgrade. Unlocks Sathack 2 special power.
+Science SCIENCE_SatelliteHackTwo
+  PrerequisiteSciences = None
+  SciencePurchasePointCost = 0; note that this means "not purchasable", NOT "free"!
+  IsGrantable = Yes
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -975,3 +975,15 @@ SpecialPower SupW_SuperweaponNeutronMissile
   ShortcutPower           = Yes     ;Capable of being fired by the side-bar shortcut.
   AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.
 End
+
+; Patch104p @balance commy2 06/08/2022 Sathack 2 ability converted to manually activated special power.
+;------------------------------------------------------------------------------
+SpecialPower SuperweaponSatelliteHackTwo
+  Enum                = SPECIAL_COMMUNICATIONS_DOWNLOAD
+  ReloadTime          = 240000 ; in milliseconds
+  RequiredScience     = SCIENCE_SatelliteHackTwo
+  PublicTimer         = No
+  InitiateSound       = CIAIntelligenceActivate
+  AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.
+  ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
+End


### PR DESCRIPTION
Fixes #782
Fixes #241

Keeps same duration and cooldown, but instead of being automatically activated, it is now an ability similar to Strat Center Intelligence.

![shot_20220806_120226_1](https://user-images.githubusercontent.com/6576312/183244372-4345e770-74f2-4f0b-aeee-4dc787edc34d.jpg)

