### PR TITLE
Change: Enable Speaker Tower On Propaganda Center

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -6701,6 +6701,25 @@ FXList FX_PropagandaTowerSubliminalPulse
   End
 End
 
+; Patch104p @balance commy2 06/08/2022 Propaganda effect with offsets for Propaganda Center
+; ----------------------------------------------
+FXList FX_PropagandaCenterPropagandaPulse
+  ParticleSystem
+    Name = SonicRange
+    Offset = X:-18.6 Y:-48.7 Z:45.0
+    OrientToObject = Yes
+  End
+End
+
+; ----------------------------------------------
+FXList FX_PropagandaCenterSubliminalPulse
+  ParticleSystem
+    Name = SonicRangeUpgraded
+    Offset = X:-18.6 Y:-48.7 Z:45.0
+    OrientToObject = Yes
+  End
+End
+
 ; ----------------------------------------------
 ; Patch104p @bugfix Stubbjax 06/09/2021 New Listening Outpost Propaganda effects to fix alignment
 FXList FX_ListeningOutpostPropagandaPulse

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -30890,6 +30890,8 @@ Object ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -31723,6 +31725,17 @@ Object ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  ; Patch104p @balance commy2 06/08/2022 Add Speaker Tower effect to Propaganda Center
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -10878,6 +10878,8 @@ Object Infa_ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -11711,6 +11713,17 @@ Object Infa_ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  ; Patch104p @balance commy2 06/08/2022 Add Speaker Tower effect to Propaganda Center
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -13490,6 +13490,8 @@ Object Nuke_ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -14323,6 +14325,17 @@ Object Nuke_ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  ; Patch104p @balance commy2 06/08/2022 Add Speaker Tower effect to Propaganda Center
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -12494,6 +12494,8 @@ Object Tank_ChinaPropagandaCenter
   ; *** ART Parameters ***
   SelectPortrait         = SNPropCentr_L
   ButtonImage            = SNPropCentr
+  UpgradeCameo1          = Upgrade_ChinaSubliminalMessaging
+
   Draw                   = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ;day
@@ -13327,6 +13329,17 @@ Object Tank_ChinaPropagandaCenter
     Upgradable            = Yes
     UpgradedTriggeredBy   = Upgrade_ChinaEMPMines
     UpgradedMineName      = ChinaEMPMine
+  End
+
+  ; Patch104p @balance commy2 06/08/2022 Add Speaker Tower effect to Propaganda Center
+  Behavior        = PropagandaTowerBehavior ModuleTag_16
+    Radius                = 150.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 2%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaCenterPropagandaPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_ChinaSubliminalMessaging
+    UpgradedHealPercentEachSecond = 4%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaCenterSubliminalPulse ;plays as often as DelayBetweenUpdates
   End
 
   Behavior             = FlammableUpdate ModuleTag_17


### PR DESCRIPTION
There is a speaker tower on the Prop Center model. This change makes it actually work just like a regular Speaker Tower.

Strat Center detects stealthed units or has a gun, while Palace has 5 fire ports. So this seems fair to me.

![shot_20220806_133551_3](https://user-images.githubusercontent.com/6576312/183247274-61922374-1a91-420e-ae78-38c7b604d26d.jpg)
