### PR TITLE
Fix: Nuke General Mig Tooltip

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -6554,7 +6554,7 @@ CommandButton Nuke_Command_ConstructChinaJetMIG
   TextLabel     = CONTROLBAR:ConstructChinaJetMIG
   ButtonImage   = SNMig
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipChinaBuildMIG
+  DescriptLabel           = CONTROLBAR:Nuke_ToolTipChinaBuildMIG
 End
 
 


### PR DESCRIPTION
The tooltip of the Nuke Mig says that it "creates a fire-storm in large groups".
It does not create a fire storm.