### PR TITLE
Fix: Air Force And Super Weapon General Spectre Tooltip

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -4621,7 +4621,7 @@ CommandButton AirF_Command_SpectreGunship
   TextLabel         = CONTROLBAR:SpectreGunship
   ButtonImage       = SASpGunship; until Samm makes a new cameo for this...
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
-  DescriptLabel     = CONTROLBAR:TooltipSpectreGunship
+  DescriptLabel     = CONTROLBAR:AirF_TooltipSpectreGunship
   RadiusCursorType  = SPECTREGUNSHIP
   InvalidCursorName     = GenericInvalid
 End
@@ -4634,7 +4634,7 @@ CommandButton AirF_Command_SpectreGunshipFromShortcut
   TextLabel         = CONTROLBAR:SpectreGunshipFromShortcut
   ButtonImage       = SASpGunship; until Samm makes a new cameo for this...
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
-  DescriptLabel     = CONTROLBAR:TooltipSpectreGunship
+  DescriptLabel     = CONTROLBAR:AirF_TooltipSpectreGunship
   RadiusCursorType  = SPECTREGUNSHIP
   InvalidCursorName     = GenericInvalid
 End


### PR DESCRIPTION
The AFG and SWG 3 stage Spectre tooltip claims the recharge time is 4 minutes. But the actual recharge time is only 3 minutes. 

SWG uses the same buttons / special power as AFG. The recharge time actually is 4 minutes for vUSA and Laser.