### PR TITLE
Fix: Rebel Counts In Demo Rebel Ambush Tooltip

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Science.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Science.ini
@@ -501,18 +501,13 @@ Science Chem_SCIENCE_RebelAmbush3
 End
 
 ; Patch104p @bugfix commy2 15/10/2021 Add Sciences for Demo General Rebel Ambush version. Enables custom description (with correct Rebel count) and power reload times.
-
-; @todo commy2, add this string to localization file and enable it below
-;CONTROLBAR:Demo_ToolTipGLAScienceRebelAmbush
-;"Allows you to create a surprise ambush of Rebels anywhere \n \n Rank 1: 4 Rebels \n Rank 2: 6 Rebels \n Rank 3: 10 Rebels \n \n Deploy from: Command Center"
-;END
-
+; Patch104p @bugfix commy2 06/08/2022 Fix Rebel counts in tooltip of Demo General Rebel Ambush.
 Science Demo_SCIENCE_RebelAmbush1
   PrerequisiteSciences = SCIENCE_GLA SCIENCE_Rank3
   SciencePurchasePointCost = 1
   IsGrantable = Yes
   DisplayName = SCIENCE:GLARebelAmbush1
-  Description = CONTROLBAR:ToolTipGLAScienceRebelAmbush ;CONTROLBAR:Demo_ToolTipGLAScienceRebelAmbush
+  Description = CONTROLBAR:Demo_ToolTipGLAScienceRebelAmbush
 End
 
 Science Demo_SCIENCE_RebelAmbush2
@@ -520,7 +515,7 @@ Science Demo_SCIENCE_RebelAmbush2
   SciencePurchasePointCost = 1
   IsGrantable = Yes
   DisplayName = SCIENCE:GLARebelAmbush2
-  Description = CONTROLBAR:ToolTipGLAScienceRebelAmbush ;CONTROLBAR:Demo_ToolTipGLAScienceRebelAmbush
+  Description = CONTROLBAR:Demo_ToolTipGLAScienceRebelAmbush
 End
 
 Science Demo_SCIENCE_RebelAmbush3
@@ -528,7 +523,7 @@ Science Demo_SCIENCE_RebelAmbush3
   SciencePurchasePointCost = 1
   IsGrantable = Yes
   DisplayName = SCIENCE:GLARebelAmbush3
-  Description = CONTROLBAR:ToolTipGLAScienceRebelAmbush ;CONTROLBAR:Demo_ToolTipGLAScienceRebelAmbush
+  Description = CONTROLBAR:Demo_ToolTipGLAScienceRebelAmbush
 End
 
 Science SCIENCE_CashBounty1


### PR DESCRIPTION
The tooltip says 4/8/16 Rebels, but that is only true for vGLA / Stealth and Tox. The actual numbers are 4/6/10.

This was due to a nerf by EALA to Demo Rebel Ambush during support time of ZH. The tooltip was never adjusted, because "time constraints" (lazy).