### PR TITLE
Change: Increase China Nuke Missile damage by 20% and blasts radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -321,6 +321,7 @@ Object SupW_NeutronMissile
   End
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+  ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_06
     DestructionDelay    = 3501
@@ -331,8 +332,8 @@ Object SupW_NeutronMissile
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -340,9 +341,9 @@ Object SupW_NeutronMissile
     Blast2Enabled       = Yes
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
-    Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
+    Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -350,9 +351,9 @@ Object SupW_NeutronMissile
     Blast3Enabled       = Yes
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
-    Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
+    Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -360,9 +361,9 @@ Object SupW_NeutronMissile
     Blast4Enabled       = Yes
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
-    Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
+    Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -370,9 +371,9 @@ Object SupW_NeutronMissile
     Blast5Enabled       = Yes
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
-    Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
+    Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -380,10 +381,10 @@ Object SupW_NeutronMissile
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
-    Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
-    Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
+    Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
+    Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
+    Blast6MaxDamage     = 700.0   ;damage within inner radius of blast
+    Blast6MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2694,6 +2694,7 @@ Object BaikonurRocketDetonation
   End
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+  ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_08
     DestructionDelay    = 3501
@@ -2704,8 +2705,8 @@ Object BaikonurRocketDetonation
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -2713,9 +2714,9 @@ Object BaikonurRocketDetonation
     Blast2Enabled       = Yes
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
-    Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
+    Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -2723,9 +2724,9 @@ Object BaikonurRocketDetonation
     Blast3Enabled       = Yes
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
-    Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
+    Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -2733,9 +2734,9 @@ Object BaikonurRocketDetonation
     Blast4Enabled       = Yes
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
-    Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
+    Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -2743,9 +2744,9 @@ Object BaikonurRocketDetonation
     Blast5Enabled       = Yes
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
-    Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
+    Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -2753,10 +2754,10 @@ Object BaikonurRocketDetonation
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
-    Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
-    Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
+    Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
+    Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
+    Blast6MaxDamage     = 700.0   ;damage within inner radius of blast
+    Blast6MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1907,6 +1907,7 @@ Object NeutronMissile
   End
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+  ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_06
     DestructionDelay    = 3501
@@ -1917,8 +1918,8 @@ Object NeutronMissile
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -1926,9 +1927,9 @@ Object NeutronMissile
     Blast2Enabled       = Yes
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
-    Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
+    Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -1936,9 +1937,9 @@ Object NeutronMissile
     Blast3Enabled       = Yes
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
-    Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
+    Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -1946,9 +1947,9 @@ Object NeutronMissile
     Blast4Enabled       = Yes
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
-    Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
+    Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -1956,9 +1957,9 @@ Object NeutronMissile
     Blast5Enabled       = Yes
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
-    Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
+    Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -1966,10 +1967,10 @@ Object NeutronMissile
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
-    Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
-    Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
+    Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
+    Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
+    Blast6MaxDamage     = 700.0   ;damage within inner radius of blast
+    Blast6MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 
@@ -2031,6 +2032,7 @@ Object CargoTruckNuke
   End
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
+  ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_03
     DestructionDelay = 3501
@@ -2041,8 +2043,8 @@ Object CargoTruckNuke
     Blast1Delay         = 580     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
-    Blast1OuterRadius   = 90.0    ;objects inside this get some of the full damage
-    Blast1MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
+    Blast1MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast1MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast1ToppleSpeed   = 0.5     ;higher #'s topple faster
     Blast1PushForce     = 10.0    ;higher #'s push more
@@ -2050,9 +2052,9 @@ Object CargoTruckNuke
     Blast2Enabled       = Yes
     Blast2Delay         = 660    ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
-    Blast2InnerRadius   = 90.0    ;objects inside this get the full damage
-    Blast2OuterRadius   = 120.0   ;objects inside this get some of the full damage
-    Blast2MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
+    Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
+    Blast2MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast2MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast2ToppleSpeed   = 0.45    ;higher #'s topple faster
     Blast2PushForce     = 8.0     ;higher #'s push more
@@ -2060,9 +2062,9 @@ Object CargoTruckNuke
     Blast3Enabled       = Yes
     Blast3Delay         = 720    ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
-    Blast3InnerRadius   = 120.0   ;objects inside this get the full damage
-    Blast3OuterRadius   = 150.0   ;objects inside this get some of the full damage
-    Blast3MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
+    Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
+    Blast3MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast3MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast3ToppleSpeed   = 0.42    ;higher #'s topple faster
     Blast3PushForce     = 6.0     ;higher #'s push more
@@ -2070,9 +2072,9 @@ Object CargoTruckNuke
     Blast4Enabled       = Yes
     Blast4Delay         = 850    ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
-    Blast4InnerRadius   = 150.0   ;objects inside this get the full damage
-    Blast4OuterRadius   = 180.0   ;objects inside this get some of the full damage
-    Blast4MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
+    Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
+    Blast4MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast4MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast4ToppleSpeed   = 0.40    ;higher #'s topple faster
     Blast4PushForce     = 6.0     ;higher #'s push more
@@ -2080,9 +2082,9 @@ Object CargoTruckNuke
     Blast5Enabled       = Yes
     Blast5Delay         = 1000    ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
-    Blast5InnerRadius   = 180.0   ;objects inside this get the full damage
-    Blast5OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast5MaxDamage     = 640.0   ;damage within inner radius of blast
+    Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
+    Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
+    Blast5MaxDamage     = 700.0   ;damage within inner radius of blast
     Blast5MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast5ToppleSpeed   = 0.38    ;higher #'s topple faster
     Blast5PushForce     = 6.0     ;higher #'s push more
@@ -2090,10 +2092,10 @@ Object CargoTruckNuke
     Blast6Enabled       = Yes
     Blast6Delay         = 1180    ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
-    Blast6InnerRadius   = 210.0   ;objects inside this get the full damage
-    Blast6OuterRadius   = 210.0   ;objects inside this get some of the full damage
-    Blast6MaxDamage     = 300.0   ;damage within inner radius of blast
-    Blast6MinDamage     = 300.0   ;always do at least this much damage to objects
+    Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
+    Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
+    Blast6MaxDamage     = 700.0   ;damage within inner radius of blast
+    Blast6MinDamage     = 0.0     ;always do at least this much damage to objects
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 


### PR DESCRIPTION
Fixes #846

This change increase China Nuke Missiles damage by 20% and blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%. It becomes competitive with GLA SCUD Storm.

# Lab Test

## Superweapon Area Damage VS 64 GLA Black Markets (No Upgrade)

| Object                                | Num Destroyed | Num Damaged | Num Undamaged |
|---------------------------------------|---------------|-------------|---------------|
| Original USA Particle Cannon          | 14            | 2           | 48            |
| Original GLA SCUD Storm               | 16            | 42          | 6             |
| Original Demo GLA SCUD Storm          | 20            | 37          | 7             |
| Original China Nuke Missile           | 0             | 32          | 32            |
| Patched China Nuke Missile (6x blast) | 12            | 20          | 32            |
| Patched China Nuke Missile (this)     | 16            | 16          | 32            |

## Superweapon Area Damage VS 144 USA Supply Drop Zones

| Object                                | Num Destroyed | Num Damaged | Num Undamaged |
|---------------------------------------|---------------|-------------|---------------|
| Original USA Particle Cannon          | 16            | 0           | 128           |
| Original GLA SCUD Storm               | 32            | 30          | 82            |
| Original Demo GLA SCUD Storm          | 33            | 26          | 85            |
| Original China Nuke Missile           | 8             | 24          | 112           |
| Patched China Nuke Missile (6x blast) | 32            | 0           | 112           |
| Patched China Nuke Missile (this)     | 32            | 20          | 92            |

## Superweapon Point Damage VS SCUD Storm (Standard)

| Object                                | Damage Applied |
|---------------------------------------|----------------|
| Original USA Particle Cannon          | 85 %           |
| Original GLA SCUD Storm               | 90 %           |
| Original Demo GLA SCUD Storm          | 100 %          |
| Original China Nuke Missile           | 70 %           |
| Patched China Nuke Missile (6x blast) | 70 %           |
| Patched China Nuke Missile (this)     | 85 %           |

## Superweapon Timers

| Object                                | Timer |
|---------------------------------------|-------|
| Original USA Particle Cannon          | 04:00 |
| Original GLA SCUD Storm               | 05:00 |
| Original Demo GLA SCUD Storm          | 05:00 |
| Original China Nuke Missile           | 06:00 |
| Patched China Nuke Missile (6x blast) | 06:00 |
| Patched China Nuke Missile (this)     | 06:00 |

## Videos

### Original USA Particle Cannon

https://user-images.githubusercontent.com/4720891/184401706-d0230aeb-22eb-4dca-87e7-5a5147167b9a.mp4

### Original GLA SCUD Storm

https://user-images.githubusercontent.com/4720891/184401737-8d389b27-4efa-4e87-b892-0d1dd2ae644f.mp4

### Original Demo GLA SCUD Storm

https://user-images.githubusercontent.com/4720891/184401774-cb22f440-0ee0-4464-8ae0-a6892d3ca48e.mp4

### Original China Nuke Missile

https://user-images.githubusercontent.com/4720891/184401834-ed639d98-b707-4791-b994-e3c3fa246431.mp4

### Patched China Nuke Missile (6x blast)

https://user-images.githubusercontent.com/4720891/184401805-4021c8ff-beb8-4fd2-955e-784a591d2c74.mp4

### Patched China Nuke Missile (this)

https://user-images.githubusercontent.com/4720891/184401793-f224fbd5-ba66-4cf4-a74c-3692e2c61271.mp4


# Conclusion

China Nuke Missile Superweapon becomes a serious threat for both USA and GLA. The GLA SCUD Storm is still the best Superweapon with its larger Area damage, but the new Nuke Missile is not trailing far behind. The USA Particle Cannon is the weakest Superweapon, but it has the lowest countdown of 4 minutes, vs 5 minutes SCUD Storm and 6 minutes Nuke Missile. USA can send invincible Auroras to apply additional Point damage against structures, but will not achieve the great Area damage of both SCUD Storm and Nuke Missile.

# Stats

## USA Particle Cannon
**Pros:**
* Best Countdown time of 4:00
* Good vs Buildings
* Takes just 2 seconds to hit the target
* (Cheap for Superweapon General: 2500)

**Cons:**
* Requires Power
* Just OK vs Units
* Small effective area

## China Nuke
**Pros:**
* Good vs Buildings
* Good vs Units
* Large effective area
* Takes just 6 seconds to hit the target

**Cons:**
* Worst Countdown time of 6:00
* Requires Power

## GLA SCUD Storm
**Pros:**
* Good vs Buildings
* Good vs Units
* Large effective area
* Does not reveal if its ready to fire
* (Camo Netting for Stealth General)

**Cons:**
* Takes twice as long to build with 120 seconds
* Takes 11 seconds until the first hit

**Neutral:**
* Countdown time of 5:00