### PR TITLE
Change: Allow Supply Centers To Be Placed As Close To Supplies As Other Buildings

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
@@ -249,6 +249,8 @@ GameData
 
   BuildSpeed = 1.0
   MinDistFromEdgeOfMapForBuild = 30.0  ; buildings may not be constructed this close to a map edge
+
+  ; Patch104p @bugfix 12/08/2022 Allow Supply Centers to be placed right next to Supplies and Supply Piles.
   SupplyBuildBorder = 0.0  ; min dist you can put a supply center from a supply source
 
   ;Terrain height at structure footprint must be within this much to

--- a/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
@@ -251,6 +251,7 @@ GameData
   MinDistFromEdgeOfMapForBuild = 30.0  ; buildings may not be constructed this close to a map edge
 
   ; Patch104p @bugfix 12/08/2022 Allow Supply Centers to be placed right next to Supplies and Supply Piles.
+  ; Value was 20.0
   SupplyBuildBorder = 0.0  ; min dist you can put a supply center from a supply source
 
   ;Terrain height at structure footprint must be within this much to

--- a/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
@@ -249,7 +249,7 @@ GameData
 
   BuildSpeed = 1.0
   MinDistFromEdgeOfMapForBuild = 30.0  ; buildings may not be constructed this close to a map edge
-  SupplyBuildBorder = 20.0  ; min dist you can put a supply center from a supply source
+  SupplyBuildBorder = 0.0  ; min dist you can put a supply center from a supply source
 
   ;Terrain height at structure footprint must be within this much to
   ;be considerd "flat" and therefore buildable

--- a/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/GameData.ini
@@ -250,7 +250,7 @@ GameData
   BuildSpeed = 1.0
   MinDistFromEdgeOfMapForBuild = 30.0  ; buildings may not be constructed this close to a map edge
 
-  ; Patch104p @bugfix 12/08/2022 Allow Supply Centers to be placed right next to Supplies and Supply Piles.
+  ; Patch104p @tweak 12/08/2022 Allow Supply Centers to be placed right next to Supplies and Supply Piles.
   ; Value was 20.0
   SupplyBuildBorder = 0.0  ; min dist you can put a supply center from a supply source
 


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/550

# Before:

- Supply Centers / Supply Stashes have to be placed a certain distance away from Supplies and Supply Piles. All other buildings can be placed very close to the Supplies.

![shot_20220812_205219_2](https://user-images.githubusercontent.com/6576312/184428131-ce4a06a6-9242-4d56-8fb4-8f2e39a85751.jpg)
![shot_20220812_205222_3](https://user-images.githubusercontent.com/6576312/184428143-4abde525-dc38-4f60-b52c-c3202b97d14b.jpg)
![shot_20220812_205232_5](https://user-images.githubusercontent.com/6576312/184428153-ec79b648-3a3d-472c-9881-0724a34c3e2e.jpg)
![shot_20220812_205228_4](https://user-images.githubusercontent.com/6576312/184428158-932e1433-e7a8-495d-ac29-04144ac9940a.jpg)

# After:

![shot_20220812_205400_2](https://user-images.githubusercontent.com/6576312/184428344-ed5bac8e-7578-4862-9685-afa1e63e4562.jpg)

- All buildings can be placed freely.