### PR TITLE
Change: Optimize China Nuke Missile blast delays: Hits max 880 ms earlier

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -3901,7 +3901,6 @@ FXList WeaponFX_CINEConvoyNuke
   ParticleSystem
     Name = NukeBlastWave
     InitialDelay = 300 300 UNIFORM   ;In milliseconds
-    ;Offset = X:0.0 Y:0.0 Z:45.0
     Offset = X:0.0 Y:0.0 Z:15.0
   End
 
@@ -4801,13 +4800,13 @@ FXList FX_Nuke
 
   ParticleSystem
     Name = NukeRing
+    InitialDelay = 200 200 UNIFORM   ; Patch104p @tweak from 0 0 UNIFORM to match new blast delays visually (red ring)
     Offset = X:0.0 Y:0.0 Z:5.0
   End
 
   ParticleSystem
     Name = NukeBlastWave
-    InitialDelay = 300 300 UNIFORM   ;In milliseconds
-    ;Offset = X:0.0 Y:0.0 Z:45.0
+    InitialDelay = 0 0 UNIFORM   ; Patch104p @tweak from 300 300 UNIFORM to match new blast delays visually (white ring)
     Offset = X:0.0 Y:0.0 Z:15.0
   End
 
@@ -4874,13 +4873,13 @@ FXList FX_BaikonurNuke
 
   ParticleSystem
     Name = NukeBaikonurRing
+    InitialDelay = 200 200 UNIFORM   ; Patch104p @tweak from 0 0 UNIFORM to match new blast delays visually (red ring)
     Offset = X:0.0 Y:0.0 Z:5.0
   End
 
   ParticleSystem
     Name = NukeBlastWave
-    InitialDelay = 300 300 UNIFORM   ;In milliseconds
-    ;Offset = X:0.0 Y:0.0 Z:45.0
+    InitialDelay = 0 0 UNIFORM   ; Patch104p @tweak from 300 300 UNIFORM to match new blast delays visually (white ring)
     Offset = X:0.0 Y:0.0 Z:15.0
   End
 
@@ -8569,13 +8568,13 @@ FXList SupW_FX_Nuke
 
   ParticleSystem
     Name = NukeRing
+    InitialDelay = 200 200 UNIFORM   ; Patch104p @tweak from 0 0 UNIFORM to match new blast delays visually (red ring)
     Offset = X:0.0 Y:0.0 Z:5.0
   End
 
   ParticleSystem
     Name = NukeBlastWave
-    InitialDelay = 300 300 UNIFORM   ;In milliseconds
-    ;Offset = X:0.0 Y:0.0 Z:45.0
+    InitialDelay = 0 0 UNIFORM   ; Patch104p @tweak from 300 300 UNIFORM to match new blast delays visually (white ring)
     Offset = X:0.0 Y:0.0 Z:15.0
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -322,6 +322,7 @@ Object SupW_NeutronMissile
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
   ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
+  ; Patch104p @tweak 13/08/2022 Reduce blast delays by around 400 ms with fixed 80 ms step size. First explosion triggers 880 ms earlier than original.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_06
     DestructionDelay    = 3501
@@ -329,7 +330,7 @@ Object SupW_NeutronMissile
     FXList              = SupW_FX_Nuke
 
     Blast1Enabled       = Yes
-    Blast1Delay         = 580     ;in milliseconds
+    Blast1Delay         = 300     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
     Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
@@ -339,7 +340,7 @@ Object SupW_NeutronMissile
     Blast1PushForce     = 10.0    ;higher #'s push more
 
     Blast2Enabled       = Yes
-    Blast2Delay         = 660    ;in milliseconds
+    Blast2Delay         = 380     ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
     Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
@@ -349,7 +350,7 @@ Object SupW_NeutronMissile
     Blast2PushForce     = 8.0     ;higher #'s push more
 
     Blast3Enabled       = Yes
-    Blast3Delay         = 720    ;in milliseconds
+    Blast3Delay         = 460     ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
     Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
@@ -359,7 +360,7 @@ Object SupW_NeutronMissile
     Blast3PushForce     = 6.0     ;higher #'s push more
 
     Blast4Enabled       = Yes
-    Blast4Delay         = 850    ;in milliseconds
+    Blast4Delay         = 540     ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
     Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
@@ -369,7 +370,7 @@ Object SupW_NeutronMissile
     Blast4PushForce     = 6.0     ;higher #'s push more
 
     Blast5Enabled       = Yes
-    Blast5Delay         = 1000    ;in milliseconds
+    Blast5Delay         = 620     ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
     Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
@@ -379,7 +380,7 @@ Object SupW_NeutronMissile
     Blast5PushForce     = 6.0     ;higher #'s push more
 
     Blast6Enabled       = Yes
-    Blast6Delay         = 1180    ;in milliseconds
+    Blast6Delay         = 700     ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
     Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
@@ -388,17 +389,17 @@ Object SupW_NeutronMissile
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 
-    Blast7Enabled       = Yes
+    Blast7Enabled       = No
     Blast7Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast7ScorchDelay   = 620     ;in milliseconds
     Blast7OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast8Enabled       = Yes
+    Blast8Enabled       = No
     Blast8Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast8ScorchDelay   = 700     ;in milliseconds
     Blast8OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast9Enabled       = Yes
+    Blast9Enabled       = No
     Blast9Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast9ScorchDelay   = 800     ;in milliseconds
     Blast9OuterRadius   = 210.0   ;objects inside this get some of the full damage

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2695,6 +2695,7 @@ Object BaikonurRocketDetonation
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
   ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
+  ; Patch104p @tweak 13/08/2022 Reduce blast delays by around 400 ms with fixed 80 ms step size. First explosion triggers 880 ms earlier than original.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_08
     DestructionDelay    = 3501
@@ -2702,7 +2703,7 @@ Object BaikonurRocketDetonation
     FXList              = FX_BaikonurNuke
 
     Blast1Enabled       = Yes
-    Blast1Delay         = 580     ;in milliseconds
+    Blast1Delay         = 300     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
     Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
@@ -2712,7 +2713,7 @@ Object BaikonurRocketDetonation
     Blast1PushForce     = 10.0    ;higher #'s push more
 
     Blast2Enabled       = Yes
-    Blast2Delay         = 660    ;in milliseconds
+    Blast2Delay         = 380     ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
     Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
@@ -2722,7 +2723,7 @@ Object BaikonurRocketDetonation
     Blast2PushForce     = 8.0     ;higher #'s push more
 
     Blast3Enabled       = Yes
-    Blast3Delay         = 720    ;in milliseconds
+    Blast3Delay         = 460     ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
     Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
@@ -2732,7 +2733,7 @@ Object BaikonurRocketDetonation
     Blast3PushForce     = 6.0     ;higher #'s push more
 
     Blast4Enabled       = Yes
-    Blast4Delay         = 850    ;in milliseconds
+    Blast4Delay         = 540     ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
     Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
@@ -2742,7 +2743,7 @@ Object BaikonurRocketDetonation
     Blast4PushForce     = 6.0     ;higher #'s push more
 
     Blast5Enabled       = Yes
-    Blast5Delay         = 1000    ;in milliseconds
+    Blast5Delay         = 620     ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
     Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
@@ -2752,7 +2753,7 @@ Object BaikonurRocketDetonation
     Blast5PushForce     = 6.0     ;higher #'s push more
 
     Blast6Enabled       = Yes
-    Blast6Delay         = 1180    ;in milliseconds
+    Blast6Delay         = 700     ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
     Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
@@ -2761,17 +2762,17 @@ Object BaikonurRocketDetonation
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 
-    Blast7Enabled       = Yes
+    Blast7Enabled       = No
     Blast7Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast7ScorchDelay   = 620     ;in milliseconds
     Blast7OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast8Enabled       = Yes
+    Blast8Enabled       = No
     Blast8Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast8ScorchDelay   = 700     ;in milliseconds
     Blast8OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast9Enabled       = Yes
+    Blast9Enabled       = No
     Blast9Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast9ScorchDelay   = 800     ;in milliseconds
     Blast9OuterRadius   = 210.0   ;objects inside this get some of the full damage

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1833,7 +1833,7 @@ Object DaisyCutterGas
 End
 
 ;------------------------------------------------------------------------------
-Object NeutronMissile
+Object NeutronMissile ; This one is used by the China Nuke Missiles
 
   ; *** ART Parameters ***
   Draw               = W3DModelDraw ModuleTag_01
@@ -1908,6 +1908,7 @@ Object NeutronMissile
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
   ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
+  ; Patch104p @tweak 13/08/2022 Reduce blast delays by around 400 ms with fixed 80 ms step size. First explosion triggers 880 ms earlier than original.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_06
     DestructionDelay    = 3501
@@ -1915,7 +1916,7 @@ Object NeutronMissile
     FXList              = FX_Nuke
 
     Blast1Enabled       = Yes
-    Blast1Delay         = 580     ;in milliseconds
+    Blast1Delay         = 300     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
     Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
@@ -1925,7 +1926,7 @@ Object NeutronMissile
     Blast1PushForce     = 10.0    ;higher #'s push more
 
     Blast2Enabled       = Yes
-    Blast2Delay         = 660    ;in milliseconds
+    Blast2Delay         = 380     ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
     Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
@@ -1935,7 +1936,7 @@ Object NeutronMissile
     Blast2PushForce     = 8.0     ;higher #'s push more
 
     Blast3Enabled       = Yes
-    Blast3Delay         = 720    ;in milliseconds
+    Blast3Delay         = 460     ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
     Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
@@ -1945,7 +1946,7 @@ Object NeutronMissile
     Blast3PushForce     = 6.0     ;higher #'s push more
 
     Blast4Enabled       = Yes
-    Blast4Delay         = 850    ;in milliseconds
+    Blast4Delay         = 540     ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
     Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
@@ -1955,7 +1956,7 @@ Object NeutronMissile
     Blast4PushForce     = 6.0     ;higher #'s push more
 
     Blast5Enabled       = Yes
-    Blast5Delay         = 1000    ;in milliseconds
+    Blast5Delay         = 620     ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
     Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
@@ -1965,7 +1966,7 @@ Object NeutronMissile
     Blast5PushForce     = 6.0     ;higher #'s push more
 
     Blast6Enabled       = Yes
-    Blast6Delay         = 1180    ;in milliseconds
+    Blast6Delay         = 700     ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
     Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
@@ -1974,17 +1975,17 @@ Object NeutronMissile
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 
-    Blast7Enabled       = Yes
+    Blast7Enabled       = No
     Blast7Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast7ScorchDelay   = 620     ;in milliseconds
     Blast7OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast8Enabled       = Yes
+    Blast8Enabled       = No
     Blast8Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast8ScorchDelay   = 700     ;in milliseconds
     Blast8OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast9Enabled       = Yes
+    Blast9Enabled       = No
     Blast9Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast9ScorchDelay   = 800     ;in milliseconds
     Blast9OuterRadius   = 210.0   ;objects inside this get some of the full damage
@@ -2033,6 +2034,7 @@ Object CargoTruckNuke
 
   ; Patch104p @balance 05/09/2021 Change Nuke Missiles such that they destroy GLA holes.
   ; Patch104p @balance 13/08/2022 Increase Nuke Missile damage by 20% and outer blast radii by 2%, 3.3%, 4%, 4.4%, 4.7%, 20%.
+  ; Patch104p @tweak 13/08/2022 Reduce blast delays by around 400 ms with fixed 80 ms step size. First explosion triggers 880 ms earlier than original.
 
   Behavior = NeutronMissileSlowDeathBehavior ModuleTag_03
     DestructionDelay = 3501
@@ -2040,7 +2042,7 @@ Object CargoTruckNuke
     FXList              = FX_Nuke
 
     Blast1Enabled       = Yes
-    Blast1Delay         = 580     ;in milliseconds
+    Blast1Delay         = 300     ;in milliseconds
     Blast1ScorchDelay   = 100     ;in milliseconds
     Blast1InnerRadius   = 60.0    ;objects inside this get the full damage
     Blast1OuterRadius   = 92.0    ;objects inside this get some of the full damage
@@ -2050,7 +2052,7 @@ Object CargoTruckNuke
     Blast1PushForce     = 10.0    ;higher #'s push more
 
     Blast2Enabled       = Yes
-    Blast2Delay         = 660    ;in milliseconds
+    Blast2Delay         = 380     ;in milliseconds
     Blast2ScorchDelay   = 180     ;in milliseconds
     Blast2InnerRadius   = 92.0    ;objects inside this get the full damage
     Blast2OuterRadius   = 124.0   ;objects inside this get some of the full damage
@@ -2060,7 +2062,7 @@ Object CargoTruckNuke
     Blast2PushForce     = 8.0     ;higher #'s push more
 
     Blast3Enabled       = Yes
-    Blast3Delay         = 720    ;in milliseconds
+    Blast3Delay         = 460     ;in milliseconds
     Blast3ScorchDelay   = 260     ;in milliseconds
     Blast3InnerRadius   = 124.0   ;objects inside this get the full damage
     Blast3OuterRadius   = 156.0   ;objects inside this get some of the full damage
@@ -2070,7 +2072,7 @@ Object CargoTruckNuke
     Blast3PushForce     = 6.0     ;higher #'s push more
 
     Blast4Enabled       = Yes
-    Blast4Delay         = 850    ;in milliseconds
+    Blast4Delay         = 540     ;in milliseconds
     Blast4ScorchDelay   = 340     ;in milliseconds
     Blast4InnerRadius   = 156.0   ;objects inside this get the full damage
     Blast4OuterRadius   = 188.0   ;objects inside this get some of the full damage
@@ -2080,7 +2082,7 @@ Object CargoTruckNuke
     Blast4PushForce     = 6.0     ;higher #'s push more
 
     Blast5Enabled       = Yes
-    Blast5Delay         = 1000    ;in milliseconds
+    Blast5Delay         = 620     ;in milliseconds
     Blast5ScorchDelay   = 420     ;in milliseconds
     Blast5InnerRadius   = 188.0   ;objects inside this get the full damage
     Blast5OuterRadius   = 220.0   ;objects inside this get some of the full damage
@@ -2090,7 +2092,7 @@ Object CargoTruckNuke
     Blast5PushForce     = 6.0     ;higher #'s push more
 
     Blast6Enabled       = Yes
-    Blast6Delay         = 1180    ;in milliseconds
+    Blast6Delay         = 700     ;in milliseconds
     Blast6ScorchDelay   = 500     ;in milliseconds
     Blast6InnerRadius   = 220.0   ;objects inside this get the full damage
     Blast6OuterRadius   = 252.0   ;objects inside this get some of the full damage
@@ -2099,17 +2101,17 @@ Object CargoTruckNuke
     Blast6ToppleSpeed   = 0.35    ;higher #'s topple faster
     Blast6PushForce     = 4.0     ;higher #'s push more
 
-    Blast7Enabled       = Yes
+    Blast7Enabled       = No
     Blast7Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast7ScorchDelay   = 620     ;in milliseconds
     Blast7OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast8Enabled       = Yes
+    Blast8Enabled       = No
     Blast8Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast8ScorchDelay   = 700     ;in milliseconds
     Blast8OuterRadius   = 210.0   ;objects inside this get some of the full damage
 
-    Blast9Enabled       = Yes
+    Blast9Enabled       = No
     Blast9Delay         = 999999  ;in milliseconds, don't do the damage wave
     Blast9ScorchDelay   = 800     ;in milliseconds
     Blast9OuterRadius   = 210.0   ;objects inside this get some of the full damage


### PR DESCRIPTION
This change optimizes the blast delays of China Nuke Missile.

## Stats

Blast delays in milliseconds.

| Stat                               | Blast 1 | Blast 2 | Blast 3 | Blast 4 | Blast 5 | Blast 6 |
|------------------------------------|---------|---------|---------|---------|---------|---------|
| Original Nuke Missile Delay        |         |         |         |         |         | 1180    |
| Patched Nuke Missile Delay (1)     | 580     | 660     | 720     | 850     | 1000    | 1180    |
| Patched Nuke Missile Delay (this)  | 300     | 380     | 460     | 540     | 620     | 700     |

## Original

https://user-images.githubusercontent.com/4720891/184471223-0b8151de-9f86-4226-99c2-49dd9b6dd9bf.mp4

## Patched (this)

https://user-images.githubusercontent.com/4720891/184472521-bda7f285-234c-4883-a4e2-b78df68f7377.mp4
