### PR TITLE
Change: Reduce Toxin GLA Stinger Gamma ground damage bonus from 100% to 50% and air damage bonus from 66% to 50%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -5341,7 +5341,7 @@ Weapon GC_Chem_StingerMissileWeaponAirBeta
 End
 
 Weapon GC_Chem_StingerMissileWeaponGamma
-  PrimaryDamage = 40.0
+  PrimaryDamage = 30.0 ; Patch104p @balance from 40.0 reduce Gamma bonus of 100% to 50% to be consistent with intended Gamma bonus
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 225.0
@@ -5368,7 +5368,7 @@ Weapon GC_Chem_StingerMissileWeaponGamma
 End
 
 Weapon GC_Chem_StingerMissileWeaponAirGamma
-  PrimaryDamage = 50.0
+  PrimaryDamage = 45.0 ; Patch104p @balance from 50.0 reduce Gamma bonus of 66% to 50% to be consistent with intended Gamma bonus
   PrimaryDamageRadius = 10.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 400.0
@@ -7072,7 +7072,7 @@ Weapon Chem_StingerMissileWeaponAirBeta
 End
 
 Weapon Chem_StingerMissileWeaponGamma
-  PrimaryDamage = 40.0
+  PrimaryDamage = 30.0 ; Patch104p @balance from 40.0 reduce Gamma bonus of 100% to 50% to be consistent with intended Gamma bonus
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 225.0
@@ -7099,7 +7099,7 @@ Weapon Chem_StingerMissileWeaponGamma
 End
 
 Weapon Chem_StingerMissileWeaponAirGamma
-  PrimaryDamage = 50.0
+  PrimaryDamage = 45.0 ; Patch104p @balance from 50.0 reduce Gamma bonus of 66% to 50% to be consistent with intended Gamma bonus
   PrimaryDamageRadius = 10.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 400.0


### PR DESCRIPTION
Reference:
* #806

This change reduces Toxin GLA Stinger Gamma bonuses to be consistent with the intended bonus from the tool tip.

```
CONTROLBAR:ToolTipGLAUpgradeAnthraxGamma
US: "+50% damage bonus to all toxin units"
```

## Stats

| Weapon                                               | Damage | Bonus over Anthrax Beta | Bonux over Toxin |
|------------------------------------------------------|--------|-------------------------|------------------|
| Original StingerMissileWeapon                        | 20     |                         |                  |
| Original StingerMissileWeaponAir                     | 30     |                         |                  |
| Original Chem_StingerMissileWeaponBeta               | 20     |                         | 0%               |
| Original Chem_StingerMissileWeaponAirBeta            | 30     |                         | 0%               |
| Original Chem_StingerMissileWeaponGamma              | 40     | 100%                    | 100%             |
| Original Chem_StingerMissileWeaponAirGamma           | 50     | 66%                     | 66%              |
| Patched Chem_StingerMissileWeaponGamma (this)        | 30     | 50%                     | 50%              |
| Patched Chem_StingerMissileWeaponAirGamma (this)     | 45     | 50%                     | 50%              |

# Rationale

The Toxin Stinger Gamma bonus is very generous. The UI tool tip promises 50% bonus, but the Gamma Stinger weapon gives up to 100% bonus. There is also another +25% damage bonus for the RPG Missile Upgrade. All other GLA factions have no access to such a huge bonus. Toxin General is very capable in bunker games, therefore a reduction in the defense bonuses is justified to give its opponent factions a better chance.