### PR TITLE
Fix: GLA Buildings are missing Fortified Structures visuals during sell

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -2161,6 +2161,80 @@ Object Chem_GLABlackMarket
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -2970,6 +3044,80 @@ Object Chem_FakeGLABlackMarket
     ConditionState       =  PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBlackMkt_ENS
       Animation          = UBBlackMkt_ENS.UBBlackMkt_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -7324,6 +7324,80 @@ Object Chem_GLASupplyStash
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -8013,6 +8087,80 @@ Object Chem_FakeGLASupplyStash
       Model              = UBSupply_ENS
       ;Animation          = UBSupply_ENS.UBSupply_ENS
       ;AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -10170,6 +10170,80 @@ Object Chem_GLAArmsDealer
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -11077,6 +11151,80 @@ Object Chem_FakeGLAArmsDealer
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBArmDeal_ENS
       Animation          = UBArmDeal_ENS.UBArmDeal_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -556,6 +556,80 @@ Object Chem_GLACommandCenter
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQCE
+      Animation          = UBCmdHQCE.UBCmdHQCE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQCE_D
+      Animation          = UBCmdHQCE_D.UBCmdHQCE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQCE_E
+      Animation          = UBCmdHQCE_E.UBCmdHQCE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQCE_N
+      Animation          = UBCmdHQCE_N.UBCmdHQCE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQCE_DN
+      Animation          = UBCmdHQCE_DN.UBCmdHQCE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQCE_EN
+      Animation          = UBCmdHQCE_EN.UBCmdHQCE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQCE_S
+      Animation          = UBCmdHQCE_S.UBCmdHQCE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQCE_DS
+      Animation          = UBCmdHQCE_DS.UBCmdHQCE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQCE_ES
+      Animation          = UBCmdHQCE_ES.UBCmdHQCE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQCE_NS
+      Animation          = UBCmdHQCE_NS.UBCmdHQCE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQCE_DNS
+      Animation          = UBCmdHQCE_DNS.UBCmdHQCE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQCE_ENS
+      Animation          = UBCmdHQCE_ENS.UBCmdHQCE_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -1328,6 +1402,80 @@ Object Chem_FakeGLACommandCenter
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBCmdHQC_ENS
       Animation          = UBCmdHQC_ENS.UBCmdHQC_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQCE
+      Animation          = UBCmdHQCE.UBCmdHQCE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQCE_D
+      Animation          = UBCmdHQCE_D.UBCmdHQCE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQCE_E
+      Animation          = UBCmdHQCE_E.UBCmdHQCE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQCE_N
+      Animation          = UBCmdHQCE_N.UBCmdHQCE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQCE_DN
+      Animation          = UBCmdHQCE_DN.UBCmdHQCE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQCE_EN
+      Animation          = UBCmdHQCE_EN.UBCmdHQCE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQCE_S
+      Animation          = UBCmdHQCE_S.UBCmdHQCE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQCE_DS
+      Animation          = UBCmdHQCE_DS.UBCmdHQCE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQCE_ES
+      Animation          = UBCmdHQCE_ES.UBCmdHQCE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQCE_NS
+      Animation          = UBCmdHQCE_NS.UBCmdHQCE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQCE_DNS
+      Animation          = UBCmdHQCE_DNS.UBCmdHQCE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQCE_ENS
+      Animation          = UBCmdHQCE_ENS.UBCmdHQCE_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -8614,6 +8614,80 @@ Object Chem_GLABarracks
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -9286,6 +9360,80 @@ Object Chem_FakeGLABarracks
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBarracks_ENS
       Animation          = UBBarracks_ENS.UBBarracks_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -6537,6 +6537,80 @@ Object Chem_GLAPalace
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD
+      Model              = UBPalaceEG
+      Animation          = UBPalaceEG.UBPalaceEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD DAMAGED
+      Model              = UBPalaceEG_D
+      Animation          = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD REALLYDAMAGED
+      Model              = UBPalaceEG_E
+      Animation          = UBPalaceEG_E.UBPalaceEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT
+      Model              = UBPalaceEG_N
+      Animation          = UBPalaceEG_N.UBPalaceEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT DAMAGED
+      Model              = UBPalaceEG_DN
+      Animation          = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT REALLYDAMAGED
+      Model              = UBPalaceEG_EN
+      Animation          = UBPalaceEG_EN.UBPalaceEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW
+      Model              = UBPalaceEG_S
+      Animation          = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW DAMAGED
+      Model              = UBPalaceEG_DS
+      Animation          = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ES
+      Animation          = UBPalaceEG_ES.UBPalaceEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW
+      Model              = UBPalaceEG_NS
+      Animation          = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW DAMAGED
+      Model              = UBPalaceEG_DNS
+      Animation          = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ENS
+      Animation          = UBPalaceEG_ENS.UBPalaceEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -10120,6 +10120,80 @@ Object Demo_GLAArmsDealer
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -11027,6 +11101,80 @@ Object Demo_FakeGLAArmsDealer
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBArmDeal_ENS
       Animation          = UBArmDeal_ENS.UBArmDeal_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -7246,6 +7246,80 @@ Object Demo_GLASupplyStash
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -7934,6 +8008,80 @@ Object Demo_FakeGLASupplyStash
       Model              = UBSupply_ENS
       ;Animation          = UBSupply_ENS.UBSupply_ENS
       ;AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -8535,6 +8535,80 @@ Object Demo_GLABarracks
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -9236,6 +9310,80 @@ Object Demo_FakeGLABarracks
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBarracks_ENS
       Animation          = UBBarracks_ENS.UBBarracks_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -6461,6 +6461,80 @@ Object Demo_GLAPalace
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD
+      Model              = UBPalaceEG
+      Animation          = UBPalaceEG.UBPalaceEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD DAMAGED
+      Model              = UBPalaceEG_D
+      Animation          = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD REALLYDAMAGED
+      Model              = UBPalaceEG_E
+      Animation          = UBPalaceEG_E.UBPalaceEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT
+      Model              = UBPalaceEG_N
+      Animation          = UBPalaceEG_N.UBPalaceEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT DAMAGED
+      Model              = UBPalaceEG_DN
+      Animation          = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT REALLYDAMAGED
+      Model              = UBPalaceEG_EN
+      Animation          = UBPalaceEG_EN.UBPalaceEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW
+      Model              = UBPalaceEG_S
+      Animation          = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW DAMAGED
+      Model              = UBPalaceEG_DS
+      Animation          = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ES
+      Animation          = UBPalaceEG_ES.UBPalaceEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW
+      Model              = UBPalaceEG_NS
+      Animation          = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW DAMAGED
+      Model              = UBPalaceEG_DNS
+      Animation          = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ENS
+      Animation          = UBPalaceEG_ENS.UBPalaceEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -2297,6 +2297,80 @@ Object Demo_GLABlackMarket
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -3106,6 +3180,80 @@ Object Demo_FakeGLABlackMarket
     ConditionState       =  PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBlackMkt_ENS
       Animation          = UBBlackMkt_ENS.UBBlackMkt_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -691,6 +691,80 @@ Object Demo_GLACommandCenter
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQDE
+      Animation          = UBCmdHQDE.UBCmdHQDE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQDE_D
+      Animation          = UBCmdHQDE_D.UBCmdHQDE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQDE_E
+      Animation          = UBCmdHQDE_E.UBCmdHQDE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQDE_N
+      Animation          = UBCmdHQDE_N.UBCmdHQDE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQDE_DN
+      Animation          = UBCmdHQDE_DN.UBCmdHQDE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQDE_EN
+      Animation          = UBCmdHQDE_EN.UBCmdHQDE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQDE_S
+      Animation          = UBCmdHQDE_S.UBCmdHQDE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQDE_DS
+      Animation          = UBCmdHQDE_DS.UBCmdHQDE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQDE_ES
+      Animation          = UBCmdHQDE_ES.UBCmdHQDE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQDE_NS
+      Animation          = UBCmdHQDE_NS.UBCmdHQDE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQDE_DNS
+      Animation          = UBCmdHQDE_DNS.UBCmdHQDE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQDE_ENS
+      Animation          = UBCmdHQDE_ENS.UBCmdHQDE_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -1465,6 +1539,80 @@ Object Demo_FakeGLACommandCenter
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBCmdHQD_ENS
       Animation          = UBCmdHQD_ENS.UBCmdHQD_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQDE
+      Animation          = UBCmdHQDE.UBCmdHQDE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQDE_D
+      Animation          = UBCmdHQDE_D.UBCmdHQDE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQDE_E
+      Animation          = UBCmdHQDE_E.UBCmdHQDE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQDE_N
+      Animation          = UBCmdHQDE_N.UBCmdHQDE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQDE_DN
+      Animation          = UBCmdHQDE_DN.UBCmdHQDE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQDE_EN
+      Animation          = UBCmdHQDE_EN.UBCmdHQDE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQDE_S
+      Animation          = UBCmdHQDE_S.UBCmdHQDE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQDE_DS
+      Animation          = UBCmdHQDE_DS.UBCmdHQDE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQDE_ES
+      Animation          = UBCmdHQDE_ES.UBCmdHQDE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQDE_NS
+      Animation          = UBCmdHQDE_NS.UBCmdHQDE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQDE_DNS
+      Animation          = UBCmdHQDE_DNS.UBCmdHQDE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQDE_ENS
+      Animation          = UBCmdHQDE_ENS.UBCmdHQDE_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -17627,6 +17627,80 @@ Object GLAPalace
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD
+      Model              = UBPalaceEG
+      Animation          = UBPalaceEG.UBPalaceEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD DAMAGED
+      Model              = UBPalaceEG_D
+      Animation          = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD REALLYDAMAGED
+      Model              = UBPalaceEG_E
+      Animation          = UBPalaceEG_E.UBPalaceEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT
+      Model              = UBPalaceEG_N
+      Animation          = UBPalaceEG_N.UBPalaceEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT DAMAGED
+      Model              = UBPalaceEG_DN
+      Animation          = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT REALLYDAMAGED
+      Model              = UBPalaceEG_EN
+      Animation          = UBPalaceEG_EN.UBPalaceEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW
+      Model              = UBPalaceEG_S
+      Animation          = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW DAMAGED
+      Model              = UBPalaceEG_DS
+      Animation          = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ES
+      Animation          = UBPalaceEG_ES.UBPalaceEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW
+      Model              = UBPalaceEG_NS
+      Animation          = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW DAMAGED
+      Model              = UBPalaceEG_DNS
+      Animation          = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ENS
+      Animation          = UBPalaceEG_ENS.UBPalaceEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -26543,6 +26543,80 @@ Object GLAArmsDealer
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -27450,6 +27524,80 @@ Object FakeGLAArmsDealer
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBArmDeal_ENS
       Animation          = UBArmDeal_ENS.UBArmDeal_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -20757,6 +20757,80 @@ Object GLASupplyStash
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -21446,6 +21520,80 @@ Object FakeGLASupplyStash
       Model              = UBSupply_ENS
       ;Animation          = UBSupply_ENS.UBSupply_ENS
       ;AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -23339,6 +23339,80 @@ Object GLABarracks
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -24011,6 +24085,80 @@ Object FakeGLABarracks
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBarracks_ENS
       Animation          = UBBarracks_ENS.UBBarracks_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -10032,6 +10032,80 @@ Object GLABlackMarket
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -10841,6 +10915,80 @@ Object FakeGLABlackMarket
     ConditionState       =  PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBlackMkt_ENS
       Animation          = UBBlackMkt_ENS.UBBlackMkt_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -1733,6 +1733,80 @@ Object GLACommandCenter
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQEG
+      Animation          = UBCmdHQEG.UBCmdHQEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQEG_D
+      Animation          = UBCmdHQEG_D.UBCmdHQEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQEG_E
+      Animation          = UBCmdHQEG_E.UBCmdHQEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQEG_N
+      Animation          = UBCmdHQEG_N.UBCmdHQEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQEG_DN
+      Animation          = UBCmdHQEG_DN.UBCmdHQEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQEG_EN
+      Animation          = UBCmdHQEG_EN.UBCmdHQEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQEG_S
+      Animation          = UBCmdHQEG_S.UBCmdHQEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQEG_DS
+      Animation          = UBCmdHQEG_DS.UBCmdHQEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQEG_ES
+      Animation          = UBCmdHQEG_ES.UBCmdHQEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQEG_NS
+      Animation          = UBCmdHQEG_NS.UBCmdHQEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQEG_DNS
+      Animation          = UBCmdHQEG_DNS.UBCmdHQEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQEG_ENS
+      Animation          = UBCmdHQEG_ENS.UBCmdHQEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -2502,6 +2576,80 @@ Object FakeGLACommandCenter
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBCmdHQ_ENS
       Animation          = UBCmdHQ_ENS.UBCmdHQ_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQEG
+      Animation          = UBCmdHQEG.UBCmdHQEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQEG_D
+      Animation          = UBCmdHQEG_D.UBCmdHQEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQEG_E
+      Animation          = UBCmdHQEG_E.UBCmdHQEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQEG_N
+      Animation          = UBCmdHQEG_N.UBCmdHQEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQEG_DN
+      Animation          = UBCmdHQEG_DN.UBCmdHQEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQEG_EN
+      Animation          = UBCmdHQEG_EN.UBCmdHQEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQEG_S
+      Animation          = UBCmdHQEG_S.UBCmdHQEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQEG_DS
+      Animation          = UBCmdHQEG_DS.UBCmdHQEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQEG_ES
+      Animation          = UBCmdHQEG_ES.UBCmdHQEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQEG_NS
+      Animation          = UBCmdHQEG_NS.UBCmdHQEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQEG_DNS
+      Animation          = UBCmdHQEG_DNS.UBCmdHQEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQEG_ENS
+      Animation          = UBCmdHQEG_ENS.UBCmdHQEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -5799,6 +5799,80 @@ Object GC_Chem_GLABlackMarket
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -4888,6 +4888,80 @@ Object GC_Chem_GLASupplyStash
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -2281,6 +2281,80 @@ Object GC_Chem_GLABarracks
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -3861,6 +3861,80 @@ Object GC_Chem_GLAArmsDealer
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -3156,6 +3156,80 @@ Object GC_Chem_GLAPalace
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD
+      Model              = UBPalaceEG
+      Animation          = UBPalaceEG.UBPalaceEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD DAMAGED
+      Model              = UBPalaceEG_D
+      Animation          = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD REALLYDAMAGED
+      Model              = UBPalaceEG_E
+      Animation          = UBPalaceEG_E.UBPalaceEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT
+      Model              = UBPalaceEG_N
+      Animation          = UBPalaceEG_N.UBPalaceEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT DAMAGED
+      Model              = UBPalaceEG_DN
+      Animation          = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT REALLYDAMAGED
+      Model              = UBPalaceEG_EN
+      Animation          = UBPalaceEG_EN.UBPalaceEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW
+      Model              = UBPalaceEG_S
+      Animation          = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW DAMAGED
+      Model              = UBPalaceEG_DS
+      Animation          = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ES
+      Animation          = UBPalaceEG_ES.UBPalaceEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW
+      Model              = UBPalaceEG_NS
+      Animation          = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW DAMAGED
+      Model              = UBPalaceEG_DNS
+      Animation          = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ENS
+      Animation          = UBPalaceEG_ENS.UBPalaceEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1476,6 +1476,80 @@ Object GC_Chem_GLACommandCenter
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQCE
+      Animation          = UBCmdHQCE.UBCmdHQCE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQCE_D
+      Animation          = UBCmdHQCE_D.UBCmdHQCE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQCE_E
+      Animation          = UBCmdHQCE_E.UBCmdHQCE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQCE_N
+      Animation          = UBCmdHQCE_N.UBCmdHQCE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQCE_DN
+      Animation          = UBCmdHQCE_DN.UBCmdHQCE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQCE_EN
+      Animation          = UBCmdHQCE_EN.UBCmdHQCE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQCE_S
+      Animation          = UBCmdHQCE_S.UBCmdHQCE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQCE_DS
+      Animation          = UBCmdHQCE_DS.UBCmdHQCE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQCE_ES
+      Animation          = UBCmdHQCE_ES.UBCmdHQCE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQCE_NS
+      Animation          = UBCmdHQCE_NS.UBCmdHQCE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQCE_DNS
+      Animation          = UBCmdHQCE_DNS.UBCmdHQCE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQCE_ENS
+      Animation          = UBCmdHQCE_ENS.UBCmdHQCE_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -3740,6 +3740,80 @@ Object GC_Slth_GLAArmsDealer
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -1815,6 +1815,80 @@ Object GC_Slth_GLABarracks
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -4828,6 +4828,80 @@ Object GC_Slth_GLAPalace
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD
+      Model              = UBPalaceEG
+      Animation          = UBPalaceEG.UBPalaceEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD DAMAGED
+      Model              = UBPalaceEG_D
+      Animation          = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD REALLYDAMAGED
+      Model              = UBPalaceEG_E
+      Animation          = UBPalaceEG_E.UBPalaceEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT
+      Model              = UBPalaceEG_N
+      Animation          = UBPalaceEG_N.UBPalaceEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT DAMAGED
+      Model              = UBPalaceEG_DN
+      Animation          = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT REALLYDAMAGED
+      Model              = UBPalaceEG_EN
+      Animation          = UBPalaceEG_EN.UBPalaceEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW
+      Model              = UBPalaceEG_S
+      Animation          = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW DAMAGED
+      Model              = UBPalaceEG_DS
+      Animation          = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ES
+      Animation          = UBPalaceEG_ES.UBPalaceEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW
+      Model              = UBPalaceEG_NS
+      Animation          = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW DAMAGED
+      Model              = UBPalaceEG_DNS
+      Animation          = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ENS
+      Animation          = UBPalaceEG_ENS.UBPalaceEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -5853,6 +5853,80 @@ Object GC_Slth_GLABlackMarket
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -1077,6 +1077,80 @@ Object GC_Slth_GLASupplyStash
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -257,6 +257,80 @@ Object GC_Slth_GLACommandCenter
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQSE
+      Animation          = UBCmdHQSE.UBCmdHQSE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQSE_D
+      Animation          = UBCmdHQSE_D.UBCmdHQSE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQSE_E
+      Animation          = UBCmdHQSE_E.UBCmdHQSE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQSE_N
+      Animation          = UBCmdHQSE_N.UBCmdHQSE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQSE_DN
+      Animation          = UBCmdHQSE_DN.UBCmdHQSE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQSE_EN
+      Animation          = UBCmdHQSE_EN.UBCmdHQSE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQSE_S
+      Animation          = UBCmdHQSE_S.UBCmdHQSE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQSE_DS
+      Animation          = UBCmdHQSE_DS.UBCmdHQSE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQSE_ES
+      Animation          = UBCmdHQSE_ES.UBCmdHQSE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQSE_NS
+      Animation          = UBCmdHQSE_NS.UBCmdHQSE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQSE_DNS
+      Animation          = UBCmdHQSE_DNS.UBCmdHQSE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQSE_ENS
+      Animation          = UBCmdHQSE_ENS.UBCmdHQSE_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -7915,6 +7915,80 @@ Object Slth_GLASupplyStash
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -8618,6 +8692,80 @@ Object Slth_FakeGLASupplyStash
       Model              = UBSupply_ENS
       ;Animation          = UBSupply_ENS.UBSupply_ENS
       ;AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBSpplyEG
+      Animation          = UBSpplyEG.UBSpplyEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBSpplyEG_D
+      Animation          = UBSpplyEG_D.UBSpplyEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBSpplyEG_E
+      Animation          = UBSpplyEG_E.UBSpplyEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBSpplyEG_N
+      Animation          = UBSpplyEG_N.UBSpplyEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBSpplyEG_DN
+      Animation          = UBSpplyEG_DN.UBSpplyEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBSpplyEG_EN
+      Animation          = UBSpplyEG_EN.UBSpplyEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBSpplyEG_S
+      Animation          = UBSpplyEG_S.UBSpplyEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBSpplyEG_DS
+      Animation          = UBSpplyEG_DS.UBSpplyEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ES
+      Animation          = UBSpplyEG_ES.UBSpplyEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBSpplyEG_NS
+      Animation          = UBSpplyEG_NS.UBSpplyEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBSpplyEG_DNS
+      Animation          = UBSpplyEG_DNS.UBSpplyEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBSpplyEG_ENS
+      Animation          = UBSpplyEG_ENS.UBSpplyEG_ENS
+      AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -10815,6 +10815,80 @@ Object Slth_GLAArmsDealer
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -11736,6 +11810,80 @@ Object Slth_FakeGLAArmsDealer
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBArmDeal_ENS
       Animation          = UBArmDeal_ENS.UBArmDeal_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBArmDlEG
+      Animation          = UBArmDlEG.UBArmDlEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBArmDlEG_D
+      Animation          = UBArmDlEG_D.UBArmDlEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBArmDlEG_E
+      Animation          = UBArmDlEG_E.UBArmDlEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBArmDlEG_N
+      Animation          = UBArmDlEG_N.UBArmDlEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBArmDlEG_DN
+      Animation          = UBArmDlEG_DN.UBArmDlEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBArmDlEG_EN
+      Animation          = UBArmDlEG_EN.UBArmDlEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBArmDlEG_S
+      Animation          = UBArmDlEG_S.UBArmDlEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBArmDlEG_DS
+      Animation          = UBArmDlEG_DS.UBArmDlEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ES
+      Animation          = UBArmDlEG_ES.UBArmDlEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBArmDlEG_NS
+      Animation          = UBArmDlEG_NS.UBArmDlEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBArmDlEG_DNS
+      Animation          = UBArmDlEG_DNS.UBArmDlEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBArmDlEG_ENS
+      Animation          = UBArmDlEG_ENS.UBArmDlEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -2189,6 +2189,80 @@ Object Slth_GLABlackMarket
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -3010,6 +3084,80 @@ Object Slth_FakeGLABlackMarket
     ConditionState       =  PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBlackMkt_ENS
       Animation          = UBBlackMkt_ENS.UBBlackMkt_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBlkMktEG
+      Animation          = UBBlkMktEG.UBBlkMktEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBlkMktEG_D
+      Animation          = UBBlkMktEG_D.UBBlkMktEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBlkMktEG_E
+      Animation          = UBBlkMktEG_E.UBBlkMktEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBlkMktEG_N
+      Animation          = UBBlkMktEG_N.UBBlkMktEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBlkMktEG_DN
+      Animation          = UBBlkMktEG_DN.UBBlkMktEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBlkMktEG_EN
+      Animation          = UBBlkMktEG_EN.UBBlkMktEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBlkMktEG_S
+      Animation          = UBBlkMktEG_S.UBBlkMktEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBlkMktEG_DS
+      Animation          = UBBlkMktEG_DS.UBBlkMktEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ES
+      Animation          = UBBlkMktEG_ES.UBBlkMktEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBlkMktEG_NS
+      Animation          = UBBlkMktEG_NS.UBBlkMktEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBlkMktEG_DNS
+      Animation          = UBBlkMktEG_DNS.UBBlkMktEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBlkMktEG_ENS
+      Animation          = UBBlkMktEG_ENS.UBBlkMktEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -7118,6 +7118,80 @@ Object Slth_GLAPalace
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD
+      Model              = UBPalaceEG
+      Animation          = UBPalaceEG.UBPalaceEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD DAMAGED
+      Model              = UBPalaceEG_D
+      Animation          = UBPalaceEG_D.UBPalaceEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD REALLYDAMAGED
+      Model              = UBPalaceEG_E
+      Animation          = UBPalaceEG_E.UBPalaceEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT
+      Model              = UBPalaceEG_N
+      Animation          = UBPalaceEG_N.UBPalaceEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT DAMAGED
+      Model              = UBPalaceEG_DN
+      Animation          = UBPalaceEG_DN.UBPalaceEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT REALLYDAMAGED
+      Model              = UBPalaceEG_EN
+      Animation          = UBPalaceEG_EN.UBPalaceEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW
+      Model              = UBPalaceEG_S
+      Animation          = UBPalaceEG_S.UBPalaceEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW DAMAGED
+      Model              = UBPalaceEG_DS
+      Animation          = UBPalaceEG_DS.UBPalaceEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ES
+      Animation          = UBPalaceEG_ES.UBPalaceEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW
+      Model              = UBPalaceEG_NS
+      Animation          = UBPalaceEG_NS.UBPalaceEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW DAMAGED
+      Model              = UBPalaceEG_DNS
+      Animation          = UBPalaceEG_DNS.UBPalaceEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED USER_1 SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBPalaceEG_ENS
+      Animation          = UBPalaceEG_ENS.UBPalaceEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -557,6 +557,80 @@ Object Slth_GLACommandCenter
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQSE
+      Animation          = UBCmdHQSE.UBCmdHQSE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQSE_D
+      Animation          = UBCmdHQSE_D.UBCmdHQSE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQSE_E
+      Animation          = UBCmdHQSE_E.UBCmdHQSE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQSE_N
+      Animation          = UBCmdHQSE_N.UBCmdHQSE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQSE_DN
+      Animation          = UBCmdHQSE_DN.UBCmdHQSE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQSE_EN
+      Animation          = UBCmdHQSE_EN.UBCmdHQSE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQSE_S
+      Animation          = UBCmdHQSE_S.UBCmdHQSE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQSE_DS
+      Animation          = UBCmdHQSE_DS.UBCmdHQSE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQSE_ES
+      Animation          = UBCmdHQSE_ES.UBCmdHQSE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQSE_NS
+      Animation          = UBCmdHQSE_NS.UBCmdHQSE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQSE_DNS
+      Animation          = UBCmdHQSE_DNS.UBCmdHQSE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQSE_ENS
+      Animation          = UBCmdHQSE_ENS.UBCmdHQSE_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -1345,6 +1419,80 @@ Object Slth_FakeGLACommandCenter
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBCmdHQS_ENS
       Animation          = UBCmdHQS_ENS.UBCmdHQS_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBCmdHQSE
+      Animation          = UBCmdHQSE.UBCmdHQSE
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBCmdHQSE_D
+      Animation          = UBCmdHQSE_D.UBCmdHQSE_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBCmdHQSE_E
+      Animation          = UBCmdHQSE_E.UBCmdHQSE_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBCmdHQSE_N
+      Animation          = UBCmdHQSE_N.UBCmdHQSE_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBCmdHQSE_DN
+      Animation          = UBCmdHQSE_DN.UBCmdHQSE_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBCmdHQSE_EN
+      Animation          = UBCmdHQSE_EN.UBCmdHQSE_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBCmdHQSE_S
+      Animation          = UBCmdHQSE_S.UBCmdHQSE_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBCmdHQSE_DS
+      Animation          = UBCmdHQSE_DS.UBCmdHQSE_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBCmdHQSE_ES
+      Animation          = UBCmdHQSE_ES.UBCmdHQSE_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBCmdHQSE_NS
+      Animation          = UBCmdHQSE_NS.UBCmdHQSE_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBCmdHQSE_DNS
+      Animation          = UBCmdHQSE_DNS.UBCmdHQSE_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBCmdHQSE_ENS
+      Animation          = UBCmdHQSE_ENS.UBCmdHQSE_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -9231,6 +9231,80 @@ Object Slth_GLABarracks
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
 
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
     ConditionState       = AWAITING_CONSTRUCTION
       Model              = NONE
     End
@@ -9919,6 +9993,80 @@ Object Slth_FakeGLABarracks
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
       Model              = UBBarracks_ENS
       Animation          = UBBarracks_ENS.UBBarracks_ENS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+
+    ; Patch104p @bugfix 13/08/2022 Keep Fortified Structure visuals while selling the building.
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD
+      Model              = UBBarrksEG
+      Animation          = UBBarrksEG.UBBarrksEG
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD DAMAGED
+      Model              = UBBarrksEG_D
+      Animation          = UBBarrksEG_D.UBBarrksEG_D
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD REALLYDAMAGED
+      Model              = UBBarrksEG_E
+      Animation          = UBBarrksEG_E.UBBarrksEG_E
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT
+      Model              = UBBarrksEG_N
+      Animation          = UBBarrksEG_N.UBBarrksEG_N
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT DAMAGED
+      Model              = UBBarrksEG_DN
+      Animation          = UBBarrksEG_DN.UBBarrksEG_DN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT REALLYDAMAGED
+      Model              = UBBarrksEG_EN
+      Animation          = UBBarrksEG_EN.UBBarrksEG_EN
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW
+      Model              = UBBarrksEG_S
+      Animation          = UBBarrksEG_S.UBBarrksEG_S
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW DAMAGED
+      Model              = UBBarrksEG_DS
+      Animation          = UBBarrksEG_DS.UBBarrksEG_DS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ES
+      Animation          = UBBarrksEG_ES.UBBarrksEG_ES
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW
+      Model              = UBBarrksEG_NS
+      Animation          = UBBarrksEG_NS.UBBarrksEG_NS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW DAMAGED
+      Model              = UBBarrksEG_DNS
+      Animation          = UBBarrksEG_DNS.UBBarrksEG_DNS
+      AnimationMode      = LOOP
+      Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+    End
+    ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED GARRISONED SOLD NIGHT SNOW REALLYDAMAGED
+      Model              = UBBarrksEG_ENS
+      Animation          = UBBarrksEG_ENS.UBBarrksEG_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/470

This change makes it so buildings with Fortified Structures upgrade do not lose their "visual fortifications" (sand bags, barbed wire etc.) while being sold.

This does not affect any damage taken.

Note that the fortifications will not be shown while the building is being constructed. However, the armor bonus from Fortified Structures does not apply while the building is being constructed either, so this is the desired behaviour.