### PR TITLE
Change: Redistribute Toxin Tractor Gamma damage bonus to stay within 50% max

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -5663,7 +5663,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_ToxinTruckGunGamma
-  PrimaryDamage               = 20.5
+  PrimaryDamage               = 17.5 ; Patch104p @tweak from 20.5 to give 40% bonus over Anthrax Beta (-30% total bonus over default)
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
@@ -5688,7 +5688,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_ToxinTruckGunGammaPlusOne
-  PrimaryDamage               = 24.5
+  PrimaryDamage               = 22.5 ; Patch104p @tweak from 24.5 to give 50% bonus over Anthrax Beta (-20% total bonus over default)
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
@@ -5713,7 +5713,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_ToxinTruckGunGammaPlusTwo
-  PrimaryDamage               = 28.5
+  PrimaryDamage               = 30.0 ; Patch104p @tweak from 28.5 to give 50% bonus over Anthrax Beta (+15% total bonus over default)
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
@@ -5824,7 +5824,7 @@ End
 Weapon Chem_ToxinTruckSprayerGamma
   PrimaryDamage               = 0
   PrimaryDamageRadius         = 0.0
-  SecondaryDamage             = 2.5
+  SecondaryDamage             = 3.0 ; Patch104p @tweak from 2.5 to give 20% bonus over Anthrax Beta (+25% total bonus over default)
   SecondaryDamageRadius       = 75.0
   AttackRange                 = 15.0
   DamageType                  = POISON


### PR DESCRIPTION
Reference:
* #806

This change redistributes GLA Toxin Tractor Gamma bonuses to be consistent with the intended bonus from the tool tip.

```
CONTROLBAR:ToolTipGLAUpgradeAnthraxGamma
US: "+50% damage bonus to all toxin units"
```

Note: There is a follow up change to this one:
* #900 

## Stats

![fixed_toxin_truck](https://user-images.githubusercontent.com/4720891/184501990-b614d245-089c-4d2e-8a62-f62a62e597ad.png)

# Rationale

The Toxin Tractor damage values are just a bit wild. The first 2 Gamma ToxinTruckGun's give 64% and 63% relative bonus over Anthrax Beta, while the 3rd gives 42%. The first Gamma ToxinTruckSprayer gives 0% bonus over Anthrax Beta, but the others 33% and 28% relative bonus over Anthrax Beta. This change redistributes the damages to make more sense.
| Weapon                                        | Bonus over Anthrax Beta | Bonus over Toxin   | Change over Toxin  |
|-----------------------------------------------|-------------------------|--------------------|---------------------|
| Original Chem_ToxinTruckGunGamma              | +64%                    | +105%              |                     |
| Original Chem_ToxinTruckGunGammaPlusOne       | +63%                    | +145%              |                     |
| Original Chem_ToxinTruckGunGammaPlusTwo       | +42%                    | +185%              |                     |
| Original Chem_ToxinTruckSprayerGamma          | +0%                     | +25%               |                     |
| Original Chem_ToxinTruckSprayerGammaPlusOne   | +33%                    | +75%               |                     |
| Original Chem_ToxinTruckSprayerGammaPlusTwo   | +28%                    | +125%              |                     |
| Patched Chem_ToxinTruckGunGamma (this)        | +40%                    | +75%               | -30%                |
| Patched Chem_ToxinTruckGunGammaPlusOne (this) | +50%                    | +125%              | -20%                |
| Patched Chem_ToxinTruckGunGammaPlusTwo (this) | +50%                    | +200%              | +15%                |
| Patched Chem_ToxinTruckSprayerGamma  (this)   | +20%                    | +50%               | +25%                |