### PR TITLE
Cleanup: Remove Overwritten ObjectCreationList

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5889,7 +5889,7 @@ ObjectCreationList Nuke_SUPERWEAPON_ChinaCarpetBomb
     DropOffset = X:0 Y:0 Z:-2
     DropVariance = X:30 Y:40 Z:0
     DropDelay = 300  ;500       ; time in between each item dropped (if more than one)
-    Payload = GC_Nuke_ChinaCarpetBomb 10
+    Payload = Nuke_ChinaCarpetBomb 10
     DeliveryDistance = 350
     DeliveryDecalRadius = 180
     DeliveryDecal
@@ -9091,34 +9091,6 @@ ObjectCreationList Nuke_OCL_RadiationFieldSmall
    ObjectNames = Nuke_RadiationFieldSmall
    Disposition = ON_GROUND_ALIGNED
  End
-End
-
-
-
-
-; -----------------------------------------------------------------------------
-ObjectCreationList Nuke_SUPERWEAPON_ChinaCarpetBomb
-  DeliverPayload
-    Transport = ChinaJetCarpetBomber
-    StartAtPreferredHeight = Yes
-    StartAtMaxSpeed = Yes
-    MaxAttempts = 1
-    DropOffset = X:0 Y:0 Z:-2
-    DropVariance = X:30 Y:40 Z:0
-    DropDelay = 300  ;500       ; time in between each item dropped (if more than one)
-    Payload = Nuke_ChinaCarpetBomb 10
-    DeliveryDistance = 350
-    DeliveryDecalRadius = 180
-    DeliveryDecal
-      Texture           = SCCCarpBomb
-      Style             = SHADOW_ALPHA_DECAL
-      OpacityMin        = 25%
-      OpacityMax        = 50%
-      OpacityThrobTime  = 500
-      Color             = R:255 G:0 B:0 A:255
-      OnlyVisibleToOwningPlayer = Yes
-    End
-  End
 End
 
 


### PR DESCRIPTION
- There are two copies of Nuke_SUPERWEAPON_ChinaCarpetBomb.
- In this file, the second entry will always overite the first.
- The first copy refers to an object named "GC_Nuke_ChinaCarpetBomb" that does not even exist.

This pull request removes the broken copy. This has no actual effect on the game.