### PR TITLE
Change: Increase ToxinTruckGunGamma damage from 17.5 to 18.75

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -5663,7 +5663,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_ToxinTruckGunGamma
-  PrimaryDamage               = 17.5 ; Patch104p @tweak from 20.5 to give 40% bonus over Anthrax Beta (-30% total bonus over default)
+  PrimaryDamage               = 18.75 ; Patch104p @tweak from 20.5 to give 50% bonus over Anthrax Beta, 88% bonus over Default
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
@@ -5688,7 +5688,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_ToxinTruckGunGammaPlusOne
-  PrimaryDamage               = 22.5 ; Patch104p @tweak from 24.5 to give 50% bonus over Anthrax Beta (-20% total bonus over default)
+  PrimaryDamage               = 22.5 ; Patch104p @tweak from 24.5 to give 50% bonus over Anthrax Beta, 125% bonus over Default
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
@@ -5713,7 +5713,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_ToxinTruckGunGammaPlusTwo
-  PrimaryDamage               = 30.0 ; Patch104p @tweak from 28.5 to give 50% bonus over Anthrax Beta (+15% total bonus over default)
+  PrimaryDamage               = 30.0 ; Patch104p @tweak from 28.5 to give 50% bonus over Anthrax Beta, 200% bonus over Default
   PrimaryDamageRadius         = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 100.0
@@ -5824,7 +5824,7 @@ End
 Weapon Chem_ToxinTruckSprayerGamma
   PrimaryDamage               = 0
   PrimaryDamageRadius         = 0.0
-  SecondaryDamage             = 3.0 ; Patch104p @tweak from 2.5 to give 20% bonus over Anthrax Beta (+25% total bonus over default)
+  SecondaryDamage             = 3.0 ; Patch104p @tweak from 2.5 to give 20% bonus over Anthrax Beta, 50% bonus over Default
   SecondaryDamageRadius       = 75.0
   AttackRange                 = 15.0
   DamageType                  = POISON


### PR DESCRIPTION
Continuation of
* #889

Slightly increases ToxinTruckGunGamma damage.

| Weapon                                        | Bonus over Anthrax Beta | Bonus over Toxin | Change over Toxin |
|-----------------------------------------------|-------------------------|------------------|-------------------|
| Original Chem_ToxinTruckGunGamma              | +64%                    | +105%            |                   |
| Original Chem_ToxinTruckGunGammaPlusOne       | +63%                    | +145%            |                   |
| Original Chem_ToxinTruckGunGammaPlusTwo       | +42%                    | +185%            |                   |
| Original Chem_ToxinTruckSprayerGamma          | +0%                     | +25%             |                   |
| Original Chem_ToxinTruckSprayerGammaPlusOne   | +33%                    | +75%             |                   |
| Original Chem_ToxinTruckSprayerGammaPlusTwo   | +28%                    | +125%            |                   |
| Patched Chem_ToxinTruckGunGamma (1)           | +40%                    | +75%             | -30%              |
| Patched Chem_ToxinTruckGunGamma (this)        | +50%                    | +88%             | -20%              |
| Patched Chem_ToxinTruckGunGammaPlusOne (1)    | +50%                    | +125%            | -20%              |
| Patched Chem_ToxinTruckGunGammaPlusTwo (1)    | +50%                    | +200%            | +15%              |
| Patched Chem_ToxinTruckSprayerGamma  (1)      | +20%                    | +50%             | +25%              |
