### PR TITLE
Fix: GLA Mob Members Missing Scream When Burned

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -14380,7 +14380,7 @@ Object Chem_GLAInfantryAngryMobPistol01
   Behavior = SlowDeathBehavior DeathTag_04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireGLA ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -14705,7 +14705,7 @@ Object Chem_GLAInfantryAngryMobRock02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -15628,7 +15628,7 @@ Object Chem_GLAInfantryAngryMobMolotov02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14868,7 +14868,7 @@ Object Demo_GLAInfantryAngryMobPistol01
   Behavior = SlowDeathBehavior DeathTag_04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireGLA ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -15217,7 +15217,7 @@ Object Demo_GLAInfantryAngryMobRock02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -16162,7 +16162,7 @@ Object Demo_GLAInfantryAngryMobMolotov02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1960,7 +1960,7 @@ Object GLAInfantryAngryMobPistol01
   Behavior = SlowDeathBehavior DeathTag_04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireGLA ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -2285,7 +2285,7 @@ Object GLAInfantryAngryMobRock02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -3208,7 +3208,7 @@ Object GLAInfantryAngryMobMolotov02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -15341,7 +15341,7 @@ Object Slth_GLAInfantryAngryMobPistol01
   Behavior = SlowDeathBehavior DeathTag_04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireGLA ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -15666,7 +15666,7 @@ Object Slth_GLAInfantryAngryMobRock02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -16589,7 +16589,7 @@ Object Slth_GLAInfantryAngryMobMolotov02
   Behavior = SlowDeathBehavior ModuleTag_Death04
     DeathTypes          = NONE +BURNED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_GIDie
+    FX                  = INITIAL FX_DieByFireFemale ; Patch104p @bugfix commy2 14/08/2022 Fix mob members have no scream when burned.
     OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05


### PR DESCRIPTION
- more fixes for https://github.com/TheSuperHackers/GeneralsGamePatch/issues/866

FX_GIDie is an empty effects list, so they die silently when killed by Dragon tank.