### PR TITLE
Fix: Microwave Passive Emitter Vs Stinger Site Interaction

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -746,7 +746,7 @@ Armor StingerSiteArmor  ;used for anti-air base defenses.  Vulnerable to steatlh
   Armor = GATTLING             30%   ;resistant to gattling tank
   Armor = COMANCHE_VULCAN      50%
   Armor = RADIATION             0%   ;Radiation does no damage to buildings.
-  Armor = MICROWAVE             1%
+  Armor = MICROWAVE             0%   ;Patch104p @bugfix commy2 15/08/2022 Fix hit effect on Stinger Site with nearby Microwave tank.
   Armor = SNIPER              100%   ;***This is required for snipers to be able to attack and kill stinger soldiers! Must be > 0! (Value irrelevant since the soldiers will use their % to modify the damage)
   Armor = POISON              100%   ; Similarly, this lets the toxin tractor attack to kill the soldiers
   Armor = SURRENDER             0%   ;And this is for Flashbangs

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -6369,7 +6369,8 @@ Object Chem_GLAStingerSite
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
     ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    ; Patch104p @bugfix commy2 15/08/2022 Fix Stinger Site fail to forward microwave passive emitter damage to Stinger Troopers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +MICROWAVE
     SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -6262,7 +6262,8 @@ Object Demo_GLAStingerSite
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
     ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    ; Patch104p @bugfix commy2 15/08/2022 Fix Stinger Site fail to forward microwave passive emitter damage to Stinger Troopers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +MICROWAVE
     SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -34266,7 +34266,8 @@ Object GLAStingerSiteNoHole
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
     ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    ; Patch104p @bugfix commy2 15/08/2022 Fix Stinger Site fail to forward microwave passive emitter damage to Stinger Troopers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +MICROWAVE
     SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -958,7 +958,8 @@ Object GC_Chem_GLAStingerSite
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
     ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    ; Patch104p @bugfix commy2 15/08/2022 Fix Stinger Site fail to forward microwave passive emitter damage to Stinger Troopers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +MICROWAVE
     SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -2932,7 +2932,8 @@ Object GC_Slth_GLAStingerSite
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
     ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    ; Patch104p @bugfix commy2 15/08/2022 Fix Stinger Site fail to forward microwave passive emitter damage to Stinger Troopers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +MICROWAVE
     SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -6951,7 +6951,8 @@ Object Slth_GLAStingerSite
     ;**Careful with these damage types -- because area damage types will already
     ;**damage slaves.
     ; Patch104p @bugfix commy2 01/01/2022 Fix Stinger Troopers receive damage from Flashbangs despite the Stinger Site not being selectable as target by Flashbang-Rangers.
-    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION
+    ; Patch104p @bugfix commy2 15/08/2022 Fix Stinger Site fail to forward microwave passive emitter damage to Stinger Troopers.
+    PropagateDamageTypesToSlavesWhenExisting = NONE +SMALL_ARMS +SNIPER +POISON +RADIATION +MICROWAVE
     SwallowDamageTypesIfSlavesNotExisting = NONE +SNIPER +POISON; Take no damage if no one to pass this to
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.


### PR DESCRIPTION
- fixes https://github.com/TheSuperHackers/GeneralsGamePatch/issues/637

1.04:
- Non vGLA Stinger Troopers will not be individually damaged by the Microwave, but instead all die at the same time after a longer while.
- There is a strange hit effect on the Stinger Site.
- For vGLA, the hit effect only appears after all Troopers have been killed.