### PR TITLE
Fix: Demo General Units Unable To Suicide When Close Or Inside Buildings

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -4871,7 +4871,7 @@ End
 ; WITHOUT BEING PERMITTED TO TARGET ENEMIES WITH IT!!!!
 Weapon TerroristSuicideNotARealWeapon
   LeechRangeWeapon = Yes
-  AttackRange = 0.0
+  AttackRange = 999999.0 ; Patch104p @bugfix commy2 15/08/2022 Fix Demogen units getting stuck when ordered to suicide inside buildings.
   PrimaryDamage = 0.0
   PrimaryDamageRadius = 0.0
   DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/338

The weapon is only ever used by the Demogen Suicide button, so range can be safely changed to max. This makes the units explode instantly instead of attempt to leave the building, potentially getting stuck or not suiciding immediatly when ordered.