### PR TITLE
Fix: Bones Visible On Double Scrapped Quad Cannon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -17690,6 +17690,7 @@ Object Chem_GLAVehicleQuadCannon
       HideSubObject = TURRET TURRETUP02 BarrelUp01FX01 BarrelUp01FX02 BarrelUp01FX03 BarrelUp01FX04
     End
 
+    ; Patch104p @bugfix commy2 20/08/2022 Hide visible bones BarrelUp02MS0X.
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
       Turret = TURRETUP02
@@ -17701,7 +17702,7 @@ Object Chem_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
@@ -17715,7 +17716,7 @@ Object Chem_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
@@ -17729,7 +17730,7 @@ Object Chem_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19006,6 +19006,7 @@ Object Demo_GLAVehicleQuadCannon
       HideSubObject = TURRET TURRETUP02 BarrelUp01FX01 BarrelUp01FX02 BarrelUp01FX03 BarrelUp01FX04
     End
 
+    ; Patch104p @bugfix commy2 20/08/2022 Hide visible bones BarrelUp02MS0X.
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
       Turret = TURRETUP02
@@ -19017,7 +19018,7 @@ Object Demo_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
@@ -19031,7 +19032,7 @@ Object Demo_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
@@ -19045,7 +19046,7 @@ Object Demo_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2580,6 +2580,7 @@ Object GC_Chem_GLAVehicleQuadCannon
       HideSubObject = TURRET TURRETUP02 BarrelUp01FX01 BarrelUp01FX02 BarrelUp01FX03 BarrelUp01FX04
     End
 
+    ; Patch104p @bugfix commy2 20/08/2022 Hide visible bones BarrelUp02MS0X.
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
       Turret = TURRETUP02
@@ -2591,7 +2592,7 @@ Object GC_Chem_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
@@ -2605,7 +2606,7 @@ Object GC_Chem_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
@@ -2619,7 +2620,7 @@ Object GC_Chem_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -7140,6 +7140,7 @@ Object GC_Slth_GLAVehicleQuadCannon
       HideSubObject = TURRET TURRETUP02 BarrelUp01FX01 BarrelUp01FX02 BarrelUp01FX03 BarrelUp01FX04
     End
 
+    ; Patch104p @bugfix commy2 20/08/2022 Hide visible bones BarrelUp02MS0X.
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
       Turret = TURRETUP02
@@ -7154,7 +7155,7 @@ Object GC_Slth_GLAVehicleQuadCannon
       WeaponMuzzleFlash = TERTIARY   BarrelUp02FX
       WeaponRecoilBone  = TERTIARY   BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
@@ -7171,7 +7172,7 @@ Object GC_Slth_GLAVehicleQuadCannon
       WeaponMuzzleFlash = TERTIARY   BarrelUp02FX
       WeaponRecoilBone  = TERTIARY   BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
@@ -7188,7 +7189,7 @@ Object GC_Slth_GLAVehicleQuadCannon
       WeaponMuzzleFlash = TERTIARY   BarrelUp02FX
       WeaponRecoilBone  = TERTIARY   BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3387,6 +3387,7 @@ Object GLAVehicleQuadCannon
       HideSubObject = TURRET TURRETUP02 BarrelUp01FX01 BarrelUp01FX02 BarrelUp01FX03 BarrelUp01FX04
     End
 
+    ; Patch104p @bugfix commy2 20/08/2022 Hide visible bones BarrelUp02MS0X.
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
       Turret = TURRETUP02
@@ -3398,7 +3399,7 @@ Object GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
@@ -3412,7 +3413,7 @@ Object GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
@@ -3426,7 +3427,7 @@ Object GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19124,6 +19124,7 @@ Object Slth_GLAVehicleQuadCannon
       HideSubObject = TURRET TURRETUP02 BarrelUp01FX01 BarrelUp01FX02 BarrelUp01FX03 BarrelUp01FX04
     End
 
+    ; Patch104p @bugfix commy2 20/08/2022 Hide visible bones BarrelUp02MS0X.
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVQuadCann
       Turret = TURRETUP02
@@ -19135,7 +19136,7 @@ Object Slth_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
@@ -19149,7 +19150,7 @@ Object Slth_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
@@ -19163,7 +19164,7 @@ Object Slth_GLAVehicleQuadCannon
       WeaponMuzzleFlash = SECONDARY BarrelUp02FX
       WeaponRecoilBone  = SECONDARY BarrelUp02
       ShowSubObject = TURRETUP02
-      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04
+      HideSubObject = TURRETUP01 TURRET BarrelUp02FX01 BarrelUp02FX02 BarrelUp02FX03 BarrelUp02FX04 BarrelUp02MS01 BarrelUp02MS02 BarrelUp02MS03 BarrelUp02MS04
     End
 
     TrackMarks = EXTnkTrack.tga


### PR DESCRIPTION
# before
![shot_20220820_110222_1](https://user-images.githubusercontent.com/6576312/185738148-2a32c352-0792-4e63-a4ac-509a84d9993b.jpg)

# after
![shot_20220820_110411_4](https://user-images.githubusercontent.com/6576312/185738162-8a565240-489f-4e11-a00d-23aebb483d40.jpg)

These cubes are where muzzle effect will show and are not supposed to be drawn.