### PR TITLE
Fix: Infantry Muzzle Flash Stuck During Transition Animations

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -3369,7 +3369,7 @@ Object AirF_AmericaInfantryRanger
       WeaponFireFXBone  = SECONDARY Muzzle
       WeaponLaunchBone  = SECONDARY Muzzle
       TransitionKey     = TRANS_Stand
-
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState      = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -558,7 +558,7 @@ Object AmericaInfantryRanger
       WeaponFireFXBone  = SECONDARY Muzzle
       WeaponLaunchBone  = SECONDARY Muzzle
       TransitionKey     = TRANS_Stand
-
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState      = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -16771,7 +16771,7 @@ Object Boss_InfantryRanger
       WeaponFireFXBone  = SECONDARY Muzzle
       WeaponLaunchBone  = SECONDARY Muzzle
       TransitionKey     = TRANS_Stand
-
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState      = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -33,6 +33,7 @@ Object ChinaInfantryRedguard
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       TransitionKey       = TRANS_Stand
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12698,6 +12698,7 @@ Object Demo_GLAInfantryRebel
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       TransitionKey       = TRANS_Standing
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -1696,6 +1696,7 @@ Object GC_Slth_GLAInfantryRebel
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       TransitionKey       = TRANS_Standing
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -32,6 +32,7 @@ Object GLAInfantryRebel
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       TransitionKey       = TRANS_Standing
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1665,6 +1665,7 @@ Object GLAInfantryAngryMobPistol01
       WeaponMuzzleFlash = PRIMARY MuzzleFX
       WeaponFireFXBone = SECONDARY MuzzleAK
       WeaponMuzzleFlash = SECONDARY MuzzleAKFX
+      HideSubObject     = MuzzleFX01 MuzzleAKFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ; Drawing pistol
@@ -2354,6 +2355,7 @@ ObjectReskin GLAInfantryAngryMobPistol03 GLAInfantryAngryMobPistol01
       WeaponFireFXBone = SECONDARY MuzzleAK
       WeaponMuzzleFlash = SECONDARY MuzzleAKFX
       WeaponFireFXBone = TERTIARY "UIMOB03 R HAND"
+      HideSubObject    = MuzzleFX01 MuzzleAKFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ; Drawing pistol
@@ -2925,6 +2927,7 @@ ObjectReskin GLAInfantryAngryMobPistol05 GLAInfantryAngryMobPistol01
 
       WeaponFireFXBone = PRIMARY Muzzle01
       WeaponMuzzleFlash = PRIMARY Muzzle01
+      HideSubObject     = MuzzleFX01 MuzzleAKFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ; Drawing pistol

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -14874,6 +14874,7 @@ Object Infa_ChinaInfantryMiniGunner
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       TransitionKey       = TRANS_Stand
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -2925,7 +2925,7 @@ Object Lazr_AmericaInfantryRanger
       WeaponFireFXBone  = SECONDARY Muzzle
       WeaponLaunchBone  = SECONDARY Muzzle
       TransitionKey     = TRANS_Stand
-
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState      = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1456,6 +1456,7 @@ Object Nuke_ChinaInfantryRedguard
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       TransitionKey       = TRANS_Stand
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13417,6 +13417,7 @@ Object Slth_GLAInfantryRebel
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       TransitionKey       = TRANS_Standing
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -3402,7 +3402,7 @@ Object SupW_AmericaInfantryRanger
       WeaponFireFXBone  = SECONDARY Muzzle
       WeaponLaunchBone  = SECONDARY Muzzle
       TransitionKey     = TRANS_Stand
-
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState      = REALLYDAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1187,6 +1187,7 @@ Object Tank_ChinaInfantryRedguard
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       TransitionKey       = TRANS_Stand
+      HideSubObject       = MuzzleFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState        = REALLYDAMAGED


### PR DESCRIPTION
# before
https://user-images.githubusercontent.com/6576312/185739197-da89e98d-232c-462b-bd7b-0f4dd1767143.mp4

# after
https://user-images.githubusercontent.com/6576312/185739198-b6818e40-50ed-4b7e-9f69-841697db3161.mp4

- [x] Red Guard / Minigunner
- [x] Ranger
- [x] Angry Mob

- Note: muzzle flash, including glow are still drawn during the actual fire animation
- Also note that this bug happens sporadically and is apparently more likely on night or snow maps