### PR TITLE
Tweak Minigunner Recoil Animation

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -14850,6 +14850,7 @@ Object Infa_ChinaInfantryMiniGunner
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix Minigunner tracer emerges from feet instead of muzzle when aiming at airborne targets.
   ; Patch104p @bugfix commy2 11/09/2021 Fix Minigunner weapon recoil animation did not fit rate of fire.
+  ; Patch104p @tweak commy2 20/08/2022 Make recoil speed up with weapon.
 
   Draw = W3DModelDraw ModuleTag_01
 
@@ -14876,40 +14877,105 @@ Object Infa_ChinaInfantryMiniGunner
       TransitionKey       = TRANS_Stand
     End
 
+    ConditionState        = CONTINUOUS_FIRE_SLOW
+      IdleAnimation       = NICNSC_SKL.NICNSC_STA 0 35
+      IdleAnimation       = NICNSC_SKL.NICNSC_IDA
+      IdleAnimation       = NICNSC_SKL.NICNSC_IDB
+      AnimationMode       = ONCE
+      TransitionKey       = TRANS_Stand
+    End
+    AliasConditionState   = CONTINUOUS_FIRE_MEAN
+    AliasConditionState   = CONTINUOUS_FIRE_FAST
+
     ConditionState        = REALLYDAMAGED
       IdleAnimation       = NICNSC_SKL.NICNSC_STB
       AnimationMode       = ONCE
       TransitionKey       = TRANS_StandDamaged
     End
+    AliasConditionState = REALLYDAMAGED CONTINUOUS_FIRE_SLOW
+    AliasConditionState = REALLYDAMAGED CONTINUOUS_FIRE_MEAN
+    AliasConditionState = REALLYDAMAGED CONTINUOUS_FIRE_FAST
 
     ; ------- Machine Gun Animations
 
-    ConditionState      = USING_WEAPON_A
+    ConditionState      = USING_WEAPON_A CONTINUOUS_FIRE_SLOW
+      Animation         = NICNSC_SKL.NICNSC_ATA
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 2 2
+      TransitionKey     = TRANS_Firing
+    End
+
+    ConditionState      = USING_WEAPON_A CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+      Animation         = NICNSC_SKL.NICNSC_ATC
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 2 2
+      TransitionKey     = TRANS_FiringDamaged
+    End
+
+    ConditionState      = USING_WEAPON_A CONTINUOUS_FIRE_MEAN
+      Animation         = NICNSC_SKL.NICNSC_ATA
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 3 3
+      TransitionKey     = TRANS_Firing
+    End
+
+    ConditionState      = USING_WEAPON_A CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+      Animation         = NICNSC_SKL.NICNSC_ATC
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 3 3
+      TransitionKey     = TRANS_FiringDamaged
+    End
+
+    ConditionState      = USING_WEAPON_A CONTINUOUS_FIRE_FAST
       Animation         = NICNSC_SKL.NICNSC_ATA
       AnimationMode     = LOOP
       AnimationSpeedFactorRange = 4 4
       TransitionKey     = TRANS_Firing
     End
 
-    ConditionState      = USING_WEAPON_A REALLYDAMAGED
+    ConditionState      = USING_WEAPON_A CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Animation         = NICNSC_SKL.NICNSC_ATC
       AnimationMode     = LOOP
       AnimationSpeedFactorRange = 4 4
       TransitionKey     = TRANS_FiringDamaged
     End
 
-    ConditionState      = USING_WEAPON_B
+    ConditionState      = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
       Animation         = NICNSC_SKL.NICNSC_ATA2
       AnimationMode     = LOOP
-      AnimationSpeedFactorRange = 4 4
+      AnimationSpeedFactorRange = 2 2
  ;    TransitionKey     = TRANS_Firing
     End
 
-    ConditionState      = USING_WEAPON_B REALLYDAMAGED
+    ConditionState      = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+      Animation         = NICNSC_SKL.NICNSC_ATC2
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 2 2
+ ;    TransitionKey     = TRANS_FiringDamaged
+    End
+
+    ConditionState      = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
+      Animation         = NICNSC_SKL.NICNSC_ATA2
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 3 3
+    End
+
+    ConditionState      = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+      Animation         = NICNSC_SKL.NICNSC_ATC2
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 3 3
+    End
+
+    ConditionState      = USING_WEAPON_B CONTINUOUS_FIRE_FAST
+      Animation         = NICNSC_SKL.NICNSC_ATA2
+      AnimationMode     = LOOP
+      AnimationSpeedFactorRange = 4 4
+    End
+
+    ConditionState      = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Animation         = NICNSC_SKL.NICNSC_ATC2
       AnimationMode     = LOOP
       AnimationSpeedFactorRange = 4 4
- ;    TransitionKey     = TRANS_FiringDamaged
     End
 
     ; ------- Firing-related Transitions
@@ -15027,6 +15093,12 @@ Object Infa_ChinaInfantryMiniGunner
       ParticleSysBone   = None InfantryDustTrails
     End
     AliasConditionState = MOVING ATTACKING
+    AliasConditionState = MOVING CONTINUOUS_FIRE_SLOW
+    AliasConditionState = MOVING CONTINUOUS_FIRE_SLOW ATTACKING
+    AliasConditionState = MOVING CONTINUOUS_FIRE_MEAN
+    AliasConditionState = MOVING CONTINUOUS_FIRE_MEAN ATTACKING
+    AliasConditionState = MOVING CONTINUOUS_FIRE_FAST
+    AliasConditionState = MOVING CONTINUOUS_FIRE_FAST ATTACKING
 
     ConditionState = MOVING REALLYDAMAGED
       Animation         = NICNSC_SKL.NICNSC_RNB 28
@@ -15036,6 +15108,12 @@ Object Infa_ChinaInfantryMiniGunner
       TransitionKey     = None
     End
     AliasConditionState = MOVING ATTACKING REALLYDAMAGED
+    AliasConditionState = MOVING REALLYDAMAGED CONTINUOUS_FIRE_SLOW
+    AliasConditionState = MOVING REALLYDAMAGED CONTINUOUS_FIRE_SLOW ATTACKING
+    AliasConditionState = MOVING REALLYDAMAGED CONTINUOUS_FIRE_MEAN
+    AliasConditionState = MOVING REALLYDAMAGED CONTINUOUS_FIRE_MEAN ATTACKING
+    AliasConditionState = MOVING REALLYDAMAGED CONTINUOUS_FIRE_FAST
+    AliasConditionState = MOVING REALLYDAMAGED CONTINUOUS_FIRE_FAST ATTACKING
 
     ; ------- Bldg-capture
 
@@ -15045,6 +15123,12 @@ Object Infa_ChinaInfantryMiniGunner
       AnimationMode     = ONCE
     End
     AliasConditionState = UNPACKING REALLYDAMAGED
+    AliasConditionState = UNPACKING CONTINUOUS_FIRE_SLOW
+    AliasConditionState = UNPACKING CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    AliasConditionState = UNPACKING CONTINUOUS_FIRE_MEAN
+    AliasConditionState = UNPACKING CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+    AliasConditionState = UNPACKING CONTINUOUS_FIRE_FAST
+    AliasConditionState = UNPACKING CONTINUOUS_FIRE_FAST REALLYDAMAGED
 
     ConditionState      = RAISING_FLAG
       Model             = NICNSC_F_SKN
@@ -15053,6 +15137,12 @@ Object Infa_ChinaInfantryMiniGunner
       TransitionKey     = TRANS_Raising
     End
     AliasConditionState = RAISING_FLAG REALLYDAMAGED
+    AliasConditionState = RAISING_FLAG CONTINUOUS_FIRE_SLOW
+    AliasConditionState = RAISING_FLAG CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    AliasConditionState = RAISING_FLAG CONTINUOUS_FIRE_MEAN
+    AliasConditionState = RAISING_FLAG CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+    AliasConditionState = RAISING_FLAG CONTINUOUS_FIRE_FAST
+    AliasConditionState = RAISING_FLAG CONTINUOUS_FIRE_FAST REALLYDAMAGED
 
     ConditionState      = PACKING
       Model             = NICNSC_F_SKN
@@ -15062,6 +15152,12 @@ Object Infa_ChinaInfantryMiniGunner
       TransitionKey     = TRANS_Packing
     End
     AliasConditionState = PACKING REALLYDAMAGED
+    AliasConditionState = PACKING CONTINUOUS_FIRE_SLOW
+    AliasConditionState = PACKING CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    AliasConditionState = PACKING CONTINUOUS_FIRE_MEAN
+    AliasConditionState = PACKING CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+    AliasConditionState = PACKING CONTINUOUS_FIRE_FAST
+    AliasConditionState = PACKING CONTINUOUS_FIRE_FAST REALLYDAMAGED
 
     TransitionState     = TRANS_Raising TRANS_Packing
       Model             = NICNSC_F_SKN
@@ -15078,6 +15174,9 @@ Object Infa_ChinaInfantryMiniGunner
       AnimationMode     = ONCE
       TransitionKey     = TRANS_Dying
     End
+    AliasConditionState = DYING CONTINUOUS_FIRE_SLOW
+    AliasConditionState = DYING CONTINUOUS_FIRE_MEAN
+    AliasConditionState = DYING CONTINUOUS_FIRE_FAST
 
     TransitionState     = TRANS_Dying TRANS_Flailing
       Animation         = NICNSC_SKL.NICNSC_ATDE1
@@ -15089,12 +15188,18 @@ Object Infa_ChinaInfantryMiniGunner
       AnimationMode     = LOOP
       TransitionKey     = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CONTINUOUS_FIRE_SLOW
+    AliasConditionState = DYING EXPLODED_FLAILING CONTINUOUS_FIRE_MEAN
+    AliasConditionState = DYING EXPLODED_FLAILING CONTINUOUS_FIRE_FAST
 
     ConditionState      = DYING EXPLODED_BOUNCING
       Animation         = NICNSC_SKL.NICNSC_ATDE3
       AnimationMode     = ONCE
       TransitionKey     = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CONTINUOUS_FIRE_SLOW
+    AliasConditionState = DYING EXPLODED_BOUNCING CONTINUOUS_FIRE_MEAN
+    AliasConditionState = DYING EXPLODED_BOUNCING CONTINUOUS_FIRE_FAST
 
     ; ------- Misc Animations
 
@@ -15102,7 +15207,9 @@ Object Infa_ChinaInfantryMiniGunner
       Animation         = NICNSC_SKL.NICNSC_CHA
       AnimationMode     = LOOP
     End
-
+    AliasConditionState = SPECIAL_CHEERING CONTINUOUS_FIRE_SLOW
+    AliasConditionState = SPECIAL_CHEERING CONTINUOUS_FIRE_MEAN
+    AliasConditionState = SPECIAL_CHEERING CONTINUOUS_FIRE_FAST
   End
 
   ; ***DESIGN parameters ***


### PR DESCRIPTION
- 1.04: recoil always slow (copy paste from Red Guard), does not fit at all
- patch before this: recoil always fast, fits at full firing speed
- this pull request: recoil rate increases with firing speed

https://user-images.githubusercontent.com/6576312/185745806-e8e3f9d0-8e76-4171-ac7d-67907b451333.mp4

