### PR TITLE
Upgrade Mod Builder to 1.7 and introduce File Hash Registry of original game

### DIFF
--- a/Patch104pZH/ModBundleItems.json
+++ b/Patch104pZH/ModBundleItems.json
@@ -11,7 +11,10 @@
                     {
                         "parent": "GameFilesEdited",
                         "sourceList": [
-                            "Art/W3D/*.w3d"
+                            "Art/W3D/*.W3D"
+                        ],
+                        "registryList": [
+                            "Resources/FileHashRegistry/Generals-108-GeneralsZH-104.csv"
                         ]
                     },
                     {
@@ -19,6 +22,9 @@
                         "sourceList": [
                             "Art/Textures/*.tga",
                             "Art/Textures/*.dds"
+                        ],
+                        "registryList": [
+                            "Resources/FileHashRegistry/Generals-108-GeneralsZH-104.csv"
                         ]
                     },
                     {
@@ -44,9 +50,10 @@
                     {
                         "parent": "GameFilesEdited",
                         "sourceList": [
-                            "Data/INI/Default/*.ini",
-                            "Data/INI/Object/*.ini",
-                            "Data/INI/*.ini"
+                            "Data/INI/**/*.ini"
+                        ],
+                        "registryList": [
+                            "Resources/FileHashRegistry/Generals-108-GeneralsZH-104.csv"
                         ],
                         "params": {
                             "forceEOL": "\r\n",
@@ -68,8 +75,10 @@
                     {
                         "parent": "GameFilesEdited",
                         "sourceList": [
-                            "Window/Menus/*.wnd",
-                            "Window/*.wnd"
+                            "Window/**/*.wnd"
+                        ],
+                        "registryList": [
+                            "Resources/FileHashRegistry/Generals-108-GeneralsZH-104.csv"
                         ],
                         "params": {
                             "forceEOL": "\r\n",

--- a/Patch104pZH/Scripts/Windows/Setup.bat
+++ b/Patch104pZH/Scripts/Windows/Setup.bat
@@ -3,9 +3,9 @@
 set SetupDir=%~dp0.
 
 :: Version, size and hash. Sets which Mod Builder is used.
-set ModBuilderVer=1.6
-set ModBuilderArcSize=30090046
-set ModBuilderArcSha256=2996924b7e0d38986c2482a4409e4832749c727acf7950e866bdbf773c08d9a0
+set ModBuilderVer=1.7
+set ModBuilderArcSize=30094969
+set ModBuilderArcSha256=19f38b1eb071aefe858e5b30e1b2375e578d9e7d92334fadf4ac71586477f29d
 
 :: The mod config files. Relative to this setup file.
 set ConfigFiles=^


### PR DESCRIPTION
Closes #934

This change upgrades to Mod Builder 1.7 and adds File Hash Registry to skip building unedited files.