### PR TITLE
Add: Supply Lines Upgrade To Oil Derrick

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
@@ -24888,6 +24888,9 @@ Object TechOilDerrick
   ; *** ART Parameters ***
   SelectPortrait         = SSTechOilDerrick_L
 
+  ; Patch104p @bugfix commy2 20/08/2022 Add Supply Lines upgrade icon.
+  UpgradeCameo1 = Upgrade_AmericaSupplyLines
+
   ; ========================= Main Model ===============================
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes


### PR DESCRIPTION
The upgrade works on them, so even if they are a civilian building, they should feature the icon imo.