### PR TITLE
Change: Remove PointDefenseLaser from USA Airforce Carpet Bomber

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3534,7 +3534,7 @@ CommandButton AirF_Command_PurchaseScienceCarpetBomb
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_AirF_CarpetBomb
   ButtonImage       = SAB3Carpet
-  Object            = AirF_AmericaJetB3
+  Object            = AmericaJetB3 ; Patch104p @tweak from AirF_AmericaJetB3 to use the plane without PointDefenseLaser
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -18046,7 +18046,7 @@ Object AirF_AmericaJetRaptor
     AflameDamageAmount = 3       ; taking this much damage...
     AflameDamageDelay = 500       ; this often.
   End
-  Behavior = PointDefenseLaserUpdate ModuleTag_22
+  Behavior = PointDefenseLaserUpdate ModuleTag_22 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = AirF_RaptorPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     ScanRate              = 10
@@ -18060,7 +18060,7 @@ Object AirF_AmericaJetRaptor
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
-  Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
+  Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One ; Alias ModuleTag_Laser_Two
     WeaponTemplate        = AirF_PointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     ScanRate              = 0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1991,7 +1991,7 @@ Object AmericaTankPaladin
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
-  Behavior = PointDefenseLaserUpdate ModuleTag_07
+  Behavior = PointDefenseLaserUpdate ModuleTag_07 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = PaladinPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     SecondaryTargetTypes  = INFANTRY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -16128,7 +16128,7 @@ Object Boss_JetRaptor
     AflameDamageAmount = 3       ; taking this much damage...
     AflameDamageDelay = 500       ; this often.
   End
-  Behavior = PointDefenseLaserUpdate ModuleTag_22
+  Behavior = PointDefenseLaserUpdate ModuleTag_22 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = AirF_RaptorPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     ScanRate              = 10
@@ -19722,7 +19722,7 @@ Object Boss_TankPaladin
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
-  Behavior = PointDefenseLaserUpdate ModuleTag_07
+  Behavior = PointDefenseLaserUpdate ModuleTag_07 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = PaladinPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     SecondaryTargetTypes  = INFANTRY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6362,7 +6362,7 @@ Object Lazr_AmericaTankPaladin
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
-  Behavior = PointDefenseLaserUpdate ModuleTag_07
+  Behavior = PointDefenseLaserUpdate ModuleTag_07 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = PaladinPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     SecondaryTargetTypes  = INFANTRY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -209,7 +209,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
     ;UpgradeToRemove     = SupW_Upgrade_AmericaPointDefenseDrone ModuleTag_12
     UpgradeToRemove     = Upgrade_AmericaBattleDrone ModuleTag_12
   End
-  Behavior = PointDefenseLaserUpdate ModuleTag_13
+  Behavior = PointDefenseLaserUpdate ModuleTag_13 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = SupW_PointDefenseDroneLaserWeapon
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     SecondaryTargetTypes  = INFANTRY
@@ -6833,7 +6833,7 @@ Object SupW_AmericaTankPaladin
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
-  Behavior = PointDefenseLaserUpdate ModuleTag_07
+  Behavior = PointDefenseLaserUpdate ModuleTag_07 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = PaladinPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
     SecondaryTargetTypes  = INFANTRY

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5853,7 +5853,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList AirF_SUPERWEAPON_CarpetBomb
   DeliverPayload
-    Transport = AirF_AmericaJetB3
+    Transport = AmericaJetB3 ; Patch104p @tweak from AirF_AmericaJetB3 to use the plane without PointDefenseLaser
     StartAtPreferredHeight = Yes
     StartAtMaxSpeed = Yes
     MaxAttempts = 1


### PR DESCRIPTION
* Fixes #926

This change removes the PointDefenseLaser from the USA Airforce Carpet Bomber.

# Rationale

All other USA Airforce General Promotion planes have no PointDefenseLaser, including the B52 bomber that delivers the MOAB and looks identical to the B52 Carpet Bomber.

USA Airforce General does not need this PointDefenseLaser on it to be useful either. ~~The USA Airforce Carpet Bomber has the lowest cooldown timer (2:30) of all faction carpet bombers.~~ It flies much faster than China Carpet Bombers. And it is available from Rank 1 unlike China Carpet Bombers at Rank 3.

USA Airforce opponents will now be able to shoot down the Carpet Bomber more easily with Rockets.