### PR TITLE
Revert: Some Toxin Tractor Death Explosion Particle Effect Changes

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -2203,35 +2203,6 @@ FXList FX_ToxinTruckExplosionOneFinal
 End
 
 ; Patch104p @bugfix commy2 27/08/2021 Effects used when Toxin Truck blows up, depending on Anthrax upgrades.
-
-; -----------------------------------------------------------------------------
-FXList FX_ToxinTruckExplosion
-  ParticleSystem
-    Name = BattleMasterTankExplosionSmoke
-  End
-  ParticleSystem
-    Name = BattleMasterTankExplosionDebris
-  End
-  ParticleSystem
-    Name = ScudMissleLauncherToxinExplosionArms
-    Offset = X:0 Y:0 Z:2
-  End
-  ParticleSystem
-    Name = ScudMissleLauncherToxinExplosionTrailArms
-    Offset = X:0 Y:0 Z:15
-  End
-  ViewShake
-    Type = STRONG
-  End
-  TerrainScorch
-    Type = RANDOM
-    Radius = 15
-  End
-  Sound
-    Name = TankDie
-  End
-End
-
 ; -----------------------------------------------------------------------------
 FXList FX_ToxinTruckExplosionUpgraded
   ParticleSystem
@@ -2241,12 +2212,12 @@ FXList FX_ToxinTruckExplosionUpgraded
     Name = BattleMasterTankExplosionDebris
   End
   ParticleSystem
-    Name = ScudMissleLauncherAnthraxExplosionArms
+    Name = ScudMissleLauncherAnthraxExplosionTrailArms
     Offset = X:0 Y:0 Z:2
   End
   ParticleSystem
-    Name = ScudMissleLauncherAnthraxExplosionTrailArms
-    Offset = X:0 Y:0 Z:15
+    Name = ToxicExplosionLargeUpgraded
+    Offset = X:0 Y:0 Z:5
   End
   ViewShake
     Type = STRONG
@@ -2269,12 +2240,12 @@ FXList Chem_FX_ToxinTruckExplosionGamma
     Name = BattleMasterTankExplosionDebris
   End
   ParticleSystem
-    Name = GC_Chem_ScudMissleLauncherGammaExplosionArms
+    Name = GC_Chem_ScudMissleLauncherGammaExplosionTrailArms
     Offset = X:0 Y:0 Z:2
   End
   ParticleSystem
-    Name = GC_Chem_ScudMissleLauncherGammaExplosionTrailArms
-    Offset = X:0 Y:0 Z:15
+    Name = ToxicExplosionLargeUpgraded
+    Offset = X:0 Y:0 Z:5
   End
   ViewShake
     Type = STRONG

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19597,7 +19597,7 @@ Object Demo_GLAVehicleToxinTruck
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
     OCL                       = INITIAL OCL_ToxinTractorDeathEffect
-    FX                        = FINAL FX_ToxinTruckExplosion
+    FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
   Behavior                    = InstantDeathBehavior  ModuleTag_06
     DeathTypes                = NONE +CRUSHED +SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3925,7 +3925,7 @@ Object GLAVehicleToxinTruck
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
     OCL                       = INITIAL OCL_ToxinTractorDeathEffect
-    FX                        = FINAL FX_ToxinTruckExplosion
+    FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
   ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19663,7 +19663,7 @@ Object Slth_GLAVehicleToxinTruck
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
     OCL                       = INITIAL OCL_ToxinTractorDeathEffect
-    FX                        = FINAL FX_ToxinTruckExplosion
+    FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
   ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021


### PR DESCRIPTION
- this https://github.com/TheSuperHackers/GeneralsGamePatch/pull/77 fixed the Toxin colors when upgraded
- but it also changed how the explosion looks before upgrade
- upgraded effects were based on the changed unupgraded effects

The current explosion effects on main branch look way too big for what tiny puddle is left behind.

This PR reverts the visual changes to the blown up Toxin Tractor before Anthrax upgrades. It also adjusts the fixed color versions to match this original effect.
