### PR TITLE
Fix: Add Missing Guard Mode Button To Troop Crawler And Assault Troop Crawler

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -447,7 +447,7 @@ CommandSet ChinaTroopCrawlerCommandSet
   8 = Command_TransportExit
   9 = Command_EmptyCrawler
   11 = Command_AttackMove
- ;13 = Command_Guard
+  13 = Command_Guard ; Patch104p @bugfix commy2 26/08/2022 Add missing Guard Mode button.
   14 = Command_Stop
 End
 
@@ -4145,7 +4145,7 @@ CommandSet Infa_ChinaTroopCrawlerCommandSet
   8 = Command_TransportExit
   9 = Command_EmptyCrawler
   11 = Command_AttackMove
- ;13 = Command_Guard
+  13 = Command_Guard ; Patch104p @bugfix commy2 26/08/2022 Add missing Guard Mode button.
   14 = Command_Stop
 End
 


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/961

I do not know why they disabled the Guard mode button from the Troop Crawler. It works fine with AssaultTransportAI behaviour as far as I can tell. Units will even dismount to guard.
That it's missing from the Assault Troop Crawler is just a bug.