### PR TITLE
Fix: Listening Outpost Guard Mode Range Too Large

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2620,7 +2620,7 @@ Object ChinaVehicleListeningOutpost
   End
   BuildCost       = 800
   BuildTime       = 15.0          ;in seconds
-  VisionRange     = 250
+  VisionRange     = 150 ; Patch104p @tweak commy2 26/08/2022 Guard Mode range too large, was 250.
   ShroudClearingRange = 500
   Prerequisites
     Object = ChinaWarFactory

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15786,7 +15786,7 @@ Object Infa_ChinaVehicleListeningOutpost
   End
   BuildCost       = 1000
   BuildTime       = 15.0          ;in seconds
-  VisionRange     = 250
+  VisionRange     = 150 ; Patch104p @tweak commy2 26/08/2022 Guard Mode range too large, was 250.
   ShroudClearingRange = 500
   Prerequisites
     Object = Infa_ChinaWarFactory

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4761,7 +4761,7 @@ Object Nuke_ChinaVehicleListeningOutpost
   End
   BuildCost       = 900
   BuildTime       = 15.0          ;in seconds
-  VisionRange     = 250
+  VisionRange     = 150 ; Patch104p @tweak commy2 26/08/2022 Guard Mode range too large, was 250.
   ShroudClearingRange = 500
   Prerequisites
     Object = Nuke_ChinaWarFactory

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4908,7 +4908,7 @@ Object Tank_ChinaVehicleListeningOutpost
   End
   BuildCost       = 950
   BuildTime       = 15.0          ;in seconds
-  VisionRange     = 250
+  VisionRange     = 150 ; Patch104p @tweak commy2 26/08/2022 Guard Mode range too large, was 250.
   ShroudClearingRange = 500
   Prerequisites
     Object = Tank_ChinaWarFactory


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/964

Note, this does not affect the detection range, because the Outpost's StealthDetectorUpdate module overwrites it via DetectionRange.