### PR TITLE
Fix: Angry Mob Deals No Damage With AK47

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -4710,7 +4710,7 @@ Weapon GLAAngryMobAK47Weapon
   DamageType            = MOLOTOV_COCKTAIL  ;SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile
+  ProjectileObject      = NONE
   FireFX                = WeaponFX_RangerAdvancedCombatRifleFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicRangerAdvancedCombatRifleFire
   FireSound             = AngryMobWeaponAK47
@@ -4729,7 +4729,7 @@ Weapon GLAAngryMobAK47NoDamageWeapon
   DamageType            = MOLOTOV_COCKTAIL  ;SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = NONE
+  ProjectileObject      = DummyWeaponProjectile
   FireFX                = WeaponFX_RangerAdvancedCombatRifleFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicRangerAdvancedCombatRifleFire
   FireSound             = AngryMobWeaponAK47


### PR DESCRIPTION
Fixes bug introduced in https://github.com/TheSuperHackers/GeneralsGamePatch/pull/279

I gave the dummy projectile to GLAAngryMobAK47Weapon instead of GLAAngryMobAK47**NoDamageWeapon**.

LMAO