### PR TITLE
Fix: Delete Immortal Aurora Wrecks Circling In Air

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1756,7 +1756,7 @@ Object AirF_AmericaJetAurora
   Behavior                          = JetSlowDeathBehavior ModuleTag_03
     FXOnGroundDeath                 = FX_JetOnGroundDeath
     OCLOnGroundDeath                = OCL_AuroraDeathFinalBlowUp
-    DestructionDelay                = 99999999; destruction will happen when we
+    DestructionDelay                = 10000 ; Patch104p @bugfix commy2 27/08/2022 Fix immortal Aurora wreck continuing to circle by deleting it after 10 seconds.
     RollRate                        = 0.2
     RollRateDelta                   = 100% ;each frame, rollrate = rollrate * rollrateDelta
     PitchRate                       = 0.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -1344,7 +1344,7 @@ Object AmericaJetAurora
   Behavior                          = JetSlowDeathBehavior ModuleTag_03
     FXOnGroundDeath                 = FX_JetOnGroundDeath
     OCLOnGroundDeath                = OCL_AuroraDeathFinalBlowUp
-    DestructionDelay                = 99999999; destruction will happen when we
+    DestructionDelay                = 10000 ; Patch104p @bugfix commy2 27/08/2022 Fix immortal Aurora wreck continuing to circle by deleting it after 10 seconds.
     RollRate                        = 0.2
     RollRateDelta                   = 100% ;each frame, rollrate = rollrate * rollrateDelta
     PitchRate                       = 0.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15223,7 +15223,7 @@ Object Boss_JetAurora
   Behavior                          = JetSlowDeathBehavior ModuleTag_03
     FXOnGroundDeath                 = FX_JetOnGroundDeath
     OCLOnGroundDeath                = OCL_AuroraDeathFinalBlowUp
-    DestructionDelay                = 99999999; destruction will happen when we
+    DestructionDelay                = 10000 ; Patch104p @bugfix commy2 27/08/2022 Fix immortal Aurora wreck continuing to circle by deleting it after 10 seconds.
     RollRate                        = 0.2
     RollRateDelta                   = 100% ;each frame, rollrate = rollrate * rollrateDelta
     PitchRate                       = 0.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -1102,7 +1102,7 @@ Object Lazr_AmericaJetAurora
   Behavior                          = JetSlowDeathBehavior ModuleTag_03
     FXOnGroundDeath                 = FX_JetOnGroundDeath
     OCLOnGroundDeath                = OCL_AuroraDeathFinalBlowUp
-    DestructionDelay                = 99999999; destruction will happen when we
+    DestructionDelay                = 10000 ; Patch104p @bugfix commy2 27/08/2022 Fix immortal Aurora wreck continuing to circle by deleting it after 10 seconds.
     RollRate                        = 0.2
     RollRateDelta                   = 100% ;each frame, rollrate = rollrate * rollrateDelta
     PitchRate                       = 0.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -1579,7 +1579,7 @@ Object SupW_AmericaJetAurora
   Behavior                          = JetSlowDeathBehavior ModuleTag_03
     FXOnGroundDeath                 = FX_JetOnGroundDeath
     OCLOnGroundDeath                = OCL_AuroraDeathFinalBlowUp
-    DestructionDelay                = 99999999; destruction will happen when we
+    DestructionDelay                = 10000 ; Patch104p @bugfix commy2 27/08/2022 Fix immortal Aurora wreck continuing to circle by deleting it after 10 seconds.
     RollRate                        = 0.2
     RollRateDelta                   = 100% ;each frame, rollrate = rollrate * rollrateDelta
     PitchRate                       = 0.0


### PR DESCRIPTION
Please ignore the Nuke and the Migs. I needed a savegame where this reliably happens after load for debugging.

https://user-images.githubusercontent.com/6576312/187041891-093f65c0-268b-4088-9852-e5059d531728.mp4

They still bug out and circle, but the spectactle will be cleaned up after 10 seconds maximum. This is the best I can do with INI scripting.