### PR TITLE
Fix: Broken Angry Mob Animations

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1641,6 +1641,13 @@ End
 
 
 
+; Patch104p @bugfix commy2 27/08/2022
+; Fix broken pistol reload animation
+; Fix broken molotov throw animation
+; Fix mob member with molotov is holding rock
+; Fix can't attack ground with AK47
+; Fix dust trail when moving disappears after Arm The Mob upgrade
+; Fix Angry Mob members "walks in place" instead of playing death animation when killed by certain weapon types after Arm The Mob upgrade
 ;------------------------------------------------------------------------------
 ;------------------------------------------------------------------------------
 Object GLAInfantryAngryMobPistol01
@@ -1653,46 +1660,17 @@ Object GLAInfantryAngryMobPistol01
     ;---------------------------------------------------------
     DefaultConditionState ;Idle with Pistol Holstered
       Model = UIMOB01_SKN
+      IdleAnimation = UIMOB01_SKL.UIMOB01_STA
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDA1 0 12
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDA2 0 5
       IdleAnimation = UIMOB01_SKL.UIMOB01_CHA  0 5
-      IdleAnimation = UIMOB01_SKL.UIMOB01_STA  0 5
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_A
 
-      WeaponFireFXBone = PRIMARY Muzzle
+      WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone = SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
       HideSubObject     = MuzzleFX01 MuzzleAKFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
-    End
-
-    ; Drawing pistol
-    ConditionState  = PREATTACK_A
-      Animation     = UIMOB01_SKL.UIMOB01_ATA1_ST ; start firing
-      AnimationMode = ONCE
-    End
-    AliasConditionState = PREATTACK_A FIRING_A
-    AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
-
-    ; Firing pistol
-    ConditionState = FIRING_A
-      Animation = UIMOB01_SKL.UIMOB01_ATA1_LP ; looping firing
-      AnimationMode = LOOP
-      TransitionKey = TRANS_FIRING_A
-    End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_A
-
-    ConditionState  = RELOADING_A
-      Animation     = UIMOB01_SKL.UIMOB01_ATA1_ED ; end firing
-      AnimationMode = ONCE
-    End
-
-    ; This transition allows him to put his gun away when he's finished attacking.
-    TransitionState = TRANS_FIRING_A TRANS_STAND_A
-      Animation     = UIMOB01_SKL.UIMOB01_ATA1_ED ; end firing
-      AnimationMode = ONCE
     End
 
     ConditionState = MOVING
@@ -1702,24 +1680,45 @@ Object GLAInfantryAngryMobPistol01
       TransitionKey   = MOVING
       ParticleSysBone   = None InfantryDustTrails
     End
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING PREATTACK_A
-    AliasConditionState = MOVING FIRING_A
-    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
-    AliasConditionState = MOVING RELOADING_C RELOADING_A
-    AliasConditionState = MOVING PREATTACK_C BETWEEN_FIRING_SHOTS_A
 
-    ConditionState = DYING
-      Animation = UIMOB01_SKL.UIMOB01_DA1
-      Animation = UIMOB01_SKL.UIMOB01_DA2
+    ; Drawing pistol
+    TransitionState = TRANS_STAND_A TRANS_FIRING_A
+      Animation     = UIMOB01_SKL.UIMOB01_ATA1_ST ; start firing
       AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
+      AnimationSpeedFactorRange = 2.5 2.5
     End
 
+    ; Firing pistol
+    ConditionState = ATTACKING FIRING_A
+      Animation = UIMOB01_SKL.UIMOB01_ATA1_LP ; looping firing
+      AnimationMode = LOOP
+      TransitionKey = TRANS_FIRING_A
+    End
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A
 
-    ConditionState = SPECIAL_CHEERING
-      Animation = UIMOB01_SKL.UIMOB01_CHA
+    TransitionState = TRANS_FIRING_A TRANS_RELOADING_A
+      Animation     = UIMOB01_SKL.UIMOB01_ATA1_ED ; end firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.0 2.0
+    End
+
+    ConditionState  = RELOADING_A
+      Animation     = UIMOB01_SKL.UIMOB01_STA
+      AnimationMode = ONCE
+      TransitionKey = TRANS_RELOADING_A
+    End
+
+    TransitionState = TRANS_RELOADING_A TRANS_FIRING_A
+      Animation     = UIMOB01_SKL.UIMOB01_ATA1_ST ; start firing
+      AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+    End
+
+    ; This transition allows him to put his gun away when he's finished attacking.
+    TransitionState = TRANS_FIRING_A TRANS_STAND_A
+      Animation     = UIMOB01_SKL.UIMOB01_ATA1_ED ; end firing
+      AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.0 2.0
     End
 
     ;--------------------------------------------------------
@@ -1731,14 +1730,14 @@ Object GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB01_SKN
+      IdleAnimation = UIMOB01_SKL.UIMOB01_STD
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD1 0 6
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD2 0 6
       IdleAnimation = UIMOB01_SKL.UIMOB01_CHD  0 6
-      IdleAnimation = UIMOB01_SKL.UIMOB01_STD
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_AK
     End
 
@@ -1747,110 +1746,98 @@ Object GLAInfantryAngryMobPistol01
       AnimationMode = LOOP
       Flags = RANDOMSTART
       TransitionKey   = MOVING_AK
-    End
-
-    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB01_SKL.UIMOB01_DD1
-      Animation = UIMOB01_SKL.UIMOB01_DD2
-      AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
-    End
-
-    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB01_SKL.UIMOB01_CHD
-      AnimationMode = ONCE
+      ParticleSysBone   = None InfantryDustTrails
     End
 
     ; Drawing AK47
-    ConditionState  = PREATTACK_B WEAPONSET_PLAYER_UPGRADE
+    TransitionState = TRANS_STAND_AK TRANS_FIRING_AK
       Animation     = UIMOB01_SKL.UIMOB01_ATD1_ST ; start firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-    AliasConditionState = PREATTACK_B FIRING_B WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = PREATTACK_B BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
 
     ; Firing Gun
-    ConditionState = FIRING_B WEAPONSET_PLAYER_UPGRADE
+    ConditionState = ATTACKING FIRING_A WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB01_SKL.UIMOB01_ATD1_LP ; looping firing
       AnimationMode = LOOP
-      WeaponFireFXBone = SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
       TransitionKey = TRANS_FIRING_AK
     End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
-
-
-    ConditionState  = RELOADING_B WEAPONSET_PLAYER_UPGRADE
-      Animation     = UIMOB01_SKL.UIMOB01_ATD1_ED ; end firing
-      AnimationMode = ONCE
-    End
-
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A WEAPONSET_PLAYER_UPGRADE
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_AK TRANS_STAND_AK
       Animation     = UIMOB01_SKL.UIMOB01_ATD1_ED ; end firing
       AnimationMode = ONCE
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-
-;    ;Throwing bottle----------------------------------------------------------------
-;    ConditionState = PREATTACK_C
-;      Animation     = UIMOB01_SKL.UIMOB01_ATCA_BF ; the wind up
-;    End
-;    AliasConditionState = PREATTACK_C FIRING_A
-;    AliasConditionState = PREATTACK_C RELOADING_A
-;    AliasConditionState = PREATTACK_C BETWEEN_FIRING_SHOTS_A
-;
-;    ConditionState = FIRING_C
-;      Animation     = UIMOB01_SKL.UIMOB01_ATCA_AF ; the release and follow-thru
-;      TransitionKey = TRANS_THROW
-;    End
-;    AliasConditionState = FIRING_C BETWEEN_FIRING_SHOTS_A
-;
-;    ConditionState RELOADING_C
-;      Animation =UIMOB01_SKL.UIMOB01_IDA1
-;      WaitForStateToFinishIfPossible = TRANS_THROW ; universal hub for follow-thru
-;    End
-;    AliasConditionState = RELOADING_C RELOADING_A
-;    AliasConditionState = RELOADING_C FIRING_A
-;    AliasConditionState = RELOADING_C BETWEEN_FIRING_SHOTS_A
-
-
-;    TransitionState = TRANSXXX TRANS_THROW
-;      Animation     = UIMOB01_SKL.UIMOB01_XXXXXXXXputaway gun and take out bottle
-;    End
-
-;    TransitionState = TRANS_THROW TRANS_FIRING_A
-;      Animation     = UIMOB01_SKL.UIMOB01_XXXXXXXXputaway bottle and get PISTOL
-;    End
-
-;    TransitionState = TRANSXXXAK TRANS_THROW
-;      Animation     = UIMOB01_SKL.UIMOB01_XXXXXXXXputaway AK and take out bottle
-;    End
-
-;    TransitionState = TRANS_THROW TRANS_FIRING_AK
-;      Animation     = UIMOB01_SKL.UIMOB01_XXXXXXXXputaway bottle and get AK
-;    End
 
     ;--------------------------------------------------------
 
+    ; WHILE CARRYING PISTOL
+    ConditionState = DYING
+      Animation = UIMOB01_SKL.UIMOB01_DA1
+      Animation = UIMOB01_SKL.UIMOB01_DA2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying
+    End
+
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIMOB01_SKL.UIMOB01_A_ADTE1
-      Animation = UIMOB01_SKL.UIMOB01_D_ADTE1
       AnimationMode = ONCE
     End
 
     ConditionState = DYING EXPLODED_FLAILING
       Animation = UIMOB01_SKL.UIMOB01_A_ADTE2
-      Animation = UIMOB01_SKL.UIMOB01_D_ADTE2
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIMOB01_SKL.UIMOB01_A_ADTE3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ; WHILE CARRYING AK47
+    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB01_SKL.UIMOB01_DD1
+      Animation = UIMOB01_SKL.UIMOB01_DD2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying_AK
+    End
+
+    TransitionState = TRANS_Dying_AK TRANS_Flailing_AK
+      Animation = UIMOB01_SKL.UIMOB01_D_ADTE1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB01_SKL.UIMOB01_D_ADTE2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing_AK
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB01_SKL.UIMOB01_D_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
+    End
+
+    ;--------------------------------------------------------
+
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIMOB01_SKL.UIMOB01_CHA
+      AnimationMode = ONCE
+    End
+
+    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB01_SKL.UIMOB01_CHD
+      AnimationMode = ONCE
     End
   End
 
@@ -1868,8 +1855,7 @@ Object GLAInfantryAngryMobPistol01
 
   WeaponSet
     Conditions = PLAYER_UPGRADE
-    Weapon = PRIMARY GLAAngryMobAK47NoDamageWeapon ; for atttacking in AK-proof conditions
-    Weapon = SECONDARY GLAAngryMobAK47Weapon
+    Weapon = PRIMARY GLAAngryMobAK47Weapon
   End
 
   ArmorSet
@@ -2015,20 +2001,23 @@ Object GLAInfantryAngryMobRock02
     ;---------------------------------------------------------
     DefaultConditionState
       Model = UIMOB02_SKN
+      IdleAnimation = UIMOB02_SKL.UIMOB02_STB
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDB1 0 12
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDB2 0 5
       IdleAnimation = UIMOB02_SKL.UIMOB02_CHB  0 5
-      IdleAnimation = UIMOB02_SKL.UIMOB02_STB  0 12
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_A
-
-      ;WeaponFireFXBone  = PRIMARY   "UIMOB02 R HAND"
-      ;WeaponMuzzleFlash = PRIMARY   "UIMOB02 R HAND"
-      WeaponFireFXBone =  SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
+      HideSubObject     = MuzzleAKFX01
     End
 
+    ConditionState = MOVING
+      Animation = UIMOB02_SKL.UIMOB02_RNB
+      AnimationMode = LOOP
+      Flags = RANDOMSTART
+      TransitionKey   = MOVING
+      ParticleSysBone   = None InfantryDustTrails
+    End
 
     ; Drawing rock
     ConditionState  = PREATTACK_A
@@ -2039,10 +2028,11 @@ Object GLAInfantryAngryMobRock02
     AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
 
     ; throwing rock
-    ConditionState = FIRING_A
+    ConditionState = ATTACKING FIRING_A
       Animation = UIMOB02_SKL.UIMOB02_ATB1_AF ; throw
       Animation = UIMOB02_SKL.UIMOB02_ATB2_AF ; throw
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
       TransitionKey = TRANS_FIRING_A
     End
 
@@ -2058,47 +2048,23 @@ Object GLAInfantryAngryMobRock02
     End
     AliasConditionState = RELOADING_A
 
-
-    ConditionState = MOVING
-      Animation = UIMOB02_SKL.UIMOB02_RNB
-      AnimationMode = LOOP
-      Flags = RANDOMSTART
-      TransitionKey   = MOVING
-      ParticleSysBone   = None InfantryDustTrails
-    End
-
-    ConditionState = DYING
-      Animation = UIMOB02_SKL.UIMOB02_DB1
-      Animation = UIMOB02_SKL.UIMOB02_DB2
-      AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
-    End
-
-    ConditionState = SPECIAL_CHEERING
-      Animation = UIMOB02_SKL.UIMOB02_CHB
-      Flags = RANDOMSTART
-      AnimationMode = LOOP
-    End
-
-
     ;--------------------------------------------------------
-    ; TRANSITION FROM PISTOL TO AK47
+    ; TRANSITION FROM ROCK TO AK47
     TransitionState = TRANS_STAND_A TRANS_STAND_AK
       Animation = UIMOB02_SKL.UIMOB02_TB-D
       AnimationMode = ONCE
     End
 
-
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB02_SKN
+      IdleAnimation = UIMOB02_SKL.UIMOB02_STD
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD1 0 6
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD2 0 6
       IdleAnimation = UIMOB02_SKL.UIMOB02_CHD  0 6
-      IdleAnimation = UIMOB02_SKL.UIMOB02_STD
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_AK
     End
 
@@ -2107,77 +2073,100 @@ Object GLAInfantryAngryMobRock02
       AnimationMode = LOOP
       Flags = RANDOMSTART
       TransitionKey   = MOVING_AK
-    End
-
-    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB02_SKL.UIMOB02_DD1
-      Animation = UIMOB02_SKL.UIMOB02_DD2
-      AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
-    End
-
-    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB02_SKL.UIMOB02_CHD
-      AnimationMode = ONCE
+      ParticleSysBone   = None InfantryDustTrails
     End
 
     ; Drawing AK47
-    ConditionState  = PREATTACK_B WEAPONSET_PLAYER_UPGRADE
+    TransitionState = TRANS_STAND_AK TRANS_FIRING_AK
       Animation     = UIMOB02_SKL.UIMOB02_ATD1_ST ; start firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-    AliasConditionState = PREATTACK_B FIRING_B WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = PREATTACK_B BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
 
     ; Firing Gun
-    ConditionState = FIRING_B WEAPONSET_PLAYER_UPGRADE
+    ConditionState = ATTACKING FIRING_A WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB02_SKL.UIMOB02_ATD1_LP ; looping firing
       AnimationMode = LOOP
-      WeaponFireFXBone = SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
       TransitionKey = TRANS_FIRING_AK
     End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
-
-
-    ConditionState  = RELOADING_B WEAPONSET_PLAYER_UPGRADE
-      Animation     = UIMOB02_SKL.UIMOB02_ATD1_ED ; end firing
-      AnimationMode = ONCE
-    End
-
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A WEAPONSET_PLAYER_UPGRADE
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_AK TRANS_STAND_AK
       Animation     = UIMOB02_SKL.UIMOB02_ATD1_ED ; end firing
       AnimationMode = ONCE
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
 
+    ;--------------------------------------------------------
 
-
+    ; WHILE CARRYING ROCK
+    ConditionState = DYING
+      Animation = UIMOB02_SKL.UIMOB02_DB1
+      Animation = UIMOB02_SKL.UIMOB02_DB2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying
+    End
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIMOB02_SKL.UIMOB02_B_ADTA1
-      Animation = UIMOB02_SKL.UIMOB02_D_ADTA1
       AnimationMode = ONCE
     End
 
     ConditionState = DYING EXPLODED_FLAILING
       Animation = UIMOB02_SKL.UIMOB02_B_ADTA2
-      Animation = UIMOB02_SKL.UIMOB02_D_ADTA2
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIMOB02_SKL.UIMOB02_B_ADTA3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ; WHILE CARRYING AK47
+    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB02_SKL.UIMOB02_DD1
+      Animation = UIMOB02_SKL.UIMOB02_DD2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying_AK
+    End
+
+    TransitionState = TRANS_Dying_AK TRANS_Flailing_AK
+      Animation = UIMOB02_SKL.UIMOB02_D_ADTA1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB02_SKL.UIMOB02_D_ADTA2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing_AK
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB02_SKL.UIMOB02_D_ADTA3
       AnimationMode = ONCE
       TransitionKey = None
     End
 
+    ;--------------------------------------------------------
 
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIMOB02_SKL.UIMOB02_CHB
+      AnimationMode = LOOP
+    End
+
+    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB02_SKL.UIMOB02_CHD
+      AnimationMode = ONCE
+    End
   End
-
 
 ;**** DESIGN parameters ***
 
@@ -2193,8 +2182,7 @@ Object GLAInfantryAngryMobRock02
 
   WeaponSet
     Conditions = PLAYER_UPGRADE
-    Weapon = PRIMARY GLAAngryMobAK47NoDamageWeapon ; for atttacking in AK-proof conditions
-    Weapon = SECONDARY GLAAngryMobAK47Weapon
+    Weapon = PRIMARY GLAAngryMobAK47Weapon
   End
 
   ArmorSet
@@ -2336,53 +2324,21 @@ ObjectReskin GLAInfantryAngryMobPistol03 GLAInfantryAngryMobPistol01
   Draw = W3DModelDraw DrawTag_01
     OkToChangeModelColor = Yes
 
-
-
     ; WHILE CARRYING PISTOL
     ;---------------------------------------------------------
     DefaultConditionState ;Idle with Pistol Holstered
       Model = UIMOB03_SKN
+      IdleAnimation = UIMOB03_SKL.UIMOB03_STA
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDA1 0 12
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDA2 0 5
       IdleAnimation = UIMOB03_SKL.UIMOB03_CHA  0 5
-      IdleAnimation = UIMOB03_SKL.UIMOB03_STA  0 5
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_A
 
-      WeaponFireFXBone = PRIMARY Muzzle
+      WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone = SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
-      WeaponFireFXBone = TERTIARY "UIMOB03 R HAND"
-      HideSubObject    = MuzzleFX01 MuzzleAKFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
-    End
-
-    ; Drawing pistol
-    ConditionState  = PREATTACK_A
-      Animation     = UIMOB03_SKL.UIMOB03_ATA1_ST ; start firing
-      AnimationMode = ONCE
-    End
-    AliasConditionState = PREATTACK_A FIRING_A
-    AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
-
-    ; Firing pistol
-    ConditionState = FIRING_A
-      Animation = UIMOB03_SKL.UIMOB03_ATA1_LP ; looping firing
-      AnimationMode = LOOP
-      TransitionKey = TRANS_FIRING_A
-    End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_A
-
-    ConditionState  = RELOADING_A
-      Animation     = UIMOB03_SKL.UIMOB03_ATA1_ED ; end firing
-      AnimationMode = ONCE
-    End
-
-    ; This transition allows him to put his gun away when he's finished attacking.
-    TransitionState = TRANS_FIRING_A TRANS_STAND_A
-      Animation     = UIMOB03_SKL.UIMOB03_ATA1_ED ; end firing
-      AnimationMode = ONCE
+      HideSubObject     = MuzzleFX01 MuzzleAKFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
     End
 
     ConditionState = MOVING
@@ -2392,24 +2348,45 @@ ObjectReskin GLAInfantryAngryMobPistol03 GLAInfantryAngryMobPistol01
       TransitionKey   = MOVING
       ParticleSysBone   = None InfantryDustTrails
     End
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING PREATTACK_A
-    AliasConditionState = MOVING FIRING_A
-    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
-    AliasConditionState = MOVING RELOADING_C RELOADING_A
-    AliasConditionState = MOVING PREATTACK_C BETWEEN_FIRING_SHOTS_A
 
-    ConditionState = DYING
-      Animation = UIMOB03_SKL.UIMOB03_DA1
-      Animation = UIMOB03_SKL.UIMOB03_DA2
+    ; Drawing pistol
+    TransitionState = TRANS_STAND_A TRANS_FIRING_A
+      Animation     = UIMOB03_SKL.UIMOB03_ATA1_ST ; start firing
       AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
+      AnimationSpeedFactorRange = 2.5 2.5
     End
 
+    ; Firing pistol
+    ConditionState = ATTACKING FIRING_A
+      Animation = UIMOB03_SKL.UIMOB03_ATA1_LP ; looping firing
+      AnimationMode = LOOP
+      TransitionKey = TRANS_FIRING_A
+    End
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A
 
-    ConditionState = SPECIAL_CHEERING
-      Animation = UIMOB03_SKL.UIMOB03_CHA
+    TransitionState = TRANS_FIRING_A TRANS_RELOADING_A
+      Animation     = UIMOB03_SKL.UIMOB03_ATA1_ED ; end firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.0 2.0
+    End
+
+    ConditionState  = RELOADING_A
+      Animation     = UIMOB03_SKL.UIMOB03_STA
+      AnimationMode = ONCE
+      TransitionKey = TRANS_RELOADING_A
+    End
+
+    TransitionState = TRANS_RELOADING_A TRANS_FIRING_A
+      Animation     = UIMOB03_SKL.UIMOB03_ATA1_ST ; start firing
+      AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+    End
+
+    ; This transition allows him to put his gun away when he's finished attacking.
+    TransitionState = TRANS_FIRING_A TRANS_STAND_A
+      Animation     = UIMOB03_SKL.UIMOB03_ATA1_ED ; end firing
+      AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.0 2.0
     End
 
     ;--------------------------------------------------------
@@ -2419,17 +2396,16 @@ ObjectReskin GLAInfantryAngryMobPistol03 GLAInfantryAngryMobPistol01
       AnimationMode = ONCE
     End
 
-
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB03_SKN
+      IdleAnimation = UIMOB03_SKL.UIMOB03_STD
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD1 0 6
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD2 0 6
       IdleAnimation = UIMOB03_SKL.UIMOB03_CHD  0 6
-      IdleAnimation = UIMOB03_SKL.UIMOB03_STD
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_AK
     End
 
@@ -2438,126 +2414,100 @@ ObjectReskin GLAInfantryAngryMobPistol03 GLAInfantryAngryMobPistol01
       AnimationMode = LOOP
       Flags = RANDOMSTART
       TransitionKey   = MOVING_AK
-    End
-
-    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB03_SKL.UIMOB03_DD1
-      Animation = UIMOB03_SKL.UIMOB03_DD2
-      AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
-    End
-
-    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB03_SKL.UIMOB03_CHD
-      AnimationMode = ONCE
+      ParticleSysBone   = None InfantryDustTrails
     End
 
     ; Drawing AK47
-    ConditionState  = PREATTACK_B WEAPONSET_PLAYER_UPGRADE
+    TransitionState = TRANS_STAND_AK TRANS_FIRING_AK
       Animation     = UIMOB03_SKL.UIMOB03_ATD_ST ; start firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-    AliasConditionState = PREATTACK_B FIRING_B WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = PREATTACK_B BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
 
     ; Firing Gun
-    ConditionState = FIRING_B WEAPONSET_PLAYER_UPGRADE
+    ConditionState = ATTACKING FIRING_A WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB03_SKL.UIMOB03_ATD_LP ; looping firing
       AnimationMode = LOOP
-      WeaponFireFXBone = SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
       TransitionKey = TRANS_FIRING_AK
     End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
-
-
-    ConditionState  = RELOADING_B WEAPONSET_PLAYER_UPGRADE
-      Animation     = UIMOB03_SKL.UIMOB03_ATD_ED ; end firing
-      AnimationMode = ONCE
-    End
-
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A WEAPONSET_PLAYER_UPGRADE
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_AK TRANS_STAND_AK
       Animation     = UIMOB03_SKL.UIMOB03_ATD_ED ; end firing
       AnimationMode = ONCE
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-
-
-;    ;Throwing bottle----------------------------------------------------------------
-;    ConditionState = PREATTACK_C
-;      Animation     = UIMOB03_SKL.UIMOB03_ATCA_BF ; the wind up
-;    End
-;    AliasConditionState = PREATTACK_C FIRING_A
-;    AliasConditionState = PREATTACK_C RELOADING_A
-;    AliasConditionState = PREATTACK_C BETWEEN_FIRING_SHOTS_A
-;
-;    ConditionState = FIRING_C
-;      Animation     = UIMOB03_SKL.UIMOB03_ATCA_AF ; the release and follow-thru
-;      TransitionKey = TRANS_THROW
-;    End
-;    AliasConditionState = FIRING_C BETWEEN_FIRING_SHOTS_A
-;
-;    ConditionState RELOADING_C
-;      Animation =UIMOB03_SKL.UIMOB03_IDA1
-;      WaitForStateToFinishIfPossible = TRANS_THROW ; universal hub for follow-thru
-;
-;    End
-;    AliasConditionState = RELOADING_C RELOADING_A
-;    AliasConditionState = RELOADING_C FIRING_A
-;    AliasConditionState = RELOADING_C BETWEEN_FIRING_SHOTS_A
-
-
-;    TransitionState = TRANSXXX TRANS_THROW
-;      Animation     = UIMOB03_SKL.UIMOB03_XXXXXXXXputaway gun and take out bottle
-;    End
-
-;    TransitionState = TRANS_THROW TRANS_FIRING_A
-;      Animation     = UIMOB03_SKL.UIMOB03_XXXXXXXXputaway bottle and get PISTOL
-;    End
-
-;    TransitionState = TRANSXXXAK TRANS_THROW
-;      Animation     = UIMOB03_SKL.UIMOB03_XXXXXXXXputaway AK and take out bottle
-;    End
-
-;    TransitionState = TRANS_THROW TRANS_FIRING_AK
-;      Animation     = UIMOB03_SKL.UIMOB03_XXXXXXXXputaway bottle and get AK
-;    End
-
-
-
-
 
     ;--------------------------------------------------------
 
-
-
-
-
+    ; WHILE CARRYING PISTOL
+    ConditionState = DYING
+      Animation = UIMOB03_SKL.UIMOB03_DA1
+      Animation = UIMOB03_SKL.UIMOB03_DA2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying
+    End
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIMOB03_SKL.UIMOB03_A_ADTD1
-      Animation = UIMOB03_SKL.UIMOB03_D_ADTD1
       AnimationMode = ONCE
     End
 
     ConditionState = DYING EXPLODED_FLAILING
       Animation = UIMOB03_SKL.UIMOB03_A_ADTD2
-      Animation = UIMOB03_SKL.UIMOB03_D_ADTD2
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIMOB03_SKL.UIMOB03_A_ADTD3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ; WHILE CARRYING AK47
+    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB03_SKL.UIMOB03_DD1
+      Animation = UIMOB03_SKL.UIMOB03_DD2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying_AK
+    End
+
+    TransitionState = TRANS_Dying_AK TRANS_Flailing_AK
+      Animation = UIMOB03_SKL.UIMOB03_D_ADTD1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB03_SKL.UIMOB03_D_ADTD2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing_AK
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB03_SKL.UIMOB03_D_ADTD3
       AnimationMode = ONCE
       TransitionKey = None
     End
 
+    ;--------------------------------------------------------
 
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIMOB03_SKL.UIMOB03_CHA
+      AnimationMode = ONCE
+    End
+
+    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB03_SKL.UIMOB03_CHD
+      AnimationMode = ONCE
+    End
   End
-
 
   Geometry = CYLINDER
   GeometryMajorRadius = 3.0 ; very thin
@@ -2580,36 +2530,38 @@ Object GLAInfantryAngryMobRock04
     ;---------------------------------------------------------
     DefaultConditionState
       Model = UIMOB04_SKN
+      IdleAnimation = UIMOB04_SKL.UIMOB04_STB
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDB1 0 12
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDB2 0 5
       IdleAnimation = UIMOB04_SKL.UIMOB04_CHB  0 5
-      IdleAnimation = UIMOB04_SKL.UIMOB04_STB  0 12
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_A
-      WaitForStateToFinishIfPossible TRANS_FIRING_A
-
-      ;WeaponFireFXBone  = PRIMARY   "UIMOB04 R HAND"
-      ;WeaponMuzzleFlash = PRIMARY   "UIMOB04 R HAND"
-      WeaponFireFXBone =  SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
+      HideSubObject     = MuzzleAKFX01
     End
 
+    ConditionState = MOVING
+      Animation = UIMOB04_SKL.UIMOB04_RUN
+      AnimationMode = LOOP
+      Flags = RANDOMSTART
+      TransitionKey   = MOVING
+      ParticleSysBone   = None InfantryDustTrails
+    End
 
     ; Drawing rock
     ConditionState  = PREATTACK_A
       Animation     = UIMOB04_SKL.UIMOB04_ATB2_BF ; wind up
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 1.0 1.0
     End
     AliasConditionState = PREATTACK_A FIRING_A
     AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
 
     ; throwing rock
-    ConditionState = FIRING_A
+    ConditionState = ATTACKING FIRING_A
       Animation = UIMOB04_SKL.UIMOB04_ATB1_AF ; throw
       Animation = UIMOB04_SKL.UIMOB04_ATB2_AF ; throw
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
       TransitionKey = TRANS_FIRING_A
     End
 
@@ -2625,55 +2577,24 @@ Object GLAInfantryAngryMobRock04
     End
     AliasConditionState = RELOADING_A
 
-    ConditionState = MOVING
-      Animation = UIMOB04_SKL.UIMOB04_RUN
-      AnimationMode = LOOP
-      Flags = RANDOMSTART
-      TransitionKey   = MOVING
-      ParticleSysBone   = None InfantryDustTrails
-    End
-
-    ConditionState = DYING
-      Animation = UIMOB04_SKL.UIMOB04_DB1
-      Animation = UIMOB04_SKL.UIMOB04_DB2
-      AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
-    End
-
-    ConditionState = SPECIAL_CHEERING
-      Animation = UIMOB04_SKL.UIMOB04_CHB
-      Flags = RANDOMSTART
-      AnimationMode = LOOP
-    End
-
-
-
-
-
-
-
-
     ;--------------------------------------------------------
-    ; TRANSITION FROM PISTOL TO AK47
+    ; TRANSITION FROM ROCK TO AK47
     TransitionState = TRANS_STAND_A TRANS_STAND_AK
       Animation = UIMOB04_SKL.UIMOB04_TB-D
       AnimationMode = ONCE
     End
 
-
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB04_SKN
+      IdleAnimation = UIMOB04_SKL.UIMOB04_STD
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD1 0 6
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD2 0 6
       IdleAnimation = UIMOB04_SKL.UIMOB04_CHD  0 6
-      IdleAnimation = UIMOB04_SKL.UIMOB04_STD
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_AK
-      WeaponFireFXBone = SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
     End
 
     ConditionState = MOVING WEAPONSET_PLAYER_UPGRADE
@@ -2681,83 +2602,100 @@ Object GLAInfantryAngryMobRock04
       AnimationMode = LOOP
       Flags = RANDOMSTART
       TransitionKey   = MOVING_AK
-    End
-
-    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB04_SKL.UIMOB04_DD1
-      Animation = UIMOB04_SKL.UIMOB04_DD2
-      AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
-    End
-
-    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB04_SKL.UIMOB04_CHD
-      AnimationMode = ONCE
+      ParticleSysBone   = None InfantryDustTrails
     End
 
     ; Drawing AK47
-    ConditionState  = PREATTACK_B WEAPONSET_PLAYER_UPGRADE
+    TransitionState = TRANS_STAND_AK TRANS_FIRING_AK
       Animation     = UIMOB04_SKL.UIMOB04_ATD1_ST ; start firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-    AliasConditionState = PREATTACK_B FIRING_B WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = PREATTACK_B BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
 
     ; Firing Gun
-    ConditionState = FIRING_B WEAPONSET_PLAYER_UPGRADE
+    ConditionState = ATTACKING FIRING_A WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB04_SKL.UIMOB04_ATD1_LP ; looping firing
       AnimationMode = LOOP
-      WeaponFireFXBone = PRIMARY MuzzleAK
+      WeaponFireFXBone  = PRIMARY MuzzleAK
       WeaponMuzzleFlash = PRIMARY MuzzleAKFX
       TransitionKey = TRANS_FIRING_AK
     End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
-
-
-    ConditionState  = RELOADING_B WEAPONSET_PLAYER_UPGRADE
-      Animation     = UIMOB04_SKL.UIMOB04_ATD1_ED ; end firing
-      AnimationMode = ONCE
-    End
-
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A WEAPONSET_PLAYER_UPGRADE
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_AK TRANS_STAND_AK
       Animation     = UIMOB04_SKL.UIMOB04_ATD1_ED ; end firing
       AnimationMode = ONCE
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
 
+    ;--------------------------------------------------------
 
-
-
-
-
-
-
-
+    ; WHILE CARRYING ROCK
+    ConditionState = DYING
+      Animation = UIMOB04_SKL.UIMOB04_DB1
+      Animation = UIMOB04_SKL.UIMOB04_DB2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying
+    End
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIMOB04_SKL.UIMOB04_B_ADTF1
-      Animation = UIMOB04_SKL.UIMOB04_D_ADTF1
       AnimationMode = ONCE
     End
 
     ConditionState = DYING EXPLODED_FLAILING
       Animation = UIMOB04_SKL.UIMOB04_B_ADTF2
-      Animation = UIMOB04_SKL.UIMOB04_D_ADTF2
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIMOB04_SKL.UIMOB04_B_ADTF3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ; WHILE CARRYING AK47
+    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB04_SKL.UIMOB04_DD1
+      Animation = UIMOB04_SKL.UIMOB04_DD2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying_AK
+    End
+
+    TransitionState = TRANS_Dying_AK TRANS_Flailing_AK
+      Animation = UIMOB04_SKL.UIMOB04_D_ADTF1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB04_SKL.UIMOB04_D_ADTF2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing_AK
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB04_SKL.UIMOB04_D_ADTF3
       AnimationMode = ONCE
       TransitionKey = None
     End
 
+    ;--------------------------------------------------------
 
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIMOB04_SKL.UIMOB04_CHB
+      AnimationMode = LOOP
+    End
+
+    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB04_SKL.UIMOB04_CHD
+      AnimationMode = ONCE
+    End
   End
-
 
 ;**** DESIGN parameters ***
 
@@ -2773,8 +2711,7 @@ Object GLAInfantryAngryMobRock04
 
   WeaponSet
     Conditions = PLAYER_UPGRADE
-    Weapon = PRIMARY GLAAngryMobAK47NoDamageWeapon ; for atttacking in AK-proof conditions
-    Weapon = SECONDARY GLAAngryMobAK47Weapon
+    Weapon = PRIMARY GLAAngryMobAK47Weapon
   End
 
   ArmorSet
@@ -2911,50 +2848,21 @@ ObjectReskin GLAInfantryAngryMobPistol05 GLAInfantryAngryMobPistol01
   Draw = W3DModelDraw DrawTag_01
     OkToChangeModelColor = Yes
 
-
-
     ; WHILE CARRYING PISTOL
     ;---------------------------------------------------------
     DefaultConditionState ;Idle with Pistol Holstered
       Model = UIMOB05_SKN
+      IdleAnimation = UIMOB05_SKL.UIMOB05_STA
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDA1 0 12
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDA2 0 5
       IdleAnimation = UIMOB05_SKL.UIMOB05_CHA  0 5
-      IdleAnimation = UIMOB05_SKL.UIMOB05_STA  0 5
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_A
 
-      WeaponFireFXBone = PRIMARY Muzzle01
-      WeaponMuzzleFlash = PRIMARY Muzzle01
+      WeaponFireFXBone  = PRIMARY Muzzle
+      WeaponMuzzleFlash = PRIMARY MuzzleFX
       HideSubObject     = MuzzleFX01 MuzzleAKFX01 ; Patch104p @bugfix commy2 20/08/2022 Manually hide muzzle flash to make it not show permantently during transitions on some night or snow maps.
-    End
-
-    ; Drawing pistol
-    ConditionState  = PREATTACK_A
-      Animation     = UIMOB05_SKL.UIMOB05_ATA1_ST ; start firing
-      AnimationMode = ONCE
-    End
-    AliasConditionState = PREATTACK_A FIRING_A
-    AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
-
-    ; Firing pistol
-    ConditionState = FIRING_A
-      Animation = UIMOB05_SKL.UIMOB05_ATA1_LP ; looping firing
-      AnimationMode = LOOP
-      TransitionKey = TRANS_FIRING_A
-    End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_A
-
-    ConditionState  = RELOADING_A
-      Animation     = UIMOB05_SKL.UIMOB05_ATA1_ED ; end firing
-      AnimationMode = ONCE
-    End
-
-    ; This transition allows him to put his gun away when he's finished attacking.
-    TransitionState = TRANS_FIRING_A TRANS_STAND_A
-      Animation     = UIMOB05_SKL.UIMOB05_ATA1_ED ; end firing
-      AnimationMode = ONCE
     End
 
     ConditionState = MOVING
@@ -2964,48 +2872,65 @@ ObjectReskin GLAInfantryAngryMobPistol05 GLAInfantryAngryMobPistol01
       TransitionKey   = MOVING
       ParticleSysBone   = None InfantryDustTrails
     End
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING PREATTACK_A
-    AliasConditionState = MOVING FIRING_A
-    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
-    AliasConditionState = MOVING RELOADING_C RELOADING_A
-    AliasConditionState = MOVING PREATTACK_C BETWEEN_FIRING_SHOTS_A
 
-    ConditionState = DYING
-      Animation = UIMOB05_SKL.UIMOB05_DA1
-      Animation = UIMOB05_SKL.UIMOB05_DA2
+    ; Drawing pistol
+    TransitionState = TRANS_STAND_A TRANS_FIRING_A
+      Animation     = UIMOB05_SKL.UIMOB05_ATA1_ST ; start firing
       AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
+      AnimationSpeedFactorRange = 2.5 2.5
     End
 
+    ; Firing pistol
+    ConditionState = ATTACKING FIRING_A
+      Animation = UIMOB05_SKL.UIMOB05_ATA1_LP ; looping firing
+      AnimationMode = LOOP
+      TransitionKey = TRANS_FIRING_A
+    End
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A
 
-    ConditionState = SPECIAL_CHEERING
-      Animation = UIMOB05_SKL.UIMOB05_CHA
+    TransitionState = TRANS_FIRING_A TRANS_RELOADING_A
+      Animation     = UIMOB05_SKL.UIMOB05_ATA1_ED ; end firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.0 2.0
+    End
+
+    ConditionState  = RELOADING_A
+      Animation     = UIMOB05_SKL.UIMOB05_STA
+      AnimationMode = ONCE
+      TransitionKey = TRANS_RELOADING_A
+    End
+
+    TransitionState = TRANS_RELOADING_A TRANS_FIRING_A
+      Animation     = UIMOB05_SKL.UIMOB05_ATA1_ST ; start firing
+      AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+    End
+
+    ; This transition allows him to put his gun away when he's finished attacking.
+    TransitionState = TRANS_FIRING_A TRANS_STAND_A
+      Animation     = UIMOB05_SKL.UIMOB05_ATA1_ED ; end firing
+      AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.0 2.0
     End
 
     ;--------------------------------------------------------
-
     ; TRANSITION FROM PISTOL TO AK47
     TransitionState = TRANS_STAND_A TRANS_STAND_AK
       Animation = UIMOB05_SKL.UIMOB05_TA-D
       AnimationMode = ONCE
     End
 
-
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB05_SKN
+      IdleAnimation = UIMOB05_SKL.UIMOB05_STD
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD1 0 6
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD2 0 6
       IdleAnimation = UIMOB05_SKL.UIMOB05_CHD  0 6
-      IdleAnimation = UIMOB05_SKL.UIMOB05_STD
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
+      AnimationSpeedFactorRange = 0.9 1.1
       TransitionKey = TRANS_STAND_AK
-      WeaponFireFXBone = SECONDARY MuzzleAK
-      WeaponMuzzleFlash = SECONDARY MuzzleAKFX
     End
 
     ConditionState = MOVING WEAPONSET_PLAYER_UPGRADE
@@ -3013,127 +2938,100 @@ ObjectReskin GLAInfantryAngryMobPistol05 GLAInfantryAngryMobPistol01
       AnimationMode = LOOP
       Flags = RANDOMSTART
       TransitionKey   = MOVING_AK
-    End
-
-    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB05_SKL.UIMOB05_DD1
-      Animation = UIMOB05_SKL.UIMOB05_DD2
-      AnimationMode = ONCE
-      TransitionKey = TRANS_Dying
-    End
-
-    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
-      Animation = UIMOB05_SKL.UIMOB05_CHD
-      AnimationMode = ONCE
+      ParticleSysBone   = None InfantryDustTrails
     End
 
     ; Drawing AK47
-    ConditionState  = PREATTACK_B WEAPONSET_PLAYER_UPGRADE
+    TransitionState = TRANS_STAND_AK TRANS_FIRING_AK
       Animation     = UIMOB05_SKL.UIMOB05_ATD1_ST ; start firing
       AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-    AliasConditionState = PREATTACK_B FIRING_B WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = PREATTACK_B BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
 
     ; Firing Gun
-    ConditionState = FIRING_B WEAPONSET_PLAYER_UPGRADE
+    ConditionState = ATTACKING FIRING_A WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB05_SKL.UIMOB05_ATD1_LP ; looping firing
       AnimationMode = LOOP
-      WeaponFireFXBone = PRIMARY MuzzleAK
+      WeaponFireFXBone  = PRIMARY MuzzleAK
       WeaponMuzzleFlash = PRIMARY MuzzleAKFX
       TransitionKey = TRANS_FIRING_AK
     End
-    AliasConditionState  = BETWEEN_FIRING_SHOTS_B WEAPONSET_PLAYER_UPGRADE
-
-
-    ConditionState  = RELOADING_B WEAPONSET_PLAYER_UPGRADE
-      Animation     = UIMOB05_SKL.UIMOB05_ATD1_ED ; end firing
-      AnimationMode = ONCE
-    End
-
+    AliasConditionState  = BETWEEN_FIRING_SHOTS_A WEAPONSET_PLAYER_UPGRADE
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_AK TRANS_STAND_AK
       Animation     = UIMOB05_SKL.UIMOB05_ATD1_ED ; end firing
       AnimationMode = ONCE
+      WeaponFireFXBone  = PRIMARY MuzzleAK
+      WeaponMuzzleFlash = PRIMARY MuzzleAKFX
     End
-
-
-;    ;Throwing bottle----------------------------------------------------------------
-;    ConditionState = PREATTACK_C
-;      Animation     = UIMOB05_SKL.UIMOB05_ATCA_BF ; the wind up
-;    End
-;    AliasConditionState = PREATTACK_C FIRING_A
-;    AliasConditionState = PREATTACK_C RELOADING_A
-;    AliasConditionState = PREATTACK_C BETWEEN_FIRING_SHOTS_A
-;
-;    ConditionState = FIRING_C
-;      Animation     = UIMOB05_SKL.UIMOB05_ATCA_AF ; the release and follow-thru
-;      TransitionKey = TRANS_THROW
-;    End
-;    AliasConditionState = FIRING_C BETWEEN_FIRING_SHOTS_A
-;
-;    ConditionState RELOADING_C
-;      Animation =UIMOB05_SKL.UIMOB05_IDA1
-;      WaitForStateToFinishIfPossible = TRANS_THROW ; universal hub for follow-thru
-;    End
-;    AliasConditionState = RELOADING_C RELOADING_A
-;    AliasConditionState = RELOADING_C FIRING_A
-;    AliasConditionState = RELOADING_C BETWEEN_FIRING_SHOTS_A
-
-
-;    TransitionState = TRANSXXX TRANS_THROW
-;      Animation     = UIMOB05_SKL.UIMOB05_XXXXXXXXputaway gun and take out bottle
-;    End
-
-;    TransitionState = TRANS_THROW TRANS_FIRING_A
-;      Animation     = UIMOB05_SKL.UIMOB05_XXXXXXXXputaway bottle and get PISTOL
-;    End
-
-;    TransitionState = TRANSXXXAK TRANS_THROW
-;      Animation     = UIMOB05_SKL.UIMOB05_XXXXXXXXputaway AK and take out bottle
-;    End
-
-
-;    TransitionState = TRANS_THROW TRANS_FIRING_AK
-;      Animation     = UIMOB05_SKL.UIMOB05_XXXXXXXXputaway bottle and get AK
-;    End
-
-
-
-
 
     ;--------------------------------------------------------
 
-
-
-
-
+    ; WHILE CARRYING PISTOL
+    ConditionState = DYING
+      Animation = UIMOB05_SKL.UIMOB05_DA1
+      Animation = UIMOB05_SKL.UIMOB05_DA2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying
+    End
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIMOB05_SKL.UIMOB05_A_ADTA1
-      Animation = UIMOB05_SKL.UIMOB05_D_ADTA1
       AnimationMode = ONCE
     End
 
     ConditionState = DYING EXPLODED_FLAILING
       Animation = UIMOB05_SKL.UIMOB05_A_ADTA2
-      Animation = UIMOB05_SKL.UIMOB05_D_ADTA2
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIMOB05_SKL.UIMOB05_A_ADTA3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ; WHILE CARRYING AK47
+    ConditionState = DYING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB05_SKL.UIMOB05_DD1
+      Animation = UIMOB05_SKL.UIMOB05_DD2
+      AnimationMode = ONCE
+      TransitionKey = TRANS_Dying_AK
+    End
+
+    TransitionState = TRANS_Dying_AK TRANS_Flailing_AK
+      Animation = UIMOB05_SKL.UIMOB05_D_ADTA1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB05_SKL.UIMOB05_D_ADTA2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing_AK
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING WEAPONSET_PLAYER_UPGRADE
       Animation = UIMOB05_SKL.UIMOB05_D_ADTA3
       AnimationMode = ONCE
       TransitionKey = None
     End
 
+    ;--------------------------------------------------------
 
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIMOB05_SKL.UIMOB05_CHA
+      AnimationMode = ONCE
+    End
+
+    ConditionState = SPECIAL_CHEERING WEAPONSET_PLAYER_UPGRADE
+      Animation = UIMOB05_SKL.UIMOB05_CHD
+      AnimationMode = ONCE
+    End
   End
-
-
 
   Geometry = CYLINDER
   GeometryMajorRadius = 3.0 ; very thin
@@ -3152,50 +3050,19 @@ Object GLAInfantryAngryMobMolotov02
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
-    ; WHILE CARRYING ROCK
+    ; WHILE CARRYING MOLOTOV
     ;---------------------------------------------------------
     DefaultConditionState
       Model = UIMOB02_SKN
+      IdleAnimation = UIMOB02_SKL.UIMOB02_STB
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDB1 0 12
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDB2 0 5
       IdleAnimation = UIMOB02_SKL.UIMOB02_CHB  0 5
-      IdleAnimation = UIMOB02_SKL.UIMOB02_STB  0 12
       AnimationMode = ONCE
-      AnimationSpeedFactorRange 0.9 1.1
-      TransitionKey = TRANS_STAND_B
-
-      WeaponFireFXBone  = SECONDARY   "UIMOB02 R HAND"
-
+      AnimationSpeedFactorRange = 0.9 1.1
+      TransitionKey = TRANS_STAND_A
+      HideSubObject = Rock_01
     End
-
-
-    ; Drawing rock
-    ConditionState  = PREATTACK_B
-      Animation     = UIMOB02_SKL.UIMOB02_ATCB_BF ; wind up
-      AnimationMode = ONCE
-    End
-    AliasConditionState = PREATTACK_B FIRING_B
-    AliasConditionState = PREATTACK_B BETWEEN_FIRING_SHOTS_B
-
-    ; throwing rock
-    ConditionState = FIRING_B
-      Animation = UIMOB02_SKL.UIMOB02_ATCB_AF ; throw
-      AnimationMode = ONCE
-      TransitionKey = TRANS_FIRING_B
-    End
-
-    ConditionState = BETWEEN_FIRING_SHOTS_B
-      Animation         = UIMOB02_SKL.UIMOB02_STB
-      AnimationMode     = ONCE
-      ; this is basically a trick: this guy has a nontrivial animation for firing,
-      ; and a long recycle time between shots. we want him to finish his fire animation
-      ; (unless he's ordered to do something else), so this is just a handy trick that
-      ; says, "if the previous state had this transition key, allow it to finish before
-      ; switching to us, if possible".
-      WaitForStateToFinishIfPossible = TRANS_FIRING_B
-    End
-    AliasConditionState = RELOADING_B
-
 
     ConditionState = MOVING
       Animation = UIMOB02_SKL.UIMOB02_RNB
@@ -3205,23 +3072,42 @@ Object GLAInfantryAngryMobMolotov02
       ParticleSysBone   = None InfantryDustTrails
     End
 
+    ; Drawing molotov
+    ConditionState  = PREATTACK_A
+      Animation     = UIMOB02_SKL.UIMOB02_ATCB_BF ; wind up
+      AnimationMode = ONCE
+    End
+    AliasConditionState = PREATTACK_A FIRING_A
+    AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
+
+    ; throwing molotov
+    ConditionState = FIRING_A
+      Animation = UIMOB02_SKL.UIMOB02_ATCB_AF ; throw
+      AnimationMode = ONCE
+      AnimationSpeedFactorRange = 2.5 2.5
+      TransitionKey = TRANS_FIRING_A
+    End
+
+    ConditionState = BETWEEN_FIRING_SHOTS_A
+      Animation         = UIMOB02_SKL.UIMOB02_STB
+      AnimationMode     = ONCE
+      ; this is basically a trick: this guy has a nontrivial animation for firing,
+      ; and a long recycle time between shots. we want him to finish his fire animation
+      ; (unless he's ordered to do something else), so this is just a handy trick that
+      ; says, "if the previous state had this transition key, allow it to finish before
+      ; switching to us, if possible".
+      WaitForStateToFinishIfPossible = TRANS_FIRING_A
+    End
+    AliasConditionState = RELOADING_A
+
+    ;--------------------------------------------------------
+
     ConditionState = DYING
       Animation = UIMOB02_SKL.UIMOB02_DB1
       Animation = UIMOB02_SKL.UIMOB02_DB2
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-
-    ConditionState = SPECIAL_CHEERING
-      Animation = UIMOB02_SKL.UIMOB02_CHB
-      Flags = RANDOMSTART
-      AnimationMode = LOOP
-    End
-
-
-
-
-
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIMOB02_SKL.UIMOB02_B_ADTA1
@@ -3243,9 +3129,12 @@ Object GLAInfantryAngryMobMolotov02
       TransitionKey = None
     End
 
-
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIMOB02_SKL.UIMOB02_CHB
+      Flags = RANDOMSTART
+      AnimationMode = LOOP
+    End
   End
-
 
 ;**** DESIGN parameters ***
 
@@ -3315,11 +3204,6 @@ Object GLAInfantryAngryMobMolotov02
   Behavior = SquishCollide ModuleTag_08
     ;nothing
   End
-
-  Behavior = WeaponSetUpgrade UpgradeTag_01
-    TriggeredBy = Upgrade_GLAArmTheMob
-  End
-
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01


### PR DESCRIPTION
- Fix: Broken pistol reloading animation
- Fix: Broken molotov throw animation
- Fix: Mob member with molotov is holding rock
- Fix: Can't attack ground with AK47
- Fix: Dust trail when moving disappears after Arm The Mob upgrade
- Fix: Angry Mob members "walks in place" instead of playing death animation when killed by certain weapon types after Arm The Mob

# before

https://user-images.githubusercontent.com/6576312/187032918-ee9e5c22-c42f-4055-bfe8-6e0cc1ddc58f.mp4

# after

https://user-images.githubusercontent.com/6576312/187032930-940810b4-5398-4c7d-8dd8-1ceac877eecf.mp4


