### PR TITLE
Fix: Nuke Battlemaster Uses Button And Portrait From Normal Battlemaster

### DIFF
--- a/Patch104pZH/GameFilesEdited/Art/Textures/SNNukeBattlemaster.tga
+++ b/Patch104pZH/GameFilesEdited/Art/Textures/SNNukeBattlemaster.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42d36137baa3b08ff4badb098435efd589da85be1274604d311898631f6722b1
+size 65580

--- a/Patch104pZH/GameFilesEdited/Art/Textures/SNNukeBattlemaster_L.tga
+++ b/Patch104pZH/GameFilesEdited/Art/Textures/SNNukeBattlemaster_L.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3d9baca5c53a478ec5d90dd3a7fcac24b7d26e1d8e12df3818364e4a4925b5a
+size 65580

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -6282,7 +6282,7 @@ CommandButton Nuke_Command_ConstructChinaTankBattleMaster
   Command       = UNIT_BUILD
   Object        = Nuke_ChinaTankBattleMaster
   TextLabel     = CONTROLBAR:ConstructGLATankBattleMaster
-  ButtonImage   = SNBattlemaster
+  ButtonImage   = SNNukeBattlemaster ; Patch104p @tweak commy2 20/08/2022 Use art that resembles unit.
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildBattlemaster
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/MappedImages/TextureSize_512/SNUserInterface512.INI
+++ b/Patch104pZH/GameFilesEdited/Data/INI/MappedImages/TextureSize_512/SNUserInterface512.INI
@@ -1370,3 +1370,19 @@ MappedImage SSCashHack3
   Status = NONE
 End
 
+; Patch104p @tweak commy2 20/08/2022 Art taken from NProject.
+MappedImage SNNukeBattlemaster_L
+  Texture = SNNukeBattlemaster_L.tga
+  TextureWidth = 128
+  TextureHeight = 128
+  Coords = Left:1 Top:1 Right:121 Bottom:97
+  Status = NONE
+End
+
+MappedImage SNNukeBattlemaster
+  Texture = SNNukeBattlemaster.tga
+  TextureWidth = 128
+  TextureHeight = 128
+  Coords = Left:1 Top:1 Right:61 Bottom:49
+  Status = NONE
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16548,8 +16548,9 @@ End
 Object Nuke_ChinaTankBattleMaster
 
   ; *** ART Parameters ***
-  SelectPortrait         = SNNukeBtleMstr_L
-  ButtonImage            = SNBattlemaster
+  ; Patch104p @tweak commy2 20/08/2022 Use art that resembles unit.
+  SelectPortrait         = SNNukeBattlemaster_L
+  ButtonImage            = SNNukeBattlemaster
 
   UpgradeCameo1 = Upgrade_Nationalism
   UpgradeCameo2 = Upgrade_ChinaWGUraniumShells


### PR DESCRIPTION
Art is from NProject.

# before / 1.04

![shot_20220820_094917_1](https://user-images.githubusercontent.com/6576312/185735131-49619e4a-06ff-40dd-bafc-790d591675a0.jpg)

![shot_20220820_094921_2](https://user-images.githubusercontent.com/6576312/185735137-a9799063-f2eb-46e5-b08d-4c6538d0c8cf.jpg)

- same icon as normal Battlemaster, art does not resemble unit
- button and portrait are different, portrait has radiation sign

# after / patch

![shot_20220820_094208_1](https://user-images.githubusercontent.com/6576312/185735152-9552286a-cb4e-4545-86ea-99633c6bdd43.jpg)

![shot_20220820_094213_3](https://user-images.githubusercontent.com/6576312/185735155-b0cbde01-644e-4ba9-bc59-b192bb671552.jpg)

- art resembles unit
- radiation sign on button and portrait