### PR TITLE
Fix: SWG Particle Cannon Uses Portrait Of Normal Particle Cannon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Art/Textures/SASWGParticleCannon.tga
+++ b/Patch104pZH/GameFilesEdited/Art/Textures/SASWGParticleCannon.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23a012ef1538dfa8343b1ea4dcb28246f20730ef1a47f1d6bf9b94425b61f779
+size 65580

--- a/Patch104pZH/GameFilesEdited/Art/Textures/SASWGParticleCannon_L.tga
+++ b/Patch104pZH/GameFilesEdited/Art/Textures/SASWGParticleCannon_L.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01069a5c5d7e0c8730a8947364c71f80b6238546d6e74669e93880711fa900b1
+size 65580

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -6925,7 +6925,7 @@ CommandButton SupW_Command_ConstructAmericaParticleCannonUplink
   Command       = DOZER_CONSTRUCT
   Object        = SupW_AmericaParticleCannonUplink
   TextLabel     = CONTROLBAR:ConstructAmericaParticleCannonUplink
-  ButtonImage   = SALwPwrPrtCan
+  ButtonImage   = SASWGParticleCannon ; Patch104p @tweak commy2 20/08/2022 Use updated art to match portrait.
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildParticleCannon
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/MappedImages/TextureSize_512/SAUserInterface512.INI
+++ b/Patch104pZH/GameFilesEdited/Data/INI/MappedImages/TextureSize_512/SAUserInterface512.INI
@@ -1386,3 +1386,19 @@ MappedImage SAStealth
   Status = NONE
 End
 
+; Patch104p @tweak commy2 20/08/2022 Art taken from NProject.
+MappedImage SASWGParticleCannon_L
+  Texture = SASWGParticleCannon_L.tga
+  TextureWidth = 128
+  TextureHeight = 128
+  Coords = Left:1 Top:1 Right:121 Bottom:97
+  Status = NONE
+End
+
+MappedImage SASWGParticleCannon
+  Texture = SASWGParticleCannon.tga
+  TextureWidth = 128
+  TextureHeight = 128
+  Coords = Left:1 Top:1 Right:61 Bottom:49
+  Status = NONE
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -8963,8 +8963,9 @@ End
 Object SupW_AmericaParticleCannonUplink
 
   ; *** ART Parameters ***
-  SelectPortrait         = SAUplink_L
-  ButtonImage            = SAUplink
+  ; Patch104p @tweak commy2 20/08/2022 Make portrait match button and be unique.
+  SelectPortrait         = SASWGParticleCannon_L
+  ButtonImage            = SASWGParticleCannon
 
   Draw = W3DModelDraw ModuleTag_01
     ExtraPublicBone        = FX01


### PR DESCRIPTION
# before
![shot_20220820_104753_2](https://user-images.githubusercontent.com/6576312/185737047-cee9e55b-06ca-4964-8d68-94d004c6f59c.jpg)
![shot_20220820_104744_1](https://user-images.githubusercontent.com/6576312/185737053-9b64ff90-8e42-4e2b-a9a0-f33dcc9f0fac.jpg)

- SWG has unique button, but the same portrait as other USA
- button has blue and red team color mixed in different places

# after
![shot_20220820_104337_1](https://user-images.githubusercontent.com/6576312/185737071-8fbf8582-862b-4ceb-86b1-431c0189b349.jpg)

- portrai and button match
- team color changed to blue