### PR TITLE
Fix: Female Poison And Burned Sound Effects Use Chinese Male Sound Files

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -82,14 +82,14 @@ End
 ; ----------------------------------------------
 FXList FX_DieByFireFemale
   Sound
-    Name = DieByFireChina
+    Name = DieByFireFemale ; Patch104p @bugfix commy2 28/08/2022 Fix female effect using male sound files.
   End
 End
 
 ; ----------------------------------------------
 FXList FX_DieByToxinFemale
   Sound
-    Name = DieByToxinChina
+    Name = DieByToxinFemale ; Patch104p @bugfix commy2 28/08/2022 Fix female effect using male sound files.
   End
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -4243,8 +4243,9 @@ AudioEvent DieByToxinChina
   Type = world shrouded everyone
 End
 
+; Patch104p @feature commy2 28/08/2022 Added previously unused 'idiftoxe' sound.
 AudioEvent DieByToxinFemale
-  Sounds = idiftoxa idiftoxb idiftoxc idiftoxd
+  Sounds = idiftoxa idiftoxb idiftoxc idiftoxd idiftoxe
   Control = random
   Volume = 90
   Limit = 3


### PR DESCRIPTION
- wires female poison and fire deaths effects to correctly use the female sound files
- adds a previously unused sound file to the list of sound files