### PR TITLE
Fix: Broken USA Dozer Dirt Particles When Clearing Mines

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6572,6 +6572,7 @@ Object AirF_AmericaVehicleDozer
       Animation         = AVCONSTDOZ_AD.AVCONSTDOZ_AD
       AnimationMode     = ONCE
       ParticleSysBone   = EXHAUSTFX01 DozerSmokeHeavy
+      ParticleSysBone   = DIRTFX01 DozerDirtFall ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles missing when damaged.
       TransitionKey     = TRANS_DIGGING_DAMAGED
     End
 
@@ -6597,9 +6598,8 @@ Object AirF_AmericaVehicleDozer
     TireRotationMultiplier      = 0.2   ; this * speed = rotation.
     PowerslideRotationAddition  = 0   ; This vehicle doesn't powerslide.
 
-  ParticlesAttachedToAnimatedBones = Yes
-
-
+    ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles falling of shovel.
+    ;ParticlesAttachedToAnimatedBones = Yes
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1657,6 +1657,7 @@ Object AmericaVehicleDozer
       Animation         = AVCONSTDOZ_AD.AVCONSTDOZ_AD
       AnimationMode     = ONCE
       ParticleSysBone   = EXHAUSTFX01 DozerSmokeHeavy
+      ParticleSysBone   = DIRTFX01 DozerDirtFall ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles missing when damaged.
       TransitionKey     = TRANS_DIGGING_DAMAGED
     End
 
@@ -1682,9 +1683,8 @@ Object AmericaVehicleDozer
     TireRotationMultiplier      = 0.2   ; this * speed = rotation.
     PowerslideRotationAddition  = 0   ; This vehicle doesn't powerslide.
 
-  ParticlesAttachedToAnimatedBones = Yes
-
-
+    ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles falling of shovel.
+    ;ParticlesAttachedToAnimatedBones = Yes
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -81,6 +81,7 @@ Object Boss_VehicleDozer
       Animation         = AVCONSTDOZ_AD.AVCONSTDOZ_AD
       AnimationMode     = ONCE
       ParticleSysBone   = EXHAUSTFX01 DozerSmokeHeavy
+      ParticleSysBone   = DIRTFX01 DozerDirtFall ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles missing when damaged.
       TransitionKey     = TRANS_DIGGING_DAMAGED
     End
 
@@ -106,9 +107,8 @@ Object Boss_VehicleDozer
     TireRotationMultiplier      = 0.2   ; this * speed = rotation.
     PowerslideRotationAddition  = 0   ; This vehicle doesn't powerslide.
 
-  ParticlesAttachedToAnimatedBones = Yes
-
-
+    ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles falling of shovel.
+    ;ParticlesAttachedToAnimatedBones = Yes
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6031,6 +6031,7 @@ Object Lazr_AmericaVehicleDozer
       Animation         = AVCONSTDOZ_AD.AVCONSTDOZ_AD
       AnimationMode     = ONCE
       ParticleSysBone   = EXHAUSTFX01 DozerSmokeHeavy
+      ParticleSysBone   = DIRTFX01 DozerDirtFall ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles missing when damaged.
       TransitionKey     = TRANS_DIGGING_DAMAGED
     End
 
@@ -6056,9 +6057,8 @@ Object Lazr_AmericaVehicleDozer
     TireRotationMultiplier      = 0.2   ; this * speed = rotation.
     PowerslideRotationAddition  = 0   ; This vehicle doesn't powerslide.
 
-  ParticlesAttachedToAnimatedBones = Yes
-
-
+    ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles falling of shovel.
+    ;ParticlesAttachedToAnimatedBones = Yes
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6506,6 +6506,7 @@ Object SupW_AmericaVehicleDozer
       Animation         = AVCONSTDOZ_AD.AVCONSTDOZ_AD
       AnimationMode     = ONCE
       ParticleSysBone   = EXHAUSTFX01 DozerSmokeHeavy
+      ParticleSysBone   = DIRTFX01 DozerDirtFall ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles missing when damaged.
       TransitionKey     = TRANS_DIGGING_DAMAGED
     End
 
@@ -6531,9 +6532,8 @@ Object SupW_AmericaVehicleDozer
     TireRotationMultiplier      = 0.2   ; this * speed = rotation.
     PowerslideRotationAddition  = 0   ; This vehicle doesn't powerslide.
 
-  ParticlesAttachedToAnimatedBones = Yes
-
-
+    ; Patch104p @bugfix commy2 26/08/2022 Fix dirt particles falling of shovel.
+    ;ParticlesAttachedToAnimatedBones = Yes
   End
 
 


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/930

https://user-images.githubusercontent.com/6576312/186968730-24bdff4b-5c34-4423-87c1-ed71eeefff78.mp4

`ParticlesAttachedToAnimatedBones` does not appear to be required by USA Dozer. (It is not used by China Dozer either.) Removing the token fixes the position of the dirt particles falling of the shovel. (Those dirt spawners also are the only animated bones in the model.)

Also fixes: Dirt particles are missing when Dozer clearing mines is damaged.

previous: https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1001