### PR TITLE
Change: Implement Previously Unused Nuke Helix Texture

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -268,6 +268,7 @@ End
 
 
 
+; Patch104p @feature commy2 13/08/2022 Implement previously unused Nuke Helix texture.
 ;----------------------------------------------------------------------------------------------------------
 Object Nuke_ChinaVehicleHelix
 
@@ -288,12 +289,12 @@ Object Nuke_ChinaVehicleHelix
       ParticlesAttachedToAnimatedBones = Yes
 
     DefaultConditionState
-      Model = NVHELIX
-      Animation = NVHELIX.NVHELIX
+      Model = NVHelixNG
+      Animation = NVHelixNG.NVHelixNG
       AnimationMode = LOOP
       WeaponFireFXBone    = PRIMARY Muzzle03
       WeaponMuzzleFlash   = PRIMARY TurretFX03
-      HideSubObject       = BombWing
+      HideSubObject       = BombWing Bomb01 Bomb02
     End
 
     ConditionState = MOVING
@@ -302,33 +303,33 @@ Object Nuke_ChinaVehicleHelix
     End
 
     ConditionState = REALLYDAMAGED
-      Model = NVHELIX_d
-      Animation = NVHELIX_d.NVHELIX_d
+      Model = NVHelixNG_D
+      Animation = NVHelixNG_D.NVHelixNG_D
       AnimationMode = LOOP
     End
     ConditionState = REALLYDAMAGED MOVING
-      Model = NVHELIX_d
-      Animation = NVHELIX_d.NVHELIX_d
+      Model = NVHelixNG_D
+      Animation = NVHelixNG_D.NVHelixNG_D
       AnimationMode = LOOP
       ParticleSysBone = SMOKE01 HelixExhaust
       ParticleSysBone = SMOKE02 HelixExhaust
     End
 
     ConditionState = RUBBLE
-      Model = NVHELIX_d
-      Animation = NVHELIX_d.NVHELIX_d
+      Model = NVHelixNG_D
+      Animation = NVHelixNG_D.NVHelixNG_D
       AnimationMode = LOOP
     End
     ConditionState = RUBBLE MOVING
-      Model = NVHELIX_d
-      Animation = NVHELIX_d.NVHELIX_d
+      Model = NVHelixNG_D
+      Animation = NVHelixNG_D.NVHelixNG_D
       AnimationMode = LOOP
       ParticleSysBone = SMOKE01 HelixExhaust
       ParticleSysBone = SMOKE02 HelixExhaust
     End
 
     ConditionState = RUBBLE SPECIAL_DAMAGED
-      Model = NVHELIX_d
+      Model = NVHelixNG_D
     End
 
     OkToChangeModelColor = Yes


### PR DESCRIPTION
There is an unused texture for the Nuke Helix. Since the Nuke Helix can indeed drop nuclear bombs, I think using this would be neat.

![shot_20220813_180742_1](https://user-images.githubusercontent.com/6576312/184502017-70eab837-f0d5-4f18-b352-70c2df1368ea.jpg)

previous: https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1003