### PR TITLE
Standard Patriot Missile Systems now track infantry

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1971,11 +1971,13 @@ Weapon AnthraxGammaBombWeapon
   AutoReloadsClip     = No
 End
 
+; Patch104p @balance Stubbjax 24/08/2022 Standard Patriot Missile Systems now track infantry.
+
 ;------------------------------------------------------------------------------
 Weapon PatriotMissileWeapon
   PrimaryDamage               = 30.0
   PrimaryDamageRadius         = 5.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 225.0
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
@@ -2003,7 +2005,7 @@ End
 Weapon PatriotMissileWeaponAir
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 350.0
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
@@ -2032,7 +2034,7 @@ End
 Weapon PatriotMissileAssistWeapon
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range
   DamageType                  = EXPLOSION          ; ignored for projectile weapons
   DeathType                   = EXPLODED


### PR DESCRIPTION
* old PR: #965

Created by Stubbjax.

Patriot Missile Systems now track infantry. This is an implementation of proposal 3 for https://github.com/TheSuperHackers/GeneralsGamePatch/issues/897.

### Footage of the change:

https://user-images.githubusercontent.com/11547761/186201457-d59e907c-6a0a-4079-8d5e-68ac3b4bfe32.mp4

### Rationale:

This is an interesting change because it helps distinguish the Patriot more from the Firebase, which similarly tracks vehicles but not infantry. It offers deeper strategic diversity in the form of additional / greater anti-infantry options, which other proposals such as higher damage output or price reductions don't effectively provide. It also gains some similarity / consistency with the Technical's RPG weapon, which tracks infantry and deals the same type of damage. Bonus benefit: It feels nice when the rocket directly hits the infantry.

While the change does take away some micro opportunities - e.g. where the attacker moves an infantry unit around to waste the Patriot's shots or the attacker specifically targets stationary infantry - it should be noted that these micro opportunities rarely manifest in competitive games anyway (and in casual games where they are more common, players are often not skilled enough to do so). These opportunities will remain with the EMP (anti-vehicle) variant and Firebases, where they are already fairly common.

This change also amplifies the dynamic with China's `Red Guard Training` power, as an unranked Red Guard will take 4 missiles to kill, whereas a veteran Red Guard will take 5, thus having a greater influence on Troop Crawler attacks. The difference is much clearer without moving targets to waste shots on.

With this change, the Patriot Missile System gains a few extra use cases, while still remaining a relatively niche option so that the current gameplay / meta is maintained.