### PR TITLE
Fix: GLA SCUD missile times out without inflicting damage

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3110,7 +3110,7 @@ Object SCUDMissile
   End
   Behavior = MissileAIUpdate ModuleTag_07
     TryToFollowTarget = No
-    FuelLifetime = 5000
+    FuelLifetime = 6000 ; Patch104p @bugfix Stubbjax 22/08/2022 Fixed premature SCUD missile detonation
     IgnitionDelay = 0
 ;   IgnitionFX = FX_ScudStormIgnition ;NOT WORKING
     InitialVelocity = 50                ; in dist/sec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3110,7 +3110,8 @@ Object SCUDMissile
   End
   Behavior = MissileAIUpdate ModuleTag_07
     TryToFollowTarget = No
-    FuelLifetime = 6000 ; Patch104p @bugfix Stubbjax 22/08/2022 Fixed premature SCUD missile detonation
+    FuelLifetime = 9999 ; Patch104p @bugfix Stubbjax 22/08/2022 Fixed premature SCUD missile deletion
+    DetonateOnNoFuel = Yes
     IgnitionDelay = 0
 ;   IgnitionFX = FX_ScudStormIgnition ;NOT WORKING
     InitialVelocity = 50                ; in dist/sec


### PR DESCRIPTION
* old PR: #956

Fixed a rare case where SCUD missiles would detonate too early under certain conditions and not cause any damage.

### Conditions:
- High terrain
- Salvage upgrade
- Search and Destroy battle plan

### Footage of the problem:

https://user-images.githubusercontent.com/11547761/185892021-90d51436-1c70-42ff-b107-a28fad7d6872.mp4