### PR TITLE
Change: Improved Sentry Drones

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6955,11 +6955,11 @@ Object AirF_AmericaVehicleSentryDrone
     DetectionRate            = 900   ; how often to rescan for stealthed things in my sight (msec)
     DetectionRange           = 225   ;Dustin, enable this for independant balancing!
   End
-
-;  Behavior = GrantUpgradeCreate ModuleTag_13
-;    UpgradeToGrant = Upgrade_AmericaSentryDroneGun
-;    ExemptStatus = UNDER_CONSTRUCTION
-;  End
+  Behavior = AutoHealBehavior ModuleTag_13
+    StartsActive  = Yes
+    HealingAmount = 1
+    HealingDelay  = 1000
+  End
 
   Geometry = BOX
   GeometryMajorRadius = 9.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6819,7 +6819,7 @@ Object AirF_AmericaVehicleSentryDrone
     Armor           = SentryDroneArmor
     DamageFX        = TruckDamageFX
   End
-  BuildCost       = 850
+  BuildCost       = 600
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6895,10 +6895,10 @@ Object AirF_AmericaVehicleSentryDrone
       MaxIdleScanAngle      = 360     ; in degrees off the natural turret angle
     End
     AutoAcquireEnemiesWhenIdle = Yes ;Stealthed ; Means "Yes when idle, even if I am stealthed"
-    PackTime = 1000
-    UnpackTime = 1000
+    PackTime = 0
+    UnpackTime = 0
     TurretsFunctionOnlyWhenDeployed = Yes
-    TurretsMustCenterBeforePacking = Yes
+    TurretsMustCenterBeforePacking = No
   End
 
   Locomotor = SET_NORMAL SentryLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6958,8 +6958,9 @@ Object AirF_AmericaVehicleSentryDrone
   End
   Behavior = AutoHealBehavior ModuleTag_13
     StartsActive  = Yes
-    HealingAmount = 1
+    HealingAmount = 2
     HealingDelay  = 1000
+    StartHealingDelay = 3000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6836,6 +6836,7 @@ Object AirF_AmericaVehicleSentryDrone
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
   ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
+  ; Patch104p @balance Stubbjax 25/08/2022 Removed deployment times, reduced price, reduced build time, fixed stealth sounds, added auto-healing ability.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6844,6 +6844,8 @@ Object AirF_AmericaVehicleSentryDrone
   VoiceAttack           = SentryDroneVoiceMove
   SoundMoveStart        = SentryDroneMoveStart
   SoundMoveStartDamaged = SentryDroneMoveStart
+  SoundStealthOn        = StealthOn
+  SoundStealthOff       = StealthOff
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = SentryDroneVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6820,7 +6820,7 @@ Object AirF_AmericaVehicleSentryDrone
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600
-  BuildTime       = 10.0          ;in seconds
+  BuildTime       = 8.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1674,7 +1674,7 @@ Object MISSION_AmericaVehicleSentryDrone
     Armor           = HumveeArmor
     DamageFX        = TruckDamageFX
   End
-  BuildCost       = 800
+  BuildCost       = 600
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 180
   ShroudClearingRange = 350

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1689,6 +1689,8 @@ Object MISSION_AmericaVehicleSentryDrone
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = AmericaVehicleSentryDroneCommandSet
 
+  ; Patch104p @balance Stubbjax 25/08/2022 Removed deployment times, reduced price, reduced build time, fixed stealth sounds, added auto-healing ability.
+
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect
   VoiceMove             = SentryDroneVoiceMove

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1675,7 +1675,7 @@ Object MISSION_AmericaVehicleSentryDrone
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600
-  BuildTime       = 10.0          ;in seconds
+  BuildTime       = 8.0          ;in seconds
   VisionRange     = 180
   ShroudClearingRange = 350
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1793,8 +1793,9 @@ Object MISSION_AmericaVehicleSentryDrone
   End
   Behavior = AutoHealBehavior ModuleTag_13
     StartsActive  = Yes
-    HealingAmount = 1
+    HealingAmount = 2
     HealingDelay  = 1000
+    StartHealingDelay = 3000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1696,6 +1696,8 @@ Object MISSION_AmericaVehicleSentryDrone
   VoiceAttack           = SentryDroneVoiceMove
   SoundMoveStart        = NoSound
   SoundMoveStartDamaged = NoSound
+  SoundStealthOn        = StealthOn
+  SoundStealthOff       = StealthOff
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1729,10 +1729,10 @@ Object MISSION_AmericaVehicleSentryDrone
       MaxIdleScanAngle      = 360     ; in degrees off the natural turret angle
     End
     AutoAcquireEnemiesWhenIdle = Yes
-    PackTime = 1000
-    UnpackTime = 1000
+    PackTime = 0
+    UnpackTime = 0
     TurretsFunctionOnlyWhenDeployed = Yes
-    TurretsMustCenterBeforePacking = Yes
+    TurretsMustCenterBeforePacking = No
   End
 
   Locomotor = SET_NORMAL SentryLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1789,6 +1789,12 @@ Object MISSION_AmericaVehicleSentryDrone
     DetectionRate             = 900   ; how often to rescan for stealthed things in my sight (msec)
     ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
   End
+  Behavior = AutoHealBehavior ModuleTag_13
+    StartsActive  = Yes
+    HealingAmount = 1
+    HealingDelay  = 1000
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 9.0
   GeometryMinorRadius = 7.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2297,6 +2297,12 @@ Object AmericaVehicleSentryDrone
     DetectionRate            = 900   ; how often to rescan for stealthed things in my sight (msec)
     DetectionRange           = 225 ;Dustin, enable this for independant balancing!
   End
+  Behavior = AutoHealBehavior ModuleTag_13
+    StartsActive  = Yes
+    HealingAmount = 1
+    HealingDelay  = 1000
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 9.0
   GeometryMinorRadius = 7.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2237,10 +2237,10 @@ Object AmericaVehicleSentryDrone
       MaxIdleScanAngle      = 360     ; in degrees off the natural turret angle
     End
     AutoAcquireEnemiesWhenIdle = Yes ;Stealthed ; Means "Yes when idle, even if I am stealthed"
-    PackTime = 1000
-    UnpackTime = 1000
+    PackTime = 0
+    UnpackTime = 0
     TurretsFunctionOnlyWhenDeployed = Yes
-    TurretsMustCenterBeforePacking = Yes
+    TurretsMustCenterBeforePacking = No
   End
 
   Locomotor = SET_NORMAL SentryLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2161,7 +2161,7 @@ Object AmericaVehicleSentryDrone
     Armor           = SentryDroneArmor
     DamageFX        = TruckDamageFX
   End
-  BuildCost       = 800
+  BuildCost       = 600
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2162,7 +2162,7 @@ Object AmericaVehicleSentryDrone
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600
-  BuildTime       = 10.0          ;in seconds
+  BuildTime       = 8.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2178,6 +2178,7 @@ Object AmericaVehicleSentryDrone
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects when damaged.
   ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
+  ; Patch104p @balance Stubbjax 25/08/2022 Removed deployment times, reduced price, reduced build time, fixed stealth sounds, added auto-healing ability.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2300,8 +2300,9 @@ Object AmericaVehicleSentryDrone
   End
   Behavior = AutoHealBehavior ModuleTag_13
     StartsActive  = Yes
-    HealingAmount = 1
+    HealingAmount = 2
     HealingDelay  = 1000
+    StartHealingDelay = 3000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2186,6 +2186,8 @@ Object AmericaVehicleSentryDrone
   VoiceAttack           = SentryDroneVoiceMove
   SoundMoveStart        = SentryDroneMoveStart
   SoundMoveStartDamaged = SentryDroneMoveStart
+  SoundStealthOn        = StealthOn
+  SoundStealthOff       = StealthOff
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = SentryDroneVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19918,6 +19918,7 @@ Object Boss_VehicleSentryDrone
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
   ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
+  ; Patch104p @balance Stubbjax 25/08/2022 Removed deployment times, reduced price, reduced build time, fixed stealth sounds, added auto-healing ability.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19901,7 +19901,7 @@ Object Boss_VehicleSentryDrone
     Armor           = SentryDroneArmor
     DamageFX        = TruckDamageFX
   End
-  BuildCost       = 800
+  BuildCost       = 600
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20039,8 +20039,9 @@ Object Boss_VehicleSentryDrone
   End
   Behavior = AutoHealBehavior ModuleTag_13
     StartsActive  = Yes
-    HealingAmount = 1
+    HealingAmount = 2
     HealingDelay  = 1000
+    StartHealingDelay = 3000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19976,10 +19976,10 @@ Object Boss_VehicleSentryDrone
       MaxIdleScanAngle      = 360     ; in degrees off the natural turret angle
     End
     AutoAcquireEnemiesWhenIdle = Yes ;Stealthed ; Means "Yes when idle, even if I am stealthed"
-    PackTime = 1000
-    UnpackTime = 1000
+    PackTime = 0
+    UnpackTime = 0
     TurretsFunctionOnlyWhenDeployed = Yes
-    TurretsMustCenterBeforePacking = Yes
+    TurretsMustCenterBeforePacking = No
   End
 
   Locomotor = SET_NORMAL SentryLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19926,6 +19926,8 @@ Object Boss_VehicleSentryDrone
   VoiceAttack           = SentryDroneVoiceMove
   SoundMoveStart        = SentryDroneMoveStart
   SoundMoveStartDamaged = SentryDroneMoveStart
+  SoundStealthOn        = StealthOn
+  SoundStealthOff       = StealthOff
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = SentryDroneVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19902,7 +19902,7 @@ Object Boss_VehicleSentryDrone
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600
-  BuildTime       = 10.0          ;in seconds
+  BuildTime       = 8.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20036,6 +20036,12 @@ Object Boss_VehicleSentryDrone
     DetectionRate            = 900   ; how often to rescan for stealthed things in my sight (msec)
     DetectionRange           = 225 ;Dustin, enable this for independant balancing!
   End
+  Behavior = AutoHealBehavior ModuleTag_13
+    StartsActive  = Yes
+    HealingAmount = 1
+    HealingDelay  = 1000
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 9.0
   GeometryMinorRadius = 7.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6531,7 +6531,7 @@ Object Lazr_AmericaVehicleSentryDrone
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600
-  BuildTime       = 10.0          ;in seconds
+  BuildTime       = 8.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6530,7 +6530,7 @@ Object Lazr_AmericaVehicleSentryDrone
     Armor           = SentryDroneArmor
     DamageFX        = TruckDamageFX
   End
-  BuildCost       = 800
+  BuildCost       = 600
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6666,6 +6666,12 @@ Object Lazr_AmericaVehicleSentryDrone
     DetectionRate            = 900   ; how often to rescan for stealthed things in my sight (msec)
     DetectionRange           = 225 ;Dustin, enable this for independant balancing!
   End
+  Behavior = AutoHealBehavior ModuleTag_13
+    StartsActive  = Yes
+    HealingAmount = 1
+    HealingDelay  = 1000
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 9.0
   GeometryMinorRadius = 7.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6606,10 +6606,10 @@ Object Lazr_AmericaVehicleSentryDrone
       MaxIdleScanAngle      = 360     ; in degrees off the natural turret angle
     End
     AutoAcquireEnemiesWhenIdle = Yes ;Stealthed ; Means "Yes when idle, even if I am stealthed"
-    PackTime = 1000
-    UnpackTime = 1000
+    PackTime = 0
+    UnpackTime = 0
     TurretsFunctionOnlyWhenDeployed = Yes
-    TurretsMustCenterBeforePacking = Yes
+    TurretsMustCenterBeforePacking = No
   End
 
   Locomotor = SET_NORMAL SentryLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6555,6 +6555,8 @@ Object Lazr_AmericaVehicleSentryDrone
   VoiceAttack           = SentryDroneVoiceMove
   SoundMoveStart        = SentryDroneMoveStart
   SoundMoveStartDamaged = SentryDroneMoveStart
+  SoundStealthOn        = StealthOn
+  SoundStealthOff       = StealthOff
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = SentryDroneVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6669,8 +6669,9 @@ Object Lazr_AmericaVehicleSentryDrone
   End
   Behavior = AutoHealBehavior ModuleTag_13
     StartsActive  = Yes
-    HealingAmount = 1
+    HealingAmount = 2
     HealingDelay  = 1000
+    StartHealingDelay = 3000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6547,6 +6547,7 @@ Object Lazr_AmericaVehicleSentryDrone
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
   ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
+  ; Patch104p @balance Stubbjax 25/08/2022 Removed deployment times, reduced price, reduced build time, fixed stealth sounds, added auto-healing ability.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7076,10 +7076,10 @@ Object SupW_AmericaVehicleSentryDrone
       MaxIdleScanAngle      = 360     ; in degrees off the natural turret angle
     End
     AutoAcquireEnemiesWhenIdle = Yes ;Stealthed ; Means "Yes when idle, even if I am stealthed"
-    PackTime = 1000
-    UnpackTime = 1000
+    PackTime = 0
+    UnpackTime = 0
     TurretsFunctionOnlyWhenDeployed = Yes
-    TurretsMustCenterBeforePacking = Yes
+    TurretsMustCenterBeforePacking = No
   End
 
   Locomotor = SET_NORMAL SentryLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7017,6 +7017,7 @@ Object SupW_AmericaVehicleSentryDrone
 
   ; Patch104p @bugfix commy2 04/09/2021 Added missing move start sound effects from vanilla USA Sentry Drone.
   ; Patch104p @bugfix commy2 09/09/2021 Added missing sound when unit leaves factory.
+  ; Patch104p @balance Stubbjax 25/08/2022 Removed deployment times, reduced price, reduced build time, fixed stealth sounds, added auto-healing ability.
 
   ; *** AUDIO Parameters ***
   VoiceSelect           = SentryDroneVoiceSelect

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7001,7 +7001,7 @@ Object SupW_AmericaVehicleSentryDrone
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600
-  BuildTime       = 10.0          ;in seconds
+  BuildTime       = 8.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7136,6 +7136,12 @@ Object SupW_AmericaVehicleSentryDrone
     DetectionRate            = 900   ; how often to rescan for stealthed things in my sight (msec)
     DetectionRange           = 225 ;Dustin, enable this for independant balancing!
   End
+  Behavior = AutoHealBehavior ModuleTag_13
+    StartsActive  = Yes
+    HealingAmount = 1
+    HealingDelay  = 1000
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 9.0
   GeometryMinorRadius = 7.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7000,7 +7000,7 @@ Object SupW_AmericaVehicleSentryDrone
     Armor           = SentryDroneArmor
     DamageFX        = TruckDamageFX
   End
-  BuildCost       = 1000
+  BuildCost       = 600
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 200
   ShroudClearingRange = 350

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7139,8 +7139,9 @@ Object SupW_AmericaVehicleSentryDrone
   End
   Behavior = AutoHealBehavior ModuleTag_13
     StartsActive  = Yes
-    HealingAmount = 1
+    HealingAmount = 2
     HealingDelay  = 1000
+    StartHealingDelay = 3000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7025,6 +7025,8 @@ Object SupW_AmericaVehicleSentryDrone
   VoiceAttack           = SentryDroneVoiceMove
   SoundMoveStart        = SentryDroneMoveStart
   SoundMoveStartDamaged = SentryDroneMoveStart
+  SoundStealthOn        = StealthOn
+  SoundStealthOff       = StealthOff
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     VoiceCreate         = SentryDroneVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -183,10 +183,11 @@ Upgrade Upgrade_AmericaChemicalSuits
   ResearchSound      = RangerVoiceUpgradeChemSuits
 End
 
+; Patch104p @balance Stubbjax 08/09/2022 Reduced cost and research time by 50%.
 Upgrade Upgrade_AmericaSentryDroneGun
   DisplayName        = UPGRADE:AmericaSentryDroneGun
-  BuildTime          = 30.0
-  BuildCost          = 1000
+  BuildTime          = 15.0
+  BuildCost          = 500
   ButtonImage        = SASentryUpgr
 End
 


### PR DESCRIPTION
* old PR: #970
* Fixes: #862

Improved Sentry Drones so that they don't suck as much. This implementation comprises several proposals from https://github.com/TheSuperHackers/GeneralsGamePatch/issues/862. Further adjustments may be necessary, but this should form a solid, low-risk foundation.

### Summary of changes:

- Removed the invisible 1s pack and unpack delays
- Reduced prices from $1000/$850/$800 to $600
- Reduced build times from 10s to 8s
- Added a minor healing function of 1hp / second (Sentries have 300hp)
- Fixed the lack of stealth / unstealth sounds
- Reduced machine gun upgrade cost and research time from $1000 / 30s to $500 / 15s

### Footage of changes:

https://user-images.githubusercontent.com/11547761/186616126-7ad02caf-25bc-4d73-94ae-d2177e487faf.mp4

The footage should hopefully demonstrate the greatly improved responsiveness of the drones, as well as their minor healing ability.

### Rationale:

These changes should assist in making Sentry Drones more versatile and provide greater strategic diversity for USA factions to employ, without boosting them too much that they become a primary strategy and change the way USA is typically played.

#### Fix the broken weapon deployment behaviour

It goes without saying that Sentry Drones would be better off without the strange and invisible “weapon deployment” delay that occurs between firing and moving.

#### Reduce and standardise prices

Sentry Drones are considerably expensive units for what they do, and a Humvee with a scout drone is almost always a more cost-effective and versatile option. Reducing the price of Sentry Drones from $1000/$850/$800 to $600 would be an effective and low-risk way to boost utility, due to the fact that they serve a very specific purpose that is already readily available elsewhere, and are otherwise never used.

#### Reduce construction time

Another effective means of increasing utility is to decrease the build time from 10 to 8 seconds. Note that Sentry Drones still require the Sentry Drone Gun upgrade to become useful in combat, which prevents a reduced construction time (and several other improvements) from opening up early Sentry Drone-based strategies and potentially affecting traditional gameplay too much.

#### Add auto-repair capability

As Sentry Drones cannot rank up, a good addition would be to give them auto-repair capabilities. This would not only distinguish the unit from other vehicles a bit more, but would allow for a unique tactic where players can command the unit to stop and restealth in order to heal up at the cost of time and the opponent likely remembering the unit’s location.