### PR TITLE
Add: Heal Effect to Tech Radio Station

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -1143,8 +1143,8 @@ Object TechRadioStation
   RadarPriority       = STRUCTURE
 
   Body                = ActiveBody ModuleTag_04
-    MaxHealth         = 1500.0
-    InitialHealth     = 1500.0
+    MaxHealth         = 1000.0
+    InitialHealth     = 1000.0
   End
 
   ;Behavior = ActiveShroudUpgrade ModuleTag_05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -1143,8 +1143,8 @@ Object TechRadioStation
   RadarPriority       = STRUCTURE
 
   Body                = ActiveBody ModuleTag_04
-    MaxHealth         = 1000.0
-    InitialHealth     = 1000.0
+    MaxHealth         = 1500.0
+    InitialHealth     = 1500.0
   End
 
   ;Behavior = ActiveShroudUpgrade ModuleTag_05
@@ -1160,6 +1160,16 @@ Object TechRadioStation
   ;  UpgradeToGrant           = Upgrade_AmericaRadar
   ;  ExemptStatus      = UNDER_CONSTRUCTION
   ;End
+
+  Behavior        = PropagandaTowerBehavior ModuleTag_06Prop
+    Radius                = 250.0
+    DelayBetweenUpdates   = 2000 ; in milliseconds
+    HealPercentEachSecond = 5%   ; get this % of max health every second
+    PulseFX               = FX_PropagandaTowerSubliminalPulse ;plays as often as DelayBetweenUpdates
+    UpgradeRequired       = Upgrade_GLAWorkerFakeCommandSet 
+    UpgradedHealPercentEachSecond = 5%   ; get this % of max health every second
+    UpgradedPulseFX       = FX_PropagandaTowerSubliminalPulse ;plays as often as DelayBetweenUpdates
+  End
 
   Behavior                  = CreateObjectDie ModuleTag_08
     CreationList       = OCL_LargeStructureDebris


### PR DESCRIPTION
* old PR: #623

Jundiyy thinks it could have a bit more health.

He knows it wasn't given any modules in the end but he thinks it's good to have something as a starting ground, so it can at least be placed and used by the simple mappers, if anyone wants to give it some extra abilities and have map.ini knowledge, they can do what they want.

He thought having a Speaker Tower styled Tech building seemed quite cool. Has a larger radius than the Speaker Tower, allowing players to use the Tech as a key fighting area.

(Of course it's not going to be built by the USA Dozer but just to show how it works.)

https://youtu.be/eNZvtTivvqQ
