### PR TITLE
Fix firing elevation limits

### DIFF
--- a/Patch104pZH/Design/Tasks/nproject_tasks.txt
+++ b/Patch104pZH/Design/Tasks/nproject_tasks.txt
@@ -178,7 +178,7 @@ the list of known bugs and how to prevent them. If you encounter bugs that not l
  - [MAYBE]       All factions Cargo Planes now have equal stats
  - [IMPROVEMENT][MINOR] Fixed the Cargo Plane propeller texture error that have small thin gray lines
  - [MAYBE]       Standardized unit transport size. Like an Overlord that needs more transport slot than a Technical
- - [IMPROVEMENT][MAJOR] Fixed the issues with firing elevation limit. Now both tanks and artillery can attack very high/low targets alike
+ - [DONE][MAJOR] Fixed the issues with firing elevation limit. Now both tanks and artillery can attack very high/low targets alike
  Reason: Certain maps have topology which can force units to path around to reach their targets, even if it is within reach of their weapon.
  - [NOTRELEVANT] Tank armor received damage from INFANTRY_MISSILE reduced from 100% to 85%
  - [NOTRELEVANT] Tank armor received damage from POISON reduced from 25% to 15%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -4716,6 +4716,9 @@ Weapon GLAAngryMobMolotovCocktailProjectileWeapon
   PreAttackDelay = 500 ;2000    ; linked to the length of throw animation
   PreAttackType = PER_SHOT ; Do the delay every single shot
   ProjectileDetonationFX = WeaponFX_MolotovCocktailDetonation
+ ; Patch104p @bugfix hanfield 29/08/2021 Removed MaxTargetPitch.
+ ; This parameter made units perform poorly on rough terrain.
+
   ;MaxTargetPitch = 57 ; this is important so that they do not lob the bottles on their mobmates
 
   ProjectileCollidesWith = STRUCTURES WALLS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -19,8 +19,11 @@ Weapon MarauderTankGun
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 170.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 300                           ; dist/sec
@@ -48,8 +51,11 @@ Weapon MarauderTankGunUpgradeOne
   PrimaryDamageRadius = 5.0
   AttackRange = 170.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 400                           ; dist/sec
@@ -76,8 +82,11 @@ Weapon MarauderTankGunUpgradeTwo
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 170.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 500                           ; dist/sec
@@ -104,8 +113,11 @@ Weapon ScorpionTankGun
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 150.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 400                           ; dist/sec
@@ -166,8 +178,11 @@ Weapon ScorpionTankGunPlusOne
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 150.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 400                           ; dist/sec
@@ -238,8 +253,11 @@ Weapon OverlordTankGun
   SecondaryDamage = 20.0
   SecondaryDamageRadius = 10.0
   AttackRange = 175.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 300                           ; dist/sec
@@ -270,8 +288,11 @@ Weapon StrategyCenterGun
   ScatterRadiusVsInfantry = 15.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 400.0
   MinimumAttackRange = 100.0
-  MinTargetPitch = 45                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 80                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = 45                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 80                          ; ditto
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 150                           ; dist/sec
@@ -298,8 +319,11 @@ Weapon BattleMasterTankGun
   PrimaryDamageRadius     = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange             = 150.0
-  MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch          = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch          = 15                          ; ditto
   DamageType              = ARMOR_PIERCING
   DeathType               = NORMAL
   WeaponSpeed             = 400                           ; dist/sec
@@ -327,8 +351,11 @@ Weapon CrusaderTankGun
   PrimaryDamageRadius     = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange             = 150.0
-  MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch          = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch          = 15                          ; ditto
   DamageType              = ARMOR_PIERCING
   DeathType               = NORMAL
   WeaponSpeed             = 400                           ; dist/sec
@@ -351,8 +378,11 @@ Weapon PaladinTankGun
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 150.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 300                           ; dist/sec
@@ -506,8 +536,11 @@ Weapon TechnicalCannonWeapon
   PrimaryDamageRadius       = 25.0
   ScatterRadiusVsInfantry   = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange               = 150.0
-  MinTargetPitch            = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch            = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch            = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch            = 15                          ; ditto
   DamageType                = GATTLING
   DeathType                 = EXPLODED
   WeaponSpeed               = 300                          ; dist/sec
@@ -1496,7 +1529,7 @@ Weapon ToxinShellWeaponUpgraded ; No extra damage, just lays down a damage field
   DeathType = EXPLODED
   WeaponSpeed = 99999.0
   ProjectileObject = NONE
-  FireFX = WeaponFX_ToxinShellWeaponUpgraded  ; Patch104p @bugfix commy2 28/08/2021 Fixes Toxin Shells losing impact effect after Anthrax upgrade.
+  FireFX = WeaponFX_ToxinShellWeaponUpgraded ; Patch104p @bugfix commy2 28/08/2021 Fixes Toxin Shells losing impact effect after Anthrax upgrade.
   FireOCL = OCL_PoisonFieldUpgradedSmall
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 0                   ; time between shots, msec
@@ -1607,7 +1640,7 @@ Weapon ScudStormWeapon
   ProjectileExhaust = ScudMissileExhaust
   FireFX = WeaponFX_ScudStormMissile
   FireSound = ScudStormLaunch
-  ;ProjectileDetonationFX = ScudStormMissileDetonation  ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
+  ;ProjectileDetonationFX = ScudStormMissileDetonation ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = Min:100 Max:1000
   ClipSize = 9
@@ -1669,7 +1702,7 @@ Weapon ScudStormDamageWeaponUpgraded
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 600         ; dist/sec
-  FireFX = ScudStormMissileDetonationUpgraded   ; Patch104p @bugfix Use blue particle effect when missile is upgraded with Anthrax Beta. commy2 27/08/2021
+  FireFX = ScudStormMissileDetonationUpgraded  ; Patch104p @bugfix Use blue particle effect when missile is upgraded with Anthrax Beta. commy2 27/08/2021
   FireOCL = OCL_PoisonFieldUpgradedLarge  ; So this weapon will do normal damage, and create this object
   RadiusDamageAffects = SELF ALLIES ENEMIES NEUTRALS  ; Patch104p @bugfix commy2 11/09/2021 Fix Scud Storm immune when hitting itself.
   DelayBetweenShots = 0               ; time between shots, msec
@@ -3829,8 +3862,11 @@ Weapon InfernoCannonGun
   ScatterRadiusVsInfantry     = 30.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 300
   MinimumAttackRange = 50.0
-  MinTargetPitch = -90
-  MaxTargetPitch = 79
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -90
+  ;MaxTargetPitch = 79
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 250         ; dist/sec
@@ -3859,8 +3895,11 @@ Weapon InfernoCannonGunUpgraded
   ScatterRadiusVsInfantry     = 30.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 300
   MinimumAttackRange = 50.0
-  MinTargetPitch = -90
-  MaxTargetPitch = 79
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -90
+  ;MaxTargetPitch = 79
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 250         ; dist/sec
@@ -4677,7 +4716,7 @@ Weapon GLAAngryMobMolotovCocktailProjectileWeapon
   PreAttackDelay = 500 ;2000    ; linked to the length of throw animation
   PreAttackType = PER_SHOT ; Do the delay every single shot
   ProjectileDetonationFX = WeaponFX_MolotovCocktailDetonation
-  MaxTargetPitch = 57 ; this is important so that they do not lob the bottles on their mobmates
+  ;MaxTargetPitch = 57 ; this is important so that they do not lob the bottles on their mobmates
 
   ProjectileCollidesWith = STRUCTURES WALLS
 End
@@ -5131,8 +5170,11 @@ Weapon MilitiaTankGun
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 120.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 400                           ; dist/sec
@@ -5204,8 +5246,11 @@ Weapon ArtilleryPlatformGun
   ScatterRadiusVsInfantry = 15.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 350.0 ;500.0
   MinimumAttackRange = 50.0
-  MinTargetPitch = -10                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 80                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -10                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 80                          ; ditto
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 150                           ; dist/sec
@@ -6034,8 +6079,11 @@ Weapon BattleShipGunReal
   ScatterRadiusVsInfantry = 15.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 20000.0
   MinimumAttackRange = 50.0
-  MinTargetPitch = 45                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 80                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = 45                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 80                          ; ditto
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 500                           ; dist/sec
@@ -6112,8 +6160,11 @@ Weapon FireBaseHowitzerGun
   ScatterRadiusVsInfantry = 15.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 275.0
   MinimumAttackRange = 50.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = EXPLOSION
   DeathType = NORMAL
   WeaponSpeed = 300         ; dist/sec
@@ -6146,7 +6197,7 @@ Weapon Chem_ToxinShellWeaponGamma ; No extra damage, just lays down a damage fie
   DeathType = EXPLODED
   WeaponSpeed = 99999.0
   ProjectileObject = NONE
-  FireFX = Chem_WeaponFX_ToxinShellWeaponGamma  ; Patch104p @bugfix commy2 28/08/2021 Fixes Toxin Shells losing impact effect after Anthrax upgrade.
+  FireFX = Chem_WeaponFX_ToxinShellWeaponGamma ; Patch104p @bugfix commy2 28/08/2021 Fixes Toxin Shells losing impact effect after Anthrax upgrade.
   FireOCL = OCL_PoisonFieldGammaSmall
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 0                   ; time between shots, msec
@@ -6337,8 +6388,11 @@ Weapon Tank_BattleMasterTankGun
   PrimaryDamageRadius     = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange             = 150.0
-  MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch          = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch          = 15                          ; ditto
   DamageType              = ARMOR_PIERCING
   DeathType               = NORMAL
   WeaponSpeed             = 400                           ; dist/sec
@@ -6371,8 +6425,11 @@ Weapon Tank_OverlordTankGun
   SecondaryDamage = 20.0
   SecondaryDamageRadius = 10.0
   AttackRange = 175.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 300                           ; dist/sec
@@ -6516,8 +6573,11 @@ Weapon Lazr_CrusaderTankGun
   PrimaryDamageRadius     = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange             = 150.0
-  MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch          = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch          = 15                          ; ditto
   DamageType              = ARMOR_PIERCING
   DeathType               = NORMAL
   WeaponSpeed             = 99999                           ; dist/sec
@@ -6540,8 +6600,11 @@ Weapon Lazr_PaladinTankGun
   PrimaryDamageRadius = 3.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 150.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 99999                           ; dist/sec
@@ -6692,7 +6755,7 @@ Weapon GC_Chem_ScudStormWeapon
   ProjectileExhaust = ScudMissileExhaust
   FireFX = WeaponFX_ScudStormMissile
   FireSound = ScudStormLaunch
-  ;ProjectileDetonationFX = ScudStormMissileDetonation  ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
+  ;ProjectileDetonationFX = ScudStormMissileDetonation ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = Min:100 Max:1000
   ClipSize = 9
@@ -6738,7 +6801,7 @@ Weapon Chem_ScudStormDamageWeaponGamma
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 600         ; dist/sec
-  FireFX = Chem_ScudStormMissileDetonationGamma   ; Patch104p @bugfix Use pink particle effect when missile is upgraded with Anthrax Gamma. commy2 27/08/2021
+  FireFX = Chem_ScudStormMissileDetonationGamma  ; Patch104p @bugfix Use pink particle effect when missile is upgraded with Anthrax Gamma. commy2 27/08/2021
   FireOCL = OCL_PoisonFieldGammaLarge  ; So this weapon will do normal damage, and create this object
   RadiusDamageAffects = SELF ALLIES ENEMIES NEUTRALS  ; Patch104p @bugfix commy2 11/09/2021 Fix Scud Storm immune when hitting itself.
   DelayBetweenShots = 0               ; time between shots, msec
@@ -7310,8 +7373,11 @@ Weapon Chem_ScorpionTankGunPlusOne
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 150.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 400                           ; dist/sec
@@ -7794,7 +7860,7 @@ Weapon Demo_ScudStormWeapon
   ProjectileExhaust = ScudMissileExhaust
   FireFX = WeaponFX_ScudStormMissile
   FireSound = ScudStormLaunch
-  ;ProjectileDetonationFX = ScudStormMissileDetonation  ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
+  ;ProjectileDetonationFX = ScudStormMissileDetonation ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = Min:100 Max:1000
   ClipSize = 9
@@ -7877,8 +7943,11 @@ Weapon Nuke_BattleMasterTankGun
   PrimaryDamageRadius     = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange             = 150.0
-  MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch          = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch          = 15                          ; ditto
   DamageType              = ARMOR_PIERCING
   DeathType               = NORMAL
   WeaponSpeed             = 400                           ; dist/sec
@@ -7960,8 +8029,11 @@ Weapon Nuke_OverlordTankGun
   SecondaryDamage = 20.0
   SecondaryDamageRadius = 10.0
   AttackRange = 175.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 300                           ; dist/sec
@@ -8056,7 +8128,7 @@ Weapon Chem_ScudStormWeapon
   ProjectileExhaust = ScudMissileExhaust
   FireFX = WeaponFX_ScudStormMissile
   FireSound = ScudStormLaunch
-  ;ProjectileDetonationFX = ScudStormMissileDetonation  ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
+  ;ProjectileDetonationFX = ScudStormMissileDetonation ; Patch104p @bugfix commy2 27/08/2021 Lets projectile detonation weapon choose the correct effect depending on the upgrade.
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = Min:100 Max:1000
   ClipSize = 9
@@ -8326,8 +8398,11 @@ Weapon REDMarauderTankGun
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 170.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 300                           ; dist/sec
@@ -8355,8 +8430,11 @@ Weapon REDMarauderTankGunUpgradeOne
   PrimaryDamageRadius = 5.0
   AttackRange = 170.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 400                           ; dist/sec
@@ -8383,8 +8461,11 @@ Weapon REDMarauderTankGunUpgradeTwo
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 170.0
-  MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
-  MaxTargetPitch = 15                          ; ditto
+  ; Patch104p @bugfix hanfield 29/08/2021 Removed Min/MaxTargetPitch.
+  ; This parameter made units perform poorly on rough terrain.
+ 
+  ;MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
+  ;MaxTargetPitch = 15                          ; ditto
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 500                           ; dist/sec


### PR DESCRIPTION
* old PR: #111

All weapons which previously had TargetPitch parameters no longer have this. This allows them to acquire targets regardless of minor elevation differences.