### PR TITLE
Scud Storm launch can no longer be cancelled by accident

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5680,6 +5680,12 @@ Object Chem_GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -5002,6 +5002,12 @@ Object Demo_GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13547,6 +13547,12 @@ Object GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
+  
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5730,6 +5730,11 @@ Object Slth_GLAScudStorm
     DeathFX       = FX_BuildingDie
   End
 
+  ; Patch104p @bugfix hanfield 06/09/2021 Added LockWeaponCreate to prevent the Scud Storm weapon from switching to primary 
+  ; if a player changes - or forces to change - targets while the Scud Launcher is firing
+  Behavior = LockWeaponCreate ModuleTag_ScudBugFix
+    SlotToLock = SECONDARY 
+  End
 ;  Behavior = GrantUpgradeCreate ModuleTag_900
 ;    UpgradeToGrant = Upgrade_GLACamoNetting
 ;  End


### PR DESCRIPTION
* old PR: #234

Scud Storm, if given a target or ordered to force fire while launching, would try to swap to a non-existent primary weapon and thereby stop the launch. This commit fixes that.