### PR TITLE
Quad Test "Normal Generic Vet"

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2736,6 +2736,15 @@ Weapon QuadCannonGun
   AntiAirborneVehicle   = No
   AntiAirborneInfantry  = No
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; APBullets
+  WeaponBonus           = VETERAN RATE_OF_FIRE  80%
+  WeaponBonus           = VETERAN DAMAGE        125%
+  WeaponBonus           = ELITE   RATE_OF_FIRE  60%
+  WeaponBonus           = ELITE   DAMAGE        150%
+  WeaponBonus           = HERO    RATE_OF_FIRE  40%
+  WeaponBonus           = HERO    DAMAGE        175%
+  WeaponBonus           = TARGET_FAERIE_FIRE  RATE_OF_FIRE  50%
+  WeaponBonus           = ENTHUSIASTIC        RATE_OF_FIRE  75%
+  WeaponBonus           = SUBLIMINAL          RATE_OF_FIRE  75%
 End
 
 ;------------------------------------------------------------------------------
@@ -2758,11 +2767,20 @@ Weapon QuadCannonGunAir
   AntiAirborneInfantry  = Yes
   AntiGround = No
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; APBullets
+  WeaponBonus           = VETERAN RATE_OF_FIRE  80%
+  WeaponBonus           = VETERAN DAMAGE        125%
+  WeaponBonus           = ELITE   RATE_OF_FIRE  60%
+  WeaponBonus           = ELITE   DAMAGE        150%
+  WeaponBonus           = HERO    RATE_OF_FIRE  40%
+  WeaponBonus           = HERO    DAMAGE        175%
+  WeaponBonus           = TARGET_FAERIE_FIRE  RATE_OF_FIRE  50%
+  WeaponBonus           = ENTHUSIASTIC        RATE_OF_FIRE  75%
+  WeaponBonus           = SUBLIMINAL          RATE_OF_FIRE  75%
 End
 
 ;------------------------------------------------------------------------------
 Weapon QuadCannonGunUpgradeOne
-  PrimaryDamage         = 8.0
+  PrimaryDamage         = 6.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 150.0
   DamageType            = SMALL_ARMS
@@ -2779,11 +2797,14 @@ Weapon QuadCannonGunUpgradeOne
   AntiAirborneVehicle   = No
   AntiAirborneInfantry  = No
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; APBullets
+  WeaponBonus           = VETERAN DAMAGE        125%
+  WeaponBonus           = ELITE   DAMAGE        150%
+  WeaponBonus           = HERO    DAMAGE        175%
 End
 
 ;------------------------------------------------------------------------------
 Weapon QuadCannonGunUpgradeOneAir
-  PrimaryDamage         = 5.0
+  PrimaryDamage         = 3.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 350.0
   DamageType            = SMALL_ARMS
@@ -2801,11 +2822,14 @@ Weapon QuadCannonGunUpgradeOneAir
   AntiAirborneInfantry  = Yes
   AntiGround = No
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; APBullets
+  WeaponBonus           = VETERAN DAMAGE        125%
+  WeaponBonus           = ELITE   DAMAGE        150%
+  WeaponBonus           = HERO    DAMAGE        175%
 End
 
 ;------------------------------------------------------------------------------
 Weapon QuadCannonGunUpgradeTwo
-  PrimaryDamage         = 8.0
+  PrimaryDamage         = 7.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 150.0
   DamageType            = SMALL_ARMS
@@ -2816,17 +2840,20 @@ Weapon QuadCannonGunUpgradeTwo
   VeterancyFireFX       = HEROIC WeaponFX_HeroicQuadCannonGunFire
   FireSound             = QuadCannonWeapon
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 25 ;125               ; time between shots, msec
+  DelayBetweenShots     = 50; 25 ;125               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AntiAirborneVehicle   = No
   AntiAirborneInfantry  = No
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; APBullets
+  WeaponBonus           = VETERAN DAMAGE        125%
+  WeaponBonus           = ELITE   DAMAGE        150%
+  WeaponBonus           = HERO    DAMAGE        175%
 End
 
 ;------------------------------------------------------------------------------
 Weapon QuadCannonGunUpgradeTwoAir
-  PrimaryDamage         = 5.0
+  PrimaryDamage         = 3.5
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 350.0
   DamageType            = SMALL_ARMS
@@ -2837,13 +2864,16 @@ Weapon QuadCannonGunUpgradeTwoAir
   VeterancyFireFX       = HEROIC WeaponFX_HeroicQuadCannonGunFire
   FireSound             = QuadCannonWeapon
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 25 ;125               ; time between shots, msec
+  DelayBetweenShots     = 50; 25 ;125               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = Yes
   AntiGround = No
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; APBullets
+  WeaponBonus           = VETERAN DAMAGE        125%
+  WeaponBonus           = ELITE   DAMAGE        150%
+  WeaponBonus           = HERO    DAMAGE        175%
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
* old PR: #359

# THIS IS FOR TESTING PURPOSES ONLY

#### 1.04 unbugged vet (all units, except Tractor):
| | ROF | DMG | DPS |
|------|-------|-------|-------|
| vet1 | +20% | +10% | +32% |
| vet2 | +40% | +20% | +68% |
| vet3 | +60% | +30% | +108% |

#### 1.04 Quad bugged vet (ROF quantization):
| | ROF | DMG | DPS |
|------------------|-------|-------|-------|
| vet1 | +100% | +10% | +120% |
| vet2 | +100% | +20% | +140% |
| vet3 | +100% | +30% | +160% |
| scrap +1, no vet | +100% | -20% | +60% |
| scrap +2, no vet | +100% | -20% | +60% |
| scrap +1, vet | 0% | -20% | - |
| scrap +2, vet | 0% | -20% | - |

#### This branch:
| | ROF | DMG | DPS |
|------------------|-------|-------|-------|
| vet1 | **0%** | **+35%** | +35% |
| vet2 | **0%** | **+70%** | +70% |
| vet3 | **0%** | **+105%** | +105% |
| scrap +1 | **+100%** | **-40%** | +20% |
| scrap +1, vet 1 | +100% | -19% | +62% |
| scrap +1, vet 2 | +100% | +2% | +104% |
| scrap +1, vet 3 | +100% | +23% | +146% |
| scrap +2 | **+100%** | **-30%** | +40% |
| scrap +2, vet 1 | +100% | -5.5% | +89% |
| scrap +2, vet 2 | +100% | +19% | +138% |
| scrap +2, vet 3 | +100% | +43.5% | +187% |
