### PR TITLE
Change: Remove assault behavior from China Troopcrawler

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -246,7 +246,8 @@ Object ChinaVehicleTroopCrawlerEmpty
   VoiceSelect = TroopCrawlerVoiceSelect
   VoiceMove = TroopCrawlerVoiceMove
   VoiceGuard = TroopCrawlerVoiceMove
-  VoiceAttack = TroopCrawlerVoiceAttack
+  ;VoiceAttack = TroopCrawlerVoiceAttack ; Patch104p @tweak disable because attack no longer does much other than driving
+  VoiceAttack = TroopCrawlerVoiceMove
   SoundMoveStart = TroopCrawlerMoveStart
   SoundMoveStartDamaged = TroopCrawlerMoveStart
   SoundEnter = HumveeEnter
@@ -299,9 +300,14 @@ Object ChinaVehicleTroopCrawlerEmpty
 ;      ControlledWeaponSlots = PRIMARY
 ;    End
 ;  End
-  Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
-    MembersGetHealedAtLifeRatio = 0.5
+
+  ; Patch104p @bugfix xezon 31/08/2022 Use 'TransportAIUpdate'
+  Behavior = TransportAIUpdate ModuleTag_Transport
   End
+
+  ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
+  ;  MembersGetHealedAtLifeRatio = 0.5
+  ;End
 
   Locomotor = SET_NORMAL TroopCrawlerLocomotor
   Behavior = PhysicsBehavior ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1119,7 +1119,8 @@ Object ChinaVehicleTroopCrawler
   VoiceSelect = TroopCrawlerVoiceSelect
   VoiceMove = TroopCrawlerVoiceMove
   VoiceGuard = TroopCrawlerVoiceMove
-  VoiceAttack = TroopCrawlerVoiceAttack
+  ;VoiceAttack = TroopCrawlerVoiceAttack ; Patch104p @tweak disable because attack no longer does much other than driving
+  VoiceAttack = TroopCrawlerVoiceMove
   SoundMoveStart = TroopCrawlerMoveStart
   SoundMoveStartDamaged = TroopCrawlerMoveStart
   SoundEnter = HumveeEnter
@@ -1174,9 +1175,14 @@ Object ChinaVehicleTroopCrawler
 ;      ControlledWeaponSlots = PRIMARY
 ;    End
 ;  End
-  Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
-    MembersGetHealedAtLifeRatio = 0.5
+
+  ; Patch104p @bugfix xezon 31/08/2022 Use regular 'TransportAIUpdate' instead of bugged 'AssaultTransportAIUpdate'.
+  Behavior = TransportAIUpdate ModuleTag_Transport
   End
+
+  ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
+  ;  MembersGetHealedAtLifeRatio = 0.5
+  ;End
 
   Locomotor = SET_NORMAL TroopCrawlerLocomotor
   Behavior = PhysicsBehavior ModuleTag_05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3232,7 +3232,8 @@ Object Nuke_ChinaVehicleTroopCrawler
   VoiceSelect = TroopCrawlerVoiceSelect
   VoiceMove = TroopCrawlerVoiceMove
   VoiceGuard = TroopCrawlerVoiceMove
-  VoiceAttack = TroopCrawlerVoiceAttack
+  ;VoiceAttack = TroopCrawlerVoiceAttack ; Patch104p @tweak disable because attack no longer does much other than driving
+  VoiceAttack = TroopCrawlerVoiceMove
   SoundMoveStart = TroopCrawlerMoveStart
   SoundMoveStartDamaged = TroopCrawlerMoveStart
   SoundEnter = HumveeEnter
@@ -3284,9 +3285,14 @@ Object Nuke_ChinaVehicleTroopCrawler
 ;      ControlledWeaponSlots = PRIMARY
 ;    End
 ;  End
-  Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
-    MembersGetHealedAtLifeRatio = 0.5
+
+  ; Patch104p @bugfix xezon 31/08/2022 Use regular 'TransportAIUpdate' instead of bugged 'AssaultTransportAIUpdate'.
+  Behavior = TransportAIUpdate ModuleTag_Transport
   End
+
+  ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
+  ;  MembersGetHealedAtLifeRatio = 0.5
+  ;End
 
   Locomotor = SET_NORMAL TroopCrawlerLocomotor
   Behavior = PhysicsBehavior ModuleTag_05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3857,7 +3857,8 @@ Object Tank_ChinaVehicleTroopCrawler
   VoiceSelect = TroopCrawlerVoiceSelect
   VoiceMove = TroopCrawlerVoiceMove
   VoiceGuard = TroopCrawlerVoiceMove
-  VoiceAttack = TroopCrawlerVoiceAttack
+  ;VoiceAttack = TroopCrawlerVoiceAttack ; Patch104p @tweak disable because attack no longer does much other than driving
+  VoiceAttack = TroopCrawlerVoiceMove
   SoundMoveStart = TroopCrawlerMoveStart
   SoundMoveStartDamaged = TroopCrawlerMoveStart
   SoundEnter = HumveeEnter
@@ -3909,9 +3910,14 @@ Object Tank_ChinaVehicleTroopCrawler
 ;      ControlledWeaponSlots = PRIMARY
 ;    End
 ;  End
-  Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
-    MembersGetHealedAtLifeRatio = 0.5
+
+  ; Patch104p @bugfix xezon 31/08/2022 Use regular 'TransportAIUpdate' instead of bugged 'AssaultTransportAIUpdate'.
+  Behavior = TransportAIUpdate ModuleTag_Transport
   End
+
+  ;Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
+  ;  MembersGetHealedAtLifeRatio = 0.5
+  ;End
 
   Locomotor = SET_NORMAL TroopCrawlerLocomotor
   Behavior = PhysicsBehavior ModuleTag_05


### PR DESCRIPTION
This change removes the assault behavior from China Troopcrawler, because it is buggy and exploitable to a certain extend.

The Troopcrawler now can be evacuated manually. The passengers cannot shoot out of the vehicle. Giving attack orders is still possible, so it can drive to attack targets with other units on attack command. The attack audio has been replaced with move audio, because it essentially no longer attacks.