### PR TITLE
Fix up Empty China Troopcrawler

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -171,19 +171,47 @@ Object ChinaVehicleTroopCrawlerEmpty
   ; *** ART Parameters ***
   SelectPortrait         = SNTransport_L
   ButtonImage            = SNTransport
-  Draw = W3DTankDraw ModuleTag_01
+
+  ;UpgradeCameo1 = NONE
+  ;UpgradeCameo2 = NONE
+  ;UpgradeCameo3 = NONE
+  ;UpgradeCameo4 = NONE
+  ;UpgradeCameo5 = NONE
+
+  Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
-    TrackMarks = EXTireTrack.tga
     ConditionState = NONE
       Model = NVTCrawler
+      ;note, the IRSonar particle system is added in StealthDetectorUpdate.cpp, not here
     End
-    ConditionState       = REALLYDAMAGED
+    ConditionState       = REALLYDAMAGED RUBBLE ; THIS IS VERY IMPORTANT... DO NOT REMOVE 'RUBBLE'
+                                                ; @todo find out why a non-animating model like this has such trouble matching
+                                                ; reallydamaged against moving against rubble, etc.
       Model              = NVTCrawler_D
     End
-    ConditionState       = RUBBLE
-      Model              = NVTCrawler_D
-    End
+
+    TrackMarks = EXTireTrack.tga
+
+    Dust = RocketBuggyDust
+    DirtSpray = RocketBuggyDirtSpray
+    ; PowerslideSpray = RocketBuggyDirtPowerSlide doesn't powerslide
+
+    ; These parameters are only used if the model has a separate suspension,
+    ; and the locomotor has HasSuspension = Yes.
+    LeftFrontTireBone     = Wheel01
+    RightFrontTireBone    = Wheel08
+    LeftRearTireBone      = Wheel03
+    RightRearTireBone     = Wheel05
+    MidLeftFrontTireBone  = Wheel02
+    MidRightFrontTireBone = Wheel07
+    MidLeftRearTireBone   = Wheel04
+    MidRightRearTireBone  = Wheel06
+
+    TireRotationMultiplier      = 0.2   ; this * speed = rotation.
+    PowerslideRotationAddition  = 0   ; This vehicle doesn't powerslide.
+
   End
+
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TroopCrawler
@@ -199,10 +227,10 @@ Object ChinaVehicleTroopCrawlerEmpty
     Armor           = TankArmor
     DamageFX        = TankDamageFX
   End
-  BuildCost       = 700
-  BuildTime       = 1.0          ;in seconds
-  VisionRange     = 150
-  ShroudClearingRange = 150
+  BuildCost       = 200
+  BuildTime       = 10.0          ;in seconds
+  VisionRange     = 175
+  ShroudClearingRange = 400
   Prerequisites
     Object = ChinaWarFactory
   End
@@ -221,13 +249,17 @@ Object ChinaVehicleTroopCrawlerEmpty
   VoiceAttack = TroopCrawlerVoiceAttack
   SoundMoveStart = TroopCrawlerMoveStart
   SoundMoveStartDamaged = TroopCrawlerMoveStart
-
+  SoundEnter = HumveeEnter
+  SoundExit = HumveeExit
   UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
-    VoiceCreate     = TroopCrawlerVoiceCreate
+    VoiceCreate = TroopCrawlerVoiceCreate
     TurretMoveStart = NoSound
-    TurretMoveLoop  = TurretMoveLoop
-    VoiceUnload     = TroopCrawlerVoiceUnload
+    TurretMoveLoop = TurretMoveLoop
+    TruckLandingSound = NoSound
+    TruckPowerslideSound = NoSound
+    VoiceCrush = TroopCrawlerVoiceCrush
+    VoiceUnload = TroopCrawlerVoiceUnload
     VoiceEnter = TroopCrawlerVoiceMove
   End
 
@@ -237,8 +269,8 @@ Object ChinaVehicleTroopCrawlerEmpty
   KindOf = PRELOAD SELECTABLE CAN_ATTACK CAN_CAST_REFLECTIONS TRANSPORT VEHICLE SCORE
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 240.0
+    InitialHealth   = 240.0
 
     ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
     ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
@@ -246,45 +278,75 @@ Object ChinaVehicleTroopCrawlerEmpty
     SubdualDamageHealRate = 500
     SubdualDamageHealAmount = 50
   End
-  Behavior = AIUpdateInterface ModuleTag_03
-    Turret
-      ControlledWeaponSlots = PRIMARY
-    End
+
+  Behavior = StealthDetectorUpdate ModuleTag_03
+    DetectionRate             = 900   ; how often to rescan for stealthed things in my sight (msec)
+    ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
+    CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
+    CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
+    PingSound                 = IRPing
+    LoudPingSound             = IRPingLoud
+    IRParticleSysName         = IRDetectSonar
+    IRBrightParticleSysName   = IRDetectSonarBright
+    IRGridParticleSysName     = IRDetectGrid
+    IRBeaconParticleSysName   = IRLenzflare
+    IRParticleSysBone         = IRFX
   End
+
+;OBSOLETE
+;  Behavior = AIUpdateInterface ModuleTag_04
+;    Turret
+;      ControlledWeaponSlots = PRIMARY
+;    End
+;  End
+  Behavior = AssaultTransportAIUpdate ModuleTag_NewAI
+    MembersGetHealedAtLifeRatio = 0.5
+  End
+
   Locomotor = SET_NORMAL TroopCrawlerLocomotor
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 50.0
   End
 
-
-  Behavior = SlowDeathBehavior  ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 5
-    ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 0
-    DestructionDelayVariance = 200
-    FX = FINAL FX_BuggyNewDeathExplosion
-    OCL = FINAL OCL_FinalTroopCrawlerDebris
-  End
-
   Behavior = TransportContain ModuleTag_06
     Slots = 8
+    ScatterNearbyOnExit = No
     HealthRegen%PerSec = 10
     DamagePercentToUnits = 10%
-    AllowInsideKindOf  = INFANTRY
+    AllowInsideKindOf = INFANTRY
+    ExitDelay = 250
+    NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
+    GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting
   End
 
+  Behavior = SlowDeathBehavior ModuleTag_07
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    DestructionDelay = 1
+    FX  = FINAL    FX_SupplyTruckExplosionOneFinal
+    OCL = FINAL    OCL_FinalTroopCrawlerDebris
+  End
 
-  ; A crushing defeat
-  Behavior = FXListDie ModuleTag_07
+  Behavior                 = TransitionDamageFX ModuleTag_08
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_NukeCannonDamageTransition
+  End
+
+  Behavior = DestroyDie ModuleTag_09
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
+  Behavior = FXListDie ModuleTag_10
     DeathTypes = NONE +CRUSHED +SPLATTED
     DeathFX = FX_CarCrush
   End
-  Behavior = CreateObjectDie ModuleTag_08
+
+  ; A crushing defeat
+  Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED
-    CreationList = OCL_CrusaderTank_CrushEffect
+    DeathFX = FX_CarCrush
   End
-  Behavior = CreateCrateDie ModuleTag_09
+
+  Behavior = CreateCrateDie ModuleTag_12
     CrateData = SalvageCrateData
     ;CrateData = EliteTankCrateData
     ;CrateData = HeroicTankCrateData


### PR DESCRIPTION
This change fixes up the Empty China Troopcrawler by streamlining it with the regular Troopcrawler. It is not clear whether or not this Object is used in game.

Untested.