### PR TITLE
Rename language bundle items

### DIFF
--- a/Patch104pZH/ModBundleItems.json
+++ b/Patch104pZH/ModBundleItems.json
@@ -110,7 +110,7 @@
                 ]
             },
             {
-                "name": "LanguageArabic",
+                "name": "CoreLangArabic",
                 "big": true,
                 "setGameLanguageOnInstall": "Arabic",
                 "files": [
@@ -136,7 +136,7 @@
                 ]
             },
             {
-                "name": "LanguageBrazilian",
+                "name": "CoreLangBrazilian",
                 "big": true,
                 "setGameLanguageOnInstall": "Brazilian",
                 "files": [
@@ -162,7 +162,7 @@
                 ]
             },
             {
-                "name": "LanguageChinese",
+                "name": "CoreLangChinese",
                 "big": true,
                 "setGameLanguageOnInstall": "Chinese",
                 "files": [
@@ -192,7 +192,7 @@
                 ]
             },
             {
-                "name": "LanguageEnglish",
+                "name": "CoreLangEnglish",
                 "big": true,
                 "setGameLanguageOnInstall": "English",
                 "files": [
@@ -218,7 +218,7 @@
                 ]
             },
             {
-                "name": "LanguageFrench",
+                "name": "CoreLangFrench",
                 "big": true,
                 "setGameLanguageOnInstall": "French",
                 "files": [
@@ -248,7 +248,7 @@
                 ]
             },
             {
-                "name": "LanguageGerman",
+                "name": "CoreLangGerman",
                 "big": true,
                 "setGameLanguageOnInstall": "German",
                 "files": [
@@ -278,7 +278,7 @@
                 ]
             },
             {
-                "name": "LanguageItalian",
+                "name": "CoreLangItalian",
                 "big": true,
                 "setGameLanguageOnInstall": "Italian",
                 "files": [
@@ -304,7 +304,7 @@
                 ]
             },
             {
-                "name": "LanguageKorean",
+                "name": "CoreLangKorean",
                 "big": true,
                 "setGameLanguageOnInstall": "Korean",
                 "files": [
@@ -334,7 +334,7 @@
                 ]
             },
             {
-                "name": "LanguagePolish",
+                "name": "CoreLangPolish",
                 "big": true,
                 "setGameLanguageOnInstall": "Polish",
                 "files": [
@@ -360,7 +360,7 @@
                 ]
             },
             {
-                "name": "LanguageRussian",
+                "name": "CoreLangRussian",
                 "big": true,
                 "setGameLanguageOnInstall": "Russian",
                 "files": [
@@ -386,7 +386,7 @@
                 ]
             },
             {
-                "name": "LanguageSpanish",
+                "name": "CoreLangSpanish",
                 "big": true,
                 "setGameLanguageOnInstall": "Spanish",
                 "files": [

--- a/Patch104pZH/ModBundlePacks.json
+++ b/Patch104pZH/ModBundlePacks.json
@@ -12,7 +12,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageArabic",
+                    "CoreLangArabic",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -25,7 +25,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageBrazilian",
+                    "CoreLangBrazilian",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -38,7 +38,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageChinese",
+                    "CoreLangChinese",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -51,7 +51,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageEnglish",
+                    "CoreLangEnglish",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -64,7 +64,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageFrench",
+                    "CoreLangFrench",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -77,7 +77,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageGerman",
+                    "CoreLangGerman",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -90,7 +90,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageItalian",
+                    "CoreLangItalian",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -103,7 +103,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageKorean",
+                    "CoreLangKorean",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -116,7 +116,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguagePolish",
+                    "CoreLangPolish",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -129,7 +129,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageRussian",
+                    "CoreLangRussian",
                     "OptionalArt",
                     "RecoveredArt"
                 ]
@@ -142,7 +142,7 @@
                     "CoreINI",
                     "CoreMaps",
                     "CoreWindow",
-                    "LanguageSpanish",
+                    "CoreLangSpanish",
                     "OptionalArt",
                     "RecoveredArt"
                 ]


### PR DESCRIPTION
Language bundles are part of core, so might as well make it clear in bundle name.