### PR TITLE
Emergency Repair Proposal 1, Shorter Recharge Time (4min -> 2min)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -564,10 +564,11 @@ SpecialPower SpecialPowerCommunicationsDownload
 ;  ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
 End
 
+; Patch104p @balance commy2 23/07/2022 Decrease reload time.
 ;------------------------------------------------------------------------------
 SpecialPower SuperweaponEmergencyRepair
   Enum              = SPECIAL_REPAIR_VEHICLES
-  ReloadTime        = 240000 ; in milliseconds
+  ReloadTime        = 120000 ; in milliseconds
   RequiredScience   = SCIENCE_EmergencyRepair1
   PublicTimer       = No
   SharedSyncedTimer   = Yes
@@ -580,7 +581,7 @@ End
 ;------------------------------------------------------------------------------
 SpecialPower Early_SuperweaponEmergencyRepair
   Enum              = EARLY_SPECIAL_REPAIR_VEHICLES
-  ReloadTime        = 240000 ; in milliseconds
+  ReloadTime        = 120000 ; in milliseconds
   RequiredScience   = Early_SCIENCE_EmergencyRepair1
   PublicTimer       = No
   SharedSyncedTimer   = Yes


### PR DESCRIPTION
* old PR: #740

Implementation of proposal 1 for #707.

After this pull request, the recharge time of Emergency Repair is halfed. The player needs to wait 2 minutes instead of 4 to use the ability again.