### PR TITLE
Emergency Repair Proposal 4, Heal Infantry And Buildings Too

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -419,6 +419,7 @@ Object GPSScrambler_InvisibleMarker
 
 End
 
+; Patch104p @balance commy2 23/07/2022 Make Emergency Repair heal infantry and buildings as well.
 ;------------------------------------------------------------------------------
 Object RepairVehiclesInArea_InvisibleMarker_Level1
   ; ***DESIGN parameters ***
@@ -447,7 +448,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level1
     HealingDelay      = 1 ; msec ; essentially sleep forever, since lifetime is 0, below
     Radius            = 100.0
     StartsActive      = Yes
-    KindOf            = VEHICLE
+    KindOf            = VEHICLE INFANTRY STRUCTURE
     SingleBurst       = Yes
   End
 
@@ -485,7 +486,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level2
     HealingDelay      = 1 ; msec ; essentially sleep forever, since lifetime is 0, below
     Radius            = 100.0
     StartsActive      = Yes
-    KindOf            = VEHICLE
+    KindOf            = VEHICLE INFANTRY STRUCTURE
     SingleBurst       = Yes
   End
 
@@ -523,7 +524,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level3
     HealingDelay      = 1 ; msec ; essentially sleep forever, since lifetime is 0, below
     Radius            = 100.0
     StartsActive      = Yes
-    KindOf            = VEHICLE
+    KindOf            = VEHICLE INFANTRY STRUCTURE
     SingleBurst       = Yes
   End
 


### PR DESCRIPTION
* old PR: #743

Implementation of proposal 4 for https://github.com/TheSuperHackers/GeneralsGamePatch/issues/707.

After this pull request, the Emergency Repair heals infantry as well as buildings in addition to just vehicles.

Note: this needs translations for anything other than EN and DE.