### PR TITLE
Emergency Repair Proposal 5, Repair Vehicles In Area Over Time

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -419,6 +419,7 @@ Object GPSScrambler_InvisibleMarker
 
 End
 
+; Patch104p @balance commy2 23/07/2022 Make repair effect linger and heal over time.
 ;------------------------------------------------------------------------------
 Object RepairVehiclesInArea_InvisibleMarker_Level1
   ; ***DESIGN parameters ***
@@ -428,13 +429,13 @@ Object RepairVehiclesInArea_InvisibleMarker_Level1
   Draw = W3DModelDraw ModuleTag_NOTREALLYADRAW
 
     DefaultConditionState
-      Model = None
+      Model = EXAMineGroup
       ParticleSysBone = None GPSRotisserie
       ParticleSysBone = None RepairCloud
     End
   End
 
-  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE FS_FAKE
 
   ; *** ENGINEERING Parameters ***
   Body = ImmortalBody ModuleTag_01
@@ -443,18 +444,22 @@ Object RepairVehiclesInArea_InvisibleMarker_Level1
   End
 
   Behavior = AutoHealBehavior ModuleTag_02
-    HealingAmount     = 100
-    HealingDelay      = 1 ; msec ; essentially sleep forever, since lifetime is 0, below
-    Radius            = 100.0
+    HealingAmount     = 5
+    HealingDelay      = 250 ; msec
+    Radius            = 150.0
     StartsActive      = Yes
     KindOf            = VEHICLE
-    SingleBurst       = Yes
+    ;SingleBurst       = Yes
   End
 
   Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
-    MinLifetime = 0 ;one pulse
-    MaxLifetime = 0
+    MinLifetime = 10000
+    MaxLifetime = 10000
   End
+
+  ShadowTexture = SCCRepair
+  ShadowSizeX   = 300
+  ShadowSizeY   = 300
 End
 
 ;------------------------------------------------------------------------------
@@ -466,13 +471,13 @@ Object RepairVehiclesInArea_InvisibleMarker_Level2
   Draw = W3DModelDraw ModuleTag_NOTREALLYADRAW
 
     DefaultConditionState
-      Model = None
+      Model = EXAMineGroup
       ParticleSysBone = None GPSRotisserie
       ParticleSysBone = None RepairCloud
     End
   End
 
-  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE FS_FAKE
 
   ; *** ENGINEERING Parameters ***
   Body = ImmortalBody ModuleTag_01
@@ -481,18 +486,22 @@ Object RepairVehiclesInArea_InvisibleMarker_Level2
   End
 
   Behavior = AutoHealBehavior ModuleTag_02
-    HealingAmount     = 200
-    HealingDelay      = 1 ; msec ; essentially sleep forever, since lifetime is 0, below
-    Radius            = 100.0
+    HealingAmount     = 5
+    HealingDelay      = 250 ; msec
+    Radius            = 150.0
     StartsActive      = Yes
     KindOf            = VEHICLE
-    SingleBurst       = Yes
+    ;SingleBurst       = Yes
   End
 
   Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
-    MinLifetime = 0
-    MaxLifetime = 0
+    MinLifetime = 20000
+    MaxLifetime = 20000
   End
+
+  ShadowTexture = SCCRepair
+  ShadowSizeX   = 300
+  ShadowSizeY   = 300
 End
 
 ;------------------------------------------------------------------------------
@@ -504,13 +513,13 @@ Object RepairVehiclesInArea_InvisibleMarker_Level3
   Draw = W3DModelDraw ModuleTag_NOTREALLYADRAW
 
     DefaultConditionState
-      Model = None
+      Model = EXAMineGroup
       ParticleSysBone = None GPSRotisserie
       ParticleSysBone = None RepairCloud
     End
   End
 
-  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE FS_FAKE
 
   ; *** ENGINEERING Parameters ***
   Body = ImmortalBody ModuleTag_01
@@ -519,18 +528,22 @@ Object RepairVehiclesInArea_InvisibleMarker_Level3
   End
 
   Behavior = AutoHealBehavior ModuleTag_02
-    HealingAmount     = 300
-    HealingDelay      = 1 ; msec ; essentially sleep forever, since lifetime is 0, below
-    Radius            = 100.0
+    HealingAmount     = 5
+    HealingDelay      = 250 ; msec
+    Radius            = 150.0
     StartsActive      = Yes
     KindOf            = VEHICLE
-    SingleBurst       = Yes
+    ;SingleBurst       = Yes
   End
 
   Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
-    MinLifetime = 0
-    MaxLifetime = 0
+    MinLifetime = 30000
+    MaxLifetime = 30000
   End
+
+  ShadowTexture = SCCRepair
+  ShadowSizeX   = 300
+  ShadowSizeY   = 300
 End
 
 ;------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -453,7 +453,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level1
   End
 
   Behavior = AutoHealBehavior ModuleTag_03
-    HealingAmount     = 10
+    HealingAmount     = 15
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
@@ -504,7 +504,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level2
   End
 
   Behavior = AutoHealBehavior ModuleTag_03
-    HealingAmount     = 10
+    HealingAmount     = 15
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
@@ -555,7 +555,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level3
   End
 
   Behavior = AutoHealBehavior ModuleTag_03
-    HealingAmount     = 10
+    HealingAmount     = 15
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -448,11 +448,20 @@ Object RepairVehiclesInArea_InvisibleMarker_Level1
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
-    KindOf            = VEHICLE STRUCTURE
+    KindOf            = VEHICLE
     ;SingleBurst       = Yes
   End
 
-  Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
+  Behavior = AutoHealBehavior ModuleTag_03
+    HealingAmount     = 10
+    HealingDelay      = 250 ; msec
+    Radius            = 150.0
+    StartsActive      = Yes
+    KindOf            = STRUCTURE
+    ;SingleBurst       = Yes
+  End
+
+  Behavior = DeletionUpdate ModuleTag_04 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
     MinLifetime = 10000
     MaxLifetime = 10000
   End
@@ -490,11 +499,20 @@ Object RepairVehiclesInArea_InvisibleMarker_Level2
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
-    KindOf            = VEHICLE STRUCTURE
+    KindOf            = VEHICLE
     ;SingleBurst       = Yes
   End
 
-  Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
+  Behavior = AutoHealBehavior ModuleTag_03
+    HealingAmount     = 10
+    HealingDelay      = 250 ; msec
+    Radius            = 150.0
+    StartsActive      = Yes
+    KindOf            = STRUCTURE
+    ;SingleBurst       = Yes
+  End
+
+  Behavior = DeletionUpdate ModuleTag_04 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
     MinLifetime = 20000
     MaxLifetime = 20000
   End
@@ -532,11 +550,20 @@ Object RepairVehiclesInArea_InvisibleMarker_Level3
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
-    KindOf            = VEHICLE STRUCTURE
+    KindOf            = VEHICLE
     ;SingleBurst       = Yes
   End
 
-  Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
+  Behavior = AutoHealBehavior ModuleTag_03
+    HealingAmount     = 10
+    HealingDelay      = 250 ; msec
+    Radius            = 150.0
+    StartsActive      = Yes
+    KindOf            = STRUCTURE
+    ;SingleBurst       = Yes
+  End
+
+  Behavior = DeletionUpdate ModuleTag_04 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
     MinLifetime = 30000
     MaxLifetime = 30000
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -419,7 +419,7 @@ Object GPSScrambler_InvisibleMarker
 
 End
 
-; Patch104p @balance commy2 23/07/2022 Make repair effect linger and heal over time.
+; Patch104p @balance commy2 23/07/2022 Make repair effect linger and heal over time and also repair buildings.
 ;------------------------------------------------------------------------------
 Object RepairVehiclesInArea_InvisibleMarker_Level1
   ; ***DESIGN parameters ***
@@ -448,7 +448,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level1
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
-    KindOf            = VEHICLE
+    KindOf            = VEHICLE STRUCTURE
     ;SingleBurst       = Yes
   End
 
@@ -490,7 +490,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level2
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
-    KindOf            = VEHICLE
+    KindOf            = VEHICLE STRUCTURE
     ;SingleBurst       = Yes
   End
 
@@ -532,7 +532,7 @@ Object RepairVehiclesInArea_InvisibleMarker_Level3
     HealingDelay      = 250 ; msec
     Radius            = 150.0
     StartsActive      = Yes
-    KindOf            = VEHICLE
+    KindOf            = VEHICLE STRUCTURE
     ;SingleBurst       = Yes
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5843,6 +5843,7 @@ ObjectCreationList SUPERWEAPON_RepairVehicles1
   CreateObject
     ObjectNames = RepairVehiclesInArea_InvisibleMarker_Level1
     Count = 1
+    Disposition = LIKE_EXISTING ; Patch104p @balance commy2 23/07/2022 Prevent rotating decal randomly on ability placement.
   End
 End
 
@@ -5852,6 +5853,7 @@ ObjectCreationList SUPERWEAPON_RepairVehicles2
   CreateObject
     ObjectNames = RepairVehiclesInArea_InvisibleMarker_Level2
     Count = 1
+    Disposition = LIKE_EXISTING ; Patch104p @balance commy2 23/07/2022 Prevent rotating decal randomly on ability placement.
   End
 End
 
@@ -5861,6 +5863,7 @@ ObjectCreationList SUPERWEAPON_RepairVehicles3
   CreateObject
     ObjectNames = RepairVehiclesInArea_InvisibleMarker_Level3
     Count = 1
+    Disposition = LIKE_EXISTING ; Patch104p @balance commy2 23/07/2022 Prevent rotating decal randomly on ability placement.
   End
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -564,6 +564,7 @@ SpecialPower SpecialPowerCommunicationsDownload
 ;  ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
 End
 
+; Patch104p @balance commy2 23/07/2022 Increase radius by 50%.
 ;------------------------------------------------------------------------------
 SpecialPower SuperweaponEmergencyRepair
   Enum              = SPECIAL_REPAIR_VEHICLES
@@ -571,7 +572,7 @@ SpecialPower SuperweaponEmergencyRepair
   RequiredScience   = SCIENCE_EmergencyRepair1
   PublicTimer       = No
   SharedSyncedTimer   = Yes
-  RadiusCursorRadius  = 100
+  RadiusCursorRadius  = 150
   InitiateAtLocationSound = EmergencyRepairActivate
   ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
   AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.
@@ -584,7 +585,7 @@ SpecialPower Early_SuperweaponEmergencyRepair
   RequiredScience   = Early_SCIENCE_EmergencyRepair1
   PublicTimer       = No
   SharedSyncedTimer   = Yes
-  RadiusCursorRadius  = 100
+  RadiusCursorRadius  = 150
   InitiateAtLocationSound = EmergencyRepairActivate
   ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
   AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -565,10 +565,11 @@ SpecialPower SpecialPowerCommunicationsDownload
 End
 
 ; Patch104p @balance commy2 23/07/2022 Increase radius by 50%.
+; Patch104p @balance commy2 03/08/2023 Reduce recharge time from 4 to 3 minutes.
 ;------------------------------------------------------------------------------
 SpecialPower SuperweaponEmergencyRepair
   Enum              = SPECIAL_REPAIR_VEHICLES
-  ReloadTime        = 240000 ; in milliseconds
+  ReloadTime        = 180000 ; in milliseconds
   RequiredScience   = SCIENCE_EmergencyRepair1
   PublicTimer       = No
   SharedSyncedTimer   = Yes
@@ -581,7 +582,7 @@ End
 ;------------------------------------------------------------------------------
 SpecialPower Early_SuperweaponEmergencyRepair
   Enum              = EARLY_SPECIAL_REPAIR_VEHICLES
-  ReloadTime        = 240000 ; in milliseconds
+  ReloadTime        = 180000 ; in milliseconds
   RequiredScience   = Early_SCIENCE_EmergencyRepair1
   PublicTimer       = No
   SharedSyncedTimer   = Yes


### PR DESCRIPTION
* old PR: TheSuperHackers/GeneralsGamePatch#744

Implementation of proposal 5 for TheSuperHackers/GeneralsGamePatch#707.

After this pull request, the repair effect lingers for 10 seconds (with visible decal). The vehicles are repaired over time instead of in one burst. Upgrading the ability increases how long the effect lasts (to 20 and 30 seconds respectively). Upgrading the ability does not increase the healing speed. The total healing amount only differs due to the time the ability lasts. The radius is increased by +50% (which equals +125% area).

Vehicles can move in and out of the repair area. They are only repaired while inside the area.

https://user-images.githubusercontent.com/6576312/180599717-03c0d0d9-29dd-43f8-bc17-97725ab3f7c3.mp4

Note: this needs translations for anything other than EN and DE.