### PR TITLE
Fix: Scud Launcher With Demolitions Upgrade Deals Full Explosion Damage When Destroyed By Enemy

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20302,11 +20302,20 @@ Object Demo_GLAVehicleScudLauncher
 ;    DeathTypes = NONE +SUICIDED
 ;  End
 
-  Behavior = FireWeaponWhenDeadBehavior ModuleTag_George
+  ; Patch104p @bugfix commy2 02/09/2022 Fix Scud Launcher deals full suicide damage when destroyed by enemy.
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
+    DeathTypes = NONE +SUICIDED
   End;
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag999
+    DeathWeapon   = Demo_DestroyedWeapon
+    StartsActive  = No
+    TriggeredBy   = Demo_Upgrade_SuicideBomb
+    DeathTypes = ALL -SUICIDED
+  End
 
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = Demo_GLAVehicleScudLauncherCommandSetUpgrade


### PR DESCRIPTION
1.04:

- Any* other Demo unit with Demolitions upgrade deals 50 damage to nearby enemies when destroyed. This is upgraded to 500 damage when actively blown up by the player using the Suicide ability.

- Scud Launcher always deals 500.

patch:

- All units behave as described above, including the Scud Launcher


\* aside from Combat Bike, Bomb Truck and bugged units like the Battle Bus**
** fixed in main branch