### PR TITLE
Change: Use Different Explosion Effect For Passive Demogen Destruction Weapon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8791,8 +8791,32 @@ FXList WeaponFX_DemoSuicideDynamitePackDetonationPlusFire
   ParticleSystem
     Name = HotPillarArms
   End
+  ParticleSystem
+    Name = DemoTrapLenzFlare
+  End
   ViewShake
     Type = NORMAL
+  End
+  TerrainScorch
+    Type = RANDOM
+    Radius = 15
+  End
+End
+
+; Patch104p @tweak commy2 02/09/2022 Effect for unit with Demolitions upgrade getting destroyed by enemy.
+; ----------------------------------------------
+FXList WeaponFX_DemoDestroyedDynamitePackDetonation
+  Sound
+    Name = ExplosionBarrel
+  End
+  ParticleSystem
+    Name = Explosion
+  End
+  ParticleSystem
+    Name = DemoExplosionSmoke
+  End
+  ViewShake
+    Type = SUBTLE
   End
   TerrainScorch
     Type = RANDOM

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6931,7 +6931,7 @@ Weapon Demo_DestroyedWeapon
   ClipSize = 1
   ClipReloadTime = 0
   AutoReloadsClip = No
-  FireFX = WeaponFX_DemoSuicideDynamitePackDetonationPlusFire
+  FireFX = WeaponFX_DemoDestroyedDynamitePackDetonation ; Patch104p @tweak commy2 02/09/2022 Use different effect for passive destruction.
   FireSound = CarBomberDie
 End
 


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/850

Much smaller explosion without the red donut cloud, because the weapon does small damage (wouldn't even two shot a Red Guard!). Most importantly, it no longer plays the Terrorist Suicide sound effect.