### PR TITLE
Fix: Visible Permanent Muzzle Flash When Placing First Fire Base

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -16837,6 +16837,7 @@ Object AirF_AmericaFireBase
       TurretPitch       = TURRETEL
       WeaponLaunchBone  = PRIMARY   MUZZLE01
       WeaponFireFXBone  = PRIMARY   MUZZLEFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 02/09/2022 Hide muzzle flash from first placement ghost.
     End
 
     ConditionState      = DAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -36088,6 +36088,7 @@ Object AmericaFireBase
       TurretPitch       = TURRETEL
       WeaponLaunchBone  = PRIMARY   MUZZLE01
       WeaponFireFXBone  = PRIMARY   MUZZLEFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 02/09/2022 Hide muzzle flash from first placement ghost.
     End
 
     ConditionState      = DAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -15965,6 +15965,7 @@ Object Lazr_AmericaFireBase
       TurretPitch       = TURRETEL
       WeaponLaunchBone  = PRIMARY   MUZZLE01
       WeaponFireFXBone  = PRIMARY   MUZZLEFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 02/09/2022 Hide muzzle flash from first placement ghost.
     End
 
     ConditionState      = DAMAGED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -15906,6 +15906,7 @@ Object SupW_AmericaFireBase
       TurretPitch       = TURRETEL
       WeaponLaunchBone  = PRIMARY   MUZZLE01
       WeaponFireFXBone  = PRIMARY   MUZZLEFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 02/09/2022 Hide muzzle flash from first placement ghost.
     End
 
     ConditionState      = DAMAGED


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1077

This is a hack. The muzzle flash is still shown when firing correctly despite HideSubObject.