### PR TITLE
Fix: Destroyed Listening Outpost Radar Dish Spawns In Air, Has Very Low Weight

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -8889,12 +8889,13 @@ End
 ; -----------------------------------------------------------------------------
 ; Chunks of ListeningOutpost
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak commy2 02/09/2022 Fix spawn position and weight of radar dish.
 ObjectCreationList OCL_InitialListeningOutpostDebris
   CreateDebris
     ModelNames        = NVLOUTPOST_D2  ;dish
-    Offset            = X:-30.096 Y:0.0 Z:35.0
+    Offset            = X:-30.096 Y:0.0 Z:15.0
     Count             = 1
-    Mass              = 9.0
+    Mass              = 20.0
     Disposition       = RANDOM_FORCE
     MinForceMagnitude = 40
     MaxForceMagnitude = 50


### PR DESCRIPTION
# Original
https://user-images.githubusercontent.com/6576312/188211721-5f60c456-575a-4a4a-9df9-59a0e4ae918b.mp4

# Patched
https://user-images.githubusercontent.com/6576312/188211725-b15f6518-14fa-423f-a127-118aa15486bf.mp4

