### PR TITLE
Fix: Granger Fails To Call In Carpet Bomber In Generals' Challenge

### DIFF
--- a/Patch104pZH/GameFilesEdited/Maps/GC_AirGeneral/map.ini
+++ b/Patch104pZH/GameFilesEdited/Maps/GC_AirGeneral/map.ini
@@ -31,3 +31,16 @@ END
 ;------------------------------------------
 
 ; [None yet]
+
+; Patch104p @bugfix commy2 13/08/2022 Fix Granger failing to order Carpet Bomber.
+Object AirF_AmericaStrategyCenter
+  AddModule
+    Behavior = GrantScienceUpgrade ModuleTag_CarpetBomberFix01
+      GrantScience = SCIENCE_AirF_CarpetBomb
+      TriggeredBy = Upgrade_DummyUpgrade
+    End
+    Behavior = GrantUpgradeCreate ModuleTag_CarpetBomberFix02
+      UpgradeToGrant = Upgrade_DummyUpgrade
+    End
+  End
+End


### PR DESCRIPTION
He doesn't have the science that is required since ZH 1.02 patch and thus fails to call it.