### PR TITLE
Fix: Kassad Bare Stinger Troopers Are Unselectable

### DIFF
--- a/Patch104pZH/GameFilesEdited/Maps/GC_Stealth/map.ini
+++ b/Patch104pZH/GameFilesEdited/Maps/GC_Stealth/map.ini
@@ -1,0 +1,17 @@
+; Patch104p @bugfix commy2 03/09/2022 Fix unselectable Stinger Soldiers.
+Object Slth_GLAStingerSite
+  ReplaceModule ModuleTag_06
+    Behavior                = SpawnBehavior ModuleTag_06_Override
+      SpawnNumber           = 3
+      SpawnReplaceDelay     = 30000 ;msec
+      SpawnTemplateName     = GLAInfantryStingerSoldier ; use these instead, so the others can be modified
+      CanReclaimOrphans     = No
+      SpawnedRequireSpawner = Yes
+      SlavesHaveFreeWill = No
+    End
+  End
+End
+
+Object Slth_GLAInfantryStingerSoldier
+  KindOf = +SELECTABLE -CLICK_THROUGH
+End


### PR DESCRIPTION
First module replaces the Stealthgen Troopers with vGLA Troopers inside the Stinger Site. This is necessary, otherwise all the troopers inside the site are selectable as well.