### PR TITLE
Fix: Stinger Trooper Walk Animation Shortly After Firing

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13376,6 +13376,7 @@ Object Chem_GLAInfantryStingerSoldier
     ConditionState = MOVING
       Animation = UISmsd_SKL.UISmsd_WKB 25
       AnimationMode = LOOP
+      WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
 
     ConditionState = DYING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13873,6 +13873,7 @@ Object Demo_GLAInfantryStingerSoldier
     ConditionState = MOVING
       Animation = UISmsd_SKL.UISmsd_WKB 25
       AnimationMode = LOOP
+      WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
 
     ConditionState = DYING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -152,6 +152,7 @@ Object GC_Chem_GLAInfantryStingerSoldier
     ConditionState = MOVING
       Animation = UISmsd_SKL.UISmsd_WKB 25
       AnimationMode = LOOP
+      WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
 
     ConditionState = DYING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -477,6 +477,7 @@ Object GC_Slth_GLAInfantryStingerSoldier
     ConditionState = MOVING
       Animation = UISmsd_SKL.UISmsd_WKB 25
       AnimationMode = LOOP
+      WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
 
     ConditionState = DYING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1001,6 +1001,7 @@ Object GLAInfantryStingerSoldier
     ConditionState = MOVING
       Animation = UISmsd_SKL.UISmsd_WKB 25
       AnimationMode = LOOP
+      WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
 
     ConditionState = DYING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14387,6 +14387,7 @@ Object Slth_GLAInfantryStingerSoldier
     ConditionState = MOVING
       Animation = UISmsd_SKL.UISmsd_WKB 25
       AnimationMode = LOOP
+      WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
 
     ConditionState = DYING


### PR DESCRIPTION
Because it inherits `WaitForStateToFinishIfPossible` from `DefaultConditionState`, the unit slides over the ground with the reloading animation if moved right after shooting the missile launcher.

Doesn't ever come into play aside from special mission like GC vs Stealth.

Note that the same fix was applied by EALA to the death animations already. They probably never noticed this being an issue with the MOVING animation state, because this guy only ever moves in cutscenes.