### PR TITLE
Fix: z clipping particles

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -2067,6 +2067,7 @@ FXList FX_GattlingExplosionOneFinal
   End
   ParticleSystem
     Name = BattleMasterTankExplosionShockwave
+    Offset = X:0 Y:0 Z:2 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   End
   ViewShake
     Type = STRONG
@@ -3503,6 +3504,7 @@ FXList WeaponFX_EMPRocketDetonation
   End
   ParticleSystem
     Name = EMPPatriotRing
+    Offset = X:0.0 Y:0.0 Z:1.0 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   End
   Sound
     Name = ExplosionPatriotEMP
@@ -3987,6 +3989,7 @@ FXList WeaponFX_DemoTrapDetonation
   End
   ParticleSystem
     Name = DemoTrapLenzFlare
+    Offset = X:0.0 Y:0.0 Z:1.0 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   End
   ParticleSystem
     Name = BombTruckHEShockwave
@@ -6070,11 +6073,13 @@ FXList WeaponFX_EMPPulseImpact
   ParticleSystem
     Name = EMPLensFlare1
   End
- ParticleSystem
+  ParticleSystem
     Name = EMPLensFlare2
+    Offset = X:0.0 Y:0.0 Z:2.0 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   End
-ParticleSystem
+  ParticleSystem
     Name = EMPRing
+    Offset = X:0.0 Y:0.0 Z:1.0 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   End
 
   Sound
@@ -8373,7 +8378,7 @@ FXList Nuke_WeaponFX_NukeCannon
 
   ParticleSystem
     Name = NukeCannonRing
-    Offset = X:0.0 Y:0.0 Z:0.0
+    Offset = X:0.0 Y:0.0 Z:5.0 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   End
 
   ParticleSystem
@@ -8761,6 +8766,7 @@ FXList WeaponFX_DemoSuicideDynamitePackDetonation
   End
   ParticleSystem
     Name = DemoTrapLenzFlare
+    Offset = X:0.0 Y:0.0 Z:1.0 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   End
   ViewShake
     Type = NORMAL

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -35615,7 +35615,7 @@ ParticleSystem GLAViralOutbreakClouds
   BurstDelay = 3.00 3.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.00 Y:0.00 Z:0.02
+  DriftVelocity = X:0.00 Y:0.00 Z:0.01 ; Patch104p @tweak from Z:0.02 to be consistent with other puddles
   VelocityType = OUTWARD
   VelOutward = 0.25 1.00
   VelOutwardOther = 0.00 0.00


### PR DESCRIPTION
This change fixes all z clipping particles I could find.

## Original Demo Trap

https://user-images.githubusercontent.com/4720891/188271577-e08a981e-6f2f-4e9c-88a0-b1b5a7effd9b.mp4

## Patched Demo Trap

https://user-images.githubusercontent.com/4720891/188271586-23ecd778-e6fc-4dce-89a3-d21aa2b2f1ea.mp4

## Original EMP

https://user-images.githubusercontent.com/4720891/188271605-0d7bf426-6035-4f2a-a833-ce8e0f54d9d9.mp4

## Patched EMP

https://user-images.githubusercontent.com/4720891/188271615-8a1ea8cf-e099-4c41-b820-9a3571378fe5.mp4
