### PR TITLE
Fix: China Command Center Has Second Clipping Building At Night When Damaged

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -353,6 +353,7 @@ Object Boss_CommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
+      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYard_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -353,7 +353,7 @@ Object Boss_CommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
-      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYard_EN
@@ -470,6 +470,7 @@ Object Boss_CommandCenter
       Animation          = NBConYard_DN.NBConYard_DN
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT REALLYDAMAGED
       Model              = NBConYard_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -3151,7 +3151,7 @@ Object ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
-      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYard_EN
@@ -3268,6 +3268,7 @@ Object ChinaCommandCenter
       Animation          = NBConYard_DN.NBConYard_DN
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT REALLYDAMAGED
       Model              = NBConYard_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -3151,6 +3151,7 @@ Object ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
+      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYard_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -3217,6 +3217,7 @@ Object Infa_ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
+      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYardI_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -3217,7 +3217,7 @@ Object Infa_ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
-      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYardI_EN
@@ -3334,6 +3334,7 @@ Object Infa_ChinaCommandCenter
       Animation          = NBConYardI_DN.NBConYardI_DN
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT REALLYDAMAGED
       Model              = NBConYardI_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4998,6 +4998,7 @@ Object Nuke_ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
+      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYardN_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4998,7 +4998,7 @@ Object Nuke_ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
-      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYardN_EN
@@ -5115,6 +5115,7 @@ Object Nuke_ChinaCommandCenter
       Animation          = NBConYardN_DN.NBConYardN_DN
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT REALLYDAMAGED
       Model              = NBConYardN_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15614,6 +15614,7 @@ Object Tank_ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
+      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYardT_EN

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15614,7 +15614,7 @@ Object Tank_ChinaCommandCenter
       ParticleSysBone    = Smoke01 SmolderingSmoke
       ParticleSysBone    = Smoke02 SmolderingSmoke
       ParticleSysBone    = Smoke03 SmolderingSmoke
-      HideSubObject      = Object03 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBConYardT_EN
@@ -15731,6 +15731,7 @@ Object Tank_ChinaCommandCenter
       Animation          = NBConYardT_DN.NBConYardT_DN
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Object03 Object04 Mesh03 ; Patch104p @bugfix commy2 03/09/2022 Fix two buildings in different damage states clipping inside each other.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT REALLYDAMAGED
       Model              = NBConYardT_EN


### PR DESCRIPTION
# before
![shot_20220903_150126_1](https://user-images.githubusercontent.com/6576312/188272314-8529fe6e-8fde-4c11-b5e5-71aca330101f.jpg)


# after 

![shot_20220903_152110_1](https://user-images.githubusercontent.com/6576312/188272315-14181ceb-3c1f-4bc6-a46a-5d4adf0aa3c4.jpg)


Note: 'after' is essentially how the building looks already when damaged on day, snow and snow+night maps.

It may be preferable to remove the rogue objects from the model instead.