### PR TITLE
Fix: Helix With Bunker Cannot Be Ordered To Aim At Airborne Targets

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -24,7 +24,7 @@ https://github.com/commy2/zerohour/issues/206 [MAYBE]                 Combat Chi
 https://github.com/commy2/zerohour/issues/205 [DONE]                  Listening Outpost Damaged Smoke Effect Sticks After Repair
 https://github.com/commy2/zerohour/issues/204 [WONTFIX]               Fire Base Cannot Order Passengers To Attack Airborne Targets
 https://github.com/commy2/zerohour/issues/203 [MAYBE][NPROJECT]       Overlord With Bunker Cannot Order Passengers To Attack Airborne Targets
-https://github.com/commy2/zerohour/issues/202 [MAYBE][NPROJECT]       Helix With Bunker Cannot Order Passengers To Attack Airborne Targets
+https://github.com/commy2/zerohour/issues/202 [DONE][NPROJECT]        Helix With Bunker Cannot Order Passengers To Attack Airborne Targets
 https://github.com/commy2/zerohour/issues/201 [NOTRELEVANT][NPROJECT] Fire Bases Require A Power Plant Despite Not Requiring Power
 https://github.com/commy2/zerohour/issues/200 [NOTRELEVANT][NPROJECT] Air Force General Gets Carpet Bomber At Rank 1
 https://github.com/commy2/zerohour/issues/199 [IMPROVEMENT]           Countermeasures Reduce AA Gun Damage By 37.5% Instead Of The Intended 25% (Adjust text or damage)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15430,12 +15430,13 @@ Object Boss_VehicleHelix
     DamageFX        = None
   End
 
+  ; Patch104p @bugfix commy2 13/09/2021 Fix Helix with Bunker unable to order passengers to attack airborne targets.
 
   WeaponSet
     Conditions          = None
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
   End
@@ -15444,9 +15445,12 @@ Object Boss_VehicleHelix
     Conditions          = PLAYER_UPGRADE
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
+    Weapon              = SECONDARY   HelicopterUpgradedDummyWeapon
+    PreferredAgainst    = SECONDARY   AIRCRAFT
+    AutoChooseSources   = SECONDARY   FROM_PLAYER FROM_SCRIPT FROM_AI
   End
 
 
@@ -15597,6 +15601,7 @@ Object Boss_VehicleHelix
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
+    ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -89,12 +89,13 @@ Object ChinaVehicleHelix
     DamageFX        = None
   End
 
+  ; Patch104p @bugfix commy2 13/09/2021 Fix Helix with Bunker unable to order passengers to attack airborne targets.
 
   WeaponSet
     Conditions          = None
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
   End
@@ -103,9 +104,12 @@ Object ChinaVehicleHelix
     Conditions          = PLAYER_UPGRADE
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
+    Weapon              = SECONDARY   HelicopterUpgradedDummyWeapon
+    PreferredAgainst    = SECONDARY   AIRCRAFT
+    AutoChooseSources   = SECONDARY   FROM_PLAYER FROM_SCRIPT FROM_AI
   End
 
 
@@ -254,6 +258,7 @@ Object ChinaVehicleHelix
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No
+    ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15891,12 +15891,13 @@ Object Infa_ChinaVehicleHelix
     DamageFX        = None
   End
 
+  ; Patch104p @bugfix commy2 13/09/2021 Fix Helix with Bunker unable to order passengers to attack airborne targets.
 
   WeaponSet
     Conditions          = None
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
   End
@@ -15905,9 +15906,12 @@ Object Infa_ChinaVehicleHelix
     Conditions          = PLAYER_UPGRADE
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
+    Weapon              = SECONDARY   HelicopterUpgradedDummyWeapon
+    PreferredAgainst    = SECONDARY   AIRCRAFT
+    AutoChooseSources   = SECONDARY   FROM_PLAYER FROM_SCRIPT FROM_AI
   End
 
 
@@ -16019,13 +16023,13 @@ Object Infa_ChinaVehicleHelix
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No
+    ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
   End
-  ;--------------------------
 
   Behavior = WeaponSetUpgrade ModuleTag_30
     TriggeredBy = Upgrade_ChinaBlackNapalm
   End
-;---------------------------
+  ;--------------------------
 
   Behavior = SpecialAbility ModuleTag_32
     SpecialPowerTemplate = SpecialAbilityHelixNapalmBomb
@@ -16161,6 +16165,10 @@ Object Infa_ChinaHelixBattleBunker
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = Yes
+  End
+
+  Behavior = WeaponSetUpgrade ModuleTag_30
+    TriggeredBy = Upgrade_Infa_ChinaHelixBattleBunker
   End
 
   Behavior             = DestroyDie ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -359,12 +359,13 @@ Object Nuke_ChinaVehicleHelix
     DamageFX        = None
   End
 
+  ; Patch104p @bugfix commy2 13/09/2021 Fix Helix with Bunker unable to order passengers to attack airborne targets.
 
   WeaponSet
     Conditions          = None
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
   End
@@ -373,9 +374,12 @@ Object Nuke_ChinaVehicleHelix
     Conditions          = PLAYER_UPGRADE
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
+    Weapon              = SECONDARY   HelicopterUpgradedDummyWeapon
+    PreferredAgainst    = SECONDARY   AIRCRAFT
+    AutoChooseSources   = SECONDARY   FROM_PLAYER FROM_SCRIPT FROM_AI
   End
 
 
@@ -527,6 +531,7 @@ Object Nuke_ChinaVehicleHelix
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
+    ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -89,12 +89,13 @@ Object Tank_ChinaVehicleHelix
     DamageFX        = None
   End
 
+  ; Patch104p @bugfix commy2 13/09/2021 Fix Helix with Bunker unable to order passengers to attack airborne targets.
 
   WeaponSet
     Conditions          = None
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
   End
@@ -103,9 +104,12 @@ Object Tank_ChinaVehicleHelix
     Conditions          = PLAYER_UPGRADE
     ;----------------------------
     Weapon              = PRIMARY     HelixMinigunWeapon
-    PreferredAgainst    = PRIMARY     INFANTRY
+    PreferredAgainst    = PRIMARY     INFANTRY VEHICLE
     AutoChooseSources   = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     ;----------------------------
+    Weapon              = SECONDARY   HelicopterUpgradedDummyWeapon
+    PreferredAgainst    = SECONDARY   AIRCRAFT
+    AutoChooseSources   = SECONDARY   FROM_PLAYER FROM_SCRIPT FROM_AI
   End
 
 
@@ -256,6 +260,7 @@ Object Tank_ChinaVehicleHelix
     ExitDelay               = 100
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
+    ArmedRidersUpgradeMyWeaponSet = Yes ; Patch104p @bugfix commy2 13/09/2021 Enable anti air dummy weapon when passengers are loaded inside.
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6444,6 +6444,7 @@ Weapon Infa_MiniGunnerGunAir
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade
+  WeaponBonus           = GARRISONED RANGE 77%  ; Patch104p @bugfix commy2 14/09/2021 Remove GARRISONED range bonus from Minigunner vs airborne targets.
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = Yes
   AntiGround            = No
@@ -6764,6 +6765,27 @@ Weapon ListeningOutpostUpgradedDummyWeapon
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = No
   AntiAirborneVehicle   = Yes
+End
+
+; Patch104p @bugfix commy2 13/09/2021 Add weapon used by Helix with Bunker to order passengers to attack airborne targets.
+
+;------------------------------------------------------------------------------
+Weapon HelicopterUpgradedDummyWeapon
+  PrimaryDamage         = 0.1
+  PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
+  AttackRange           = 150.0
+  DamageType            = SMALL_ARMS
+  DeathType             = NORMAL
+  WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
+  ProjectileObject      = DummyWeaponProjectile
+  RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots     = 1000               ; time between shots, msec
+  ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime        = 0              ; how long to reload a Clip, msec
+  AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
+  AntiAirborneVehicle   = Yes
+  AntiAirborneInfantry  = No
+  AntiGround            = No
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
* old PR: #342

- Fixes #300

ZH 1.04

- A Helix with Bunker upgrade and garrisoned troops can not be ordered to attack airborne units - unless it is grouped with other units that can.

After patch:

- The Helix will be able to order passengers to attack airborne units.

Drawback:

- The Helix will be able to use the dummy weapon against air units even without Bunker if there are passengers loaded. The passengers won't be able to fire, but the Helix will move in range. This is not perfect, but way better than what we have now.
