### PR TITLE
Fix: Toxin General RPG-Trooper Shoots Stinger Missiles

### DIFF
--- a/Patch104pZH/Design/Tasks/commy2_tasks.txt
+++ b/Patch104pZH/Design/Tasks/commy2_tasks.txt
@@ -77,7 +77,7 @@ https://github.com/commy2/zerohour/issues/145 [DONE][NPROJEC!]        Toxin Gene
 https://github.com/commy2/zerohour/issues/144 [IMPROVEMENT]           Overlord Does Not Fit Into Chinook But Only Takes 3 Slots Inside Helix
 https://github.com/commy2/zerohour/issues/143 [DONE]                  GPS Scrambled Rangers And Red Guards Remain Stealthed While Capturing Buildings
 https://github.com/commy2/zerohour/issues/142 [IMPROVEMENT][NPROJECT] Fire Base Shoots At Awkward Angle
-https://github.com/commy2/zerohour/issues/141 [PENDING][NPROJECT]     Toxin General RPG-Trooper Shoots Stinger Missiles
+https://github.com/commy2/zerohour/issues/141 [DONE][NPROJECT]        Toxin General RPG-Trooper Shoots Stinger Missiles
 https://github.com/commy2/zerohour/issues/140 [DONE][NPROJEC!]        Gattling Helix Sometimes Fires At Airborne Units
 https://github.com/commy2/zerohour/issues/139 [DONE][NPROJEC!]        Dummy Weapons Cause Notifications And Hit Effects
 https://github.com/commy2/zerohour/issues/138 [IMPROVEMENT][NPROJECT] Nuke Battlemaster Uses Normal Battlemaster Button

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7134,7 +7134,7 @@ Weapon Chem_TunnelDefenderRocketWeaponBeta
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -7163,7 +7163,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGamma
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -7174,8 +7174,8 @@ Weapon Chem_TunnelDefenderRocketWeaponGamma
   AutoReloadsClip             = Yes
   FireSound                   = RPGTrooperWeapon
   FireFX                      = None
-  ProjectileDetonationFX = WeaponFX_StingerMissileDetonation
-; ProjectileDetonationOCL = OCL_PoisonFieldGammaSmall
+  ProjectileDetonationFX      = WeaponFX_RocketBuggyMissileDetonation
+; ProjectileDetonationOCL     = OCL_PoisonFieldUpgradedSmall
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle = No
   AntiAirborneInfantry = No
@@ -7192,7 +7192,7 @@ Weapon Chem_TunnelDefenderRocketWeaponBetaAir
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -7220,7 +7220,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGammaAir
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600               ; ignored for projectile weapons
-  ProjectileObject            = Chem_StingerMissile
+  ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
@@ -7231,7 +7231,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGammaAir
   AutoReloadsClip             = Yes
   FireSound                   = RPGTrooperWeapon
   FireFX                      = None
-  ProjectileDetonationFX = WeaponFX_StingerMissileDetonation
+  ProjectileDetonationFX      = WeaponFX_RocketBuggyMissileDetonation
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle = Yes
   AntiAirborneInfantry = No


### PR DESCRIPTION
* old PR: #394

ZH 1.04

- The Toxin RPG-Trooper shoots stinger missiles.

patch:

- The Toxin RPG-Trooper shoots "RPG" "missiles"