### PR TITLE
Fix: Worker Dies First Time Trying To Rebuild Scud Storm

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13556,8 +13556,14 @@ Object GLAScudStorm
 
 End
 
+; Patch104p @bugfix commy2 30/07/2022 Fix poor Worker dies of poison first time trying to rebuild.
+; Hole objects must always be defined before any object that would require it.
 ;------------------------------------------------------------------------------
-ObjectReskin GLAHoleScudStorm GLAHole
+Object GLAHoleScudStorm
+
+  ; *** ART Parameters ***
+  SelectPortrait           = SUHole_L
+  ButtonImage              = SUHole_L
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -13590,8 +13596,67 @@ ObjectReskin GLAHoleScudStorm GLAHole
 ;    End
 ;  End
 
+  PlacementViewAngle       = -135
+
+  ; ***DESIGN parameters ***
+  DisplayName       = OBJECT:GLAHole
+  Side              = GLA
+  EditorSorting     = SYSTEM
+  Prerequisites
+    Object = GLACommandCenter
+  End
+  BuildCost         = 100
+  BuildTime         = 10.0           ; in seconds
+  EnergyProduction  = 0
+  VisionRange       = 50.0           ; Shroud clearing distance
+  ShroudClearingRange = 50
+  ArmorSet
+    Conditions      = None
+    Armor           = StructureArmor
+    DamageFX        = StructureDamageFXNoShake
+  End
   MaxSimultaneousOfType = DeterminedBySuperweaponRestriction ; Normally unlimited, but can be selected by players in multiplayer games
   MaxSimultaneousLinkKey = Superweapon  ; Count all superweapons **AND THE GLA SCUD STORM REBUILD HOLE** as one "type" for MaxSimultaneousOfType
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect = TunnelNetworkSelect
+  SoundOnDamaged        = BuildingDamagedStateLight
+  SoundOnReallyDamaged  = BuildingDestroy
+
+  UnitSpecificSounds
+    UnderConstruction     = UnderConstructionLoop
+  End
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority     = STRUCTURE
+  KindOf            = PRELOAD STRUCTURE SELECTABLE IMMOBILE REBUILD_HOLE CAN_SEE_THROUGH_STRUCTURE IMMUNE_TO_CAPTURE SCORE_DESTROY MP_COUNT_FOR_VICTORY
+  Body              = StructureBody ModuleTag_03
+    ; To set the health for a particular hole, edit the entry in the object
+    ; that will leave the hole behind (edit the RebuildHoleExposeDie entry)
+    MaxHealth       = 9999999.9  ;bigger than anything realistic we use
+    InitialHealth   = 9999999.9  ;bigger than anything realistic we use
+  End
+  Behavior                    = RebuildHoleBehavior ModuleTag_04
+    WorkerObjectName          = GLAInfantryWorker
+    WorkerRespawnDelay        = 40000 ;in milliseconds
+    HoleHealthRegen%PerSecond = 0.5%    ;regen this % of HoleMaxHealth per second
+  End
+
+  Behavior             = CreateObjectDie ModuleTag_13
+    CreationList  = OCL_LargeStructureDebris
+  End
+  Behavior             = FXListDie ModuleTag_14
+    DeathFX       = FX_StructureSmallDeath
+  End
+
+
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 25.0
+  GeometryHeight      = 5.0
+  GeometryIsSmall     = No
+  Shadow              = SHADOW_VOLUME
+  BuildCompletion     = PLACED_BY_PLAYER
 
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -8599,7 +8599,7 @@ Object GC_Slth_GLAScudStorm
     SubdualDamageHealAmount = 100
   End
   Behavior        = RebuildHoleExposeDie ModuleTag_08
-    HoleName      = GC_Slth_GLAHoleScudStorm
+    HoleName      = GLAHoleScudStorm ; Patch104p @bugfix commy2 30/07/2022 Fix Worker dies from poison on first try.
     HoleMaxHealth = 500.0
   End
 


### PR DESCRIPTION
* old PR: #793
* Fixes #757
* Fixes #758

1.04: First Worker dies in poison cloud

Patch: Worker waits until poison cloud is gone

This has one drawback. If the new first Worker is killed, it will take 40 seconds instead of 20 seconds for another one to come out. Is this fine?