### PR TITLE
Fix: Spawn SCUD Storm Hole Worker after Toxin Puddle disappears - after 30 seconds instead of 20 seconds

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13556,8 +13556,14 @@ Object GLAScudStorm
 
 End
 
+; Patch104p @bugfix xezon 04/09/2022 Fix poor Worker dies of poison first time trying to rebuild.
+; Hole objects must always be defined before any object that would require it.
 ;------------------------------------------------------------------------------
-ObjectReskin GLAHoleScudStorm GLAHole
+Object GLAHoleScudStorm
+
+  ; *** ART Parameters ***
+  SelectPortrait           = SUHole_L
+  ButtonImage              = SUHole_L
   Draw                     = W3DModelDraw ModuleTag_01
     OkToChangeModelColor   = Yes
     ConditionState         = NONE
@@ -13590,8 +13596,69 @@ ObjectReskin GLAHoleScudStorm GLAHole
 ;    End
 ;  End
 
+  PlacementViewAngle = -135
+
+  ; ***DESIGN parameters ***
+  DisplayName       = OBJECT:GLAHole
+  Side              = GLA
+  EditorSorting     = SYSTEM
+
+  Prerequisites
+    Object = GLACommandCenter
+  End
+
+  BuildCost         = 100
+  BuildTime         = 10.0           ; in seconds
+  EnergyProduction  = 0
+  VisionRange       = 50.0           ; Shroud clearing distance
+  ShroudClearingRange = 50
+
+  ArmorSet
+    Conditions      = None
+    Armor           = StructureArmor
+    DamageFX        = StructureDamageFXNoShake
+  End
+
   MaxSimultaneousOfType = DeterminedBySuperweaponRestriction ; Normally unlimited, but can be selected by players in multiplayer games
   MaxSimultaneousLinkKey = Superweapon  ; Count all superweapons **AND THE GLA SCUD STORM REBUILD HOLE** as one "type" for MaxSimultaneousOfType
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect = TunnelNetworkSelect
+  SoundOnDamaged = BuildingDamagedStateLight
+  SoundOnReallyDamaged = BuildingDestroy
+
+  UnitSpecificSounds
+    UnderConstruction = UnderConstructionLoop
+  End
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority     = STRUCTURE
+  KindOf            = PRELOAD STRUCTURE SELECTABLE IMMOBILE REBUILD_HOLE CAN_SEE_THROUGH_STRUCTURE IMMUNE_TO_CAPTURE SCORE_DESTROY MP_COUNT_FOR_VICTORY
+  Body              = StructureBody ModuleTag_03
+    ; To set the health for a particular hole, edit the entry in the object
+    ; that will leave the hole behind (edit the RebuildHoleExposeDie entry)
+    MaxHealth       = 9999999.9  ;bigger than anything realistic we use
+    InitialHealth   = 9999999.9  ;bigger than anything realistic we use
+  End
+  Behavior                    = RebuildHoleBehavior ModuleTag_04
+    WorkerObjectName          = GLAInfantryWorker
+    WorkerRespawnDelay        = 30000
+    HoleHealthRegen%PerSecond = 0.5%    ;regen this % of HoleMaxHealth per second
+  End
+
+  Behavior = CreateObjectDie ModuleTag_13
+    CreationList = OCL_LargeStructureDebris
+  End
+  Behavior = FXListDie ModuleTag_14
+    DeathFX = FX_StructureSmallDeath
+  End
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 25.0
+  GeometryHeight      = 5.0
+  GeometryIsSmall     = No
+  Shadow              = SHADOW_VOLUME
+  BuildCompletion     = PLACED_BY_PLAYER
 
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLASystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLASystem.ini
@@ -107,6 +107,61 @@ Object GC_Chem_PoisonFieldGammaMedium
 
 End
 
+; Patch104p @bugfix xezon 04/09/2022 Creates GC_Chem_PoisonFieldGammaMedium optimized for Scud Storms
+;------------------------------------------------------------------------------
+Object GC_Chem_PoisonFieldGammaMedium_ScudStorm
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model = NONE
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  EditorSorting = SYSTEM
+  KindOf = IMMOBILE CLEANUP_HAZARD STICK_TO_TERRAIN_SLOPE INERT NO_COLLIDE
+  ArmorSet
+    Conditions      = None
+    Armor           = HazardousMaterialArmor
+  End
+
+  ; ***AUDIO parameters ***
+  SoundAmbient      = AnthraxPoolAmbientLoop
+
+
+  ; *** ENGINEERING Parameters ***
+  Body = ActiveBody ModuleTag_02
+    MaxHealth        = 120.0
+    InitialHealth    = 120.0
+  End
+  Behavior = FireWeaponUpdate ModuleTag_03
+    Weapon = Chem_MediumPoisonFieldWeaponGamma
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_04
+    MinLifetime = 26000
+    MaxLifetime = 26000
+  End
+
+  Behavior = FireWeaponUpdate ModuleTag_05
+    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+  End
+
+  Behavior = DestroyDie ModuleTag_06
+  End
+
+  Behavior = FXListDie ModuleTag_07
+    DeathFX = FX_AnthraxPoolDie
+  End
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 40.0
+  GeometryHeight      = 1.0
+  GeometryIsSmall     = No
+
+End
+
 ;------------------------------------------------------------------------------
 Object GC_Chem_PoisonFieldGammaSmall
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -8599,7 +8599,7 @@ Object GC_Slth_GLAScudStorm
     SubdualDamageHealAmount = 100
   End
   Behavior        = RebuildHoleExposeDie ModuleTag_08
-    HoleName      = GC_Slth_GLAHoleScudStorm
+    HoleName      = GLAHoleScudStorm ; Patch104p @bugfix xezon 04/09/2022 Fix Worker dies from poison on first try.
     HoleMaxHealth = 500.0
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -1877,6 +1877,63 @@ Object PoisonFieldMedium
 
 End
 
+; Patch104p @bugfix xezon 04/09/2022 Creates PoisonFieldMedium optimized for Scud Storms
+;------------------------------------------------------------------------------
+Object PoisonFieldMedium_ScudStorm
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model = NONE
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  EditorSorting = SYSTEM
+  KindOf = IMMOBILE CLEANUP_HAZARD STICK_TO_TERRAIN_SLOPE INERT NO_COLLIDE
+
+  ; ***AUDIO parameters ***
+  SoundAmbient      = ToxicPoolAmbientLoop
+
+  ; *** ENGINEERING Parameters ***
+  ArmorSet
+    Conditions      = None
+    Armor           = HazardousMaterialArmor
+  End
+
+  ; *** ENGINEERING Parameters ***
+  Body = ActiveBody ModuleTag_02
+    MaxHealth        = 100.0
+    InitialHealth    = 100.0
+  End
+
+  Behavior = FireWeaponUpdate ModuleTag_03
+    Weapon = MediumPoisonFieldWeapon
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_04
+    MinLifetime = 26000
+    MaxLifetime = 26000
+  End
+
+  Behavior = FireWeaponUpdate ModuleTag_05
+    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+  End
+
+  Behavior = DestroyDie ModuleTag_06
+  End
+
+  Behavior = FXListDie ModuleTag_07
+    DeathFX = FX_ToxicPoolDie
+  End
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 40.0
+  GeometryHeight      = 1.0
+  GeometryIsSmall     = No
+
+End
+
 ;------------------------------------------------------------------------------
 Object PoisonFieldSmall
 
@@ -2019,6 +2076,61 @@ Object PoisonFieldUpgradedMedium
   Behavior = LifetimeUpdate ModuleTag_04
     MinLifetime = 30000
     MaxLifetime = 30000
+  End
+
+  Behavior = FireWeaponUpdate ModuleTag_05
+    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+  End
+
+  Behavior = DestroyDie ModuleTag_06
+  End
+
+  Behavior = FXListDie ModuleTag_07
+    DeathFX = FX_AnthraxPoolDie
+  End
+
+  Geometry            = CYLINDER
+  GeometryMajorRadius = 40.0
+  GeometryHeight      = 1.0
+  GeometryIsSmall     = No
+
+End
+
+; Patch104p @bugfix xezon 04/09/2022 Creates PoisonFieldMedium optimized for Scud Storms
+;------------------------------------------------------------------------------
+Object PoisonFieldUpgradedMedium_ScudStorm
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model = NONE
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  EditorSorting = SYSTEM
+  KindOf = IMMOBILE CLEANUP_HAZARD STICK_TO_TERRAIN_SLOPE INERT NO_COLLIDE
+  ArmorSet
+    Conditions      = None
+    Armor           = HazardousMaterialArmor
+  End
+
+  ; ***AUDIO parameters ***
+  SoundAmbient      = AnthraxPoolAmbientLoop
+
+
+  ; *** ENGINEERING Parameters ***
+  Body = ActiveBody ModuleTag_02
+    MaxHealth        = 120.0
+    InitialHealth    = 120.0
+  End
+  Behavior = FireWeaponUpdate ModuleTag_03
+    Weapon = MediumPoisonFieldWeaponUpgraded
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_04
+    MinLifetime = 26000
+    MaxLifetime = 26000
   End
 
   Behavior = FireWeaponUpdate ModuleTag_05

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -77,6 +77,15 @@ ObjectCreationList OCL_PoisonFieldSmall
  End
 End
 
+; Patch104p @bugfix xezon 04/09/2022 Creates PoisonFieldMedium optimized for Scud Storms
+; ----------------------------------------------
+ObjectCreationList OCL_PoisonFieldMedium_ScudStorm
+ CreateObject
+   ObjectNames = PoisonFieldMedium_ScudStorm
+   Disposition = ON_GROUND_ALIGNED
+ End
+End
+
 ; Patch104p @bugfix commy2 31/07/2022 Creates green Anthrax Bomb poison cloud.
 ; ----------------------------------------------
 ObjectCreationList OCL_PoisonFieldAnthraxBomb
@@ -122,6 +131,15 @@ End
 ObjectCreationList OCL_PoisonFieldUpgradedSmall
  CreateObject
    ObjectNames = PoisonFieldUpgradedSmall
+   Disposition = ON_GROUND_ALIGNED
+ End
+End
+
+; Patch104p @bugfix xezon 04/09/2022 Creates PoisonFieldUpgradedMedium optimized for Scud Storms
+; ----------------------------------------------
+ObjectCreationList OCL_PoisonFieldUpgradedMedium_ScudStorm
+ CreateObject
+   ObjectNames = PoisonFieldUpgradedMedium_ScudStorm
    Disposition = ON_GROUND_ALIGNED
  End
 End
@@ -8367,7 +8385,14 @@ ObjectCreationList OCL_PoisonFieldGammaSmall
  End
 End
 
-
+; Patch104p @bugfix xezon 04/09/2022 Creates GC_Chem_PoisonFieldGammaMedium optimized for Scud Storms
+; ----------------------------------------------
+ObjectCreationList OCL_PoisonFieldGammaMedium_ScudStorm
+ CreateObject
+   ObjectNames = GC_Chem_PoisonFieldGammaMedium_ScudStorm
+   Disposition = ON_GROUND_ALIGNED
+ End
+End
 
 
 ;---------------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8759,7 +8759,7 @@ Weapon ScudStormDeathWeapon
   WeaponSpeed                 = 99999.0
   ProjectileObject            = NONE
   FireFX                      = WeaponFX_HighExplosiveBioBombDetonation
-  FireOCL                     = OCL_PoisonFieldMedium
+  FireOCL                     = OCL_PoisonFieldMedium_ScudStorm
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 0                   ; time between shots, msec
   ClipSize                    = 1                            ; how many shots in a Clip (0 == infinite)
@@ -8779,7 +8779,7 @@ Weapon ScudStormDeathWeaponBeta
   WeaponSpeed                 = 99999.0
   ProjectileObject            = NONE
   FireFX                      = WeaponFX_HighExplosiveAnthraxBombDetonation
-  FireOCL                     = OCL_PoisonFieldUpgradedMedium
+  FireOCL                     = OCL_PoisonFieldUpgradedMedium_ScudStorm
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 0                   ; time between shots, msec
   ClipSize                    = 1                            ; how many shots in a Clip (0 == infinite)
@@ -8799,7 +8799,7 @@ Weapon Chem_ScudStormDeathWeaponGamma
   WeaponSpeed                 = 99999.0
   ProjectileObject            = NONE
   FireFX                      = Chem_WeaponFX_HighExplosiveGammaBombDetonation
-  FireOCL                     = OCL_PoisonFieldGammaMedium
+  FireOCL                     = OCL_PoisonFieldGammaMedium_ScudStorm
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 0                   ; time between shots, msec
   ClipSize                    = 1                            ; how many shots in a Clip (0 == infinite)


### PR DESCRIPTION
* Closes #1095
* Fixes #757
* Fixes #758

This change spawns the SCUD Storm Hole worker in 30 seconds instead of 20 seconds intervals. This will prevent the first worker from dying in the poison. No EVA event is triggered for damaging the spawned worker. Effectively a SCUD Storm can rebuild 10 seconds quicker than originally. The Toxin Field time has been adjusted to accommodate the Worker spawn time properly.

| Object                        | Build Time | Repair Time | Hole Repair Time | Toxin Field Time |
|-------------------------------|------------|-------------|------------------|------------------|
| Original USA Particle         | 60         | 60 max      |                  |                  |
| Original China Nuke           | 60         | 60 max      |                  |                  |
| Original GLA SCUD             | 120        | 120 max     | 160              | 30               |
| Original Demo GLA SCUD        | 120        | 120 max     | 160              | 30               |
| Patched Demo GLA SCUD (1)     | 120        | 120 max     | 140              |                  |
| Patched GLA SCUD (this)       | 120        | 120 max     | 150              | 26               |
| Patched Demo GLA SCUD (this)  | 120        | 120 max     | 150              |                  |

Note: It is not possible to use an external worker to continue repair a GLA building from GLA hole. Therefore the reduction in Toxin Field time is practically inconsequential.

This proposal was originally discussed in:
* #793

## Original

Worker spawns in the Toxin and dies.

![shot_20220725_191426_7](https://user-images.githubusercontent.com/4720891/180838228-580eb3e4-19e9-400c-b6ac-e882f2be6084.jpg)

## Patched 

Worker spawns just as the Toxin disappears.

https://user-images.githubusercontent.com/4720891/188309681-60cb4219-6787-4352-8272-cc172b15c4e3.mp4
