### PR TITLE
Fix: Rocket Buggy Missile Deleted Before Reaching Reinforcement Pad At Max Distance

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3019,7 +3019,7 @@ Object RocketBuggyMissile
   End
   Behavior = MissileAIUpdate ModuleTag_07
     TryToFollowTarget               = Yes
-    FuelLifetime                    = 1800
+    FuelLifetime                    = 1900 ; Patch104p @bugfix commy2 19/08/2022 Give just enough range to hit Reinforcement Pads at max range. Was 1800.
     InitialVelocity                 = 150                ; in dist/sec
     IgnitionDelay                   = 0
     DistanceToTravelBeforeTurning   = 3


### PR DESCRIPTION
* old PR TheSuperHackers/GeneralsGamePatch#929
* Fixes TheSuperHackers/GeneralsGameCode#142
* Closes TheSuperHackers/GeneralsGamePatch#1100
* Closes https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1101

1850 (+1 frame) wasn't enough to make all rockets hit, only half of them did.