### PR TITLE
Fix: Rocket Buggy Missile Deleted When Running Out Of Fuel

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3019,8 +3019,12 @@ Object RocketBuggyMissile
   Behavior = PhysicsBehavior ModuleTag_06
     Mass = 1
   End
+
+  ; Patch104p @bugfix commy2 19/08/2022 Make Buggy rocket explode when running out of fuel.
+  ; This will enable the rocket to hit Reinforcement Pads and display particle effects instead of vanishing.
   Behavior = MissileAIUpdate ModuleTag_07
     TryToFollowTarget               = Yes
+    DetonateOnNoFuel                = Yes
     FuelLifetime                    = 1800
     InitialVelocity                 = 150                ; in dist/sec
     IgnitionDelay                   = 0


### PR DESCRIPTION
* old PR TheSuperHackers/GeneralsGamePatch#931
* Fixes TheSuperHackers/GeneralsGameCode#142
* Fixes TheSuperHackers/GeneralsGameCode#141
* closes TheSuperHackers/GeneralsGamePatch#1099
* Closes https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1101

`MissileAIUpdate` module has an optional `DetonateOnNoFuel` token. When set to yes, the missile will no longer be deleted after `FuelLifetime`, but instead killed with `DETONATED` death type. This triggers the damage and effects from `BuggyRocketWeapon`, which otherwise would not happen.

Benefits: 
- no extended range like the other fix
- fixes the particle issue, which would persist with the other pull request

Drawbacks:
- stray Buggy Missiles that would previously be outrunned now hit unsuspecting units that happen to be where the missile runs out of fuel