### PR TITLE
Fix: Rocket Buggy Missile Times Out Before Reaching Reinforcement Pad

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -444,7 +444,7 @@ Object TechReinforcementPad
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf              = STRUCTURE SELECTABLE IMMOBILE SCORE TECH_BUILDING CAPTURABLE NO_COLLIDE AUTO_RALLYPOINT CONSERVATIVE_BUILDING
+  KindOf              = STRUCTURE SELECTABLE IMMOBILE SCORE TECH_BUILDING CAPTURABLE AUTO_RALLYPOINT CONSERVATIVE_BUILDING ; Patch104p @bugfix commy2 11/09/2021 Remove NO_COLLIDE to make Rocket Buggy missiles hit from max range.
   RadarPriority       = STRUCTURE
 
   Body                = ActiveBody ModuleTag_04
@@ -903,7 +903,7 @@ Object TechRepairbay
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf              = STRUCTURE SELECTABLE IMMOBILE SCORE TECH_BUILDING CAPTURABLE NO_COLLIDE CONSERVATIVE_BUILDING
+  KindOf              = STRUCTURE SELECTABLE IMMOBILE SCORE TECH_BUILDING CAPTURABLE CONSERVATIVE_BUILDING ; Patch104p @bugfix commy2 11/09/2021 Remove NO_COLLIDE to make Rocket Buggy missiles hit from max range.
   RadarPriority       = STRUCTURE
 
   Body                = ActiveBody ModuleTag_04


### PR DESCRIPTION
- close https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1099
- close https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1100

This removes the NO_COLLIDE flag from Reinforcement Pad (and RepairBay), which makes Rocket Buggy Missiles collide with the borders of the building and prevents them from timing out.

HOWEVER, this means that the parachuting vehicle will avoid the building before landing. Example of this bug from NProject:


https://user-images.githubusercontent.com/6576312/188304421-864536f8-b8d8-400b-872e-a77a1ef7db5f.mp4

