### PR TITLE
Experimental: Let Pilots Enter Comanches

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -1820,10 +1820,7 @@ Object AmericaVehicleComanche
     DeathFX = FX_ComancheStartDeath
   End
 
-  Behavior = JetAIUpdate ModuleTag_06
-    MinHeight                     = 5
-    NeedsRunway                   = No
-    KeepsParkingSpaceWhenAirborne = No
+  Behavior = ChinookAIUpdate ModuleTag_06
     AutoAcquireEnemiesWhenIdle    = Yes
     ; note that comanches do not return to base when idle
 
@@ -1905,6 +1902,30 @@ Object AmericaVehicleComanche
     AflameDamageAmount = 3       ; taking this much damage...
     AflameDamageDelay = 500       ; this often.
   End
+
+  Behavior = OverlordContain ModuleTag_PilotEnter01
+    Slots                 = 1
+    ScatterNearbyOnExit   = No
+    DamagePercentToUnits  = 100%
+    AllowInsideKindOf     = NO_GARRISON
+    ExitDelay             = 250
+    NumberOfExitPaths     = 1; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
+  End
+
+  Behavior = ObjectCreationUpgrade ModuleTag_PilotEnter02
+    UpgradeObject = OCL_PilotNoCanEnterVehicleDummy
+    TriggeredBy = Upgrade_Veterancy_HEROIC
+  End
+
+  ;Behavior = ObjectCreationUpgrade ModuleTag_PilotEnter03
+  ;  UpgradeObject = OCL_PilotNotShowOnVehicleWhenEnterAttackingVehicle
+  ;  TriggeredBy = AirF_Upgrade_StealthComanche
+  ;End
+
+  ;Behavior = GrantUpgradeCreate ModuleTag_PilotEnter04
+  ;  UpgradeToGrant = AirF_Upgrade_StealthComanche
+  ;  ExemptStatus = UNDER_CONSTRUCTION
+  ;End
 
   Geometry = BOX
   GeometryMajorRadius = 20.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3307,3 +3307,38 @@ Object Boss_StartingThings
     OCL      = OCL_Boss_VehicleDozer
   End
 End
+
+;------------------------------------------------------------------------------
+Object AmericaPilotNoCanEnterDummyObject
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model = NONE
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  Side = GLA
+  TransportSlotCount = 1
+  EditorSorting = SYSTEM
+  KindOf = PRELOAD CLICK_THROUGH INFANTRY NO_GARRISON IGNORED_IN_GUI
+  ArmorSet
+    Conditions      = None
+    Armor           = InvulnerableAllArmor
+  End
+
+  ; *** ENGINEERING Parameters ***
+  Body = ActiveBody ModuleTag_02
+    MaxHealth        = 100.0
+    InitialHealth    = 100.0
+  End
+
+  Behavior = DeletionUpdate ModuleTag_03
+    MinLifetime = 0.1
+    MaxLifetime = 0.1
+  End
+
+  Behavior = DestroyDie ModuleTag_07
+  End
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -9279,3 +9279,21 @@ ObjectCreationList OCL_Boss_VehicleDozer
     Offset = X:0 Y:0 Z:0
   End
 End
+
+; -----------------------------------------------------------------------------
+ObjectCreationList OCL_PilotNotShowOnVehicleWhenEnterAttackingVehicle
+  CreateObject
+    ObjectNames       = AmericaPilotNoCanEnterDummyObject
+    Count             = 1
+    ContainInsideSourceObject = Yes
+  End
+End
+
+; -----------------------------------------------------------------------------
+ObjectCreationList OCL_PilotNoCanEnterVehicleDummy
+  CreateObject
+    ObjectNames       = AmericaPilotNoCanEnterDummyObject
+    Count             = 99
+    ContainInsideSourceObject = Yes
+  End
+End


### PR DESCRIPTION
* old PR #570

ZH 1.04:

Pilots can enter Comanches, but only while they are landed for repairs.

Shockwave:

Pilots can be ordered to enter Comanches. The Comanche will land. If the Pilot walks into the landed Comanche, it will be promoted.

However if the Comanche lands on the Pilot standing below the Comanche, the Pilot will enter the Comanche without promoting it.

There is a fix in SW called `PilotNotShowOnVehicleWhenEnterAttackingVehicle` which in this case prevents the Pilot from being drawn inside the Comanche. However, it will not fix the underlying issue.

I don't like the fix in it's current state. To get this to work properly, we likely need Thyme. Putting this here anyway, as maybe someone smarter can come up with a good solution.

The `PilotNotShowOnVehicleWhenEnterAttackingVehicle` hackfix is commented out for easier debugging.
