### PR TITLE
Point Defense Laser Proposal 5, Laser Guided Missile Immune To PDL

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3391,6 +3391,82 @@ Object MissileDefenderMissile
 
 End
 
+; Patch104p @balance commy2 22/07/2022 Add laser guided missile object that ignores point defense lasers.
+;------------------------------------------------------------------------------
+Object MissileDefenderLaserGuidedMissile
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    OkToChangeModelColor = Yes
+    DefaultConditionState
+      Model = ExMsslTm
+    End
+    ConditionState = JAMMED
+      ParticleSysBone = None SparksMedium
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName      = OBJECT:RangerTeamMissile
+  EditorSorting   = SYSTEM
+  VisionRange = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = ProjectileArmor
+    DamageFX        = None
+  End
+
+  ; *** ENGINEERING Parameters ***
+  KindOf = PROJECTILE ; Patch104p, this is not a SMALL_MISSILE
+  Body = ActiveBody ModuleTag_02
+    MaxHealth       = 100.0
+    InitialHealth   = 100.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    ; A projectile is not disabled, but instead loses target and scatters
+    SubdualDamageCap = 200
+    SubdualDamageHealRate = 100000
+    SubdualDamageHealAmount = 50
+  End
+
+; ---- begin Projectile death behaviors
+  Behavior = InstantDeathBehavior DeathModuleTag_01
+    DeathTypes = NONE +DETONATED
+    ; we detonated normally.
+    ; no FX, just quiet destroy ourselves
+  End
+  Behavior = InstantDeathBehavior DeathModuleTag_02
+    DeathTypes = NONE +LASERED
+    ; shot down by laser.
+    FX         = FX_GenericMissileDisintegrate
+    OCL        = OCL_GenericMissileDisintegrate
+  End
+  Behavior = InstantDeathBehavior DeathModuleTag_03
+    DeathTypes = ALL -LASERED -DETONATED
+    ; shot down by nonlaser.
+    FX         = FX_GenericMissileDeath
+  End
+; ---- end Projectile death behaviors
+
+  Behavior = PhysicsBehavior ModuleTag_06
+    Mass = 1
+  End
+  Behavior = MissileAIUpdate ModuleTag_07
+    TryToFollowTarget               = Yes;;;;;;;;;No
+    FuelLifetime                    = 3000
+    InitialVelocity                 = 150                ; in dist/sec
+    IgnitionDelay                   = 0
+    DistanceToTravelBeforeTurning   = 3
+    IgnitionFX                      = FX_BuggyMissileIgnition
+  End
+  Locomotor = SET_NORMAL MissileDefenderMissileLocomotor
+  Geometry = Sphere
+  GeometryIsSmall = Yes
+  GeometryMajorRadius = 2.0
+
+End
+
 ;------------------------------------------------------------------------------
 Object TunnelDefenderMissile
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -793,6 +793,7 @@ Weapon MissileDefenderMissileWeapon
   ProjectileCollidesWith      = STRUCTURES
 End
 
+; Patch104p @balance commy2 22/07/2022 Make weapon immune to point defense lasers.
 ;------------------------------------------------------------------------------
 Weapon MissileDefenderLaserGuidedMissileWeapon
   PrimaryDamage = 40.0
@@ -802,7 +803,7 @@ Weapon MissileDefenderLaserGuidedMissileWeapon
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 600
-  ProjectileObject = MissileDefenderMissile
+  ProjectileObject = MissileDefenderLaserGuidedMissile
   ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   ScatterRadius = 0       ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly


### PR DESCRIPTION
* old PR #729

* Fixes #638

With this pull request, Missile Defender missiles fired in laser guided mode only are not targeted by any point defense lasers.