### PR TITLE
Point Defense Laser Proposal 6, Remove Secondary PDL From King Raptor

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17991,13 +17991,14 @@ Object AirF_AmericaJetRaptor
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
-  Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One ; Alias ModuleTag_Laser_Two
-    WeaponTemplate        = AirF_PointDefenseLaser
-    PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
-    ScanRate              = 0
-    ScanRange             = 200.0
-    PredictTargetVelocityFactor = 1.0
-  End
+  ; Patch104p @balance commy2 22/07/2022 Remove secondary point defense laser from King Raptor.
+  ;Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One ; Alias ModuleTag_Laser_Two
+  ;  WeaponTemplate        = AirF_PointDefenseLaser
+  ;  PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
+  ;  ScanRate              = 0
+  ;  ScanRange             = 200.0
+  ;  PredictTargetVelocityFactor = 1.0
+  ;End
 
   Behavior                = ArmorUpgrade ModuleTag_Armor25
     TriggeredBy           = Upgrade_AmericaCountermeasures


### PR DESCRIPTION
* old PR #730

* Fixes #638

With this pull request, the King Raptor will only have one point defense laser like other AFG planes instead of two point defense lasers.