### PR TITLE
Point Defense Laser Proposal 7, Laser Guided Missile Resists PDL

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -562,6 +562,25 @@ Armor ProjectileArmor         ;Missles are armored from basic damage
   Armor = FLAME             0%    ;Radiation no longer affects projectiles (Caused napalm triggering issue)
 End
 
+; Patch104p @balance commy2 22/07/2022 For laser guided missile that resists point defense lasers.
+Armor LaserGuidedMissileArmor
+  Armor = DEFAULT         25%     ;this sets the level for all nonspecified damage types
+  Armor = FALLING         0%      ;projectiles are immune to falling damage
+  Armor = LASER           50%     ;lasers are anti-personel and anti-projectile only (for point defense laser)
+  Armor = SMALL_ARMS      25%     ;gives Quad and gattling a little more punch.
+  Armor = MICROWAVE         0%
+  Armor = GATTLING        25%     ;resistant to gattling tank
+  Armor = HAZARD_CLEANUP  0%      ;Not harmed by cleaning weapons
+  Armor = KILL_PILOT      0%      ;Jarmen Kell uses against vehicles only.
+  Armor = SURRENDER       0%    ;Capture type weapons are effective only against infantry.
+  Armor = SUBDUAL_MISSILE   100%
+  Armor = SUBDUAL_VEHICLE   0%
+  Armor = SUBDUAL_BUILDING  0%
+  Armor = POISON            0%    ;Poison no longer affects projectiles
+  Armor = RADIATION         0%    ;Radiation no longer affects projectiles
+  Armor = FLAME             0%    ;Radiation no longer affects projectiles (Caused napalm triggering issue)
+End
+
 ;*Be careful with this type, use in conjunction with KindOf = BALLISTIC_MISSILE to restrict targeting
 ;*to select weapons, because ballistic missile armor is weak! Weapons capable of targeting must have
 ;*AntiBallisticMissile = Yes set in the Weapon.ini.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3391,6 +3391,82 @@ Object MissileDefenderMissile
 
 End
 
+; Patch104p @balance commy2 22/07/2022 Add laser guided missile object that resists point defense lasers.
+;------------------------------------------------------------------------------
+Object MissileDefenderLaserGuidedMissile
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    OkToChangeModelColor = Yes
+    DefaultConditionState
+      Model = ExMsslTm
+    End
+    ConditionState = JAMMED
+      ParticleSysBone = None SparksMedium
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName      = OBJECT:RangerTeamMissile
+  EditorSorting   = SYSTEM
+  VisionRange = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = LaserGuidedMissileArmor
+    DamageFX        = None
+  End
+
+  ; *** ENGINEERING Parameters ***
+  KindOf = PROJECTILE SMALL_MISSILE
+  Body = ActiveBody ModuleTag_02
+    MaxHealth       = 100.0
+    InitialHealth   = 100.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    ; A projectile is not disabled, but instead loses target and scatters
+    SubdualDamageCap = 200
+    SubdualDamageHealRate = 100000
+    SubdualDamageHealAmount = 50
+  End
+
+; ---- begin Projectile death behaviors
+  Behavior = InstantDeathBehavior DeathModuleTag_01
+    DeathTypes = NONE +DETONATED
+    ; we detonated normally.
+    ; no FX, just quiet destroy ourselves
+  End
+  Behavior = InstantDeathBehavior DeathModuleTag_02
+    DeathTypes = NONE +LASERED
+    ; shot down by laser.
+    FX         = FX_GenericMissileDisintegrate
+    OCL        = OCL_GenericMissileDisintegrate
+  End
+  Behavior = InstantDeathBehavior DeathModuleTag_03
+    DeathTypes = ALL -LASERED -DETONATED
+    ; shot down by nonlaser.
+    FX         = FX_GenericMissileDeath
+  End
+; ---- end Projectile death behaviors
+
+  Behavior = PhysicsBehavior ModuleTag_06
+    Mass = 1
+  End
+  Behavior = MissileAIUpdate ModuleTag_07
+    TryToFollowTarget               = Yes;;;;;;;;;No
+    FuelLifetime                    = 3000
+    InitialVelocity                 = 150                ; in dist/sec
+    IgnitionDelay                   = 0
+    DistanceToTravelBeforeTurning   = 3
+    IgnitionFX                      = FX_BuggyMissileIgnition
+  End
+  Locomotor = SET_NORMAL MissileDefenderMissileLocomotor
+  Geometry = Sphere
+  GeometryIsSmall = Yes
+  GeometryMajorRadius = 2.0
+
+End
+
 ;------------------------------------------------------------------------------
 Object TunnelDefenderMissile
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -793,6 +793,7 @@ Weapon MissileDefenderMissileWeapon
   ProjectileCollidesWith      = STRUCTURES
 End
 
+ ; Patch104p @balance commy2 22/07/2022 Make weapon resist point defense lasers.
 ;------------------------------------------------------------------------------
 Weapon MissileDefenderLaserGuidedMissileWeapon
   PrimaryDamage = 40.0
@@ -802,7 +803,7 @@ Weapon MissileDefenderLaserGuidedMissileWeapon
   DamageType = ARMOR_PIERCING
   DeathType = NORMAL
   WeaponSpeed = 600
-  ProjectileObject = MissileDefenderMissile
+  ProjectileObject = MissileDefenderLaserGuidedMissile
   ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   ScatterRadius = 0       ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly


### PR DESCRIPTION
* Fixes #638

With this pull request, Missile Defender missiles fired in laser guided mode will need to be zapped twice by a point defense laser before they are destroyed.