### PR TITLE
Anthrax Bomb Proposal 7, Allow Flame Weapons To Clear Poison Clouds

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -794,10 +794,17 @@ Armor InvulnerableAllArmor ; If you want to even be immune to Kill, then you wan
   Armor = UNRESISTABLE    100%
 End
 
+; Patch104p @balance commy2 23/07/2022 Allow FLAME weapons to clear poison clouds.
 Armor HazardousMaterialArmor    ;Poison fields and radiation fields have this type of armor (and only cleaned up by cleaner units)
   Armor = DEFAULT         0%
   Armor = HAZARD_CLEANUP  100%  ;Only way to get harmed (or cleaned up)
-  Armor = FLAME           0%    ;Flame can't clean it up anymore (looks dumb).
+  Armor = FLAME           100%
+End
+
+Armor RadioactiveMaterialArmor
+  Armor = DEFAULT         0%
+  Armor = HAZARD_CLEANUP  100%  ;Only way to get harmed (or cleaned up)
+  Armor = FLAME           0%
 End
 
 Armor AvalancheArmor    ;The avalanche bits will not crush each other

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17,7 +17,7 @@ Object Nuke_RadiationFieldSmall
   KindOf = IMMOBILE CLEANUP_HAZARD INERT NO_COLLIDE STICK_TO_TERRAIN_SLOPE
   ArmorSet
     Conditions      = None
-    Armor           = HazardousMaterialArmor
+    Armor           = RadioactiveMaterialArmor
   End
 
   ; ***AUDIO parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2213,7 +2213,7 @@ Object RadiationFieldLarge
   KindOf = IMMOBILE CLEANUP_HAZARD INERT NO_COLLIDE
   ArmorSet
     Conditions      = None
-    Armor           = HazardousMaterialArmor
+    Armor           = RadioactiveMaterialArmor
   End
 
   ; ***AUDIO parameters ***
@@ -2267,7 +2267,7 @@ Object RadiationFieldMedium
   KindOf = IMMOBILE CLEANUP_HAZARD INERT NO_COLLIDE
   ArmorSet
     Conditions      = None
-    Armor           = HazardousMaterialArmor
+    Armor           = RadioactiveMaterialArmor
   End
 
   ; ***AUDIO parameters ***
@@ -2321,7 +2321,7 @@ Object RadiationFieldSmall
   KindOf = IMMOBILE CLEANUP_HAZARD INERT NO_COLLIDE
   ArmorSet
     Conditions      = None
-    Armor           = HazardousMaterialArmor
+    Armor           = RadioactiveMaterialArmor
   End
 
   ; ***AUDIO parameters ***
@@ -2375,7 +2375,7 @@ Object NukeRadiationFieldWeapon
   KindOf = IMMOBILE CLEANUP_HAZARD INERT NO_COLLIDE
   ArmorSet
     Conditions      = None
-    Armor           = HazardousMaterialArmor
+    Armor           = RadioactiveMaterialArmor
   End
 
   ; ***AUDIO parameters ***


### PR DESCRIPTION
* old PR #749

Some weird idea to try regarding #55

This makes FLAME weapons (Dragon Tank, Inferno Cannon, Mig) clear up poison fields. It does not make it clear up radiation fields.