### PR TITLE
Fix: Prevent Jarmen From Sniping Pilot Of Landed Chinook or Helix

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -512,6 +512,7 @@ End
 ;-----------------------------------------------------------------------------------
 
 
+; Patch104p @bugfix 12/08/2022 Prevent Jarmen from sniping pilot of grounded Chinook or Helix.
 Armor ChinookArmor
   Armor = DEFAULT           50%  ;this sets the level for all nonspecified damage types
   Armor = INFANTRY_MISSILE  25%
@@ -521,6 +522,7 @@ Armor ChinookArmor
   Armor = SNIPER            0%
   Armor = MICROWAVE         0%
   Armor = HAZARD_CLEANUP    0%      ;Not harmed by cleaning weapons
+  Armor = KILL_PILOT        0%      ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER         0%
   Armor = SUBDUAL_MISSILE   0%
   Armor = SUBDUAL_VEHICLE   0%
@@ -537,6 +539,7 @@ Armor HelixArmor
   Armor = SNIPER            0%
   Armor = MICROWAVE         0%
   Armor = HAZARD_CLEANUP    0%      ;Not harmed by cleaning weapons
+  Armor = KILL_PILOT        0%      ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER         0%
   Armor = SUBDUAL_MISSILE   0%
   Armor = SUBDUAL_VEHICLE   0%


### PR DESCRIPTION
- old PR TheSuperHackers/GeneralsGamePatch#877
- fixes TheSuperHackers/GeneralsGameCode#35
- fixes TheSuperHackers/GeneralsGamePatch#661
- closes TheSuperHackers/GeneralsGamePatch#180
- closes TheSuperHackers/GeneralsGamePatch#1110

Sniping Pilots does not work well with Helicopters that have units inside. Infantry won't evacuate and Helix may be unable to be captured despite being neutral. Arguably no Helicopter should be snipable, because Comanches aren't either.