### PR TITLE
Fix: Fuel Air Bomb Animation Bug

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1803,6 +1803,11 @@ Object DaisyCutterGas
 ;  End
 
   ; *** DESIGN Parameters ***
+  ; Patch104p @bugfix commy2 16/08/2022 Fix animation bugging out when dummy is hit by crossfire.
+  ArmorSet
+    Conditions      = None
+    Armor           = InvulnerableAllArmor
+  End
 
   ; *** ENGINEERING Parameters ***
   KindOf = IMMOBILE UNATTACKABLE


### PR DESCRIPTION
* old PR #918
* fixes #610

When Fuel Air Bomb gas cloud is hit by crossfire, it may die thus aborting the explosion animation. The damage still occurs normally anyway, so this fix is only visual.

Crossfire was simulated using:

```ini
  Behavior = FireWeaponUpdate ModuleTag_DEBUG
    Weapon = CrossfireSimulatorWeapon
  End
```
on building and
```ini
;------------------------------------------------------------------------------
Weapon CrossfireSimulatorWeapon
  PrimaryDamage = 8.0
  PrimaryDamageRadius = 100.0
  DamageDealtAtSelfPosition = Yes
  AttackRange = 100.0
  DamageType = EXPLOSION
  DeathType = EXPLODED
  WeaponSpeed = 600                     ;  dist/sec
  RadiusDamageAffects = ENEMIES
  DelayBetweenShots = 250                ; time between shots, msec
End
```