### PR TITLE
Add: Decontamination Ability To Toxin Tractor

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1920,6 +1920,21 @@ CommandButton Command_GLAToxinTractorContaminateGround
   UnitSpecificSound       = ToxinTractorVoiceModeContam
 End
 
+CommandButton Command_GLAToxinTractorCleanupArea
+  Command                 = FIRE_WEAPON
+  SpecialPower            = SpecialAbilityToxinTractorCleanupArea
+  WeaponSlot              = TERTIARY
+  Options                 = NEED_TARGET_POS OK_FOR_MULTI_SELECT ; CONTEXTMODE_COMMAND <- uncomment to remove attacking voice when area is selected
+  TextLabel               = CONTROLBAR:AmbulanceCleanupArea
+  ButtonImage             = SSDetox
+  ButtonBorderType        = ACTION
+  DescriptLabel           = CONTROLBAR:CleanupAreaDescription
+  RadiusCursorType        = AMBULANCE
+  CursorName              = Target
+  InvalidCursorName       = GenericInvalid
+  UnitSpecificSound       = NoSound
+End
+
 CommandButton Command_GLAInfantryRebelCaptureBuilding
   Command                 = SPECIAL_POWER
   SpecialPower            = SpecialAbilityRebelCaptureBuilding

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -344,6 +344,7 @@ End
 
 CommandSet GLAVehicleToxinTruckCommandSet
   1  = Command_GLAToxinTractorContaminateGround
+  2  = Command_GLAToxinTractorCleanupArea
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -17933,6 +17933,8 @@ Object Chem_GLAVehicleToxinTruck
       WeaponLaunchBone = PRIMARY WeaponA
       WeaponFireFXBone = SECONDARY Spigot
       WeaponLaunchBone = SECONDARY Spigot
+      WeaponFireFXBone = TERTIARY WeaponA
+      WeaponLaunchBone = TERTIARY WeaponA
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE
 
@@ -17969,6 +17971,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
 
@@ -17979,6 +17983,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
     END
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
@@ -17988,6 +17994,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxGammaPuddleContinuous
     END
 
@@ -17999,6 +18007,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
     End
     AliasConditionState REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
     AliasConditionState RUBBLE WEAPONSET_CRATEUPGRADE_ONE
@@ -18012,6 +18022,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
     END
     ConditionState = USING_WEAPON_B REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
@@ -18022,6 +18034,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxGammaPuddleContinuous
     END
 
@@ -18033,6 +18047,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
 
@@ -18043,6 +18059,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
     END
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
@@ -18052,6 +18070,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxGammaPuddleContinuous
     END
 
@@ -18063,6 +18083,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
     End
     AliasConditionState REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
     AliasConditionState RUBBLE WEAPONSET_CRATEUPGRADE_TWO
@@ -18076,6 +18098,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
     END
     ConditionState = USING_WEAPON_B REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
@@ -18086,6 +18110,8 @@ Object Chem_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxGammaPuddleContinuous
     END
 
@@ -18112,39 +18138,51 @@ Object Chem_GLAVehicleToxinTruck
     Conditions        = None
     Weapon            = PRIMARY     ToxinTruckGunUpgraded
     Weapon            = SECONDARY   ToxinTruckSprayerUpgraded
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = PLAYER_UPGRADE
     Weapon            = PRIMARY     Chem_ToxinTruckGunGamma
     Weapon            = SECONDARY   Chem_ToxinTruckSprayerGamma
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = PRIMARY     FROM_PLAYER FROM_SCRIPT FROM_AI
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_ONE
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusOne
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusOne
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_ONE PLAYER_UPGRADE
     Weapon            = PRIMARY     Chem_ToxinTruckGunGammaPlusOne
     Weapon            = SECONDARY   Chem_ToxinTruckSprayerGammaPlusOne
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_TWO
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusTwo
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusTwo
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_TWO PLAYER_UPGRADE
     Weapon            = PRIMARY     Chem_ToxinTruckGunGammaPlusTwo
     Weapon            = SECONDARY   Chem_ToxinTruckSprayerGammaPlusTwo
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
 
   ArmorSet
@@ -18211,8 +18249,10 @@ Object Chem_GLAVehicleToxinTruck
       AllowsPitch               = Yes
       MinPhysicalPitch          = -20 ; If allows pitch, the lowest I can dip down to shoot.  defaults to 0 (horizontal)
       TurretFireAngleSweep      = PRIMARY 8
+      TurretFireAngleSweep      = TERTIARY 8
       TurretSweepSpeedModifier  = PRIMARY 0.5    ; Sweep slower than you turn
-      ControlledWeaponSlots     = PRIMARY
+      TurretSweepSpeedModifier  = TERTIARY 0.5
+      ControlledWeaponSlots     = PRIMARY TERTIARY
     End
   End
   Locomotor             = SET_NORMAL ToxinTruckLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3630,6 +3630,8 @@ Object GLAVehicleToxinTruck
       WeaponLaunchBone = PRIMARY WeaponA
       WeaponFireFXBone = SECONDARY Spigot
       WeaponLaunchBone = SECONDARY Spigot
+      WeaponFireFXBone = TERTIARY WeaponA
+      WeaponLaunchBone = TERTIARY WeaponA
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE
 
@@ -3666,6 +3668,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
 
@@ -3676,6 +3680,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
@@ -3685,6 +3691,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -3696,6 +3704,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
     End
     AliasConditionState REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
     AliasConditionState RUBBLE WEAPONSET_CRATEUPGRADE_ONE
@@ -3709,6 +3719,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
@@ -3719,6 +3731,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -3730,6 +3744,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
 
@@ -3740,6 +3756,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
@@ -3749,6 +3767,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -3760,6 +3780,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
     End
     AliasConditionState REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
     AliasConditionState RUBBLE WEAPONSET_CRATEUPGRADE_TWO
@@ -3773,6 +3795,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
@@ -3783,6 +3807,8 @@ Object GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -3810,37 +3836,49 @@ Object GLAVehicleToxinTruck
     Conditions        = None
     Weapon            = PRIMARY     ToxinTruckGun
     Weapon            = SECONDARY   ToxinTruckSprayer
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = PLAYER_UPGRADE
     Weapon            = PRIMARY     ToxinTruckGunUpgraded
     Weapon            = SECONDARY   ToxinTruckSprayerUpgraded
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_ONE
     Weapon            = PRIMARY     ToxinTruckGunPlusOne
     Weapon            = SECONDARY   ToxinTruckSprayerPlusOne
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_ONE PLAYER_UPGRADE
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusOne
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusOne
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_TWO
     Weapon            = PRIMARY     ToxinTruckGunPlusTwo
     Weapon            = SECONDARY   ToxinTruckSprayerPlusTwo
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_TWO PLAYER_UPGRADE
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusTwo
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusTwo
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
 
   ArmorSet
@@ -3907,8 +3945,10 @@ Object GLAVehicleToxinTruck
       AllowsPitch               = Yes
       MinPhysicalPitch          = -20 ; If allows pitch, the lowest I can dip down to shoot.  defaults to 0 (horizontal)
       TurretFireAngleSweep      = PRIMARY 8
+      TurretFireAngleSweep      = TERTIARY 8
       TurretSweepSpeedModifier  = PRIMARY 0.5    ; Sweep slower than you turn
-      ControlledWeaponSlots     = PRIMARY
+      TurretSweepSpeedModifier  = TERTIARY 0.5
+      ControlledWeaponSlots     = PRIMARY TERTIARY
     End
   End
   Locomotor             = SET_NORMAL ToxinTruckLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19369,6 +19369,8 @@ Object Slth_GLAVehicleToxinTruck
       WeaponLaunchBone = PRIMARY WeaponA
       WeaponFireFXBone = SECONDARY Spigot
       WeaponLaunchBone = SECONDARY Spigot
+      WeaponFireFXBone = TERTIARY WeaponA
+      WeaponLaunchBone = TERTIARY WeaponA
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE
 
@@ -19405,6 +19407,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
 
@@ -19415,6 +19419,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
@@ -19424,6 +19430,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -19435,6 +19443,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
     End
     AliasConditionState REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
     AliasConditionState RUBBLE WEAPONSET_CRATEUPGRADE_ONE
@@ -19448,6 +19458,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE
@@ -19458,6 +19470,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = Turret TurretUP02 ToxTanks00 HouseColor01 ToxTanks03 HouseColor04
       WeaponFireFXBone = PRIMARY WeaponB
       WeaponLaunchBone = PRIMARY WeaponB
+      WeaponFireFXBone = TERTIARY WeaponB
+      WeaponLaunchBone = TERTIARY WeaponB
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -19469,6 +19483,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
     End
     AliasConditionState WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
 
@@ -19479,6 +19495,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
@@ -19488,6 +19506,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -19499,6 +19519,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
     End
     AliasConditionState REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
     AliasConditionState RUBBLE WEAPONSET_CRATEUPGRADE_TWO
@@ -19512,6 +19534,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none ToxinPuddleContinuous
     END
     ConditionState = USING_WEAPON_B REALLYDAMAGED WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
@@ -19522,6 +19546,8 @@ Object Slth_GLAVehicleToxinTruck
       HideSubObject = TurretUP01 Turret ToxTanks00 HouseColor01 ToxTanks01 HouseColor02
       WeaponFireFXBone = PRIMARY WeaponC
       WeaponLaunchBone = PRIMARY WeaponC
+      WeaponFireFXBone = TERTIARY WeaponC
+      WeaponLaunchBone = TERTIARY WeaponC
       ParticleSysBone = none AnthraxPuddleContinuous
     END
 
@@ -19549,37 +19575,49 @@ Object Slth_GLAVehicleToxinTruck
     Conditions        = None
     Weapon            = PRIMARY     ToxinTruckGun
     Weapon            = SECONDARY   ToxinTruckSprayer
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = PLAYER_UPGRADE
     Weapon            = PRIMARY     ToxinTruckGunUpgraded
     Weapon            = SECONDARY   ToxinTruckSprayerUpgraded
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_ONE
     Weapon            = PRIMARY     ToxinTruckGunPlusOne
     Weapon            = SECONDARY   ToxinTruckSprayerPlusOne
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_ONE PLAYER_UPGRADE
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusOne
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusOne
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_TWO
     Weapon            = PRIMARY     ToxinTruckGunPlusTwo
     Weapon            = SECONDARY   ToxinTruckSprayerPlusTwo
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_TWO PLAYER_UPGRADE
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusTwo
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusTwo
+    Weapon            = TERTIARY    ToxinTruckCleanHazardWeapon
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+    AutoChooseSources = TERTIARY    NONE ;Special attack only
   End
 
   ArmorSet
@@ -19646,8 +19684,10 @@ Object Slth_GLAVehicleToxinTruck
       AllowsPitch               = Yes
       MinPhysicalPitch          = -20 ; If allows pitch, the lowest I can dip down to shoot.  defaults to 0 (horizontal)
       TurretFireAngleSweep      = PRIMARY 8
+      TurretFireAngleSweep      = TERTIARY 8
       TurretSweepSpeedModifier  = PRIMARY 0.5    ; Sweep slower than you turn
-      ControlledWeaponSlots     = PRIMARY
+      TurretSweepSpeedModifier  = TERTIARY 0.5
+      ControlledWeaponSlots     = PRIMARY TERTIARY
     End
   End
   Locomotor             = SET_NORMAL ToxinTruckLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -987,3 +987,11 @@ SpecialPower SuperweaponSatelliteHackTwo
   AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.
   ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
 End
+
+;-----------------------------------------------------------------------------
+SpecialPower SpecialAbilityToxinTractorCleanupArea
+  Enum              = SPECIAL_INVALID
+  ReloadTime        = 0   ; in milliseconds
+  PublicTimer       = No
+  RadiusCursorRadius  = 50
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3415,6 +3415,31 @@ Weapon ToxinTruckSprayerUpgradedPlusTwo
 End
 
 ;------------------------------------------------------------------------------
+Weapon ToxinTruckCleanHazardWeapon
+  PrimaryDamage               = 100.0
+  PrimaryDamageRadius         = 50.0
+  AttackRange                 = 100.0
+  MinimumAttackRange          = 10.0
+  DamageType                  = HAZARD_CLEANUP
+  DeathType                   = NORMAL
+  WeaponSpeed                 = 600                     ;  dist/sec
+  WeaponRecoil                = 0                      ; angle to deflect the model when firing
+  ProjectileObject            = CleanupStreamProjectile
+  FireFX                      = WeaponFX_CleanupFireWeapon
+  ProjectileDetonationFX      = WeaponFX_CleanupToxinDetonation
+  FireSound                   = ToxinTractorWeaponLoop
+  FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
+  RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots           = 40                ; time between shots, msec
+  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0                   ; how long to reload a Clip, msec
+  AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
+  ProjectileStreamName        = CleanupHazardProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
+  ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
+End
+
+;------------------------------------------------------------------------------
 Weapon FireWallSegmentWeapon
   PrimaryDamage               = 4.0
   PrimaryDamageRadius         = 10.0


### PR DESCRIPTION
* old PR #972

Idea from [MTKing4](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/55#issuecomment-1193170691).

This adds a decontamination ability to the Toxin Tractor.

Combined with https://github.com/TheSuperHackers/GeneralsGamePatch/pull/749 it would mean that all 12 factions have a cleanup unit to counter the Anthrax Bomb.

PR only works with vGLA Tractor.
