### PR TITLE
Change: Increase Super Hacker Vehicle Hack range by +3%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1515,7 +1515,8 @@ Object Infa_ChinaInfantryHacker
   End
   Behavior = SpecialAbilityUpdate ModuleTag_13
     SpecialPowerTemplate    = SpecialAbilityBlackLotusDisableVehicleHack
-    StartAbilityRange       = 150.0
+    StartAbilityRange       = 155.0 ; Patch104p @balance From 150 increase ability range to be just slightly above the firing range of regular idle tanks (150).
+    ;AbilityAbortRange       = 235.0 ; Patch104p @balance Abort ability when target moves out of range by 80 units
     UnpackTime              = 2000 ;6730 ;animation time is 6730 (changing this will scale anim speed)
     PackTime                = 1000 ;2800 ;animation time is 5800 (changing this will scale anim speed)
     PreparationTime         = 2000 ;time to complete hack once prepared (unpacked)


### PR DESCRIPTION
* old PR #790

Increase Super Hacker Vehicle Hack range by +3%.

3% does not sound like much, but this is the difference between life and death vs idle units. With this change Super Hacker can try engage idle tanks. When idle, meaning no guard or retaliation, Super Hacker can successfully disable Tank without getting shot at.

Most Tanks Attack Range: 150
Original Super Hacker Attack Range: 150
Patched Super Hacker Attack Range: 155

This change needs to be closely monitored. If Super Hacker can be abused in some way because of it, then it should be reverted.

## Original
![shot_20220730_165202_4](https://user-images.githubusercontent.com/4720891/181919861-d18bb2a0-223e-4f40-8921-5193183bbafb.jpg)

![shot_20220730_165206_5](https://user-images.githubusercontent.com/4720891/181919866-26ce9720-94ab-4fcf-b2df-4440ce47aba7.jpg)

## Patched
![shot_20220730_165004_1](https://user-images.githubusercontent.com/4720891/181919880-9abd2039-d09b-4374-bdd0-6d9030dde54b.jpg)

![shot_20220730_165014_2](https://user-images.githubusercontent.com/4720891/181919882-933df347-6429-438f-8da2-399e5f0e9966.jpg)

