### PR TITLE
Change: Increase Regular Lotus Vehicle Hack range by +30%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17956,7 +17956,8 @@ Object Boss_InfantryBlackLotus
   End
   Behavior = SpecialAbilityUpdate ModuleTag_11
     SpecialPowerTemplate    = SpecialAbilityBlackLotusDisableVehicleHack
-    StartAbilityRange       = 150.0
+    StartAbilityRange       = 195.0 ; Patch104p @balance From 150 increase ability range to allow disable vehicles more comfortably
+    ;AbilityAbortRange       = 275.0 ; Patch104p @balance Abort ability when target moves out of range by 80 units
     UnpackTime              = 2000 ;6730 ;animation time is 6730 (changing this will scale anim speed)
     PackTime                = 1000 ;2800 ;animation time is 5800 (changing this will scale anim speed)
     PreparationTime         = 2000 ;time to complete hack once prepared (unpacked)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -751,7 +751,8 @@ Object ChinaInfantryBlackLotus
   End
   Behavior = SpecialAbilityUpdate ModuleTag_11
     SpecialPowerTemplate    = SpecialAbilityBlackLotusDisableVehicleHack
-    StartAbilityRange       = 150.0
+    StartAbilityRange       = 195.0 ; Patch104p @balance From 150 increase ability range to allow disable vehicles more comfortably
+    ;AbilityAbortRange       = 275.0 ; Patch104p @balance Abort ability when target moves out of range by 80 units
     UnpackTime              = 2000 ;6730 ;animation time is 6730 (changing this will scale anim speed)
     PackTime                = 1000 ;2800 ;animation time is 5800 (changing this will scale anim speed)
     PreparationTime         = 2000 ;time to complete hack once prepared (unpacked)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -790,7 +790,8 @@ Object Infa_ChinaInfantryBlackLotus
   End
   Behavior = SpecialAbilityUpdate ModuleTag_11
     SpecialPowerTemplate    = SpecialAbilityBlackLotusDisableVehicleHack
-    StartAbilityRange       = 300.0
+    StartAbilityRange       = 300.0 ; Super Lotus has incredible range
+    ;AbilityAbortRange       = 380.0 ; Patch104p @balance Abort ability when target moves out of range by 80 units
     UnpackTime              = 2000 ;6730 ;animation time is 6730 (changing this will scale anim speed)
     PackTime                = 1000 ;2800 ;animation time is 5800 (changing this will scale anim speed)
     PreparationTime         = 2000 ;time to complete hack once prepared (unpacked)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2137,7 +2137,8 @@ Object Nuke_ChinaInfantryBlackLotus
   End
   Behavior = SpecialAbilityUpdate ModuleTag_11
     SpecialPowerTemplate    = SpecialAbilityBlackLotusDisableVehicleHack
-    StartAbilityRange       = 150.0
+    StartAbilityRange       = 195.0 ; Patch104p @balance From 150 increase ability range to allow disable vehicles more comfortably
+    ;AbilityAbortRange       = 275.0 ; Patch104p @balance Abort ability when target moves out of range by 80 units
     UnpackTime              = 2000 ;6730 ;animation time is 6730 (changing this will scale anim speed)
     PackTime                = 1000 ;2800 ;animation time is 5800 (changing this will scale anim speed)
     PreparationTime         = 2000 ;time to complete hack once prepared (unpacked)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1867,7 +1867,8 @@ Object Tank_ChinaInfantryBlackLotus
   End
   Behavior = SpecialAbilityUpdate ModuleTag_11
     SpecialPowerTemplate    = SpecialAbilityBlackLotusDisableVehicleHack
-    StartAbilityRange       = 150.0
+    StartAbilityRange       = 195.0 ; Patch104p @balance From 150 increase ability range to allow disable vehicles more comfortably
+    ;AbilityAbortRange       = 275.0 ; Patch104p @balance Abort ability when target moves out of range by 80 units
     UnpackTime              = 2000 ;6730 ;animation time is 6730 (changing this will scale anim speed)
     PackTime                = 1000 ;2800 ;animation time is 5800 (changing this will scale anim speed)
     PreparationTime         = 2000 ;time to complete hack once prepared (unpacked)


### PR DESCRIPTION
* old PR #796
* Related #1114
* Related #1102

This change adds 30% range on top of all China Black Lotus vehicle hacks, except of Super Lotus.

Black Lotus can now try engage idle tanks. When idle, meaning no guard or retaliation, Black Lotus can successfully disable tanks without getting shot at. However, when tanks are on duty, Lotus can be attacked as usual.

## Relevant ranges
| Object | Hack Range | Attack Range | Stealth Detection Range |
|--------|-----------:|-------------:|------------------------:|
| Most Tanks               |     | 150 |     |
| USA Tomahawk             |     | 300 |     |
| China Overlord           |     | 175 |     |
| China Overlord Gattling  |     | 225 | 200 |
| China Inferno            |     | 300 |     |
| GLA Marauder             |     | 170 |     |
| GLA Rocket Buggy         |     | 300 |     |
| USA Scout Drone          |     |     | 150 (+75+10 wander) |
| GLA Radar Van            |     |     | 250 |
| China Outpost            |     |     | 300 |
| Original Super Lotus     | 300 |     | 300 |
| Original Lotus           | 150 |     | 300 |
| **Patched Lotus (this)** | 195 |     | 300 |

Original and patched vehicle hack range of Black Lotus is significantly lower than all main stealth scouts. USA Scout drone sways around USA vehicles in idle by 35 and on the move or attack by 75 + another 10, which puts it well within Lotus range, even after Patch.

Patched Black Lotus vehicle hack range is greater than all main weapons of regular Tanks.

# Lab Test

Find comparison tables below as to how much damage Lotus receives when trying to disable tanks on guard. Note that these are lab tests, without regular battle scenarios. Factors such as unit movements prior Lotus hack, assisting unit constellations, manual attack delay and latency are not and cannot be considered.

Note 1: Lotus was always pulled away from enemy forces as soon as the target vehicle was disabled.

Note 2: Super Lotus will disable all vehicles listed below without receiving any damage.

Note 3: No tests vs Toxin Tanks.

## Lotus vs GLA Technical on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x GLA Technical from behind  | 33%  |  0% |
| 1x GLA Technical from front   | 50%  |  0% |
| 2x GLA Technical from behind  | 50%  | 20% |
| 2x GLA Technical from front   | 100% | 40% |
| 3x GLA Technical from behind  | 90%  | 33% |
| 3x GLA Technical from front   | 100% | 50% |

## Lotus vs GLA Quad on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x GLA Quad from behind  | 60%  |   0% |
| 1x GLA Quad from front   | 80%  |  20% |
| 2x GLA Quad from behind  | 100% |  75% |
| 2x GLA Quad from front   | 100% | 100% |
| 3x GLA Quad from behind  | 100% | 100% |
| 3x GLA Quad from front   | 100% | 100% |

## Lotus vs Rocket Scorpion on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x GLA Rocket Scorpion from behind  | 60%  |   0% |
| 1x GLA Rocket Scorpion from front   | 60%  |  60% |
| 2x GLA Rocket Scorpion from behind  | 100% |  50% |
| 2x GLA Rocket Scorpion from front   | 100% | 100% |
| 3x GLA Rocket Scorpion from behind  | 100% |  90% |
| 3x GLA Rocket Scorpion from front   | 100% | 100% |

## Lotus vs China Gattling on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x China Gattling from behind  | 20%  |   5% |
| 1x China Gattling from front   | 33%  |  25% |
| 2x China Gattling from behind  | 100% |  50% |
| 2x China Gattling from front   | 100% | 100% |
| 3x China Gattling from behind  | 100% | 100% |
| 3x China Gattling from front   | 100% | 100% |

## Lotus vs Nuke China Battlemaster on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x Nuke China Battlemaster from behind  | 33% |   0% |
| 1x Nuke China Battlemaster from front   | 33% |  25% |
| 2x Nuke China Battlemaster from behind  | 50% |  20% |
| 2x Nuke China Battlemaster from front   | 60% |  40% |
| 3x Nuke China Battlemaster from behind  | 60% |  33% |
| 3x Nuke China Battlemaster from front   | 80% |  66% |

## Lotus vs China Gattling Overlord on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x China Gattling Overlord from behind  | 100% |   0% |
| 1x China Gattling Overlord from front   | 60%  |  25% |

## Lotus vs Nuke China Overlord on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x Nuke China Overlord from behind  |   0% |   0% |
| 1x Nuke China Overlord from front   |  40% |  20% |
| 2x Nuke China Overlord from behind  |   5% |   0% |
| 2x Nuke China Overlord from front   |  85% |  40% |
| 3x Nuke China Overlord from behind  |  50% |   0% |
| 3x Nuke China Overlord from front   | 100% |  60% |

## Lotus vs Nuke China Propaganda Overlord on Guard

| _______________ Enemy Object(s) _______________ | Original Lotus recv DMG | Patched Lotus recv DMG (this) |
|-------------------------------------------------|------------------------:|-------------------------------:|
| 1x Nuke China Prop Overlord from behind  |   0% |   0% |
| 1x Nuke China Prop Overlord from front   |  33% |  25% |
