### PR TITLE
Change: Increase China Nuke Cannon and China Inferno Cannon Armor against Infantry Missiles by 100%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -126,6 +126,31 @@ Armor TankArmor
   Armor = SMALL_ARMS         25%
   Armor = GATTLING           10%      ;resistant to gattling tank
   Armor = COMANCHE_VULCAN    25%
+  Armor = INFANTRY_MISSILE  100%
+  Armor = FLAME              25%
+  Armor = RADIATION          50%      ;Radiation does less damage to tanks.
+  Armor = MICROWAVE           0%
+  Armor = POISON             25%      ;Poison does a little damage, just for balance reasons.
+  Armor = SNIPER              0%
+  Armor = MELEE               0%      ;tanks don't generally take much damage other than paint damage from MELEE weapons
+  Armor = LASER               0%      ;lasers are anti-personel and anti-projectile only (for point defense laser)
+  Armor = HAZARD_CLEANUP      0%      ;Not harmed by cleaning weapons
+  Armor = PARTICLE_BEAM     100%      ;
+  Armor = KILL_PILOT        100%      ;Jarmen Kell uses against vehicles only.
+  Armor = SURRENDER           0%      ;Capture type weapons are effective only against infantry.
+  Armor = SUBDUAL_MISSILE     0%
+  Armor = SUBDUAL_VEHICLE   100%
+  Armor = SUBDUAL_BUILDING    0%
+End
+
+; Patch104p @balance xezon 03/08/2022 ArtilleryTankArmor_Patch104p is same as TankArmor, but with a reduced vulnerability against Infantry Missiles to compensate for overall low health of artillery tanks.
+
+Armor ArtilleryTankArmor_Patch104p
+  Armor = CRUSH              50%      ;tanks are extra-hard to crush
+  Armor = SMALL_ARMS         25%
+  Armor = GATTLING           10%      ;resistant to gattling tank
+  Armor = COMANCHE_VULCAN    25%
+  Armor = INFANTRY_MISSILE   50%
   Armor = FLAME              25%
   Armor = RADIATION          50%      ;Radiation does less damage to tanks.
   Armor = MICROWAVE           0%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1302,7 +1302,7 @@ Object ChinaVehicleInfernoCannon
   End
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost          = 900
@@ -1590,7 +1590,7 @@ Object ChinaVehicleNukeLauncher
 
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost       = 1600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1899,7 +1899,7 @@ Object Infa_ChinaVehicleInfernoCannon
   End
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost          = 1100
@@ -2186,7 +2186,7 @@ Object Infa_ChinaVehicleNukeLauncher
 
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost       = 1600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3412,7 +3412,7 @@ Object Nuke_ChinaVehicleInfernoCannon
   End
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost          = 900
@@ -3702,7 +3702,7 @@ Object Nuke_ChinaVehicleNukeLauncher
 
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost       = 1600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16830,7 +16830,7 @@ Object Tank_ChinaVehicleNukeLauncher
 
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost       = 1600
@@ -17025,7 +17025,7 @@ Object Tank_ChinaVehicleInfernoCannon
   End
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = ArtilleryTankArmor_Patch104p
     DamageFX        = TankDamageFX
   End
   BuildCost          = 900


### PR DESCRIPTION
* old PR #812
* Fixes #811

This change increase China Nuke Cannon and China Inferno Cannon Armor against Infantry Missiles by 100%. All other Armor types remain unchanged.

## Rationale

China Artillery Tanks are much weaker against Infantry Missiles compared to the competition.

| Object                                | Armor Type         | Health | Missile hits to kill |
|---------------------------------------|--------------------|--------|----------------------|
| Original GLA Rocket Buggy             | TruckArmor         | 120    | 6                    |
| Original GLA Scud Launcher            | TruckArmor         | 180    | 9                    |
| Original USA Tomahawk                 | TruckArmor         | 180    | 9                    |
| Original China Inferno Cannon         | TankArmor          | 120    | 3                    |
| Original China Nuke Cannon            | TankArmor          | 240    | 6                    |
| Patched China Inferno Cannon (this)   | ArtilleryTankArmor | 120    | 6                    |
| Patched China Nuke Cannon (this)      | ArtilleryTankArmor | 240    | 12                   |

Rocket Men make a good amount of forces of all factions. They are cheap and can come in masses. China's artillery is unnecessarily weak against their missiles, and an Armor buff against them should help to increase their survive-ability.

The Inferno Cannon now takes as many rockets as a GLA Rocket Buggy does. And the Nuke Cannon takes the most hits of all Artillery Tanks. However, the Nuke Cannon is very slow and requires deployment time, so Rocket Soldiers typically will have an easier time chasing it down.

## Original

https://user-images.githubusercontent.com/4720891/182667885-88828e0a-8870-49fe-8efe-61413a795642.mp4

## Patched

https://user-images.githubusercontent.com/4720891/182667939-3b44e72b-1c7f-4f0b-a0ee-9430b06fc36f.mp4
