### PR TITLE
Fix: Nuke Cannon Shell Detonation Effect Has Offset

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4984,6 +4984,35 @@ Object NukeCannonShell
 
 End
 
+; Patch104p @bugfix commy2 04/09/2022 Dummy to spawn Nuke Cannon detonation FX
+;------------------------------------------------------------------------------
+Object NukeCannonShellDetonationDummy
+
+  ; ***DESIGN parameters ***
+  EditorSorting   = SYSTEM
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
+
+  ; *** ENGINEERING Parameters ***
+  Body                  = ActiveBody ModuleTag_01
+    MaxHealth           = 1.0
+    InitialHealth       = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0   ; min lifetime in msec
+    MaxLifetime = 0   ; max lifetime in msec
+  End
+
+  Behavior = DestroyDie ModuleTag_03
+    ;nothing
+  End
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_04
+    DeathWeapon   = NukeCannonShellDetonationDummyWeapon
+    StartsActive  = Yes
+  End
+End
+
 ;------------------------------------------------------------------------------
 Object NeutronCannonShell
 
@@ -5040,6 +5069,35 @@ Object NeutronCannonShell
   GeometryIsSmall = Yes
   GeometryMajorRadius = 1.0
 
+End
+
+; Patch104p @bugfix commy2 04/09/2022 Dummy to spawn Nuke Cannon neutron detonation FX
+;------------------------------------------------------------------------------
+Object NukeCannonNeutronShellDetonationDummy
+
+  ; ***DESIGN parameters ***
+  EditorSorting   = SYSTEM
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
+
+  ; *** ENGINEERING Parameters ***
+  Body                  = ActiveBody ModuleTag_01
+    MaxHealth           = 1.0
+    InitialHealth       = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0   ; min lifetime in msec
+    MaxLifetime = 0   ; max lifetime in msec
+  End
+
+  Behavior = DestroyDie ModuleTag_03
+    ;nothing
+  End
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_04
+    DeathWeapon   = NukeCannonNeutronShellDetonationDummyWeapon
+    StartsActive  = Yes
+  End
 End
 
 ;------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -9136,6 +9136,27 @@ End
 
 
 
+; Patch104p @bugfix commy2 04/09/2022 Spawns Nuke Cannon shell dummies to trigger detonation effect at correct position.
+; ----------------------------------------------
+ObjectCreationList OCL_NukeCannonShellDetonation
+  CreateObject
+    ObjectNames = NukeCannonShellDetonationDummy
+    Disposition = ON_GROUND_ALIGNED
+  End
+  CreateObject
+    ObjectNames = RadiationFieldMedium
+    Disposition = ON_GROUND_ALIGNED
+  End
+End
+
+; ----------------------------------------------
+ObjectCreationList OCL_NukeCannonNeutronShellDetonation
+  CreateObject
+    ObjectNames = NukeCannonNeutronShellDetonationDummy
+    Disposition = ON_GROUND_ALIGNED
+  End
+End
+
 ; Patch104p @bugfix commy2 29/08/2021 Creates dummies used to handle Demolitions upgrade with the Battle Bus.
 ; -----------------------------------------------------------------------------
 ; Demolitions General

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -9143,10 +9143,6 @@ ObjectCreationList OCL_NukeCannonShellDetonation
     ObjectNames = NukeCannonShellDetonationDummy
     Disposition = ON_GROUND_ALIGNED
   End
-  CreateObject
-    ObjectNames = RadiationFieldMedium
-    Disposition = ON_GROUND_ALIGNED
-  End
 End
 
 ; ----------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3927,6 +3927,7 @@ End
 ; Patch104p @bugfix commy2 06/09/2022 Dummy weapon to create detonation effect.
 Weapon NukeCannonShellDetonationDummyWeapon
   FireFX = WeaponFX_NukeCannon
+  FireOCL = OCL_RadiationFieldMedium
 End
 
 ;------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3917,12 +3917,16 @@ Weapon NukeCannonGun
   FireFX                  = WeaponFX_NukeCannonMuzzleFlash
   FireSound               = NukeCannonWeapon
   VeterancyFireFX         = HEROIC WeaponFX_HeroicNukeCannonMuzzleFlash
-  ProjectileDetonationFX  = WeaponFX_NukeCannon
-  ProjectileDetonationOCL = OCL_RadiationFieldMedium
+  ProjectileDetonationOCL = OCL_NukeCannonShellDetonation ; Patch104p @bugfix commy2 04/09/2022 Fix Nuke Cannon shell detonation position by spawning effect via dummy object.
   RadiusDamageAffects     = SUICIDE SELF ALLIES ENEMIES NEUTRALS NOT_SIMILAR
   DelayBetweenShots       = 10000        ; time between shots, msec
   ClipSize                = 0            ; how many shots in a Clip (0 == infinite)
   ClipReloadTime          = 0            ; how long to reload a Clip, msec
+End
+
+; Patch104p @bugfix commy2 06/09/2022 Dummy weapon to create detonation effect.
+Weapon NukeCannonShellDetonationDummyWeapon
+  FireFX = WeaponFX_NukeCannon
 End
 
 ;------------------------------------------------------------------------------
@@ -6072,11 +6076,16 @@ Weapon NukeCannonNeutronWeapon
   FireFX                  = WeaponFX_NukeCannonMuzzleFlash
   FireSound               = NukeCannonWeapon
   VeterancyFireFX         = HEROIC WeaponFX_HeroicNukeCannonMuzzleFlash
-  ProjectileDetonationFX  = Neutron_WeaponFX_NukeCannon
+  ProjectileDetonationOCL = OCL_NukeCannonNeutronShellDetonation ; Patch104p @bugfix commy2 04/09/2022 Fix Nuke Cannon shell detonation position by spawning effect via dummy object.
   RadiusDamageAffects     = SUICIDE SELF ALLIES ENEMIES NEUTRALS NOT_SIMILAR NOT_AIRBORNE
   DelayBetweenShots       = 10000        ; time between shots, msec
   ClipSize                = 0            ; how many shots in a Clip (0 == infinite)
   ClipReloadTime          = 0            ; how long to reload a Clip, msec
+End
+
+; Patch104p @bugfix commy2 06/09/2022 Dummy weapon to create detonation effect.
+Weapon NukeCannonNeutronShellDetonationDummyWeapon
+  FireFX = Neutron_WeaponFX_NukeCannon
 End
 
 Weapon NeutronMineWeapon


### PR DESCRIPTION
Spawns effect via dummy, which should not suffer impressions.