### PR TITLE
Fix: Demo Trap Flare Effect fades out smoothly

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -38150,7 +38150,7 @@ ParticleSystem DemoTrapLenzFlare
   AngularDamping = 1.00 1.00
   VelocityDamping = 0.98 0.98
   Gravity = 0.00
-  Lifetime = 50.00 50.00
+  Lifetime = 60.00 60.00
   SystemLifetime = 1
   Size = 10.00 10.00
   StartSizeRate = 0.00 0.00
@@ -38164,9 +38164,9 @@ ParticleSystem DemoTrapLenzFlare
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:0 G:0 B:0 0
-  Color2 = R:147 G:0 B:0 5
-  Color3 = R:0 G:0 B:0 45
+  Color1 = R:147 G:0 B:0 5 ; Patch104p @bugfix Use Color1 to enable smooth fadeout
+  Color2 = R:0 G:0 B:0 60
+  Color3 = R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0


### PR DESCRIPTION
This change fixes fade out of Demo Trap Flare. Originally it would not transition gracefully. This happens when the Primary Color is not on `Color1`. The increased life time is to compensate for the stronger fadeout.