### PR TITLE
Change: Increase General Promotion reward from Black Lotus by 100%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18121,9 +18121,10 @@ Object Boss_InfantryBlackLotus
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
+  ; Patch104p @balance xezon 06/09/2022 Doubles all XP rewards and requirements to make it add more XP to General Promotion.
 
   ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
-  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
+  ExperienceRequired    = 0 80 160 320 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = ChinaInfantryBlackLotusCommandSet
@@ -18209,7 +18210,7 @@ Object Boss_InfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 40
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_10
@@ -18230,7 +18231,7 @@ Object Boss_InfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
+    AwardXPForTriggering    = 10  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12
@@ -18250,7 +18251,7 @@ Object Boss_InfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
+    AwardXPForTriggering  = 20 ; Patch104p @balance xezon 01/08/2022 Cash Hack gives 50% less reward than capture because it is easier to do successfully in enemy base.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -658,9 +658,10 @@ Object ChinaInfantryBlackLotus
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
+  ; Patch104p @balance xezon 06/09/2022 Doubles all XP rewards and requirements to make it add more XP to General Promotion.
 
   ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
-  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
+  ExperienceRequired    = 0 80 160 320 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = ChinaInfantryBlackLotusCommandSet
@@ -740,7 +741,7 @@ Object ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 40
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_10
@@ -761,7 +762,7 @@ Object ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
+    AwardXPForTriggering    = 10  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12
@@ -781,7 +782,7 @@ Object ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
+    AwardXPForTriggering  = 20 ; Patch104p @balance xezon 01/08/2022 Cash Hack gives 50% less reward than capture because it is easier to do successfully in enemy base.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -697,9 +697,10 @@ Object Infa_ChinaInfantryBlackLotus
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
+  ; Patch104p @balance xezon 06/09/2022 Doubles all XP rewards and requirements to make it add more XP to General Promotion.
 
   ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
-  ExperienceRequired    = 0 40 120 200 ; From 0 150 450 900
+  ExperienceRequired    = 0 80 240 400 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Infa_ChinaInfantryBlackLotusCommandSet
@@ -779,7 +780,7 @@ Object Infa_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 40
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_10
@@ -800,7 +801,7 @@ Object Infa_ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
+    AwardXPForTriggering    = 10  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12
@@ -820,7 +821,7 @@ Object Infa_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
+    AwardXPForTriggering  = 20 ; Patch104p @balance xezon 01/08/2022 Cash Hack gives 50% less reward than capture because it is easier to do successfully in enemy base.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2063,9 +2063,10 @@ Object Nuke_ChinaInfantryBlackLotus
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
+  ; Patch104p @balance xezon 06/09/2022 Doubles all XP rewards and requirements to make it add more XP to General Promotion.
 
   ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
-  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
+  ExperienceRequired    = 0 80 160 320 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Nuke_ChinaInfantryBlackLotusCommandSet
@@ -2145,7 +2146,7 @@ Object Nuke_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 40
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_10
@@ -2166,7 +2167,7 @@ Object Nuke_ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
+    AwardXPForTriggering    = 10  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12
@@ -2186,7 +2187,7 @@ Object Nuke_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
+    AwardXPForTriggering  = 20 ; Patch104p @balance xezon 01/08/2022 Cash Hack gives 50% less reward than capture because it is easier to do successfully in enemy base.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1793,9 +1793,10 @@ Object Tank_ChinaInfantryBlackLotus
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.
+  ; Patch104p @balance xezon 06/09/2022 Doubles all XP rewards and requirements to make it add more XP to General Promotion.
 
   ExperienceValue       = 50 50 100 150 ; From 50 100 150 400
-  ExperienceRequired    = 0 40 80 160 ; From 0 150 450 900
+  ExperienceRequired    = 0 80 160 320 ; From 0 150 450 900
   IsTrainable           = Yes             ;Can gain experience
   CrushableLevel        = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet            = Tank_ChinaInfantryBlackLotusCommandSet
@@ -1875,7 +1876,7 @@ Object Tank_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 20
+    AwardXPForTriggering  = 40
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_10
@@ -1896,7 +1897,7 @@ Object Tank_ChinaInfantryBlackLotus
     UnpackSound             = BlackLotusUnpack
     TriggerSound            = BlackLotusTrigger
     PrepSoundLoop           = BlackLotusPrepLoop
-    AwardXPForTriggering    = 5  ; Patch104p @balance 01/10/2021 Make ability grant XP.
+    AwardXPForTriggering    = 10  ; Patch104p @balance 01/10/2021 Make ability grant XP.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
   Behavior = SpecialAbility ModuleTag_12
@@ -1916,7 +1917,7 @@ Object Tank_ChinaInfantryBlackLotus
     UnpackSound           = BlackLotusUnpack
     TriggerSound          = BlackLotusTrigger
     PrepSoundLoop         = BlackLotusPrepLoop
-    AwardXPForTriggering  = 10 ; Patch104p @balance xezon 01/08/2022 From 20 reduce XP award so it scales better with the other awards.
+    AwardXPForTriggering  = 20 ; Patch104p @balance xezon 01/08/2022 Cash Hack gives 50% less reward than capture because it is easier to do successfully in enemy base.
     ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
   End
 


### PR DESCRIPTION
* Follow up to #807

This change doubles the General Promotion rewards gained from Black Lotus.

## Black Lotus XP

Level up requirements are unchanged.

| Object                         | ExperienceRequired | req. Vehicle Hack count | req. Cash Hack count | req. Building Cap count |
|--------------------------------|-------------------:|------------------------:|---------------------:|------------------------:|
| Original Black Lotus           | 150 450 900        |                         | 08 23 45             | 08 23 45                |
| Patched Black Lotus (1)        | 100 200 400        | 20 40 80                | 05 10 20             | 05 10 20                |
| Patched Black Lotus (2)        | 040 080 160        | 08 16 32                | 04 08 16             | 02 04 08                |
| Patched Super Lotus (2)        | 040 120 200        | 00 16 32                | 00 08 16             | 00 04 08                |
| Patched Black Lotus (3) (this) | 080 160 320        | 08 16 32                | 04 08 16             | 02 04 08                |
| Patched Super Lotus (3) (this) | 080 240 400        | 00 16 32                | 00 08 16             | 00 04 08                |

## General Rank Farming from Black Lotus Vehicle Hack XP

In theory it can be abused to grind XP when an enemy unit has been trapped. Find below hack XP time estimations based on the proposed Vehicle Hack XP reward of 10. A vehicle hack takes around 5 seconds to complete.

| General Rank | SkillPointsNeeded | req. Vehicle Hack count | req. Vehicle Hack time |
|--------------|------------------:|------------------------:|-----------------------:|
| 2            | 800               | 80                      |  400 seconds (06:40)   |
| 3            | 1500              | 150                     |  750 seconds (12:30)   |
| 4            | 2500              | 250                     | 1250 seconds (20:50)   |
| 5            | 5000              | 500                     | 2500 seconds (41:40)   |

# Rationale

Both Jarmen Kell and Colonel Burton can grant a fair amount of General Promotions to player, by killing infantry (~20 XP per kill) and by killing structures (~200 XP per kill). Originally Black Lotus is unable to compete with these rates.