### PR TITLE
Change: Reduce AFG_ComancheArmor HEALING by 10% before Upgrade

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -1080,7 +1080,7 @@ Armor AFG_ComancheArmor
   Armor = EXPLOSION         100%    ;gives patriot some more punch
   Armor = INFANTRY_MISSILE  100%    ;gives missile guys some more punch
   Armor = LASER               0%    ;lasers are anti-personel and anti-projectile only (for point defense laser)
-  Armor = HEALING           100%
+  Armor = HEALING            90%    ; Patch104p @tweak from 100% to make healing time consistent with AFG_CountermeasuresComancheArmor
   Armor = HAZARD_CLEANUP      0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT          0%    ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER           0%    ;Capture type weapons are effective only against infantry.


### PR DESCRIPTION
* old PR #821

This change makes `HEALING` of `AFG_ComancheArmor` consistent with `HEALING` of `AFG_CountermeasuresComancheArmor`.

The Airforce Comanche will repair a bit slower on the Airfield before Upgrade accordingly.

## Stats

| Object                                    | Full repair time |
|-------------------------------------------|------------------|
| Original AirF Comanche                    | 22.0             |
| Original AirF Comanche w. Countermeasures | 24.4             |
| Patched AirF Comanche                     | 24.4             |
| Patched AirF Comanche w. Countermeasures  | 24.4             |

## Additional Stats

![helihealing2](https://user-images.githubusercontent.com/4720891/182943430-47095374-51f6-4260-ad51-c9f98917bd67.png)

## Rationale

This change makes healing times on Airforce Comanche helicopter consistent. It no longer gets a penalty in healing time with Countermeasures upgrade, because the healing time is now the same before the upgrade. Healing time is not bumped to 100% on Countermeasures, as that would be a buff for the Airforce Comanche, and it is already powerful enough as is.