### PR TITLE
Change: GLA Bomb Truck no longer reveals itself in close proximity of its attack target

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18563,7 +18563,7 @@ Object Chem_GLAVehicleBombTruck
   Behavior = StealthUpdate ModuleTag_22
     StealthDelay                          = 1
     DisguisesAsTeam                       = Yes
-    RevealDistanceFromTarget              = 100.0
+    RevealDistanceFromTarget              = 0.0 ; Patch104p @tweak from 100.0 to remove unnecessary attack penalty
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
     DisguiseFX                            = FX_BombTruckDisguise
     DisguiseRevealFX                      = FX_BombTruckDisguiseReveal

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19960,7 +19960,7 @@ Object Demo_GLAVehicleBombTruck
   Behavior = StealthUpdate ModuleTag_22
     StealthDelay                          = 1
     DisguisesAsTeam                       = Yes
-    RevealDistanceFromTarget              = 100.0
+    RevealDistanceFromTarget              = 0.0 ; Patch104p @tweak from 100.0 to remove unnecessary attack penalty
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
     DisguiseFX                            = FX_BombTruckDisguise
     DisguiseRevealFX                      = FX_BombTruckDisguiseReveal

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4330,7 +4330,7 @@ Object GLAVehicleBombTruck
   Behavior = StealthUpdate ModuleTag_22
     StealthDelay                          = 1
     DisguisesAsTeam                       = Yes
-    RevealDistanceFromTarget              = 100.0
+    RevealDistanceFromTarget              = 0.0 ; Patch104p @tweak from 100.0 to remove unnecessary attack penalty
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
     DisguiseFX                            = FX_BombTruckDisguise
     DisguiseRevealFX                      = FX_BombTruckDisguiseReveal

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20068,7 +20068,7 @@ Object Slth_GLAVehicleBombTruck
   Behavior = StealthUpdate ModuleTag_22
     StealthDelay                          = 1
     DisguisesAsTeam                       = Yes
-    RevealDistanceFromTarget              = 100.0
+    RevealDistanceFromTarget              = 0.0 ; Patch104p @tweak from 100.0 to remove unnecessary attack penalty
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
     DisguiseFX                            = FX_BombTruckDisguise
     DisguiseRevealFX                      = FX_BombTruckDisguiseReveal


### PR DESCRIPTION
* old PR #864
* Fixes #855

This change sets the `RevealDistanceFromTarget` of Bomb Truck from 100 to 0.

Bomb Truck will no longer reveal itself in close proximity of its attack target.

Originally the same behavior can be achieved by moving Bomb Truck close to the target unit and self detonate it there. Originally Bomb Truck will also always apply full damage on destruction.

## Original

https://user-images.githubusercontent.com/4720891/184116679-5eb5b62f-a9e6-4c25-8f76-b0b09e93b6f4.mp4

## Patched

https://user-images.githubusercontent.com/4720891/184116697-189ba9d1-8111-4d64-9ff9-6afc4a4114dc.mp4
