### PR TITLE
Change: Improve Bomb Truck Locomotor

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -601,12 +601,12 @@ Locomotor BombTruckLocomotor
   Surfaces            = GROUND
   Speed               = 50   ; in dist/sec
   SpeedDamaged        = 50   ; in dist/sec
-  TurnRate            = 90   ; in degrees/sec
-  TurnRateDamaged     = 60   ; in degrees/sec
-  Acceleration        = 1000 ;400  ; in dist/(sec^2)
-  AccelerationDamaged = 1000 ;300  ; in dist/(sec^2)
-  Braking             = 1000 ;50   ; in dist/(sec^2)
-  MinTurnSpeed        = 0    ; in dist/sec
+  TurnRate            = 90   ; in degrees/sec  ; turn 90 degrees in 1.000 s
+  TurnRateDamaged     = 75   ; in degrees/sec  ; Patch104p @tweak from 60 to turn 90 degrees in 1.200 s instead of 1.500 s
+  Acceleration        = 250  ; in dist/(sec^2) ; Patch104p @tweak from 1000 to accelerate in 0.200 s instead of 0.050 s
+  AccelerationDamaged = 250  ; in dist/(sec^2) ; Patch104p @tweak from 1000 to accelerate in 0.200 s instead of 0.050 s
+  Braking             = 1000 ; in dist/(sec^2)
+  MinTurnSpeed        = 20   ; in dist/sec     ; Patch104p @tweak from 0 to not slow down as much when turning
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE
   Appearance          = FOUR_WHEELS
   TurnPivotOffset     = -0.5    ; where to pivot when turning (-1.0 = rear, 0.0 = center, 1.0 = front)


### PR DESCRIPTION
* old PR TheSuperHackers/GeneralsGamePatch#979
* Fixes TheSuperHackers/GeneralsGamePatch#959

This change improves Bomb Truck Locomotor. In undamaged state, no tangible difference in driving performance is expected. In damaged state, the driving performance is marginally better. Visually the driving will look and feel smoother.

| Object                       | Turn Rate (ms) | Min Turn Speed (m/s) | Time to Full Speed (ms) |
|------------------------------|----------------|----------------------|-------------------------|
| Original Bomb Truck          | 2000           | 0                    | 50                      |
| Original Bomb Truck Damaged  | 3000           | 0                    | 50                      |
| Patched Bomb Truck           | 2000           | 20                   | 200 (-300%)             |
| Patched Bomb Truck Damaged   | 2400 (-20%)    | 20                   | 200 (-300%)             |

## Considerations for Damaged State

The original Bomb Truck has an unfavorable setup where in damaged state the Speed is not lowered, but the Turn Rate is by 33%. This poses a great mismatch between forward and turn speed which is greatly visible when transitioning between these speeds and looks and feels unnatural when controlling the vehicle. Reducing the forward speed while increasing the Turn Rate is possible, however this turned out to be a considerable degradation in driving performance, because the forward motion is the most critical for the bomb truck to reach and kill its target. Meanwhile, not increasing the Turn Rate while just raising the Min Turn Speed is not satisfying either, as the vehicle would retain the speed mismatch.

The Turn Rate was thus reduced by 20% to improve the handling of the vehicle when turning. This gives the vehicle a marginal but observable performance boost when turning. Since this affects damaged state only, it does not have a major impact on the overall drive capabilities of Bomb Truck.

Lowering the speed in damaged state can be a great tool to fine tune the strength of the Bomb Truck, because it is critical for it to come close to its target.

## Considerations for Braking

Braking is unchanged. Although it could be safely lowered because it is a non critical movement setting, it does not make it look any better. The locomotor suffers from an issue that introduces stutter on brake, and increasing the brake time will prolong the stutter.

* TheSuperHackers/GeneralsGameCode#146

## Original vs Patched Locomotor Test Drive

This is a short test drive. The marginally reduced acceleration and boosted turn speed gives a slightly smoother look and feel to the vehicle. For all regular practical purposes the vehicle driving performance is indistinguishable from the original. The change in Locomotor should bear no practical difference in real matches.

Truck with Bio Upgrade = Original Locomotor
Truck with Blinking Bomb = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186974098-a444e176-a749-4b9e-9123-fcd06bf54143.mp4

## Original vs Patched Locomotor Turn Test

The patched bomb truck will benefit from the increased turn speed, if it takes turns. This balances with its worse acceleration performance on balanced drives.

Truck with Bio Upgrade = Original Locomotor
Truck with Blinking Bomb = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186974128-8f42e023-495e-4a8e-845e-1c9379fe9ef1.mp4

## Original vs Patched Locomotor Acceleration Test

The patched bomb truck will drawback from the decreased acceleration time, if it starts moving. This balances with its better turn performance on balanced drives.

Truck with Bio Upgrade = Original Locomotor
Truck with Blinking Bomb = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186974151-f51698f6-0e00-4028-b384-01c511447742.mp4

## Original vs Patched Damaged Locomotor Test Drive

This is a short test drive in damaged state. The reduced acceleration and increased Min Turn Speed gives a slightly smoother look and feel to the vehicle. The additional increased Turn Rate gives a marginal performance boost.

Truck with Bio Upgrade = Original Locomotor
Truck with Blinking Bomb = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186974448-3ca7991a-f531-4f08-ae02-c5505258d527.mp4

## Original vs Patched Damaged Locomotor Turn Test

Truck with Bio Upgrade = Original Locomotor
Truck with Blinking Bomb = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186974494-6b3439cc-4e98-4a04-bcaa-f7f1fa2ac76e.mp4

## Original vs Patched Damaged Locomotor Acceleration Test

Truck with Bio Upgrade = Original Locomotor
Truck with Blinking Bomb = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186974540-4a5d9853-fdb5-4881-acac-b39cf8fc8c86.mp4
