### PR TITLE
Change: Optimize Battle Bus Locomotor

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -633,10 +633,10 @@ Locomotor BattleBusLocomotor
   SpeedDamaged        = 50   ; in dist/sec
   TurnRate            = 90   ; in degrees/sec
   TurnRateDamaged     = 60   ; in degrees/sec
-  Acceleration        = 1000 ;400  ; in dist/(sec^2)
-  AccelerationDamaged = 1000 ;300  ; in dist/(sec^2)
-  Braking             = 1000 ;50   ; in dist/(sec^2)
-  MinTurnSpeed        = 0    ; in dist/sec
+  Acceleration        = 400  ; in dist/(sec^2) ; Patch104p @tweak from 1000 to accelerate in 0.175 s instead of 0.070 s
+  AccelerationDamaged = 280  ; in dist/(sec^2) ; Patch104p @tweak from 1000 to accelerate in 0.179 s instead of 0.050 s
+  Braking             = 1000 ; in dist/(sec^2)
+  MinTurnSpeed        = 25   ; in dist/sec     ; Patch104p @tweak from 0 to not slow down as much when turning
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE
   Appearance          = FOUR_WHEELS
   TurnPivotOffset     = -0.5    ; where to pivot when turning (-1.0 = rear, 0.0 = center, 1.0 = front)


### PR DESCRIPTION
* old PR TheSuperHackers/GeneralsGamePatch#980

This change improves Battle Bus Locomotor. In both damaged and undamaged state, no tangible difference in driving performance is expected. Visually the driving will look and feel smoother.

| Object                       | Min Turn Speed (m/s) | Time to Full Speed (ms) |
|------------------------------|----------------------|-------------------------|
| Original Battle Bus          | 0                    | 70                      |
| Original Battle Bus Damaged  | 0                    | 50                      |
| Patched Battle Bus           | 25                   | 175 (-150%)             |
| Patched Battle Bus Damaged   | 25                   | 179 (-260%)             |

## Considerations for Braking

Braking is unchanged. Although it could be safely lowered because it is a non critical movement setting, it does not make it look any better. The locomotor suffers from an issue that introduces stutter on brake, and increasing the brake time will prolong the stutter.

* TheSuperHackers/GeneralsGameCode#146

## Original vs Patched Locomotor Test Drive

This is a short test drive. The marginally reduced acceleration and boosted Min Turn Speed gives a slightly smoother look and feel to the vehicle. For all regular practical purposes the vehicle driving performance is indistinguishable from the original. The change in Locomotor should bear no practical difference in real matches.

Battle Bus with passenger = Original Locomotor
Battle Bus without passenger = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186978951-4fac45f9-8381-4ad3-b0c9-b7f2c85d7abc.mp4


## Original vs Patched Locomotor Turn Test

The patched Battle Bus will benefit from the increased Min Turn Speed, if it takes turns. This balances with its worse acceleration performance on balanced drives.

Battle Bus with passenger = Original Locomotor
Battle Bus without passenger = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186978995-5069a2fc-5398-4885-9ecc-6191191152e6.mp4


## Original vs Patched Locomotor Acceleration Test

The patched Battle Bus will drawback from the decreased acceleration time, if it starts moving. This balances with its better turn performance on balanced drives.

Battle Bus with passenger = Original Locomotor
Battle Bus without passenger = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186979016-7cf08dc0-5648-43bd-9551-918cf8561844.mp4


## Original vs Patched Damaged Locomotor Test Drive

This is a short test drive in damaged state. The reduced acceleration and increased Min Turn Speed gives a slightly smoother look and feel to the vehicle. For all regular practical purposes the vehicle driving performance is indistinguishable from the original. The change in Locomotor should bear no practical difference in real matches.

Battle Bus with passenger = Original Locomotor
Battle Bus without passenger = Patched Locomotor

https://user-images.githubusercontent.com/4720891/186979062-7b19fbca-d2e9-4866-8d7a-fa94aecc1ca2.mp4

