### PR TITLE
Change: Neutron blasts affect all aircraft

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1239,7 +1239,7 @@ Object NeutronBlastObject
 
   Behavior = NeutronBlastBehavior ModuleTag_06
     BlastRadius = 20
-    AffectAirborne = No
+    AffectAirborne = Yes
     AffectAllies = No
   End
 
@@ -5033,7 +5033,7 @@ Object NeutronCannonShell
 
   Behavior = NeutronBlastBehavior ModuleTag_06
     BlastRadius = 70
-    AffectAirborne = No
+    AffectAirborne = Yes
   End
 
   Geometry = Sphere


### PR DESCRIPTION
* old PR TheSuperHackers/GeneralsGamePatch#921
* Fixes TheSuperHackers/GeneralsGameCode#144

This change enables Neutron shells to affect all aircraft. Helicopters and jets can be emptied just like ground vehicles can, both on ground and in air.