### PR TITLE
Change: Tweak USA Drone shroud ranges

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5933,7 +5933,7 @@ Object AirF_AmericaVehicleBattleDrone
   BuildCost           = 200
   BuildTime           = 5.0          ;in seconds
   VisionRange         = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 300 ; Patch104p @tweak from 150 to see just as far as most other American vehicles do
   Prerequisites
     Object = AirF_AmericaWarFactory
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6230,7 +6230,7 @@ Object AirF_AmericaVehicleHellfireDrone
   BuildCost       = 500
   BuildTime       = 5.0          ;in seconds
   VisionRange     = 100
-  ShroudClearingRange = 500
+  ShroudClearingRange = 400 ; Patch104p @tweak from 500 to see not as much as the Scout Drone
   IsTrainable     = No  ;Can gain experience
 
   ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -852,7 +852,7 @@ Object AmericaVehicleBattleDrone
   BuildCost           = 200
   BuildTime           = 5.0          ;in seconds
   VisionRange         = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 300 ; Patch104p @tweak from 150 to see just as far as most other American vehicles do
   Prerequisites
     Object = AmericaWarFactory
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1147,7 +1147,7 @@ Object AmericaVehicleHellfireDrone
   BuildCost       = 500
   BuildTime       = 5.0          ;in seconds
   VisionRange     = 100
-  ShroudClearingRange = 500
+  ShroudClearingRange = 400 ; Patch104p @tweak from 500 to see not as much as the Scout Drone
   IsTrainable     = No  ;Can gain experience
 
   ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5165,7 +5165,7 @@ Object Lazr_AmericaVehicleBattleDrone
   BuildCost           = 200
   BuildTime           = 5.0          ;in seconds
   VisionRange         = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 300 ; Patch104p @tweak from 150 to see just as far as most other American vehicles do
   Prerequisites
     Object = Lazr_AmericaWarFactory
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5462,7 +5462,7 @@ Object Lazr_AmericaVehicleHellfireDrone
   BuildCost       = 600
   BuildTime       = 5.0          ;in seconds
   VisionRange     = 100
-  ShroudClearingRange = 500
+  ShroudClearingRange = 400 ; Patch104p @tweak from 500 to see not as much as the Scout Drone
   IsTrainable     = No  ;Can gain experience
 
   ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -128,7 +128,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
   BuildCost           = 200
   BuildTime           = 5.0          ;in seconds
   VisionRange         = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 300 ; Patch104p @tweak from 150 to see just as far as most other American vehicles do
   ExperienceValue     = 10 10 10 10 ;Experience point value at each level
   IsTrainable         = No
 
@@ -5646,7 +5646,7 @@ Object SupW_AmericaVehicleBattleDrone
   BuildCost           = 200
   BuildTime           = 5.0          ;in seconds
   VisionRange         = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 300 ; Patch104p @tweak from 150 to see just as far as most other American vehicles do
   Prerequisites
     Object = SupW_AmericaWarFactory
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5943,7 +5943,7 @@ Object SupW_AmericaVehicleHellfireDrone
   BuildCost       = 500
   BuildTime       = 5.0          ;in seconds
   VisionRange     = 100
-  ShroudClearingRange = 500
+  ShroudClearingRange = 400 ; Patch104p @tweak from 500 to see not as much as the Scout Drone
   IsTrainable     = No  ;Can gain experience
 
   ; Patch104p @balance commy2 25/09/2021 Add XP reward when killing armed drone.


### PR DESCRIPTION
* old PR #990
* Fixes #983

This change increases ShroudClearingRange of USA Battle Drone from 150 to 300 and decreases it of USA Hellfire Drone from 500 to 400.

| Object                           | Attack Range | Shroud Clearing Range | Area   | Adv. over Battle | Adv. over Hellfire |
|----------------------------------|--------------|-----------------------|--------|------------------|--------------------|
| Original USA Battle Drone        |              | 150 (+75+10 wander)   | 70685  |                  |                    |
| Original USA Hellfire Drone      | 150          | 500 (+75+10 wander)   | 785398 | +1011%           |                    |
| Original USA Scout Drone         | 110          | 500 (+75+10 wander)   | 785398 | +1011%           | +0%                |
| Patched USA Battle Drone (this)  |              | 300 (+75+10 wander)   | 282743 |                  |                    |
| Patched USA Hellfire Drone (this)| 150          | 400 (+75+10 wander)   | 502654 | +77%             |                    |
| Patched USA Scout Drone (this)   | 110          | 500 (+75+10 wander)   | 785398 | +177%            | +56%               |


## Other objects for reference

| Object                           | Shroud Clearing Range | Area       |
|----------------------------------|-----------------------|-----------:|
| Original USA Sentry Drone        | 350                   | 384845     |
| Original USA Humvee              | 320                   | 321699     |
| Original USA Missile Defender    | 400                   | 502654     |
| Original China Outpost           | 500                   | 785398     |
| Original China Lotus             | 400                   | 502654     |

# Rationale

The original Hellfire drone has a massive sight of 500 matching the Scout Drone. It costs 5 times as much as the Scout Drone, but it also has a good weapon and much more armor. The original Battle drone has a useless sight of just 150. Since most USA Tanks have a sight of 300, the Battle drone sight adds nothing in practice.

With the readjusted shroud ranges the Scout drone retains its pristine range of 500. The Hellfire shroud range is reduced a little bit, but can still see much more than all USA vehicles by a large margin. The range was not reduced further because it is the most expensive drone and it is a much less consequential change to tweak the range just as much as this change does. Meanwhile the Battle Drone now sees as far as most USA Tanks, and since it sways around its host vehicle, it will increase the shroud range just a bit while it sways. For most practical purposes, the Battle drone will not provide a tangible gain in shroud range. However, since the Hellfire Drone has a decreased shroud range, it is just fair to give the Battle Drone a larger shroud range to compensate. The Tomahawk + Battle Drone will benefit from this, because Tomahawk has a shroud range of just 200.

The new ranges offer a more logical distribution of shroud clearing ranges and make the Scout Drone more unique with its very large shroud range. Since the Scout Drone just costs 100, it is always easily accessible and a USA player can afford one to benefit of its perks.

| Object                           | Perks                                      |
|----------------------------------|--------------------------------------------|
| Patched USA Battle Drone (this)  | Machine Gun, Good Armor, Repair ability    |
| Patched USA Hellfire Drone (this)| Best Weapon, Best Armor, Good Shroud Range |
| Patched USA Scout Drone (this)   | Stealth Detection, Best Shroud Range       |

# Media

## Original Battle Drone

![original_battle](https://user-images.githubusercontent.com/4720891/187028752-39d794cb-d5a7-40d3-a999-a553cd4f62c2.jpg)

## Original Hellfire Drone

![original_hellfire](https://user-images.githubusercontent.com/4720891/187028759-cb0aaabd-c456-4092-ad9d-3e58ae4f4e01.jpg)

## original Scout Drone

![original_scout](https://user-images.githubusercontent.com/4720891/187028763-af4bb59f-9721-418c-9629-6fcbd241dfd3.jpg)

## Patched Battle Drone

![patched_battle](https://user-images.githubusercontent.com/4720891/187028773-69103f31-b3fb-4d0a-992a-7f6cfe78e853.jpg)

## Patched Hellfire Drone

![patched_hellfire](https://user-images.githubusercontent.com/4720891/187028775-867755ca-4671-469c-8ba4-adb178f81996.jpg)

