### PR TITLE
Fix: z clipping muzzle wave particles

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -9373,7 +9373,7 @@ ParticleSystem NukeCannonMuzzleWave
   BurstDelay = 1.00 1.00
   BurstCount = 10.00 10.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.00 Y:0.00 Z:0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.01 ; Patch104p @bugfix Slightly raise effect from ground to avoid z clipping
   VelocityType = ORTHO
   VelOrthoX = 0.00 0.00
   VelOrthoY = 0.00 0.00
@@ -38743,7 +38743,7 @@ ParticleSystem TankMuzzleWave
   BurstDelay = 1.00 1.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.00 Y:0.00 Z:0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.01 ; Patch104p @bugfix Slightly raise effect from ground to avoid z clipping
   VelocityType = ORTHO
   VelOrthoX = 0.00 0.00
   VelOrthoY = 0.00 0.00


### PR DESCRIPTION
This change fixes z clipping muzzle wave effects.

![shot_20220906_201535_2](https://user-images.githubusercontent.com/4720891/188709313-b4934501-22d5-41ad-aa5d-c9fad98669db.jpg)
