### PR TITLE
Change: Increase XP reward for China Minigunner by 100%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15205,7 +15205,7 @@ Object Infa_ChinaInfantryMiniGunner
   BuildCost     = 350
   BuildTime     = 10.0          ;in seconds
 
-  ExperienceValue = 5 5 10 20   ;Experience point value at each level
+  ExperienceValue = 10 10 20 40   ; Patch104p @balance from 5 5 10 20 to reward more than Red Guard
   ExperienceRequired = 0 20 40 80  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrushableLevel         = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles


### PR DESCRIPTION
* Fixes #1150

This change increases the XP reward for China Minigunner by 100%.

| Object                               | Regular | Veteran | Elite | Hero |
|--------------------------------------|---------|---------|-------|------|
| Original USA Ranger                  | 20      | 20      | 40    | 60   |
| Original GLA Rebel                   | 15      | 15      | 30    | 40   |
| Original GLA Toxin Rebel             | 25      | 30      | 35    | 45   |
| Original China Tank Hunter           | 20      | 20      | 40    | 60   |
| Original China Red Guard             | 5       | 5       | 10    | 20   |
| Original Inf China Tank Hunter       | 20      | 20      | 40    | 60   |
| Original Inf China Minigunner        | 5       | 5       | 10    | 20   |
| Patched Inf China Minigunner (this)  | 10      | 10      | 20    | 40   |

## Rationale

The XP reward of the Minigunner is very low in comparison to what it can do. It can attack ground units with +25% range compared to Red Guard. It can also attack Air units with outrageous range of 350 or more. It deals 400% more damage than Red Guard when Minigun is spun.

Identical XP reward with Red Guard is not justified. The Minigunner is a much better unit and more difficult to deal with. An even higher XP reward may be justified, however, Infantry soldiers come in high numbers, especially with China Infantry General, so it should not be unfairly set.