### PR TITLE
Change: Match level up XP of GLA Combat Bike with Jarmen Kell

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -22136,7 +22136,7 @@ Object Boss_VehicleCombatBikeTerrorist
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -17308,7 +17308,7 @@ Object Chem_GLAVehicleCombatBike
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -18582,7 +18582,7 @@ Object Demo_GLAVehicleCombatBike
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -4912,7 +4912,7 @@ Object GC_Slth_GLAVehicleCombatBike
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -5838,7 +5838,7 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -6764,7 +6764,7 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -1186,7 +1186,7 @@ Object GLAVehicleCombatBike
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -2123,7 +2123,7 @@ Object GLAVehicleCombatBikeRocket
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -3048,7 +3048,7 @@ Object GLAVehicleCombatBikeTerrorist
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18787,7 +18787,7 @@ Object Slth_GLAVehicleCombatBike
   End
 
   ExperienceValue       = 50 50 100 150    ;Experience point value at each level
-  ExperienceRequired    = 0 200 400 800  ;Experience points needed to gain each level
+  ExperienceRequired    = 0 100 200 400  ; Patch104p @tweak from 0 200 400 800 to match with Jarmen Kell
   IsTrainable           = Yes             ;Can gain experience
   ;CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles


### PR DESCRIPTION
* Fixes #1147

This change matches the level up experience of GLA Combat Bike with Jarmen Kell.

| Object                               | Required XP    |
|--------------------------------------|----------------|
| Original Hijacker                    | 0 150 450 900  |
| Original Jarmen Kell                 | 0 100 200 400  |
| Original Combat Bike                 | 0 200 400 800  |
| Patched Combat Bike                  | 0 100 200 400  |

# Rationale

All infantry units on Combat Bike will level up by the XP requirement of the Combat Bike. It is lower than the Hijacker. However, the Hijacker is unarmed, thus will not level up on a Bike unless it drives over scrap. The next GLA unit with significant XP requirement is Jarmen Kell. It is half as much as original Combat Bike, meaning Jarmen Kell would rank up twice as slow on the Combat Bike. Therefore a reduction of Combat Bike XP requirement to match Jarmen Kell is reasonable and logical. Rebels and RPG Troopers will still suffer from slow rank up times, but it cannot be individually tweaked, so this is logically the best choice. Setting the XP requirement lower than proposed would mean that Jarmen Kell would rank up faster on a Combat Bike than on foot.