### PR TITLE
Fix: Use regular size Muzzle Flash effects for China Battlemaster Tank

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -305,8 +305,8 @@ Weapon BattleMasterTankGun
   WeaponSpeed             = 400                           ; dist/sec
   WeaponRecoil            = 5                            ; angle to deflect the model when firing
   ProjectileObject        = BattleMasterTankShell
-  FireFX                  = WeaponFX_GenericTankGunNoTracerSmall
-  VeterancyFireFX         = HEROIC WeaponFX_HeroicGenericTankGunNoTracerSmall
+  FireFX                  = WeaponFX_GenericTankGunNoTracer ; Patch104p @tweak from WeaponFX_GenericTankGunNoTracerSmall
+  VeterancyFireFX         = HEROIC WeaponFX_HeroicGenericTankGunNoTracer ; Patch104p @tweak from WeaponFX_HeroicGenericTankGunNoTracerSmall
   ProjectileDetonationFX  = WeaponFX_GenericTankShellDetonation
   FireSound               = BattlemasterTankWeapon
   RadiusDamageAffects     = ALLIES ENEMIES NEUTRALS
@@ -6349,8 +6349,8 @@ Weapon Tank_BattleMasterTankGun
   WeaponSpeed             = 400                           ; dist/sec
   WeaponRecoil            = 5                            ; angle to deflect the model when firing
   ProjectileObject        = BattleMasterTankShell
-  FireFX                  = WeaponFX_GenericTankGunNoTracerSmall
-  VeterancyFireFX         = HEROIC WeaponFX_HeroicGenericTankGunNoTracerSmall
+  FireFX                  = WeaponFX_GenericTankGunNoTracer ; Patch104p @tweak from WeaponFX_GenericTankGunNoTracerSmall
+  VeterancyFireFX         = HEROIC WeaponFX_HeroicGenericTankGunNoTracer ; Patch104p @tweak from WeaponFX_HeroicGenericTankGunNoTracerSmall
   ProjectileDetonationFX  = WeaponFX_GenericTankShellDetonation
   FireSound               = BattlemasterTankWeapon
   RadiusDamageAffects     = ALLIES ENEMIES NEUTRALS
@@ -7890,8 +7890,8 @@ Weapon Nuke_BattleMasterTankGun
   WeaponSpeed             = 400                           ; dist/sec
   WeaponRecoil            = 5                            ; angle to deflect the model when firing
   ProjectileObject        = Nuke_BattleMasterTankShell
-  FireFX                  = WeaponFX_GenericTankGunNoTracerSmall
-  VeterancyFireFX         = HEROIC WeaponFX_HeroicGenericTankGunNoTracerSmall
+  FireFX                  = WeaponFX_GenericTankGunNoTracer ; Patch104p @tweak from WeaponFX_GenericTankGunNoTracerSmall
+  VeterancyFireFX         = HEROIC WeaponFX_HeroicGenericTankGunNoTracer ; Patch104p @tweak from WeaponFX_HeroicGenericTankGunNoTracerSmall
   ProjectileDetonationFX  = WeaponFX_GenericTankShellDetonation
   FireSound               = BattlemasterTankWeapon
   RadiusDamageAffects     = ALLIES ENEMIES NEUTRALS


### PR DESCRIPTION
This change replaces `WeaponFX_GenericTankGunNoTracerSmall` with `WeaponFX_GenericTankGunNoTracer` on all Battlemaster tanks.

## Rationale

Original Overlord, Crusader, Paladin, Marauder use regular Muzzle Flash.
Original Battlemaster, Scorpion use small Muzzle Flash.

This makes no sense. Battlemaster Tank deals as much damage as Crusader, Paladin and Marauder, and the gun is also similarly sized, so the particle effect should look similar too.

Scorpion Tank using small Muzzle Flash is justified, because it has a small gun which deals -66% damage.