### PR TITLE
Fix: Crusader Wreck Spawned Before Model Disappears

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -2213,7 +2213,6 @@ Object CINE_AmericaTankCrusader
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_GenericTankDeathEffect
     FX  = FINAL    FX_GenericTankDeathExplosion
     OCL = FINAL    OCL_CrusaderTurret
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1532,7 +1532,6 @@ Object AmericaTankCrusader
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_GenericTankDeathEffect
     FX  = FINAL    FX_GenericTankDeathExplosion
     OCL = FINAL    OCL_CrusaderTurret
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6319,7 +6319,6 @@ Object SupW_AmericaTankCrusader
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_GenericTankDeathEffect
     FX  = FINAL    FX_GenericTankDeathExplosion
     OCL = FINAL    OCL_CrusaderTurret
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -3938,8 +3938,16 @@ ObjectCreationList OCL_BurningEmbers
   End
 End
 
+; Patch104p @bugfix commy2 08/09/2022 Spawns wreck and turret at the same time.
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_CrusaderTurret
+  CreateObject
+    ObjectNames = DeadCrusaderHulk
+    Offset = X:0 Y:0 Z:0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 0.1
+  End
   CreateDebris
     ModelNames        = AVLeopard_D2
     Offset            = X:0.491 Y:0.028 Z:7.717
@@ -3966,7 +3974,108 @@ ObjectCreationList OCL_CrusaderTurret
     SpinRate          = 300
     BounceSound = DebrisBigMetal
   End
-
+  CreateDebris
+    ModelNames = GXMammoth_D01
+    Offset = X:17.58 Y:1.971 Z:10.282
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.5
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D02
+    Offset = X:8.581 Y:1.943 Z:9.081
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.5
+    BounceSound = VehicleDebris
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D03
+    Offset = X:19.641 Y:2.261 Z:10.569
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.5
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D04
+    Offset = X:13.587 Y:-2.29 Z:9.715
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.5
+    BounceSound = VehicleDebris
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D05
+    Offset = X:6.764 Y:-2.233 Z:8.873
+    Mass = 7.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.4
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D06
+    Offset = X:2.755 Y:-0.99 Z:8.462
+    Mass = 7.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.3
+    BounceSound = VehicleDebris
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D07
+    Offset = X:-1.818 Y:-3.702 Z:8.837
+    Mass = 7.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.3
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D08
+    Offset = X:-2.867 Y:-3.701 Z:8.741
+    Mass = 7.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.3
+    BounceSound = VehicleDebris
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D09
+    Offset = X:-3.894 Y:0.942 Z:8.463
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.3
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D10
+    Offset = X:2.963 Y:2.839 Z:8.454
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.3
+    BounceSound = VehicleDebris
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D11
+    Offset = X:-4.679 Y:2.206 Z:9.613
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.5
+  End
+  CreateDebris
+    ModelNames = GXMammoth_D12
+    Offset = X:-3.606 Y:-3.174 Z:10.986
+    Mass = 5.0
+    Count = 1
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 2.5
+    BounceSound = VehicleDebris
+  End
 End
 
 ; -----------------------------------------------------------------------------


### PR DESCRIPTION
From NPM

1.04:

- 50% chance the Crusader flings away the turret on death, if this happens, the wreck is spawned before the original object is deleted, so two models intersect for ~8 frames.

patch:

- wreck model spawns at the same time as when original model is deleted

Also changed CINE, because otherwise that unit would be broken with this change.
The fix was done by removing the OCL that spawns the wreck at MIDPOINT and instead adds the entirety of OCL_GenericTankDeathEffect to OCL_CrusaderTurret.

OCL_GenericTankDeathEffect has a bad name. It is specifically for the Crusader, not a generic tank.

