### PR TITLE
Fix: USA Pilots Can Promote GLA Combat Bikes

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4280,7 +4280,7 @@ Object AirF_AmericaInfantryPilot
 
   Behavior = VeterancyCrateCollide       ModuleTag_03
     RequiredKindOf = VEHICLE      ; we only give our bonus to VEHICLEs we collide with
-    ForbiddenKindOf = DOZER       ; but not to TRANSPORTs or DOZERs!
+    ForbiddenKindOf = DOZER CLIFF_JUMPER       ; but not to TRANSPORTs or DOZERs! Patch104p @bugfix commy2 08/09/2022 Adds CLIFF_JUMPER to prevent Pilot from promoting Combat Bikes.
     EffectRange = 0               ; 0=="affect only the thing you collide with"
     AddsOwnerVeterancy = Yes      ; we add our own veterancy to the target (rather than just +1 level)
     IsPilot = Yes                 ; set the pilot flag because it's different than the veterancy crate and has extra checking

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1534,7 +1534,7 @@ Object AmericaInfantryPilot
 
   Behavior = VeterancyCrateCollide       ModuleTag_03
     RequiredKindOf = VEHICLE      ; we only give our bonus to VEHICLEs we collide with
-    ForbiddenKindOf = DOZER       ; but not to TRANSPORTs or DOZERs!
+    ForbiddenKindOf = DOZER CLIFF_JUMPER       ; but not to TRANSPORTs or DOZERs! Patch104p @bugfix commy2 08/09/2022 Adds CLIFF_JUMPER to prevent Pilot from promoting Combat Bikes.
     EffectRange = 0               ; 0=="affect only the thing you collide with"
     AddsOwnerVeterancy = Yes      ; we add our own veterancy to the target (rather than just +1 level)
     IsPilot = Yes                 ; set the pilot flag because it's different than the veterancy crate and has extra checking

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -3826,7 +3826,7 @@ Object Lazr_AmericaInfantryPilot
 
   Behavior = VeterancyCrateCollide       ModuleTag_03
     RequiredKindOf = VEHICLE      ; we only give our bonus to VEHICLEs we collide with
-    ForbiddenKindOf = DOZER       ; but not to TRANSPORTs or DOZERs!
+    ForbiddenKindOf = DOZER CLIFF_JUMPER       ; but not to TRANSPORTs or DOZERs! Patch104p @bugfix commy2 08/09/2022 Adds CLIFF_JUMPER to prevent Pilot from promoting Combat Bikes.
     EffectRange = 0               ; 0=="affect only the thing you collide with"
     AddsOwnerVeterancy = Yes      ; we add our own veterancy to the target (rather than just +1 level)
     IsPilot = Yes                 ; set the pilot flag because it's different than the veterancy crate and has extra checking

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4310,7 +4310,7 @@ Object SupW_AmericaInfantryPilot
 
   Behavior = VeterancyCrateCollide       ModuleTag_03
     RequiredKindOf = VEHICLE      ; we only give our bonus to VEHICLEs we collide with
-    ForbiddenKindOf = DOZER       ; but not to TRANSPORTs or DOZERs!
+    ForbiddenKindOf = DOZER CLIFF_JUMPER       ; but not to TRANSPORTs or DOZERs! Patch104p @bugfix commy2 08/09/2022 Adds CLIFF_JUMPER to prevent Pilot from promoting Combat Bikes.
     EffectRange = 0               ; 0=="affect only the thing you collide with"
     AddsOwnerVeterancy = Yes      ; we add our own veterancy to the target (rather than just +1 level)
     IsPilot = Yes                 ; set the pilot flag because it's different than the veterancy crate and has extra checking


### PR DESCRIPTION
This change prevents USA Pilots from promoting GLA Combat Bikes.

# Rationale

It makes no sense, and it leads to promoted units that should never promote, such as Workers and Saboteurs. These units do not work correctly with promotions, meaning they do not receive any benefits from promotion, not even health or regen, so nothing is lost here.