### PR TITLE
Change: Require Stealth Fighter Science To Upgrade Bunker Busters

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1200,9 +1200,12 @@ CommandButton AirF_Command_UpgradeAmericaLaserMissiles
   DescriptLabel           = CONTROLBAR:AirF_TooltipUSAUpgradeLaserMissiles
 End
 
+; @tweak commy2 08/09/2022 Require Stealth Fighter science to upgrade Bunker Busters.
 CommandButton Command_UpgradeAmericaBunkerBusters
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_AmericaBunkerBusters
+  Options       = NEED_SPECIAL_POWER_SCIENCE
+  Science       = SCIENCE_StealthFighter
   TextLabel     = CONTROLBAR:UpgradeAmericaBunkerBusters
   ButtonImage   = SABunkerBust
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is


### PR DESCRIPTION
I suppose this could prevent you from upgrade units inherited from a player that surrenders, but that is never going to happen.

Note that AFG spawns with SCIENCE_StealthFighter unlocked automatically in this patch (but not 1.04).