### PR TITLE
Change: Require Nuke Cannon Science To Upgrade Neutron Shells

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1386,10 +1386,12 @@ CommandButton Command_UpgradeChinaUraniumShells
   DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaUraniumShells
 End
 
+; @tweak commy2 08/09/2022 Require Nuke Cannon science to upgrade Neutron Shells.
 CommandButton Command_UpgradeChinaNeutronShells
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_ChinaNeutronShells
-  Options       = IGNORES_UNDERPOWERED
+  Options       = NEED_SPECIAL_POWER_SCIENCE IGNORES_UNDERPOWERED
+  Science       = SCIENCE_NukeLauncher
   TextLabel     = CONTROLBAR:UpgradeChinaNeutronShells
   ButtonImage   = SNNeutShell
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is


### PR DESCRIPTION
I suppose this could prevent you from upgrade units inherited from a player that surrenders, but that is never going to happen.

Note that Nukegen spawns with SCIENCE_NukeLauncher unlocked automatically in this patch (but not 1.04).