### PR TITLE
Fix: Stealth General Saboteur Can Level Up

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17082,9 +17082,10 @@ Object Demo_GLAInfantrySaboteur
   BuildCost = 800
   BuildTime = 15.0          ;in seconds
 
+  ; @bugfix commy2 09/09/2022 Fix non vGLA Saboteurs level up by walking over crates.
   ExperienceValue     = 15 15 30 40     ;Experience point value at each level
-  ExperienceRequired  = 0 40 60 120     ;Experience points needed to gain each level
-  IsTrainable         = Yes             ;Can gain experience
+  ;ExperienceRequired  = 0 40 60 120     ;Experience points needed to gain each level
+  IsTrainable         = No             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet          = GLAInfantrySaboteurCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -4037,7 +4037,9 @@ Object GLAInfantrySaboteur
   BuildCost = 800
   BuildTime = 15.0          ;in seconds
 
+  ; @bugfix commy2 09/09/2022 Fix non vGLA Saboteurs level up by walking over crates.
   ExperienceValue     = 15 15 30 40     ;Experience point value at each level
+  ;ExperienceRequired  = 0 40 60 120     ;Experience points needed to gain each level
   IsTrainable         = No             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet          = GLAInfantrySaboteurCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17389,9 +17389,10 @@ Object Slth_GLAInfantrySaboteur
   BuildCost = 800
   BuildTime = 15.0          ;in seconds
 
+  ; @bugfix commy2 09/09/2022 Fix non vGLA Saboteurs level up by walking over crates.
   ExperienceValue     = 15 15 30 40     ;Experience point value at each level
-  ExperienceRequired  = 0 40 60 120     ;Experience points needed to gain each level
-  IsTrainable         = Yes             ;Can gain experience
+  ;ExperienceRequired  = 0 40 60 120     ;Experience points needed to gain each level
+  IsTrainable         = No             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet          = GLAInfantrySaboteurCommandSet
 


### PR DESCRIPTION
vGLA Saboteur can not level up. Saboteur also has no weapon, so it should instead just pick up money from salvage crates like Workers, Terrorists and Radar Vans do.