### PR TITLE
Fix: Particle Cannon Loops Deploy Animation When Finished While Disabled

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -10032,7 +10032,7 @@ Object AirF_AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
-    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
+    ; Patch104p @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
       Animation          = ABSDILink_A1.ABSDILink_A1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -10032,8 +10032,11 @@ Object AirF_AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
+    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
+      Animation          = ABSDILink_A1.ABSDILink_A1
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
@@ -10042,6 +10045,8 @@ Object AirF_AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
       Model              = ABSDILink_A1D
+      Animation          = ABSDILink_A1D.ABSDILink_A1D
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
@@ -10050,6 +10055,8 @@ Object AirF_AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
       Model              = ABSDILink_A1E
+      Animation          = ABSDILink_A1E.ABSDILink_A1E
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -2814,8 +2814,11 @@ Object Boss_ParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
+    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
+      Animation          = ABSDILink_A1.ABSDILink_A1
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
@@ -2824,6 +2827,8 @@ Object Boss_ParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
       Model              = ABSDILink_A1D
+      Animation          = ABSDILink_A1D.ABSDILink_A1D
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
@@ -2832,6 +2837,8 @@ Object Boss_ParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
       Model              = ABSDILink_A1E
+      Animation          = ABSDILink_A1E.ABSDILink_A1E
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -2814,7 +2814,7 @@ Object Boss_ParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
-    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
+    ; Patch104p @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
       Animation          = ABSDILink_A1.ABSDILink_A1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -5526,8 +5526,11 @@ Object AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
+    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
+      Animation          = ABSDILink_A1.ABSDILink_A1
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
@@ -5536,6 +5539,8 @@ Object AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
       Model              = ABSDILink_A1D
+      Animation          = ABSDILink_A1D.ABSDILink_A1D
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
@@ -5544,6 +5549,8 @@ Object AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
       Model              = ABSDILink_A1E
+      Animation          = ABSDILink_A1E.ABSDILink_A1E
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -5526,7 +5526,7 @@ Object AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
-    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
+    ; Patch104p @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
       Animation          = ABSDILink_A1.ABSDILink_A1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -9734,8 +9734,11 @@ Object Lazr_AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
+    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
+      Animation          = ABSDILink_A1.ABSDILink_A1
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
@@ -9744,6 +9747,8 @@ Object Lazr_AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
       Model              = ABSDILink_A1D
+      Animation          = ABSDILink_A1D.ABSDILink_A1D
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
@@ -9752,6 +9757,8 @@ Object Lazr_AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
       Model              = ABSDILink_A1E
+      Animation          = ABSDILink_A1E.ABSDILink_A1E
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
@@ -17377,8 +17384,11 @@ Object Lazr_AmericaLaserCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
+    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
+      Animation          = ABSDILink_A1.ABSDILink_A1
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
@@ -17387,6 +17397,8 @@ Object Lazr_AmericaLaserCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
       Model              = ABSDILink_A1D
+      Animation          = ABSDILink_A1D.ABSDILink_A1D
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
@@ -17395,6 +17407,8 @@ Object Lazr_AmericaLaserCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
       Model              = ABSDILink_A1E
+      Animation          = ABSDILink_A1E.ABSDILink_A1E
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
@@ -18336,8 +18350,11 @@ Object Lazr_AmericaLaserCannon
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
+    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
+      Animation          = ABSDILink_A1.ABSDILink_A1
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
@@ -18346,6 +18363,8 @@ Object Lazr_AmericaLaserCannon
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
       Model              = ABSDILink_A1D
+      Animation          = ABSDILink_A1D.ABSDILink_A1D
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
@@ -18354,6 +18373,8 @@ Object Lazr_AmericaLaserCannon
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
       Model              = ABSDILink_A1E
+      Animation          = ABSDILink_A1E.ABSDILink_A1E
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -9734,7 +9734,7 @@ Object Lazr_AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
-    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
+    ; Patch104p @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
       Animation          = ABSDILink_A1.ABSDILink_A1
@@ -17384,7 +17384,7 @@ Object Lazr_AmericaLaserCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
-    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
+    ; Patch104p @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
       Animation          = ABSDILink_A1.ABSDILink_A1
@@ -18350,7 +18350,7 @@ Object Lazr_AmericaLaserCannon
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
-    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
+    ; Patch104p @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
       Animation          = ABSDILink_A1.ABSDILink_A1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -9142,7 +9142,7 @@ Object SupW_AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
-    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
+    ; Patch104p @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
       Animation          = ABSDILink_A1.ABSDILink_A1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -9142,8 +9142,11 @@ Object SupW_AmericaParticleCannonUplink
     AliasConditionState  = NIGHT SNOW AWAITING_CONSTRUCTION
     AliasConditionState  = SNOW AWAITING_CONSTRUCTION
 
+    ; @bugfix commy2 09/09/2022 Fix Particle Cannon loops deploy animation when finished while disabled.
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABSDILink_A1
+      Animation          = ABSDILink_A1.ABSDILink_A1
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
@@ -9152,6 +9155,8 @@ Object SupW_AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
       Model              = ABSDILink_A1D
+      Animation          = ABSDILink_A1D.ABSDILink_A1D
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
@@ -9160,6 +9165,8 @@ Object SupW_AmericaParticleCannonUplink
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE
       Model              = ABSDILink_A1E
+      Animation          = ABSDILink_A1E.ABSDILink_A1E
+      AnimationMode      = MANUAL
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED RUBBLE


### PR DESCRIPTION
Fix is currently only applied to vUSA. Please confirm this solves the issue. 

Repro: 
- Start building Particle Cannon
- Shut it down with EMP or Microwave Tank, but continue building
- After it is finished 100%, let it get re-enabled

The PC should now loop the deploy animation. It does no longer do that after this patch.
Note however, that the super weapon timer will be bugged out regardless of this change.