### PR TITLE
Fix: Technical Uses Wrong Muzzle Flash When Equipped With RPG

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19106,6 +19106,7 @@ Object Chem_GLAVehicleTechnicalChassisOne
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING RELOADING_A
 
+    ; @bugfix commy2 09/09/2022 Fix Technical uses wrong muzzle flash when equipped with RPG.
     ; ------------------ technical with WEAPONSET_CRATEUPGRADE_TWO ------------------------
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       IdleAnimation = UITech_SKL.UITech_STA 0 6
@@ -19113,6 +19114,7 @@ Object Chem_GLAVehicleTechnicalChassisOne
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19121,6 +19123,7 @@ Object Chem_GLAVehicleTechnicalChassisOne
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19129,6 +19132,7 @@ Object Chem_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19137,6 +19141,7 @@ Object Chem_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19152,6 +19157,7 @@ Object Chem_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19515,6 +19521,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisTwo Chem_GLAVehicleTechnicalChassisO
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19523,6 +19530,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisTwo Chem_GLAVehicleTechnicalChassisO
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19531,6 +19539,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisTwo Chem_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19539,6 +19548,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisTwo Chem_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19554,6 +19564,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisTwo Chem_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19766,6 +19777,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisThree Chem_GLAVehicleTechnicalChassi
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19774,6 +19786,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisThree Chem_GLAVehicleTechnicalChassi
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19782,6 +19795,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisThree Chem_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19790,6 +19804,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisThree Chem_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -19805,6 +19820,7 @@ ObjectReskin Chem_GLAVehicleTechnicalChassisThree Chem_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20556,6 +20556,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING RELOADING_A
 
+    ; @bugfix commy2 09/09/2022 Fix Technical uses wrong muzzle flash when equipped with RPG.
     ; ------------------ technical with WEAPONSET_CRATEUPGRADE_TWO ------------------------
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       IdleAnimation = UITech_SKL.UITech_STA 0 6
@@ -20563,6 +20564,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20571,6 +20573,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20579,6 +20582,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20587,6 +20591,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20602,6 +20607,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21007,6 +21013,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisTwo Demo_GLAVehicleTechnicalChassisO
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21015,6 +21022,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisTwo Demo_GLAVehicleTechnicalChassisO
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21023,6 +21031,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisTwo Demo_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21031,6 +21040,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisTwo Demo_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21046,6 +21056,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisTwo Demo_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21258,6 +21269,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisThree Demo_GLAVehicleTechnicalChassi
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21266,6 +21278,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisThree Demo_GLAVehicleTechnicalChassi
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21274,6 +21287,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisThree Demo_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21282,6 +21296,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisThree Demo_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21297,6 +21312,7 @@ ObjectReskin Demo_GLAVehicleTechnicalChassisThree Demo_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -3062,6 +3062,7 @@ Object GC_Slth_GLAVehicleTechnicalChassisOne
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING RELOADING_A
 
+    ; @bugfix commy2 09/09/2022 Fix Technical uses wrong muzzle flash when equipped with RPG.
     ; ------------------ technical with WEAPONSET_CRATEUPGRADE_TWO ------------------------
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       IdleAnimation = UITech_SKL.UITech_STA 0 6
@@ -3069,6 +3070,7 @@ Object GC_Slth_GLAVehicleTechnicalChassisOne
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3077,6 +3079,7 @@ Object GC_Slth_GLAVehicleTechnicalChassisOne
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3085,6 +3088,7 @@ Object GC_Slth_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3093,6 +3097,7 @@ Object GC_Slth_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3108,6 +3113,7 @@ Object GC_Slth_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3481,6 +3487,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisTwo GC_Slth_GLAVehicleTechnicalCh
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3489,6 +3496,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisTwo GC_Slth_GLAVehicleTechnicalCh
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3497,6 +3505,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisTwo GC_Slth_GLAVehicleTechnicalCh
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3505,6 +3514,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisTwo GC_Slth_GLAVehicleTechnicalCh
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3520,6 +3530,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisTwo GC_Slth_GLAVehicleTechnicalCh
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3732,6 +3743,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisThree GC_Slth_GLAVehicleTechnical
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3740,6 +3752,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisThree GC_Slth_GLAVehicleTechnical
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3748,6 +3761,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisThree GC_Slth_GLAVehicleTechnical
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3756,6 +3770,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisThree GC_Slth_GLAVehicleTechnical
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -3771,6 +3786,7 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisThree GC_Slth_GLAVehicleTechnical
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4908,6 +4908,7 @@ Object GLAVehicleTechnicalChassisOne
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING RELOADING_A
 
+    ; @bugfix commy2 09/09/2022 Fix Technical uses wrong muzzle flash when equipped with RPG.
     ; ------------------ technical with WEAPONSET_CRATEUPGRADE_TWO ------------------------
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       IdleAnimation = UITech_SKL.UITech_STA 0 6
@@ -4915,6 +4916,7 @@ Object GLAVehicleTechnicalChassisOne
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -4923,6 +4925,7 @@ Object GLAVehicleTechnicalChassisOne
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -4931,6 +4934,7 @@ Object GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -4939,6 +4943,7 @@ Object GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -4954,6 +4959,7 @@ Object GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5317,6 +5323,7 @@ ObjectReskin GLAVehicleTechnicalChassisTwo GLAVehicleTechnicalChassisOne
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5325,6 +5332,7 @@ ObjectReskin GLAVehicleTechnicalChassisTwo GLAVehicleTechnicalChassisOne
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5333,6 +5341,7 @@ ObjectReskin GLAVehicleTechnicalChassisTwo GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5341,6 +5350,7 @@ ObjectReskin GLAVehicleTechnicalChassisTwo GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5356,6 +5366,7 @@ ObjectReskin GLAVehicleTechnicalChassisTwo GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5568,6 +5579,7 @@ ObjectReskin GLAVehicleTechnicalChassisThree GLAVehicleTechnicalChassisOne
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5576,6 +5588,7 @@ ObjectReskin GLAVehicleTechnicalChassisThree GLAVehicleTechnicalChassisOne
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5584,6 +5597,7 @@ ObjectReskin GLAVehicleTechnicalChassisThree GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5592,6 +5606,7 @@ ObjectReskin GLAVehicleTechnicalChassisThree GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -5607,6 +5622,7 @@ ObjectReskin GLAVehicleTechnicalChassisThree GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20645,6 +20645,7 @@ Object Slth_GLAVehicleTechnicalChassisOne
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE MOVING RELOADING_A
 
+    ; @bugfix commy2 09/09/2022 Fix Technical uses wrong muzzle flash when equipped with RPG.
     ; ------------------ technical with WEAPONSET_CRATEUPGRADE_TWO ------------------------
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       IdleAnimation = UITech_SKL.UITech_STA 0 6
@@ -20652,6 +20653,7 @@ Object Slth_GLAVehicleTechnicalChassisOne
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20660,6 +20662,7 @@ Object Slth_GLAVehicleTechnicalChassisOne
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20668,6 +20671,7 @@ Object Slth_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20676,6 +20680,7 @@ Object Slth_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -20691,6 +20696,7 @@ Object Slth_GLAVehicleTechnicalChassisOne
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21054,6 +21060,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisTwo Slth_GLAVehicleTechnicalChassisO
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21062,6 +21069,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisTwo Slth_GLAVehicleTechnicalChassisO
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21070,6 +21078,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisTwo Slth_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21078,6 +21087,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisTwo Slth_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21093,6 +21103,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisTwo Slth_GLAVehicleTechnicalChassisO
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21305,6 +21316,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisThree Slth_GLAVehicleTechnicalChassi
       IdleAnimation = UITech_SKL.UITech_IDB
       AnimationMode = ONCE
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21313,6 +21325,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisThree Slth_GLAVehicleTechnicalChassi
       Animation = None
       HideSubObject = UITech-SKN
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21321,6 +21334,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisThree Slth_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_MVB
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21329,6 +21343,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisThree Slth_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_TNA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End
@@ -21344,6 +21359,7 @@ ObjectReskin Slth_GLAVehicleTechnicalChassisThree Slth_GLAVehicleTechnicalChassi
       Animation = UITech_SKL.UITech_ATA
       AnimationMode = LOOP
       ShowSubObject = RPG
+      WeaponMuzzleFlash = PRIMARY MuzzleFX03
       WeaponFireFXBone = PRIMARY Muzzle03
       WeaponLaunchBone = PRIMARY Muzzle03
     End


### PR DESCRIPTION
No entry for `WeaponMuzzleFlash` means it defaults to `WeaponMuzzleFlash = MuzzleFX01` from `DefaultConditionState`, but that is for the machine gun, not the RPG.