### PR TITLE
Fix: Airforce General Fire Base Model Does Not Transition To Badly Damaged State On Snow Maps

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -16857,7 +16857,7 @@ Object AirF_AmericaFireBase
     End
 
     ConditionState      = REALLYDAMAGED RUBBLE SNOW
-      Model             = ABFIREBASE_DS
+      Model             = ABFIREBASE_ES ; Patch104p @bugfix commy2 10/09/2022 Fix model in badly damaged state on snow maps.
     End
 
     ;**************************************************************************************************************************


### PR DESCRIPTION
Was using the same model as the damaged state, unlike what happens on non-snow maps or for all other factions.