### PR TITLE
Change: Auto Reload Battery When Idle

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1971,6 +1971,7 @@ Weapon AnthraxGammaBombWeapon
   AutoReloadsClip     = No
 End
 
+; Patch104p @tweak commy2 10/09/2022 Auto reload missile battery when idle.
 ;------------------------------------------------------------------------------
 Weapon PatriotMissileWeapon
   PrimaryDamage               = 30.0
@@ -1989,6 +1990,7 @@ Weapon PatriotMissileWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = No
   AntiAirborneInfantry        = No
   AntiGround                  = Yes
@@ -2017,6 +2019,7 @@ Weapon PatriotMissileWeaponAir
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = No
@@ -6559,6 +6562,7 @@ Weapon Lazr_PaladinTankGun
   ProjectileCollidesWith = STRUCTURES WALLS
 End
 
+; Patch104p @tweak commy2 10/09/2022 Auto reload missile battery when idle.
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeapon
   PrimaryDamage               =  40.0
@@ -6576,6 +6580,7 @@ Weapon Lazr_PatriotMissileWeapon
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = No
   AntiAirborneInfantry        = No
   AntiGround                  = Yes
@@ -6587,7 +6592,6 @@ End
 
 ; Patch104p @bugfix commy2 13/09/2021 Fix sound and effect used against airborne targets and when assisting to match normal anti ground weapon.
 ; Patch104p @bugfix commy2 13/09/2021 Reduce ammo against air and when assisting to match normal anti ground weapon.
-
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeaponAir
   PrimaryDamage               = 40.0
@@ -6604,6 +6608,7 @@ Weapon Lazr_PatriotMissileWeaponAir
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = No
@@ -7521,6 +7526,7 @@ End
 
 
 
+; Patch104p @tweak commy2 10/09/2022 Auto reload missile battery when idle.
 ;------------------------------------------------------------------------------
 Weapon SupW_PatriotMissileWeapon
   PrimaryDamage               = 15.0
@@ -7539,6 +7545,7 @@ Weapon SupW_PatriotMissileWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = No
   AntiAirborneInfantry        = No
   AntiGround                  = Yes
@@ -7569,6 +7576,7 @@ Weapon SupW_PatriotMissileWeaponAir
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = No


### PR DESCRIPTION
1.04

- In case the target is destroyed or moved out of range, but the Patriot fired less than four missiles, the next time a target moves into range it will only shoot less than 4 missiles with its first salvo, because the clip is not reloaded until completely empty.

patch:

- The Patriot will reload the entire clip after being idle for ~2 seconds. (This is also how the Rocket Buggy operates for comparision).

Note: In 1.04, the player has always the option to manually empty the clips by force-firing the ground. I have never seen this used in practice, probably because this issue is rather minor, or because the current mechanics are opaque to the players.