### PR TITLE
Fix: Added the MiG's unused low fuel voice event

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -242,6 +242,7 @@ Object CINE_U06_CruiseMissileFLY
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -242,7 +242,7 @@ Object CINE_U06_CruiseMissileFLY
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
-    VoiceLowFuel          = MigVoiceLowFuel
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15796,6 +15796,7 @@ Object Boss_JetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15796,7 +15796,7 @@ Object Boss_JetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
-    VoiceLowFuel          = MigVoiceLowFuel
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -778,7 +778,7 @@ Object ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
-    VoiceLowFuel          = MigVoiceLowFuel
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -778,6 +778,7 @@ Object ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -2569,8 +2569,8 @@ Object CINE_ChinaJetMIG
   SoundAmbientRubble      = NoSound
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
-    Afterburner           = RaptorAfterburner ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
-    VoiceLowFuel          = MigVoiceLowFuel
+    Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -125,7 +125,7 @@ Object ChinaJetMIG_CinematicVersion
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
-    VoiceLowFuel          = MigVoiceLowFuel
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 
@@ -2569,7 +2569,7 @@ Object CINE_ChinaJetMIG
   SoundAmbientRubble      = NoSound
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
-    Afterburner           = RaptorAfterburner
+    Afterburner           = RaptorAfterburner ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -125,6 +125,7 @@ Object ChinaJetMIG_CinematicVersion
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 
@@ -2569,6 +2570,7 @@ Object CINE_ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -125,7 +125,7 @@ Object Infa_ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
-    VoiceLowFuel          = MigVoiceLowFuel
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -125,6 +125,7 @@ Object Infa_ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1065,6 +1065,7 @@ Object Nuke_ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1065,7 +1065,7 @@ Object Nuke_ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
-    VoiceLowFuel          = MigVoiceLowFuel
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -795,7 +795,7 @@ Object Tank_ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
-    VoiceLowFuel          = MigVoiceLowFuel
+    VoiceLowFuel          = MigVoiceLowFuel ; Patch104p @bugfix Stubbjax 10/09/2022 Added missing low fuel voice.
     VoiceGarrison         = MigVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -795,6 +795,7 @@ Object Tank_ChinaJetMIG
   UnitSpecificSounds
     VoiceCreate           = MigVoiceCreate
     Afterburner           = RaptorAfterburner
+    VoiceLowFuel          = MigVoiceLowFuel
     VoiceGarrison         = MigVoiceMove
   End
 


### PR DESCRIPTION
Added the MiG's unused low fuel voice event. Like all other planes, will play when returning to a missing airfield (unless the airfield is destroyed while the plane is returning; see TheSuperHackers/GeneralsGameCode#27).
```
vmigfua - "I'll need a landing strip!"
vmigfub - "Get me down before it's too late!"
vmigfuc - "Where is the airfield!?"
```