### PR TITLE
Fix: Added missing radio sounds to the Helix voice lines.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -4804,8 +4804,12 @@ End
 
 ; Helix
 
+; Patch104p @tweak Stubbjax 11/09/2022 Added missing radio sounds to the Helix voice lines.
+
 AudioEvent HelixVoiceSelect
   Sounds =  vhelsea vhelseb vhelsec vhelsed vhelsee
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4813,6 +4817,8 @@ End
 
 AudioEvent HelixVoiceCreate
   Sounds = vhelath
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume  = 110
   MinVolume = 100
@@ -4822,6 +4828,8 @@ End
 
 AudioEvent HelixVoiceMove
   Sounds =  vhelmoa vhelmob vhelmoc vhelmod vhelmoe
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4829,6 +4837,8 @@ End
 
 AudioEvent HelixVoiceAttack
   Sounds = vhelata vhelatb vhelatc vhelate vhelatf vhelatg
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4836,6 +4846,8 @@ End
 
 AudioEvent HelixVoiceUnload
   Sounds =  vhelunb vheluna vhelunc
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4843,6 +4855,8 @@ End
 
 AudioEvent HelixVoiceModeBunker
   Sounds = vhelu1a
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4851,6 +4865,8 @@ End
 
 AudioEvent HelixVoiceModeSpeakerTower
   Sounds = vhelu1b
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4859,6 +4875,8 @@ End
 
 AudioEvent HelixVoiceModeGattling
   Sounds = vhelu1c
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Priority = high
@@ -4868,6 +4886,8 @@ End
 
 AudioEvent HelixVoiceModeNapalmBomb
   Sounds = vhelu1d
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Priority = high
@@ -4877,6 +4897,8 @@ End
 
 AudioEvent HelixVoiceModeNuclearBomb
   Sounds = vhelu1e
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Priority = high
@@ -4886,6 +4908,8 @@ End
 
 AudioEvent HelixBunkerVoiceCreate
   Sounds = vhelu2a
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4893,6 +4917,8 @@ End
 
 AudioEvent HelixSpeakerTowerVoiceCreate
   Sounds = vhelu2b
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4900,6 +4926,8 @@ End
 
 AudioEvent HelixGattlingVoiceCreate
   Sounds = vhelu2c
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -4907,6 +4935,8 @@ End
 
 AudioEvent HelixNapalmBombVoiceCreate
   Sounds = vhelu2d
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 80
   Priority = high
@@ -4915,6 +4945,8 @@ End
 
 AudioEvent HelixNuclearBombVoiceCreate
   Sounds = vhelu2e
+  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
   Type = ui voice player


### PR DESCRIPTION
While copy / pasting units, EA clearly forgot to add the aircraft radio sounds to the Helix voice lines. These sounds are played for every other selectable aircraft in the game.

https://user-images.githubusercontent.com/11547761/189490819-59894992-13e1-4e2e-906d-9a71f793d774.mp4

