### PR TITLE
Change: Increase GattlingTankGun ContinuousFireCoast from 1000 to 2000 ms

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1140,7 +1140,8 @@ Weapon GattlingTankGun
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   ContinuousFireOne     = 2 ; How many shots at the same target constitute "Continuous Fire"
   ContinuousFireTwo     = 6 ; How many shots at the same target constitute "Continuous Fire Two"
-  ContinuousFireCoast   = 1000 ; msec we can coast without firing before we lose Continuous Fire
+  ContinuousFireCoast   = 2000 ; msec we can coast without firing before we lose Continuous Fire
+                               ; Patch104p @tweak from 1000 to prolong max damage time
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade


### PR DESCRIPTION
* Fixes #1185

This change increases GattlingTankGun ContinuousFireCoast from 1000 to 2000 ms. This matches the setup from Generals (CCG) and also the setting from the Zero Hour (ZH) GattlingTankGunAir.

| Object                          | ContinuousFireOne | ContinuousFireTwo | ContinuousFireCoast |
|---------------------------------|-------------------|-------------------|---------------------|
| Original CCG GattlingTankGun    | 3                 | 6                 | 2000                |
| Original CCG GattlingTankGunAir | 3                 | 6                 | 2000                |
| Original ZH GattlingTankGun     | 2                 | 6                 | 1000                |
| Original ZH GattlingTankGunAir  | 3                 | 6                 | 2000                |
| Patched GattlingTankGun (this)  | 2                 | 6                 | 2000                |

# Rationale

In Zero Hour it is difficult to use Pre Spin effectively before engaging enemy units, because the Spin Up time only last 1 second. With this change, Gattling Tank gun can be microed more generously to squeeze out the most damage potential.

| Object                         | Spin Level 1 DPS | Spin Level 2 DPS | Spin Level 3 DPS |
|--------------------------------|------------------|------------------|------------------|
| Original Quad Cannon (Vet 0)   | 75               |                  |                  |
| Original Quad Cannon (Vet 1)   | 165              |                  |                  |
| (#1055) Quad Cannon (Vet 1)    | 120              |                  |                  |
| Original Gattling Tank (Vet 0) | 37.5             | 75               | 112.5            |
| Original Gattling Tank (Vet 1) | 49.5             |                  | 123.75           |
