### PR TITLE
Remove DisplayName from vehicle hull objects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -395,7 +395,6 @@ Object ComancheRubbleHull
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:ComancheHull
   Side = America
 
   ; *** ENGINEERING Parameters ***
@@ -438,7 +437,6 @@ Object ChinookRubbleHull
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:ComancheHull
   Side = America
 
   ; *** ENGINEERING Parameters ***
@@ -472,7 +470,6 @@ Object HelixRubbleHull
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:ComancheHull
   Side = China  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
 
   ; *** ENGINEERING Parameters ***
@@ -609,7 +606,6 @@ Object ChinaTankOverlordDeadHull
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Overlord
   Side = China
   EditorSorting   = SYSTEM
   TransportSlotCount = 3                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -670,7 +666,6 @@ Object ChinaTankDragonDeadHull
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Overlord
   Side = China
   EditorSorting   = SYSTEM
   TransportSlotCount = 3                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
Not sure what it does, but only 5 hulls in Hulk.ini have it, and only 2 of them are even correctly set. Looks like it can be removed.