### PR TITLE
Fix and improve dead vehicle hull sink delays

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -38,9 +38,9 @@ Object DeadMicrowaveHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 8000 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -95,9 +95,9 @@ Object AmericaVehicleHumveeDeadHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 8000 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -177,7 +177,7 @@ Object ChinaVehicleNukeCannonHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 10000 ; Patch104p @tweak from 8000 to make it not disappear before it is fully sunken
   End
 End
 
@@ -412,9 +412,9 @@ Object ComancheRubbleHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 3000
-    SinkRate         = 4     ; in Dist/Sec
-    DestructionDelay = 10000
+    SinkDelay        = 1500 ; Patch104p @tweak from 3000 to be consistent with other vehicles
+    SinkRate         = 2 ; Patch104p @tweak from 4 to be consistent with other vehicles
+    DestructionDelay = 8000 ; Patch104p @performance from 10000 to optimize despawn timing
   End
 
 
@@ -455,8 +455,8 @@ Object ChinookRubbleHull
   End
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
-    SinkRate            = 1     ; in Dist/Sec
-    DestructionDelay = 16000
+    SinkRate            = 2 ; Patch104p @tweak from 1 to be consistent with other vehicles
+    DestructionDelay = 10000 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -489,8 +489,8 @@ Object HelixRubbleHull
   End
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
-    SinkRate            = 1     ; in Dist/Sec
-    DestructionDelay = 16000
+    SinkRate            = 2 ; Patch104p @tweak from 1 to be consistent with other vehicles
+    DestructionDelay = 12000 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -578,9 +578,9 @@ Object ChinaVehicleBattleMasterDeadHull
 
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 8000 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -637,9 +637,9 @@ Object ChinaTankOverlordDeadHull
 
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 10000 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -698,9 +698,9 @@ Object ChinaTankDragonDeadHull
 
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 12000 ; Patch104p @tweak from 14000 to be consistent with flame duration
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 18500 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -885,7 +885,7 @@ Object InfernoCannonHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 10000 ; Patch104p @tweak from 8000 to make it not disappear before it is fully sunken
   End
 
 End
@@ -952,10 +952,10 @@ Object DeadChinaGattlingTankHulk
 
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
-    SinkDelayVariance         = 1500
+    ;SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
-    DestructionDelayVariance  = 4000
+    DestructionDelay          = 10000 ; Patch104p @performance from 12000 to optimize despawn timing
+    ;DestructionDelayVariance  = 4000
   End
 
 End
@@ -988,10 +988,10 @@ Object DeadChinaECMTankHulk
 
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
-    SinkDelayVariance         = 1500
+    ;SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
-    DestructionDelayVariance  = 4000
+    DestructionDelay          = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
+    ;DestructionDelayVariance  = 4000
   End
 
 End
@@ -1024,10 +1024,10 @@ Object AmericaVehicleAmbulanceDeadHull
 
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
-    SinkDelayVariance         = 1500
+    ;SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
-    DestructionDelayVariance  = 4000
+    DestructionDelay          = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
+    ;DestructionDelayVariance  = 4000
   End
 
 
@@ -1076,7 +1076,7 @@ Object DeadSCUDLauncherHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 10000  ; Patch104p @performance from 12000 to make it not disappear before it is fully sunken
   End
 
 End
@@ -1110,7 +1110,7 @@ Object DeadToxinTractorHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 10000 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1144,7 +1144,7 @@ Object DeadQuadCannonHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 8000 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1178,7 +1178,7 @@ Object DeadBombTruckHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 10000 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1209,6 +1209,7 @@ Object DeadTechnicalVanHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Note: Typically does not sink into terrain as it disappears in air
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
@@ -1243,6 +1244,7 @@ Object DeadTechnicalJeepHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Note: Typically does not sink into terrain as it disappears in air
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
@@ -1277,6 +1279,7 @@ Object DeadTechnicalTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Note: Typically does not sink into terrain as it disappears in air
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
@@ -1311,6 +1314,7 @@ Object DeadRocketBuggyHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Note: Typically does not sink into terrain as it disappears in air
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
@@ -1345,6 +1349,7 @@ Object DeadCombatBikeHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Note: Does not sink into terrain as it disappears in air (on kill)
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
@@ -1514,7 +1519,7 @@ Object DeadMarauderHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
   End
 End
 
@@ -1580,7 +1585,7 @@ Object DeadScorpionHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
   End
 End
 
@@ -1611,7 +1616,7 @@ Object DestroyedMilitiaTank
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 4000
+    SinkDelay = 1500 ; Patch104p @tweak from 4000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
     DestructionDelay = 8000
   End
@@ -1646,7 +1651,7 @@ Object DeadRadarVanHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 12000 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1720,6 +1725,7 @@ Object AmericaDeadDozerHulk
 End
 
 ;------------------------------------------------------------------------------
+; Note: AmericaScoutDroneHulk is used for Hellfire Drone too.
 Object AmericaScoutDroneHulk
   ; *** ART Parameters ***
   Draw                = W3DModelDraw ModuleTag_01
@@ -1747,7 +1753,7 @@ Object AmericaScoutDroneHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 6000 ; Patch104p @performance from 8000 to optimize despawn timing
   End
 End
 
@@ -1779,7 +1785,7 @@ Object AmericaBattleDroneHulk
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 6000 ; Patch104p @performance from 8000 to optimize despawn timing
   End
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -38,9 +38,9 @@ Object DeadMicrowaveHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
+    SinkDelay = 3000 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 8000 ; Patch104p @performance from 20000 to optimize despawn timing
+    DestructionDelay = 9500 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -95,9 +95,9 @@ Object AmericaVehicleHumveeDeadHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
+    SinkDelay = 3000 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 8000 ; Patch104p @performance from 20000 to optimize despawn timing
+    DestructionDelay = 9500 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -143,9 +143,9 @@ Object AmericaVehicleTomahawkHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 End
 
@@ -175,9 +175,9 @@ Object ChinaVehicleNukeCannonHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 10000 ; Patch104p @tweak from 8000 to make it not disappear before it is fully sunken
+    DestructionDelay = 11500 ; Patch104p @tweak from 8000 to make it not disappear before it is fully sunken
   End
 End
 
@@ -214,9 +214,9 @@ Object AmericaJetRaptorHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -256,9 +256,9 @@ Object AmericaJetA10Hulk
 
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -298,9 +298,9 @@ Object SpectreHulk
 
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -335,9 +335,9 @@ Object AmericaJetStealthHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -372,9 +372,9 @@ Object AmericaJetAuroraHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -412,9 +412,9 @@ Object ComancheRubbleHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500 ; Patch104p @tweak from 3000 to be consistent with other vehicles
+    SinkDelay        = 3000 ; Patch104p @tweak from 3000 to be consistent with other vehicles
     SinkRate         = 2 ; Patch104p @tweak from 4 to be consistent with other vehicles
-    DestructionDelay = 8000 ; Patch104p @performance from 10000 to optimize despawn timing
+    DestructionDelay = 9500 ; Patch104p @performance from 10000 to optimize despawn timing
   End
 
 
@@ -454,9 +454,9 @@ Object ChinookRubbleHull
     MaxLifetime    = 20000   ; max lifetime in msec
   End
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2 ; Patch104p @tweak from 1 to be consistent with other vehicles
-    DestructionDelay = 10000 ; Patch104p @performance from 16000 to optimize despawn timing
+    DestructionDelay = 11500 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -488,9 +488,9 @@ Object HelixRubbleHull
     MaxLifetime    = 20000   ; max lifetime in msec
   End
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2 ; Patch104p @tweak from 1 to be consistent with other vehicles
-    DestructionDelay = 12000 ; Patch104p @performance from 16000 to optimize despawn timing
+    DestructionDelay = 13500 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -529,9 +529,9 @@ Object ChinaJetMIGHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -578,9 +578,9 @@ Object ChinaVehicleBattleMasterDeadHull
 
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
+    SinkDelay = 3000 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 8000 ; Patch104p @performance from 20000 to optimize despawn timing
+    DestructionDelay = 9500 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -637,9 +637,9 @@ Object ChinaTankOverlordDeadHull
 
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 1500 ; Patch104p @tweak from 14000 to be consistent with other vehicles
+    SinkDelay = 3000 ; Patch104p @tweak from 14000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 10000 ; Patch104p @performance from 20000 to optimize despawn timing
+    DestructionDelay = 11500 ; Patch104p @performance from 20000 to optimize despawn timing
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -756,9 +756,9 @@ Object ChinaVehicleTroopCrawlerDeadHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -808,9 +808,9 @@ Object ChinaVehicleAssaultTroopCrawlerDeadHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -849,9 +849,9 @@ Object DeadTankHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -883,9 +883,9 @@ Object InfernoCannonHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 10000 ; Patch104p @tweak from 8000 to make it not disappear before it is fully sunken
+    DestructionDelay  = 11500 ; Patch104p @tweak from 8000 to make it not disappear before it is fully sunken
   End
 
 End
@@ -917,9 +917,9 @@ Object DeadChinaSupplyTruckHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -951,10 +951,10 @@ Object DeadChinaGattlingTankHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     ;SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 10000 ; Patch104p @performance from 12000 to optimize despawn timing
+    DestructionDelay          = 11500 ; Patch104p @performance from 12000 to optimize despawn timing
     ;DestructionDelayVariance  = 4000
   End
 
@@ -987,10 +987,10 @@ Object DeadChinaECMTankHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     ;SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
+    DestructionDelay          = 9500 ; Patch104p @performance from 12000 to optimize despawn timing
     ;DestructionDelayVariance  = 4000
   End
 
@@ -1023,10 +1023,10 @@ Object AmericaVehicleAmbulanceDeadHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     ;SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
+    DestructionDelay          = 9500 ; Patch104p @performance from 12000 to optimize despawn timing
     ;DestructionDelayVariance  = 4000
   End
 
@@ -1074,9 +1074,9 @@ Object DeadSCUDLauncherHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 10000  ; Patch104p @performance from 12000 to make it not disappear before it is fully sunken
+    DestructionDelay  = 11500  ; Patch104p @performance from 12000 to make it not disappear before it is fully sunken
   End
 
 End
@@ -1108,9 +1108,9 @@ Object DeadToxinTractorHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 10000 ; Patch104p @performance from 16000 to optimize despawn timing
+    DestructionDelay  = 11500 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1142,9 +1142,9 @@ Object DeadQuadCannonHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 8000 ; Patch104p @performance from 16000 to optimize despawn timing
+    DestructionDelay  = 9500 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1176,9 +1176,9 @@ Object DeadBombTruckHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 10000 ; Patch104p @performance from 16000 to optimize despawn timing
+    DestructionDelay  = 11500 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1385,9 +1385,9 @@ Object DeadCrusaderHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1418,9 +1418,9 @@ Object DeadLaserTankHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1451,9 +1451,9 @@ Object DeadPaladinHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1484,9 +1484,9 @@ Object DeadAvengerHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1517,9 +1517,9 @@ Object DeadMarauderHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
+    DestructionDelay  = 9500 ; Patch104p @performance from 12000 to optimize despawn timing
   End
 End
 
@@ -1550,9 +1550,9 @@ Object DeadBattleBusHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 13500
   End
 End
 
@@ -1583,9 +1583,9 @@ Object DeadScorpionHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000 ; Patch104p @performance from 12000 to optimize despawn timing
+    DestructionDelay  = 9500 ; Patch104p @performance from 12000 to optimize despawn timing
   End
 End
 
@@ -1616,9 +1616,9 @@ Object DestroyedMilitiaTank
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 1500 ; Patch104p @tweak from 4000 to be consistent with other vehicles
+    SinkDelay = 3000 ; Patch104p @tweak from 4000 to be consistent with other vehicles
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 End
 
@@ -1649,9 +1649,9 @@ Object DeadRadarVanHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000 ; Patch104p @performance from 16000 to optimize despawn timing
+    DestructionDelay  = 13500 ; Patch104p @performance from 16000 to optimize despawn timing
   End
 
 End
@@ -1683,9 +1683,9 @@ Object ChinaDeadDozerHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -1717,9 +1717,9 @@ Object AmericaDeadDozerHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -1854,9 +1854,9 @@ Object AmericaVehicleSentryDroneHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 End
 
@@ -1900,9 +1900,9 @@ Object ChinaVehicleListeningOutpostDeadHull
   End
 
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -1949,9 +1949,9 @@ Object DeadGLAToxicSupplyTruckHulk
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000 ; Patch104p @tweak from 1500 to not sink before the wreck can be seen after explosion effects
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End


### PR DESCRIPTION
* Fixes #1183

This change fixes and improves dead vehicle hull sink and destruction delays in 2 steps.

1. Unifies all vehicle sink delays to common 1500 ms, sink speed to 2 m/s and destruction delays to whenever the model is fully sunken into terrain. A few units had very long sink times, such as Humvee, Microwave and Overlord. They are all the same now. Except for Flame Tank, because that one has a special death particle that lasts very long, so dead hull should stay with it. For GLA Battle Bus and Combat Bike the destruction timing does not work correctly originally and patched. It will disappear before sunken into terrain. Helicopters originally had slow sink speed of 1 m/s or fast sink speed of 4 m/s. This has been consolidated to 2 m/s for all hulls. GLA Rocket Buggy, Technical and Combat Bike (on kill) do not sink into terrain, as instead they just disappear on explosion, so their setups are unchanged.

2. Increases all sink and destruction delays by 1500 ms, except for flying Drone hulls and Combat Bike hull. This way dead hulls can be seen properly after explosion particles for a bit of time, otherwise hulls can barely be seen on various vehicle kills. The new sink delay of 3000 ms is also consistent with all Infantry, which is 3000 ms as well.