### PR TITLE
Fix: Wrong Positional Offset Of ECM And Gattling Tank Wrecks

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6882,7 +6882,7 @@ End
 ObjectCreationList OCL_ChinaTankGattlingDebris
   CreateObject
     ObjectNames = DeadChinaGattlingTankHulk
-    Offset      = X:-6.62 Y:0.0 Z:0.0
+    Offset      = X:0.0 Y:0.0 Z:0.0 ; Patch104p @bugfix Fix offset.
     Count       = 1
     Disposition = LIKE_EXISTING
   End
@@ -6928,7 +6928,7 @@ End
 ObjectCreationList OCL_ChinaTankECMDebris
   CreateObject
     ObjectNames = DeadChinaECMTankHulk
-    Offset      = X:-6.62 Y:0.0 Z:0.0
+    Offset      = X:0.0 Y:0.0 Z:0.0 ; Patch104p @bugfix Fix offset.
     Count       = 1
     Disposition = LIKE_EXISTING
   End


### PR DESCRIPTION
* Fixes #1206

This change fixes dead hull offsets of China ECM, Gattling.

ECM and Gattling appeared to have settings copied from Dozer and were wrong.