### PR TITLE
Fix: Prevent Pilots From Entering Humvees Without Promoting Them

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5251,6 +5251,7 @@ Object AirF_AmericaVehicleHumvee
 ;    ExitSound           = GarrisonExit
     DamagePercentToUnits = 100% ;10%
     AllowInsideKindOf  = INFANTRY
+    ForbidInsideKindOf = NO_GARRISON ; Patch104p @bugfix commy2 18/09/2022 Reject Pilots.
     ExitDelay = 250
     NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
     GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -178,6 +178,7 @@ Object AmericaVehicleHumvee
 ;    ExitSound           = GarrisonExit
     DamagePercentToUnits = 100% ;10%
     AllowInsideKindOf  = INFANTRY
+    ForbidInsideKindOf = NO_GARRISON ; Patch104p @bugfix commy2 18/09/2022 Reject Pilots.
     ExitDelay = 250
     NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
     GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -5243,6 +5243,7 @@ Object Humvee1
     ExitSound           = GarrisonExit
     DamagePercentToUnits = 20%
     AllowInsideKindOf  = INFANTRY
+    ForbidInsideKindOf = NO_GARRISON ; Patch104p @bugfix commy2 18/09/2022 Reject Pilots.
   End
 
   Behavior = SlowDeathBehavior ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4486,6 +4486,7 @@ Object Lazr_AmericaVehicleHumvee
 ;    ExitSound           = GarrisonExit
     DamagePercentToUnits = 100% ;10%
     AllowInsideKindOf  = INFANTRY
+    ForbidInsideKindOf = NO_GARRISON ; Patch104p @bugfix commy2 18/09/2022 Reject Pilots.
     ExitDelay = 250
     NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
     GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4968,6 +4968,7 @@ Object SupW_AmericaVehicleHumvee
 ;    ExitSound           = GarrisonExit
     DamagePercentToUnits = 100% ;10%
     AllowInsideKindOf  = INFANTRY
+    ForbidInsideKindOf = NO_GARRISON ; Patch104p @bugfix commy2 18/09/2022 Reject Pilots.
     ExitDelay = 250
     NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
     GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/126

This forbids `NO_GARRISON` flag objects from entering Humvee. `NO_GARRISON` is unique to Pilot and makes him unable to enter civilian buildings, Tunnels and (iirc) Bunkers. Cursor still appears and it promotes the Humvee when entered.

This means vet 3 Humvee can no longer transport Pilots.