### PR TITLE
Fix: Internet Center select audio

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -13737,7 +13737,7 @@ Object Infa_ChinaInternetCenter
   ;*******************************************************************************************************************
 
   ; *** AUDIO Parameters ***
-  VoiceSelect       = InternetCenterSelect
+  VoiceSelect       = InternetCenterSelect ; Patch104p @bugfix Stubbjax 23/09/2022 Assigned correct audio.
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -13737,7 +13737,7 @@ Object Infa_ChinaInternetCenter
   ;*******************************************************************************************************************
 
   ; *** AUDIO Parameters ***
-  VoiceSelect       = CommandCenterChinaSelect
+  VoiceSelect       = InternetCenterSelect
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16349,7 +16349,7 @@ Object Nuke_ChinaInternetCenter
   ;*******************************************************************************************************************
 
   ; *** AUDIO Parameters ***
-  VoiceSelect       = InternetCenterSelect
+  VoiceSelect       = InternetCenterSelect ; Patch104p @bugfix Stubbjax 23/09/2022 Assigned correct audio.
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16349,7 +16349,7 @@ Object Nuke_ChinaInternetCenter
   ;*******************************************************************************************************************
 
   ; *** AUDIO Parameters ***
-  VoiceSelect       = CommandCenterChinaSelect
+  VoiceSelect       = InternetCenterSelect
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15351,7 +15351,7 @@ Object Tank_ChinaInternetCenter
   ;*******************************************************************************************************************
 
   ; *** AUDIO Parameters ***
-  VoiceSelect       = InternetCenterSelect
+  VoiceSelect       = InternetCenterSelect ; Patch104p @bugfix Stubbjax 23/09/2022 Assigned correct audio.
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -15351,7 +15351,7 @@ Object Tank_ChinaInternetCenter
   ;*******************************************************************************************************************
 
   ; *** AUDIO Parameters ***
-  VoiceSelect       = CommandCenterChinaSelect
+  VoiceSelect       = InternetCenterSelect
   SoundOnDamaged        = BuildingDamagedStateLight
   SoundOnReallyDamaged  = BuildingDestroy
 


### PR DESCRIPTION
Internet Centers of China Nuke, China Tank and China Infantry now play the correct selection audio. Who knows if anyone has ever noticed this.