### PR TITLE
Change: Improved accessibility and usability of the Helix bomb drop abilities

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15618,10 +15618,11 @@ Object Boss_VehicleHelix
     SpecialObjectsPersistWhenOwnerDies = Yes
     SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
     UniqueSpecialObjectTargets = No        ;This would prevent multiple charges placed on the same object.
-    UnpackTime              = 500     ;slight delay to drop bomb
+    UnpackTime              = 0       ;slight delay to drop bomb ; Patch104p @balance Stubbjax 24/09/2022 Remove delay.
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound
+    TriggerSound = HelixBombWeapon ; Patch104p @tweak Stubbjax 24/09/2022 Added sound effect.
     LoseStealthOnTrigger      = No
     ApproachRequiresLOS       = No ; we are a helicopter, we can see everything
     NeedToFaceTarget          = No ; can drop the bomb at any angle to target

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -281,6 +281,7 @@ Object ChinaVehicleHelix
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound
+    TriggerSound = HelixBombWeapon ; Patch104p @tweak Stubbjax 24/09/2022 Added sound effect.
     LoseStealthOnTrigger      = No
     ApproachRequiresLOS       = No ; we are a helicopter, we can see everything
     NeedToFaceTarget          = No ; can drop the bomb at any angle to target

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -277,7 +277,7 @@ Object ChinaVehicleHelix
     SpecialObjectsPersistWhenOwnerDies = Yes
     SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
     UniqueSpecialObjectTargets = No        ;This would prevent multiple charges placed on the same object.
-    UnpackTime              = 500     ;slight delay to drop bomb
+    UnpackTime              = 0       ;slight delay to drop bomb ; Patch104p @balance Stubbjax 24/09/2022 Remove delay.
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16152,7 +16152,7 @@ Object Infa_ChinaVehicleHelix
     SpecialObjectsPersistWhenOwnerDies = Yes
     SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
     UniqueSpecialObjectTargets = No        ;This would prevent multiple charges placed on the same object.
-    UnpackTime              = 500     ;slight delay to drop bomb
+    UnpackTime              = 0       ;slight delay to drop bomb ; Patch104p @balance Stubbjax 24/09/2022 Remove delay.
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16156,6 +16156,7 @@ Object Infa_ChinaVehicleHelix
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound
+    TriggerSound = HelixBombWeapon ; Patch104p @tweak Stubbjax 24/09/2022 Added sound effect.
     LoseStealthOnTrigger      = No
     ApproachRequiresLOS       = No ; we are a helicopter, we can see everything
     NeedToFaceTarget          = No ; can drop the bomb at any angle to target

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -555,6 +555,7 @@ Object Nuke_ChinaVehicleHelix
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound
+    TriggerSound = HelixBombWeapon ; Patch104p @tweak Stubbjax 24/09/2022 Added sound effect.
     LoseStealthOnTrigger      = No
     ApproachRequiresLOS       = No ; we are a helicopter, we can see everything
     NeedToFaceTarget          = No ; can drop the bomb at any angle to target

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -551,7 +551,7 @@ Object Nuke_ChinaVehicleHelix
     SpecialObjectsPersistWhenOwnerDies = Yes
     SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
     UniqueSpecialObjectTargets = No        ;This would prevent multiple charges placed on the same object.
-    UnpackTime              = 500     ;slight delay to drop bomb
+    UnpackTime              = 0       ;slight delay to drop bomb ; Patch104p @balance Stubbjax 24/09/2022 Remove delay.
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -283,6 +283,7 @@ Object Tank_ChinaVehicleHelix
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound
+    TriggerSound = HelixBombWeapon ; Patch104p @tweak Stubbjax 24/09/2022 Added sound effect.
     LoseStealthOnTrigger      = No
     ApproachRequiresLOS       = No ; we are a helicopter, we can see everything
     NeedToFaceTarget          = No ; can drop the bomb at any angle to target

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -279,7 +279,7 @@ Object Tank_ChinaVehicleHelix
     SpecialObjectsPersistWhenOwnerDies = Yes
     SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
     UniqueSpecialObjectTargets = No        ;This would prevent multiple charges placed on the same object.
-    UnpackTime              = 500     ;slight delay to drop bomb
+    UnpackTime              = 0       ;slight delay to drop bomb ; Patch104p @balance Stubbjax 24/09/2022 Remove delay.
     FlipOwnerAfterUnpacking = No
     FleeRangeAfterCompletion = 0.0         ;DOes not run away after finishing ability
     UnpackSound               = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -1947,6 +1947,17 @@ AudioEvent DaisyCutterWeapon
   Type = world shrouded everyone
 End
 
+; Patch104p @tweak Stubbjax 24/09/2022 Added audio event for Helix bombs.
+AudioEvent HelixBombWeapon
+  Sounds = vdaiweaa
+  Limit = 10
+  Priority = normal
+  PitchShift = -10 10
+  VolumeShift = -10
+  Volume = 60
+  Type = world shrouded everyone
+End
+
 AudioEvent ComancheSpinExplosion
   Sounds = vcomdi2a
   Limit = 3

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -657,8 +657,8 @@ End
 Upgrade Upgrade_HelixNapalmBomb
   DisplayName        = UPGRADE:ChinaHelixNapalmBomb
   Type               = OBJECT
-  BuildTime          = 20.0
-  BuildCost          = 800
+  BuildTime          = 10.0 ; Patch104p @balance Stubbjax 24/09/2022 Reduce time and cost.
+  BuildCost          = 500
   ButtonImage        = SNHelixUp04
   ResearchSound      = HelixVoiceUpgradeNapalmBomb
   UnitSpecificSound  = OverlordExpansion
@@ -775,8 +775,8 @@ End
 Upgrade Nuke_Upgrade_HelixNukeBomb
   DisplayName        = UPGRADE:ChinaHelixNukeBomb
   Type               = OBJECT
-  BuildTime          = 20.0
-  BuildCost          = 800
+  BuildTime          = 10.0 ; Patch104p @balance Stubbjax 24/09/2022 Reduce time and cost.
+  BuildCost          = 500
   ButtonImage        = SNHelixUp05
   ResearchSound      = HelixVoiceUpgradeNuclearBomb
   UnitSpecificSound  = OverlordExpansion


### PR DESCRIPTION
Improved accessibility and usability of the Helix bomb drop abilities. Demonstration of the unpack adjustment can be seen [here](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1014#issuecomment-1231470003). Closes #1014.

- Reduced the research time from 20 seconds to 10 seconds to offset the initial cooldown
- Reduced the price from $800 to $500
- Removed the unpack delay to improve responsiveness
- Added a bomb drop trigger sound effect

The initial cooldown on the ability makes the upgrade a very difficult proposition when adapting to the current state of the battlefield. Waiting for the upgrade _and_ cooldown - an entire 30 seconds in 1.04 - is vital time and is quite simply rarely worth the wait (@ImTimK explained [here](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/991#issue-1353055385)). Reducing this initial delay from 30 seconds to 20 seconds seems like a reasonable and low-key approach to incentivise reactive / adaptive play while still requiring some initial time investment / prediction.

The price reduction is determined by comparing the unit upgrades of other factions - most notably Comanche Rocket Pods, which is a single $800 investment that then benefits all existing and future Comanches. A good comparison by @ImTimK can be found [here](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1014#issuecomment-1234050908). This is in stark contrast to the Helix's bomb ability, which not only costs $800, but $800 _per Helix_. In addition, as described [here](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/991#issuecomment-1229499022), there is a significantly heightened risk / vulnerability that accompanies the ability's use. As the bombs are most effective against large groups, and a large group often has some form of anti-air capability, there is a high risk involved in their usage. This was demonstrated (to an extent) by @MTKing4 [here](https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1093#issuecomment-1256202497). The per-unit investment combined with the heightened risk associated with the ability's usage justifies a lower price, and $500 is a reasonable price when also considering the total investment that a Helix typically requires (i.e. unit cost + bunker cost + occupants cost).

The unpack delay improves the ability's responsiveness, and affords the user much greater control and reliability. As explained [here](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1014#issuecomment-1231470003) and [here](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1014#issuecomment-1231918630), the original 500ms delay combined with typical network delay greatly reduces a user's ability to accurately and effectively control the ability, and the risk is very rarely worth it. In addtion, it attenuates some of the vulnerability that a Helix has to endure when flying above targets in order to drop the bomb.

The added sound effect serves to provide additional feedback. The visual of the bomb dropping is often hard to see, particularly when there is a lot going on. It allows the user to immediately know when the ability is triggered (though the lack of delay means they no longer need to rely on the visual before giving another order) and, more importantly, it also provides opponents with feedback and a greater chance to react. Plus it just felt odd that it was basically the only action in the game without a corresponding sound effect.