### PR TITLE
Fix: Set limits and priorities for air unit death sounds

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -402,13 +402,14 @@ AudioEvent RaptorVoiceAttack
 End
 
 AudioEvent RaptorVoiceLowFuel
-  Sounds = vrapfub ; vrapfua vrapfuc vrapfud
+  Sounds = vrapfua vrapfub vrapfuc vrapfud ; Patch104p @tweak enable all sound variants
   Control = random
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Volume  = 120
   MinVolume = 110
   Type = world player global
+  Limit = 1 ; Patch104p @tweak to not spam voice as much
 End
 
 AudioEvent RaptorVoiceUpgradeFuel
@@ -443,6 +444,8 @@ AudioEvent RaptorVoiceFalling
   Control = random
 ;  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f gradio1g
 ;  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e gradio3f gradio3g
+  Priority = LOW ; Patch104p @bugfix to be consistent with Voice Die limits
+  Limit = 3 ; Patch104p @bugfix to be consistent with Voice Die limits
   Volume = 100
   MinVolume = 80
   Type = world shrouded player
@@ -512,6 +515,8 @@ End
 AudioEvent ComancheVoiceFalling
   Sounds = vcomfaa vcomfab vcomfac vcomfad vcomfae
   Control = random
+  Priority = LOW ; Patch104p @bugfix to be consistent with Voice Die limits
+  Limit = 3 ; Patch104p @bugfix to be consistent with Voice Die limits
   Volume = 100
   MinVolume = 80
   Type = world shrouded player
@@ -530,6 +535,8 @@ End
 AudioEvent ComancheVoiceDie
   Sounds = vcomfaa vcomfab vcomfac vcomfad vcomfae
   Control = random
+  Priority = LOW ; Patch104p @bugfix to be consistent with other Voice Die limits
+  Limit = 3 ; Patch104p @bugfix to be consistent with other Voice Die limits
   Volume = 100
   MinVolume = 80
   Type = world shrouded player
@@ -617,6 +624,8 @@ End
 AudioEvent ChinookVoiceFalling
   Sounds = vchifac vchifad vchifae vchifaf ;vchifaa vchifab
   Control = random
+  Priority = LOW ; Patch104p @bugfix to be consistent with Voice Die limits
+  Limit = 3 ; Patch104p @bugfix to be consistent with Voice Die limits
   Volume = 100
   MinVolume = 80
   Type = world shrouded player
@@ -683,18 +692,21 @@ AudioEvent AuroraBomberVoiceModeSuperSonic
 End
 
 AudioEvent AuroraBomberVoiceLowFuel
-  Sounds = vaurfub ;vaurfua vaurfuc
+  Sounds = vaurfua vaurfub vaurfuc ; Patch104p @tweak enable all sound variants
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume  = 120
   MinVolume = 110
   Type = world player global
+  Limit = 1 ; Patch104p @tweak to not spam voice as much
 End
 
 AudioEvent AuroraBomberVoiceFalling
   Sounds = vaurfaa vaurfab vaurfac
   Control = random
+  Priority = LOW ; Patch104p @bugfix to be consistent with Voice Die limits
+  Limit = 3 ; Patch104p @bugfix to be consistent with Voice Die limits
   Volume = 100
   MinVolume = 80
   Type = world shrouded player
@@ -1207,8 +1219,8 @@ AudioEvent StealthFighterVoiceLowFuel
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Volume  = 120
   MinVolume = 110
-  Priority = high
   Type = world player global
+  Limit = 1 ; Patch104p @tweak to not spam voice as much
 End
 
 AudioEvent StealthFighterVoiceAirPatrol
@@ -1224,6 +1236,8 @@ End
 AudioEvent StealthFighterVoiceFalling
   Sounds = vstefaa vstefab vstefac
   Control = random
+  Priority = LOW ; Patch104p @bugfix to be consistent with Voice Die limits
+  Limit = 3 ; Patch104p @bugfix to be consistent with Voice Die limits
   Volume = 100
   MinVolume = 80
   Type = world shrouded player
@@ -1728,6 +1742,7 @@ AudioEvent MigVoiceLowFuel
   Volume  = 120
   MinVolume = 110
   Type = world player global
+  Limit = 1 ; Patch104p @tweak to not spam voice as much
 End
 
 AudioEvent MigVoiceAirPatrol
@@ -1742,6 +1757,8 @@ End
 AudioEvent MigVoiceFalling
   Sounds = vmigfaa vmigfab vmigfac vmigfac vmigfad vmigfae
   Control = random
+  Priority = LOW ; Patch104p @bugfix to be consistent with Voice Die limits
+  Limit = 3 ; Patch104p @bugfix to be consistent with Voice Die limits
   Volume = 100
   MinVolume = 80
   Type = world shrouded player


### PR DESCRIPTION
This change sets reasonable limits for air unit death sounds, including low fuel and falling. Without limits, too many audio lines can be spammed at once.