### PR TITLE
Fix: TechnicalVoiceDie limit and priority

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -3030,8 +3030,8 @@ End
 AudioEvent TechnicalVoiceDie
   Sounds = vtecdia vtecdib vtecdic vtecdid
   Control = random
-  Priority= high
-  Limit = 2
+  Priority = LOW ; Patch104p @tweak to be consistent with other Voice Die setups
+  Limit = 3 ; Patch104p @tweak to be consistent with other Voice Die setups
   VolumeShift = -15
   PitchShift= -5 5
   Volume = 65


### PR DESCRIPTION
Fixes limit and priority of TechnicalVoiceDie to be consistent with all other VoiceDie audio events.