### PR TITLE
Fix: Hide Floating Cube In Front Of Damaged Microwave Tank

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7292,9 +7292,11 @@ Object AirF_AmericaTankMicrowave
       Model         = AVTHUNDRBLT_D
       ParticleSysBone = PROJECTORGLOW09 MicrowaveLenzflare
       ParticleSysBone = NONE MicrowaveRotisserie
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
     ConditionState  = REALLYDAMAGED RUBBLE USING_WEAPON_A USING_WEAPON_B USING_WEAPON_C
       Model         = AVTHUNDRBLT_D
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
 
     TrackMarks              = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2693,9 +2693,11 @@ Object AmericaTankMicrowave
       Model         = AVTHUNDRBLT_D
       ParticleSysBone = PROJECTORGLOW09 MicrowaveLenzflare
       ParticleSysBone = NONE MicrowaveRotisserie
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
     ConditionState  = REALLYDAMAGED RUBBLE USING_WEAPON_A USING_WEAPON_B USING_WEAPON_C
       Model         = AVTHUNDRBLT_D
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
 
     TrackMarks              = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6996,9 +6996,11 @@ Object Lazr_AmericaTankMicrowave
       Model         = AVTHUNDRBLT_D
       ParticleSysBone = PROJECTORGLOW09 MicrowaveLenzflare
       ParticleSysBone = NONE MicrowaveRotisserie
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
     ConditionState  = REALLYDAMAGED RUBBLE USING_WEAPON_A USING_WEAPON_B USING_WEAPON_C
       Model         = AVTHUNDRBLT_D
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
 
     TrackMarks              = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7465,9 +7465,11 @@ Object SupW_AmericaTankMicrowave
       Model         = AVTHUNDRBLT_D
       ParticleSysBone = PROJECTORGLOW09 MicrowaveLenzflare
       ParticleSysBone = NONE MicrowaveRotisserie
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
     ConditionState  = REALLYDAMAGED RUBBLE USING_WEAPON_A USING_WEAPON_B USING_WEAPON_C
       Model         = AVTHUNDRBLT_D
+      HideSubObject   = Weapon01 ; Patch104p @bugfix commy2 24/09/2022 Hide floating voxel.
     End
 
     TrackMarks              = EXTnkTrack.tga


### PR DESCRIPTION
- partially adresses https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1257

This is a fix that does not require model file changes.