### PR TITLE
Fix: Level 3 Spectre Gunship audio

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1160,7 +1160,7 @@ Object AirF_AmericaJetSpectreGunship3
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
-  VoiceSelect         = SpectreGunshipVoiceSelect ; Patch104p @bugfix Stubbjax 25/09/2022 Added missing / audio.
+  VoiceSelect         = SpectreGunshipVoiceSelect ; Patch104p @bugfix Stubbjax 25/09/2022 Added missing audio.
   VoiceAttack         = SpectreGunshipVoiceAttack
   VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1160,11 +1160,14 @@ Object AirF_AmericaJetSpectreGunship3
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  VoiceSelect         = SpectreGunshipVoiceSelect
+  VoiceAttack         = SpectreGunshipVoiceAttack
+  VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds
     Afterburner    = SpectreGunshipAfterburnerLoop
-    HowitzerFire   = CrusaderTankWeapon
+    HowitzerFire   = SpectreHowitzerWeapon
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1160,14 +1160,14 @@ Object AirF_AmericaJetSpectreGunship3
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
-  VoiceSelect         = SpectreGunshipVoiceSelect
+  VoiceSelect         = SpectreGunshipVoiceSelect ; Patch104p @bugfix Stubbjax 25/09/2022 Added missing / audio.
   VoiceAttack         = SpectreGunshipVoiceAttack
   VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds
     Afterburner    = SpectreGunshipAfterburnerLoop
-    HowitzerFire   = SpectreHowitzerWeapon
+    HowitzerFire   = SpectreHowitzerWeapon ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed incorrect audio.
   End
 
 


### PR DESCRIPTION
The select, attack and move audio was missing for the level 3 Spectre Gunship, and the howitzer sound effect was incorrectly assigned. Values are now identical to level 1 and 2.