### PR TITLE
Fix: Level 2 and 3 Spectre Gunship damage state animation transitions

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -682,7 +682,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
     End
@@ -691,7 +691,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -706,7 +706,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 JetFireLarge
@@ -719,7 +719,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -738,7 +738,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 SpectreGunshipFireLarge
@@ -756,7 +756,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -1008,7 +1008,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
     End
@@ -1017,7 +1017,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -1032,7 +1032,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 JetFireLarge
@@ -1045,7 +1045,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -1064,7 +1064,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 SpectreGunshipFireLarge
@@ -1082,7 +1082,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -682,7 +682,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
     End
@@ -691,7 +691,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -706,7 +706,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 JetFireLarge
@@ -719,7 +719,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -738,7 +738,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 SpectreGunshipFireLarge
@@ -756,7 +756,7 @@ Object AirF_AmericaJetSpectreGunship2
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -1008,7 +1008,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
     End
@@ -1017,7 +1017,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship
       Animation       = AVSGunship.AVSGunship
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -1032,7 +1032,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 JetFireLarge
@@ -1045,7 +1045,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail
@@ -1064,7 +1064,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 SpectreContrail
       ParticleSysBone = WingTip02 SpectreContrail
       ParticleSysBone = Smoke01 SpectreGunshipFireLarge
@@ -1082,7 +1082,7 @@ Object AirF_AmericaJetSpectreGunship3
       Model           = AVSGunship_D
       Animation       = AVSGunship_D.AVSGunship_D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = MAINTAIN_FRAME_ACROSS_STATES
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 25/09/2022 Fixed animation transition.
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
       ParticleSysBone = Engine01 SpectreAfterburnerTrail


### PR DESCRIPTION
When transitioning between damage states, the level 2 and 3 Spectre Gunships would reset their animation state to the first frame, and the wings would reanimate outwards, which looks bad. This does not happen for the level 1 Spectre Gunship. This change matches the animation transition values of the level 1 Spectre Gunship to the level 2 and 3 variants.

Below is the original behaviour of level 2 and 3. Note the wings reanimate when transitioning between damage states.

https://user-images.githubusercontent.com/11547761/192134395-6418399d-7fb6-41e1-aa46-8ba861cf7c10.mp4

Below is the original behaviour of level 1 (and now 2 and 3 with this change). Note the wings do not reanimate when transitioning between damage states.

https://user-images.githubusercontent.com/11547761/192134385-7a384659-33af-4d9b-98c9-7d89d0129b06.mp4