### PR TITLE
Fix: Scud Storm Building Lights Turned Off At Night Until Damaged

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -5056,10 +5056,11 @@ Object Boss_ScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -5071,8 +5072,8 @@ Object Boss_ScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT Trans_ATTACKING_NIGHT
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -5086,8 +5087,8 @@ Object Boss_ScudStorm
     End
 
     ConditionState = ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -5104,8 +5105,8 @@ Object Boss_ScudStorm
     AliasConditionState = ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT Trans_READY_NIGHT ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 
@@ -5783,10 +5784,11 @@ Object Boss_ScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = USER_1 NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -5798,8 +5800,8 @@ Object Boss_ScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT_Upgrade Trans_ATTACKING_NIGHT_Upgrade
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -5813,8 +5815,8 @@ Object Boss_ScudStorm
     End
 
     ConditionState = USER_1 ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -5831,8 +5833,8 @@ Object Boss_ScudStorm
     AliasConditionState = USER_1 ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT_Upgrade Trans_READY_NIGHT_Upgrade ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -4054,10 +4054,11 @@ Object Chem_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4069,8 +4070,8 @@ Object Chem_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT Trans_ATTACKING_NIGHT
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4084,8 +4085,8 @@ Object Chem_GLAScudStorm
     End
 
     ConditionState = ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4102,8 +4103,8 @@ Object Chem_GLAScudStorm
     AliasConditionState = ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT Trans_READY_NIGHT ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 
@@ -4781,10 +4782,11 @@ Object Chem_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = USER_1 NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4796,8 +4798,8 @@ Object Chem_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT_Upgrade Trans_ATTACKING_NIGHT_Upgrade
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4811,8 +4813,8 @@ Object Chem_GLAScudStorm
     End
 
     ConditionState = USER_1 ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4829,8 +4831,8 @@ Object Chem_GLAScudStorm
     AliasConditionState = USER_1 ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT_Upgrade Trans_READY_NIGHT_Upgrade ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4138,10 +4138,11 @@ Object Demo_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4153,8 +4154,8 @@ Object Demo_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT Trans_ATTACKING_NIGHT
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4164,8 +4165,8 @@ Object Demo_GLAScudStorm
     End
 
     ConditionState = ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4178,8 +4179,8 @@ Object Demo_GLAScudStorm
     AliasConditionState = ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT Trans_READY_NIGHT ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -11920,10 +11920,11 @@ Object GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -11935,8 +11936,8 @@ Object GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT Trans_ATTACKING_NIGHT
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -11950,8 +11951,8 @@ Object GLAScudStorm
     End
 
     ConditionState = ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -11968,8 +11969,8 @@ Object GLAScudStorm
     AliasConditionState = ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT Trans_READY_NIGHT ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 
@@ -12647,10 +12648,11 @@ Object GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = USER_1 NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -12662,8 +12664,8 @@ Object GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT_Upgrade Trans_ATTACKING_NIGHT_Upgrade
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -12677,8 +12679,8 @@ Object GLAScudStorm
     End
 
     ConditionState = USER_1 ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -12695,8 +12697,8 @@ Object GLAScudStorm
     AliasConditionState = USER_1 ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT_Upgrade Trans_READY_NIGHT_Upgrade ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -6760,10 +6760,11 @@ Object GC_Chem_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -6775,8 +6776,8 @@ Object GC_Chem_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT Trans_ATTACKING_NIGHT
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -6790,8 +6791,8 @@ Object GC_Chem_GLAScudStorm
     End
 
     ConditionState = ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -6808,8 +6809,8 @@ Object GC_Chem_GLAScudStorm
     AliasConditionState = ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT Trans_READY_NIGHT ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 
@@ -7487,10 +7488,11 @@ Object GC_Chem_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = USER_1 NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7502,8 +7504,8 @@ Object GC_Chem_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT_Upgrade Trans_ATTACKING_NIGHT_Upgrade
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7517,8 +7519,8 @@ Object GC_Chem_GLAScudStorm
     End
 
     ConditionState = USER_1 ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7535,8 +7537,8 @@ Object GC_Chem_GLAScudStorm
     AliasConditionState = USER_1 ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT_Upgrade Trans_READY_NIGHT_Upgrade ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -7035,10 +7035,11 @@ Object GC_Slth_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7050,8 +7051,8 @@ Object GC_Slth_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT Trans_ATTACKING_NIGHT
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7065,8 +7066,8 @@ Object GC_Slth_GLAScudStorm
     End
 
     ConditionState = ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7083,8 +7084,8 @@ Object GC_Slth_GLAScudStorm
     AliasConditionState = ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT Trans_READY_NIGHT ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 
@@ -7762,10 +7763,11 @@ Object GC_Slth_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = USER_1 NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7777,8 +7779,8 @@ Object GC_Slth_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT_Upgrade Trans_ATTACKING_NIGHT_Upgrade
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7792,8 +7794,8 @@ Object GC_Slth_GLAScudStorm
     End
 
     ConditionState = USER_1 ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -7810,8 +7812,8 @@ Object GC_Slth_GLAScudStorm
     AliasConditionState = USER_1 ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT_Upgrade Trans_READY_NIGHT_Upgrade ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -4104,10 +4104,11 @@ Object Slth_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4119,8 +4120,8 @@ Object Slth_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT Trans_ATTACKING_NIGHT
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4134,8 +4135,8 @@ Object Slth_GLAScudStorm
     End
 
     ConditionState = ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4152,8 +4153,8 @@ Object Slth_GLAScudStorm
     AliasConditionState = ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT Trans_READY_NIGHT ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 
@@ -4831,10 +4832,11 @@ Object Slth_GLAScudStorm
     End
 
     ;-------------------------------------------------------------------------------------------------------------------------
-        ; NIGHT
+    ; Patch104p @bugfix commy2 02/10/2022 Fix lights out at night unless damaged.
+    ; NIGHT
     ConditionState = USER_1 NIGHT ; from underground to lying around
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4846,8 +4848,8 @@ Object Slth_GLAScudStorm
     End
 
     TransitionState = Trans_READY_NIGHT_Upgrade Trans_ATTACKING_NIGHT_Upgrade
-      Model         = UBScudStrm_A1
-      Animation     = UBScudStrm_A1.UBScudStrm_A1
+      Model         = UBScudStrm_A1N
+      Animation     = UBScudStrm_A1N.UBScudStrm_A1N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4861,8 +4863,8 @@ Object Slth_GLAScudStorm
     End
 
     ConditionState = USER_1 ATTACKING NIGHT  ; Projectile feedback code selectively hiding missiles as they shoot
-      Model         = UBScudStrm_A2
-      Animation     = UBScudStrm_A2.UBScudStrm_A2
+      Model         = UBScudStrm_A2N
+      Animation     = UBScudStrm_A2N.UBScudStrm_A2N
       AnimationMode = MANUAL
       Flags         = START_FRAME_FIRST
       WeaponLaunchBone = SECONDARY WeaponA
@@ -4879,8 +4881,8 @@ Object Slth_GLAScudStorm
     AliasConditionState = USER_1 ATTACKING BETWEEN_FIRING_SHOTS_B NIGHT
 
     TransitionState = Trans_ATTACKING_NIGHT_Upgrade Trans_READY_NIGHT_Upgrade ; empty arms going underground
-      Model         = UBScudStrm_A3
-      Animation     = UBScudStrm_A3.UBScudStrm_A3
+      Model         = UBScudStrm_A3N
+      Animation     = UBScudStrm_A3N.UBScudStrm_A3N
       AnimationMode = ONCE
       Flags         = MAINTAIN_FRAME_ACROSS_STATES2
 


### PR DESCRIPTION
1.04:
- Lights on Scud Storm are off when the building is unharmed, but get turned on when damaged
- Models for NIGHT state are missing from CCG. (REALLY)DAMAGED+NIGHT exist
- ZH adds NIGHT state models, but never uses them in *ini config

Patch:
- Lights are turned on at night regardless of damage state