### PR TITLE
Fix: Remove duplicate AntiAirborneVehicle entries

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2084,7 +2084,6 @@ Weapon TunnelDefenderRocketWeapon
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
-  AntiAirborneVehicle = Yes
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
 End
 
@@ -2113,7 +2112,6 @@ Weapon TunnelDefenderBikerRocketWeapon
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
-  AntiAirborneVehicle = Yes
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
   AcceptableAimDelta    = 20.0
 End
@@ -6830,7 +6828,6 @@ Weapon ListeningOutpostUpgradedDummyWeapon
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = No
-  AntiAirborneVehicle   = Yes
 End
 
 ;------------------------------------------------------------------------------
@@ -6865,7 +6862,6 @@ Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
   AntiAirborneVehicle   = Yes
   AntiAirborneInfantry  = No
-  AntiAirborneVehicle   = Yes
 End
 
 ;------------------------------------------------------------------------------
@@ -7465,7 +7461,6 @@ Weapon Chem_TunnelDefenderBikerRocketWeapon
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
-  AntiAirborneVehicle = Yes
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
 ; ProjectileDetonationOCL     = OCL_PoisonFieldUpgradedSmall
   AcceptableAimDelta    = 20.0
@@ -7496,7 +7491,6 @@ Weapon Chem_TunnelDefenderBikerRocketWeaponGamma
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
-  AntiAirborneVehicle = Yes
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
 ; ProjectileDetonationOCL     = OCL_PoisonFieldGammaSmall
   AcceptableAimDelta    = 20.0
@@ -8664,7 +8658,6 @@ Weapon DEMO_TunnelDefenderBikerRocketWeapon
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
-  AntiAirborneVehicle = Yes
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
   AcceptableAimDelta    = 20.0
 End
@@ -8693,7 +8686,6 @@ Weapon DemoTunnelDefenderRocketWeapon
   ProjectileCollidesWith      = STRUCTURES
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
-  AntiAirborneVehicle = Yes
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
 End
 


### PR DESCRIPTION
Not sure if this fixes anything tangible. But something is not right. AntiAirborneVehicle entries are duplicated.