### PR TITLE
Fix: Toxin GLA Tunnel Defender double firing against ground and air targets

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13196,6 +13196,7 @@ Object Chem_GLAInfantryTunnelDefender
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY Chem_TunnelDefenderRocketWeaponBetaAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix Fix double firing against ground and air targets.
   End
   WeaponSet
     Conditions          = PLAYER_UPGRADE
@@ -13203,6 +13204,7 @@ Object Chem_GLAInfantryTunnelDefender
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY Chem_TunnelDefenderRocketWeaponGammaAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix Fix double firing against ground and air targets.
   End
   ArmorSet
     Conditions      = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -872,6 +872,7 @@ Object GC_Chem_GLAInfantryTunnelDefender
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY GC_Chem_TunnelDefenderRocketWeaponBetaAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix Fix double firing against ground and air targets.
   End
   WeaponSet
     Conditions          = PLAYER_UPGRADE
@@ -879,6 +880,7 @@ Object GC_Chem_GLAInfantryTunnelDefender
     AutoChooseSources   = PRIMARY   FROM_PLAYER FROM_AI FROM_SCRIPT
     Weapon              = SECONDARY GC_Chem_TunnelDefenderRocketWeaponGammaAir
     PreferredAgainst    = SECONDARY BALLISTIC_MISSILE AIRCRAFT
+    ShareWeaponReloadTime = Yes ; Patch104p @bugfix Fix double firing against ground and air targets.
   End
   ArmorSet
     Conditions      = None


### PR DESCRIPTION
* Reference #806

This change fixes Toxin GLA Tunnel Defender double firing against ground and air targets. It is yet another reason why Toxin General is so good. Note: Tunnel Defenders from other factions do not have this issue because they have just one gun type against ground and air. Toxin General has 2.

### Video of original issue

The first Tunnel Defender is from Demo General. The second is from Toxin General.

https://user-images.githubusercontent.com/4720891/194135459-5b9c8371-a16b-4262-86ef-6cdf91a80a9a.mp4

