### PR TITLE
Change: Add slightly pitched sounds for Air weapons of Quad Cannon, Minigunner, Gattling Tank, Gattling Turret, Laser Turret

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8153,6 +8153,17 @@ FXList Lazr_WeaponFX_LaserCrusader
   End
 End
 
+FXList Lazr_WeaponFX_LaserCrusader_Air
+  Sound
+    Name = LaserCrusaderWeaponAir
+  End
+End
+
+FXList Lazr_WeaponFX_LaserCrusader_Assist
+  Sound
+    Name = LaserCrusaderWeaponAssist
+  End
+End
 
 ; -----------------------------------------------------------------------------
 ; The helix blows up with a large smokey explosion

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -1232,6 +1232,18 @@ AudioEvent QuadCannonWeapon
   Type = world shrouded everyone
 End
 
+; Patch104p @feature new sound for air weapon variant
+AudioEvent QuadCannonWeaponAir
+  Sounds = vquaweaa vquaweab vquaweac vquawead vquaweae vquaweaf vquaweag
+  Control = interrupt random
+  PitchShift = -25 -5
+  Limit = 2
+  VolumeShift = -15
+  Volume = 75
+  Priority = normal
+  Type = world shrouded everyone
+End
+
 AudioEvent QuadCannonMoveStart
   Sounds= vquastaa vquastab vquastac
   Delay=0 700
@@ -2828,9 +2840,35 @@ AudioEvent GattlingCannonWeapon
   Type = world shrouded everyone
 End
 
+; Patch104p @feature new sound for air weapon variant
+AudioEvent GattlingCannonWeaponAir
+  Control = random interrupt
+  Sounds = bgatweaa bgatweab bgatweac bgatwead
+  PitchShift = -8 -8
+  VolumeShift = -10
+  Volume = 80
+  MinRange = 175
+  Limit = 3
+  Priority = normal
+  Type = world shrouded everyone
+End
+
 AudioEvent GattlingTankWeapon
   Control = random interrupt
   Sounds =  bgatweaa bgatweab bgatweac bgatwead
+  VolumeShift = -10
+  Volume = 80
+  MinRange = 175
+  Limit = 3
+  Priority = normal
+  Type = world shrouded everyone
+End
+
+; Patch104p @feature new sound for air weapon variant
+AudioEvent GattlingTankWeaponAir
+  Control = random interrupt
+  Sounds = bgatweaa bgatweab bgatweac bgatwead
+  PitchShift = -8 -8
   VolumeShift = -10
   Volume = 80
   MinRange = 175
@@ -7545,6 +7583,19 @@ AudioEvent RedGuardMinigunnerWeapon
   Type = world shrouded everyone
 End
 
+; Patch104p @feature new sound for air weapon variant
+AudioEvent RedGuardMinigunnerWeaponAir
+  Control = random interrupt
+  Sounds = iremweaa iremweab iremweac iremwead
+  PitchShift = -10 -10
+  VolumeShift = -10
+  Volume = 80
+  MinRange = 175
+  Limit = 3
+  Priority = normal
+  Type = world shrouded everyone
+End
+
 AudioEvent CombatCycleRebelWeapon
   Control = random interrupt
   Sounds =  vcycweaa vcycweab vcycweac vcycwead vcycweae
@@ -7739,6 +7790,30 @@ AudioEvent LaserCrusaderWeapon
   Sounds      = vcrlweaa vcrlweab
   Control     = random interrupt
   PitchShift  = -5 5
+  VolumeShift = -10
+  Volume      = 75
+  Limit       = 3
+  Priority    = normal
+  Type        = world shrouded everyone
+End
+
+; Patch104p @feature new sound for air weapon variant
+AudioEvent LaserCrusaderWeaponAir
+  Sounds      = vcrlweaa vcrlweab
+  Control     = random interrupt
+  PitchShift  = -15 -5
+  VolumeShift = -10
+  Volume      = 75
+  Limit       = 3
+  Priority    = normal
+  Type        = world shrouded everyone
+End
+
+; Patch104p @feature new sound for assist weapon variant
+AudioEvent LaserCrusaderWeaponAssist
+  Sounds      = vcrlweaa vcrlweab
+  Control     = random interrupt
+  PitchShift  = -10 0
   VolumeShift = -10
   Volume      = 75
   Limit       = 3

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1158,7 +1158,7 @@ Weapon GattlingTankGunAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_GattlingTankMachineGunFire
   VeterancyFireFX       = HEROIC WeaponFX_GattlingTankMachineGunFireWithRedTracers
-  FireSound             = GattlingTankWeapon
+  FireSound             = GattlingTankWeaponAir
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 400               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -1278,7 +1278,7 @@ Weapon GattlingBuildingGunAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_GattlingCannonMachineGunFire
   VeterancyFireFX       = HEROIC WeaponFX_GattlingCannonMachineGunFireWithRedTracers
-  FireSound             = GattlingCannonWeapon
+  FireSound             = GattlingCannonWeaponAir
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 250               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -2753,7 +2753,7 @@ Weapon QuadCannonGunAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_QuadCannonGunFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicQuadCannonGunFire
-  FireSound             = QuadCannonWeapon
+  FireSound             = QuadCannonWeaponAir
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 100 ;500               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -2796,7 +2796,7 @@ Weapon QuadCannonGunUpgradeOneAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_QuadCannonGunFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicQuadCannonGunFire
-  FireSound             = QuadCannonWeapon
+  FireSound             = QuadCannonWeaponAir
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 50 ;250               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -2839,7 +2839,7 @@ Weapon QuadCannonGunUpgradeTwoAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_QuadCannonGunFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicQuadCannonGunFire
-  FireSound             = QuadCannonWeapon
+  FireSound             = QuadCannonWeaponAir
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 25 ;125               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -6493,7 +6493,7 @@ Weapon Infa_MiniGunnerGunAir
   ProjectileObject      = NONE
   FireFX                = WeaponFX_GenericMachineGunFire
   VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
-  FireSound             = RedGuardMinigunnerWeapon  ; Patch104p @bugfix commy2 11/09/2021 Fix weapon changing sound when aiming at airborne targets.
+  FireSound             = RedGuardMinigunnerWeaponAir  ; Patch104p @bugfix commy2 11/09/2021 Fix weapon changing sound when aiming at airborne targets.
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots     = 500               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
@@ -6655,7 +6655,7 @@ Weapon Lazr_PatriotMissileWeaponAir
   WeaponSpeed                 = 999999.0
   LaserName               = Lazr_PatriotLaserBeam
   LaserBoneName           = WEAPONA01
-  FireFX                  = Lazr_WeaponFX_LaserCrusader
+  FireFX                  = Lazr_WeaponFX_LaserCrusader_Air
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
@@ -6683,7 +6683,7 @@ Weapon Lazr_PatriotMissileAssistWeapon
   WeaponSpeed                 = 999999.0               ; ignored for projectile weapons
   LaserName               = Lazr_PatriotLaserBeam
   LaserBoneName           = WEAPONA01
-  FireFX                  = Lazr_WeaponFX_LaserCrusader
+  FireFX                  = Lazr_WeaponFX_LaserCrusader_Assist
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)


### PR DESCRIPTION
* Closes #1331

This change adds slightly pitched sounds to all non rocket Anti Air weapons, including Quad Cannon, Minigunner, Gattling Tank, Gattling Turret, Laser Turret. The default weapons against ground use legacy sound settings.

| Weapon                             | PitchShift Min | PitchShift Max |
|------------------------------------|---------------:|---------------:|
| QuadCannonWeapon                   | -10            | 10             |
| QuadCannonWeaponAir (this)         | -25            | -5             |
| GattlingCannonWeapon               |  0             | 0              |
| GattlingCannonWeaponAir (this)     | -8             | -8             |
| GattlingTankWeapon                 |  0             | 0              |
| GattlingTankWeaponAir (this)       | -8             | -8             |
| RedGuardMinigunnerWeapon           | 0              | 0              |
| RedGuardMinigunnerWeaponAir (this) | -10            | -10            |
| LaserCrusaderWeapon                | -5             | 5              |
| LaserCrusaderWeaponAir (this)      | -15            | -5             |
| LaserCrusaderWeaponAssist (this)   | -10            | 0              |

Adding pitched sounds for air rocket weapons in principle works and sounds good, however adding this to some of the Rocket Soldiers is not without issues. Therefore it is only added to non rocket Anti Air weapons.

The motivation of this change is the express fondness of the former Gattling Tank sound for the Minigunner Air weapon.

The pitch values may need some tweaking.

### Demo

https://user-images.githubusercontent.com/4720891/194398414-877fc599-71ae-45f7-a913-82b8e443aba3.mp4
