### PR TITLE
Fix: USA Spy Drone can no longer be selected, but attacked

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6376,7 +6376,10 @@ Object AirF_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+
+  ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  ; Patch104p @bugfix Spy Drone no longer selectable, but attackable.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE INERT NO_SELECT IGNORES_SELECT_ALL FORCEATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1299,7 +1299,9 @@ Object AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  ; Patch104p @bugfix Spy Drone no longer selectable, but attackable.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE INERT NO_SELECT IGNORES_SELECT_ALL FORCEATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5609,7 +5609,10 @@ Object Lazr_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+
+  ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  ; Patch104p @bugfix Spy Drone no longer selectable, but attackable.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE INERT NO_SELECT IGNORES_SELECT_ALL FORCEATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6089,7 +6089,10 @@ Object SupW_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+
+  ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  ; Patch104p @bugfix Spy Drone no longer selectable, but attackable.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE INERT NO_SELECT IGNORES_SELECT_ALL FORCEATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0


### PR DESCRIPTION
* Fixes #115

This change attempts to make USA Spy Drone no longer selectable, but attackable.

It can be force fired and killed normally. We need to test if regular attack and Laser Locking also works as usual. It may not.