### PR TITLE
Fix: Overlord Gatling Cannon Missing Muzzle Flash When Firing At Grounded Targets

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -459,6 +459,8 @@ Object ChinaTankOverlordGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
 
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
     AttachToBoneInContainer = FIREPOINT01
@@ -469,13 +471,19 @@ Object ChinaTankOverlordGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
@@ -484,10 +492,28 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
     End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+    End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -499,8 +525,6 @@ Object ChinaTankOverlordGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -513,16 +537,42 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+    End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
     End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+    End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16937,6 +16937,8 @@ Object Nuke_ChinaTankOverlordGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
 
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
     AttachToBoneInContainer = FIREPOINT01
@@ -16947,13 +16949,19 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
@@ -16962,10 +16970,28 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
     End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+    End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -16977,8 +17003,6 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -16991,16 +17015,42 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+    End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
     End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+    End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3178,6 +3178,8 @@ Object Tank_ChinaTankOverlordGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
 
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
     AttachToBoneInContainer = FIREPOINT01
@@ -3188,13 +3190,19 @@ Object Tank_ChinaTankOverlordGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
@@ -3203,10 +3211,28 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
     End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+    End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -3218,8 +3244,6 @@ Object Tank_ChinaTankOverlordGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -3232,16 +3256,42 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+    End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
     End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+    End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke


### PR DESCRIPTION
- partial fi.x for #1332

This includes the Emperor.