### PR TITLE
Fix: Gatling Cannon Defense Missing Muzzle Flash When Firing At Grounded Targets

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13411,6 +13411,9 @@ Object Boss_GattlingCannon
   SelectPortrait         = SNGatTower_L
   ButtonImage            = SNGatTower
   UpgradeCameo1           = Upgrade_ChinaChainGuns
+
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
 
@@ -13426,32 +13429,24 @@ Object Boss_GattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13468,34 +13463,24 @@ Object Boss_GattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13511,10 +13496,6 @@ Object Boss_GattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED SNOW
@@ -13523,10 +13504,6 @@ Object Boss_GattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -13537,10 +13514,6 @@ Object Boss_GattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13556,10 +13529,6 @@ Object Boss_GattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED NIGHT SNOW
@@ -13568,10 +13537,6 @@ Object Boss_GattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -13582,10 +13547,6 @@ Object Boss_GattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13598,22 +13559,48 @@ Object Boss_GattlingCannon
 ;---------------- ATTACKING ----------------------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = ATTACKING
+    ConditionState        = ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13626,6 +13613,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -13633,11 +13628,27 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13651,6 +13662,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING SNOW
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -13658,11 +13677,27 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13675,11 +13710,27 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13689,26 +13740,60 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13721,6 +13806,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -13728,11 +13821,27 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13746,6 +13855,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -13753,11 +13870,27 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13770,11 +13903,27 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13784,6 +13933,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
 
 
@@ -13791,86 +13948,190 @@ Object Boss_GattlingCannon
 ;------------- CONTINUOUS_FIRE_MEAN ------------------------
 ;-----------------------------------------------------------
     ;DAY
-    ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
 
     ;NIGHT    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;SNOW    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;NIGHT SNOW ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
@@ -13889,6 +14150,17 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13897,10 +14169,31 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -13917,6 +14210,17 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13925,10 +14229,31 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
      ConditionState       = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -13944,6 +14269,17 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13952,10 +14288,31 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -13966,12 +14323,22 @@ Object Boss_GattlingCannon
     ConditionState        = CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
-
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13980,10 +14347,31 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -32663,6 +32663,9 @@ Object ChinaGattlingCannon
   SelectPortrait         = SNGatTower_L
   ButtonImage            = SNGatTower
   UpgradeCameo1           = Upgrade_ChinaChainGuns
+
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
 
@@ -32678,32 +32681,24 @@ Object ChinaGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -32720,34 +32715,24 @@ Object ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -32763,10 +32748,6 @@ Object ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED SNOW
@@ -32775,10 +32756,6 @@ Object ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -32789,10 +32766,6 @@ Object ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -32808,10 +32781,6 @@ Object ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED NIGHT SNOW
@@ -32820,10 +32789,6 @@ Object ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -32834,10 +32799,6 @@ Object ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -32850,22 +32811,48 @@ Object ChinaGattlingCannon
 ;---------------- ATTACKING ----------------------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = ATTACKING
+    ConditionState        = ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -32878,6 +32865,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -32885,11 +32880,27 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -32903,6 +32914,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING SNOW
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -32910,11 +32929,27 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -32927,11 +32962,27 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -32941,26 +32992,60 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -32973,6 +33058,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -32980,11 +33073,27 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -32998,6 +33107,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -33005,11 +33122,27 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -33022,11 +33155,27 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -33036,6 +33185,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
 
 
@@ -33043,86 +33200,190 @@ Object ChinaGattlingCannon
 ;------------- CONTINUOUS_FIRE_MEAN ------------------------
 ;-----------------------------------------------------------
     ;DAY
-    ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
 
     ;NIGHT    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;SNOW    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;NIGHT SNOW ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
@@ -33141,6 +33402,17 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
@@ -33149,10 +33421,31 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -33169,6 +33462,17 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
@@ -33177,10 +33481,31 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
      ConditionState       = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -33196,6 +33521,17 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
@@ -33204,10 +33540,31 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -33218,12 +33575,22 @@ Object ChinaGattlingCannon
     ConditionState        = CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
-
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
@@ -33232,10 +33599,31 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -11729,6 +11729,9 @@ Object Infa_ChinaGattlingCannon
   SelectPortrait         = SNGatTower_L
   ButtonImage            = SNGatTower
   UpgradeCameo1           = Upgrade_ChinaChainGuns
+
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
 
@@ -11744,32 +11747,24 @@ Object Infa_ChinaGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -11786,34 +11781,24 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -11829,10 +11814,6 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED SNOW
@@ -11841,10 +11822,6 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -11855,10 +11832,6 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -11874,10 +11847,6 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED NIGHT SNOW
@@ -11886,10 +11855,6 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -11900,10 +11865,6 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -11916,22 +11877,48 @@ Object Infa_ChinaGattlingCannon
 ;---------------- ATTACKING ----------------------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = ATTACKING
+    ConditionState        = ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -11944,6 +11931,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -11951,11 +11946,27 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -11969,6 +11980,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING SNOW
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -11976,11 +11995,27 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -11993,11 +12028,27 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -12007,26 +12058,60 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -12039,6 +12124,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -12046,11 +12139,27 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -12064,6 +12173,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -12071,11 +12188,27 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -12088,11 +12221,27 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -12102,6 +12251,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
 
 
@@ -12109,86 +12266,190 @@ Object Infa_ChinaGattlingCannon
 ;------------- CONTINUOUS_FIRE_MEAN ------------------------
 ;-----------------------------------------------------------
     ;DAY
-    ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
 
     ;NIGHT    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;SNOW    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;NIGHT SNOW ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
@@ -12207,6 +12468,17 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
@@ -12215,10 +12487,31 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -12235,6 +12528,17 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
@@ -12243,10 +12547,31 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
      ConditionState       = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -12262,6 +12587,17 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
@@ -12270,10 +12606,31 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -12284,12 +12641,22 @@ Object Infa_ChinaGattlingCannon
     ConditionState        = CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
-
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
@@ -12298,10 +12665,31 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -14342,6 +14342,9 @@ Object Nuke_ChinaGattlingCannon
   SelectPortrait         = SNGatTower_L
   ButtonImage            = SNGatTower
   UpgradeCameo1           = Upgrade_ChinaChainGuns
+
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
 
@@ -14357,32 +14360,24 @@ Object Nuke_ChinaGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -14399,34 +14394,24 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -14442,10 +14427,6 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED SNOW
@@ -14454,10 +14435,6 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -14468,10 +14445,6 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -14487,10 +14460,6 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED NIGHT SNOW
@@ -14499,10 +14468,6 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -14513,10 +14478,6 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -14529,22 +14490,48 @@ Object Nuke_ChinaGattlingCannon
 ;---------------- ATTACKING ----------------------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = ATTACKING
+    ConditionState        = ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -14557,6 +14544,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -14564,11 +14559,27 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -14582,6 +14593,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING SNOW
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -14589,11 +14608,27 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -14606,11 +14641,27 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -14620,26 +14671,60 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -14652,6 +14737,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -14659,11 +14752,27 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -14677,6 +14786,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -14684,11 +14801,27 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -14701,11 +14834,27 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -14715,6 +14864,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
 
 
@@ -14722,86 +14879,190 @@ Object Nuke_ChinaGattlingCannon
 ;------------- CONTINUOUS_FIRE_MEAN ------------------------
 ;-----------------------------------------------------------
     ;DAY
-    ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
 
     ;NIGHT    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;SNOW    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;NIGHT SNOW ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
@@ -14820,6 +15081,17 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
@@ -14828,10 +15100,31 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -14848,6 +15141,17 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
@@ -14856,10 +15160,31 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
      ConditionState       = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -14875,6 +15200,17 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
@@ -14883,10 +15219,31 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -14897,12 +15254,22 @@ Object Nuke_ChinaGattlingCannon
     ConditionState        = CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
-
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
@@ -14911,10 +15278,31 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -13343,6 +13343,9 @@ Object Tank_ChinaGattlingCannon
   SelectPortrait         = SNGatTower_L
   ButtonImage            = SNGatTower
   UpgradeCameo1           = Upgrade_ChinaChainGuns
+
+  ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
 
@@ -13358,32 +13361,24 @@ Object Tank_ChinaGattlingCannon
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13400,34 +13395,24 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
+
     ConditionState        = DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
+
     ConditionState        = REALLYDAMAGED RUBBLE NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13443,10 +13428,6 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED SNOW
@@ -13455,10 +13436,6 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -13469,10 +13446,6 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13488,10 +13461,6 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
     End
 
     ConditionState        = DAMAGED NIGHT SNOW
@@ -13500,10 +13469,6 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = SmokeM01 SmokeFactionMedium
       ParticleSysBone     = SparkM01 SparksMedium
     End
@@ -13514,10 +13479,6 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = MANUAL
       Turret              = TURRET
       TurretPitch         = TURRETEL
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponFireFXBone    = SECONDARY Muzzle
-      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       ParticleSysBone     = Smoke01 SmokeFactionMedium
       ParticleSysBone     = Smoke02 SmokeFactionMedium
       ParticleSysBone     = Smoke03 SmokeFactionMedium
@@ -13530,22 +13491,48 @@ Object Tank_ChinaGattlingCannon
 ;---------------- ATTACKING ----------------------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = ATTACKING
+    ConditionState        = ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13558,6 +13545,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -13565,11 +13560,27 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13583,6 +13594,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING SNOW
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -13590,11 +13609,27 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13607,11 +13642,27 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
 
@@ -13621,26 +13672,60 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+    End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
 ;-------------------------------------------------------------
    ; DAY
-   ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13653,6 +13738,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -13660,11 +13753,27 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13678,6 +13787,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -13685,11 +13802,27 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13702,11 +13835,27 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
 
@@ -13716,6 +13865,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+    End
 
 
 
@@ -13723,86 +13880,190 @@ Object Tank_ChinaGattlingCannon
 ;------------- CONTINUOUS_FIRE_MEAN ------------------------
 ;-----------------------------------------------------------
     ;DAY
-    ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
 
     ;NIGHT    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;SNOW    ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
 
 
     ;NIGHT SNOW ---------------------------------------------------------------
-    ConditionState       = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
@@ -13821,6 +14082,17 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
+      Model               = NBGattling
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13829,10 +14101,31 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED ATTACKING
+      Model               = NBGattling_D
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
+      Model               = NBGattling_E
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -13849,6 +14142,17 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT ATTACKING
+      Model               = NBGattling_N
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13857,10 +14161,31 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED NIGHT ATTACKING
+      Model               = NBGattling_DN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
      ConditionState       = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT ATTACKING
+      Model               = NBGattling_EN
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -13876,6 +14201,17 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST SNOW ATTACKING
+      Model               = NBGattling_S
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13884,10 +14220,31 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
+      Model               = NBGattling_DS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+      Model               = NBGattling_ES
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
@@ -13898,12 +14255,22 @@ Object Tank_ChinaGattlingCannon
     ConditionState        = CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
-
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST NIGHT SNOW ATTACKING
+      Model               = NBGattling_NS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
@@ -13912,10 +14279,31 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST DAMAGED SNOW NIGHT ATTACKING
+      Model               = NBGattling_DNS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+    End
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED NIGHT SNOW ATTACKING
+      Model               = NBGattling_ENS
+      Animation           = NBGattling_A2.NBGattling_A2
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke


### PR DESCRIPTION
- partial fix for #1332