### PR TITLE
Fix: Gatling Cannon Animation Speed Swapped For Medium And Fast Mode On Day Snow Maps When Badly Damaged

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13848,13 +13848,11 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
@@ -13956,11 +13954,13 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -33100,13 +33100,11 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
@@ -33208,11 +33206,13 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -12166,13 +12166,11 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
@@ -12274,11 +12272,13 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -14779,13 +14779,11 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
@@ -14887,11 +14885,13 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -13780,13 +13780,11 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 
@@ -13888,11 +13886,13 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
+      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
 
 


### PR DESCRIPTION
- 1.04:

https://user-images.githubusercontent.com/6576312/194713537-8728ecb1-0b59-4f93-a10a-273fdba200f7.mp4

- patch:

works as expected