### PR TITLE
Fix: Emperor Has Visible Floating Bones When Damaged

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2917,6 +2917,7 @@ Object Tank_ChinaTankEmperor
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       WeaponLaunchBone = PRIMARY Muzzle
+      HideSubObject       = Smoke06 Smoke07 Smoke08 ; Patch104p @bugfix commy2 08/10/2022 Hide visible bones.
     End
 
     ConditionState        = RUBBLE


### PR DESCRIPTION
- 1.04:

![https://i.imgur.com/BwpaA2x.jpg](https://i.imgur.com/BwpaA2x.jpg)

- patch:

![https://i.imgur.com/WAkXUto.jpg](https://i.imgur.com/WAkXUto.jpg)