### PR TITLE
Fix: Slightly Damaged Gatling Cannon Appears Undamaged On Snow Maps When Firing Fast

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13947,7 +13947,7 @@ Object Boss_GattlingCannon
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
-      Model               = NBGattling_NS
+      Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -33199,7 +33199,7 @@ Object ChinaGattlingCannon
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
-      Model               = NBGattling_NS
+      Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -12265,7 +12265,7 @@ Object Infa_ChinaGattlingCannon
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
-      Model               = NBGattling_NS
+      Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -14878,7 +14878,7 @@ Object Nuke_ChinaGattlingCannon
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
-      Model               = NBGattling_NS
+      Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -13879,7 +13879,7 @@ Object Tank_ChinaGattlingCannon
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
     ConditionState        = CONTINUOUS_FIRE_FAST DAMAGED SNOW ATTACKING
-      Model               = NBGattling_NS
+      Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst


### PR DESCRIPTION
- 1.04

https://user-images.githubusercontent.com/6576312/194716054-e3f14ae3-014e-411d-be16-13895166fb12.mp4

(Snow+Damaged object uses Night+Snow model while firing fast)

- patch

works as intended

