### PR TITLE
Fix: Badly Damaged Gatling Cannon Defense Creates Smoke Clouds On Medium Fast Fire On Night Maps

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13829,9 +13829,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -33081,9 +33081,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -12147,9 +12147,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -14760,9 +14760,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -13761,9 +13761,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  vryfst
-      ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
-      ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
+      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
     End
 
 


### PR DESCRIPTION
On Summer Night maps only, when badly damaged only, the Gatling Cannon defense spawns smoke particles in medium speed fire mode, while on other maps or when undamaged / slightly, it spawns smoke particles only in fast fire mode.