### PR TITLE
Fix: Overlord Gatling Cannon Keeps Spinning Indefinitely After Firing Once

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -460,6 +460,7 @@ Object ChinaTankOverlordGattlingCannon
 
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -467,6 +468,8 @@ Object ChinaTankOverlordGattlingCannon
 
     DefaultConditionState
       Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -521,6 +524,8 @@ Object ChinaTankOverlordGattlingCannon
 
     ConditionState        = REALLYDAMAGED
       Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17400,6 +17400,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
 
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -17407,6 +17408,8 @@ Object Nuke_ChinaTankOverlordGattlingCannon
 
     DefaultConditionState
       Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -17461,6 +17464,8 @@ Object Nuke_ChinaTankOverlordGattlingCannon
 
     ConditionState        = REALLYDAMAGED
       Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3180,6 +3180,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
 
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -3187,6 +3188,8 @@ Object Tank_ChinaTankOverlordGattlingCannon
 
     DefaultConditionState
       Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -3241,6 +3244,8 @@ Object Tank_ChinaTankOverlordGattlingCannon
 
     ConditionState        = REALLYDAMAGED
       Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle


### PR DESCRIPTION
- 1.04

Gatling Cannon on Overlord/Emperor slowly spins forever after firing a single shot.

- patch

Gatling Cannon stops spinning after resting for a few seconds.