### PR TITLE
Fix: Helix Gatling Cannon Keeps Spinning Indefinitely After Firing Once

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -324,7 +324,7 @@ Object ChinaHelixGattlingCannon
   SelectPortrait         = SNGatTower_L
   ButtonImage            = SNGatTower
 
-
+  ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -332,6 +332,8 @@ Object ChinaHelixGattlingCannon
 
     DefaultConditionState
       Model               = NVHelix_G
+      Animation           = NVHelix_G.NVHelix_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -360,6 +362,8 @@ Object ChinaHelixGattlingCannon
 
     ConditionState        = REALLYDAMAGED
       Model               = NVHelix_GD
+      Animation           = NVHelix_GD.NVHelix_GD
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -604,6 +604,7 @@ Object Nuke_ChinaHelixGattlingCannon
   ;UpgradeCameo4 = NONE
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
+  ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -611,6 +612,8 @@ Object Nuke_ChinaHelixGattlingCannon
 
     DefaultConditionState
       Model               = NVHelix_G
+      Animation           = NVHelix_G.NVHelix_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -639,6 +642,8 @@ Object Nuke_ChinaHelixGattlingCannon
 
     ConditionState        = REALLYDAMAGED
       Model               = NVHelix_GD
+      Animation           = NVHelix_GD.NVHelix_GD
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -332,6 +332,7 @@ Object Tank_ChinaHelixGattlingCannon
   ;UpgradeCameo4 = NONE
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
+  ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -339,6 +340,8 @@ Object Tank_ChinaHelixGattlingCannon
 
     DefaultConditionState
       Model               = NVHelix_G
+      Animation           = NVHelix_G.NVHelix_G
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -367,6 +370,8 @@ Object Tank_ChinaHelixGattlingCannon
 
     ConditionState        = REALLYDAMAGED
       Model               = NVHelix_GD
+      Animation           = NVHelix_GD.NVHelix_GD
+      AnimationMode       = MANUAL
       Turret              = TURRET01
       TurretPitch         = TURRETEL
       WeaponFireFXBone    = PRIMARY Muzzle


### PR DESCRIPTION
- 1.04

Gatling Cannon on Helix slowly spins forever after firing a single shot.

- patch

Gatling Cannon stops spinning after resting for a few seconds.

Similar to https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1349.