### PR TITLE
Fix: Overlord Gatling Cannon Has Very Slow Firing Animation

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -458,9 +458,9 @@ Object ChinaTankOverlordGattlingCannon
   ;UpgradeCameo4 = NONE
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
-
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
+  ; Patch104p @tweak commy2 09/11/2022 Tweak firing rotation animation speed.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -479,7 +479,7 @@ Object ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
       Model               = NVOvrlrd_G
@@ -487,13 +487,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
       Model               = NVOvrlrd_G
@@ -501,13 +501,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -517,7 +517,7 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -540,7 +540,7 @@ Object ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -548,13 +548,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -562,13 +562,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -578,7 +578,7 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -460,7 +460,7 @@ Object ChinaTankOverlordGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
-  ; Patch104p @tweak commy2 09/11/2022 Tweak firing rotation animation speed.
+  ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17403,9 +17403,9 @@ Object Nuke_ChinaTankOverlordGattlingCannon
   ;UpgradeCameo4 = NONE
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
-
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
+  ; Patch104p @tweak commy2 09/11/2022 Tweak firing rotation animation speed.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -17424,7 +17424,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
       Model               = NVOvrlrd_G
@@ -17432,13 +17432,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
       Model               = NVOvrlrd_G
@@ -17446,13 +17446,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -17462,7 +17462,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -17485,7 +17485,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -17493,13 +17493,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -17507,13 +17507,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -17523,7 +17523,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17405,7 +17405,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
-  ; Patch104p @tweak commy2 09/11/2022 Tweak firing rotation animation speed.
+  ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3185,7 +3185,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
-  ; Patch104p @tweak commy2 09/11/2022 Tweak firing rotation animation speed.
+  ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3183,9 +3183,9 @@ Object Tank_ChinaTankOverlordGattlingCannon
   ;UpgradeCameo4 = NONE
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
-
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
+  ; Patch104p @tweak commy2 09/11/2022 Tweak firing rotation animation speed.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -3204,7 +3204,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
       Model               = NVOvrlrd_G
@@ -3212,13 +3212,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
       Model               = NVOvrlrd_G
@@ -3226,13 +3226,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -3242,7 +3242,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -3265,7 +3265,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -3273,13 +3273,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -3287,13 +3287,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -3303,7 +3303,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End


### PR DESCRIPTION
### 1.04

- Gatling on Overlord turns slowly when firing

### patch

- Gatling on Overlord turns exactly as fast as base defense Gatling:

https://user-images.githubusercontent.com/6576312/194762649-2570885b-ddc2-46ed-88cf-a6ce1987212b.mp4

- the values are calculated from model data

Notes:

- Overlord Gatling animation is shorter (thus faster) than base defense animation
- the Base Defense Gatling animation takes 75 frames to complete 1 cycle
- the Base Defense Gatling animation is scaled with these factors:

mode | animation speed factor
--|--
slow | 0.8
mid | 1.5
fast | 3.0

- the Overlord Gatling animation takes 30 frames to complete 1 cycle
- the Overlord Gatling animation is scaled with these factors:

mode | before | after
--|--|--
slow | 0.1 | 0.3
mid | 0.2 | 0.6
fast | 0.3 | 1.2

- the new values were calculated thus:

```py
0.75*/(75/30)  = 0.3
1.5  /(75/30)  = 0.6
3.0  /(75/30)  = 1.2

* 0.8 is presumably a result from rounding 0.75, so 0.75 was taken as base value
```
