### PR TITLE
Fix: Helix Gatling Cannon Has Very Slow Firing Animation

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -325,6 +325,7 @@ Object ChinaHelixGattlingCannon
   ButtonImage            = SNGatTower
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
+  ; Patch104p @tweak commy2 09/10/2022 Tweak firing rotation animation speed.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -343,19 +344,19 @@ Object ChinaHelixGattlingCannon
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -378,19 +379,19 @@ Object ChinaHelixGattlingCannon
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -325,7 +325,7 @@ Object ChinaHelixGattlingCannon
   ButtonImage            = SNGatTower
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
-  ; Patch104p @tweak commy2 09/10/2022 Tweak firing rotation animation speed.
+  ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -605,7 +605,7 @@ Object Nuke_ChinaHelixGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
-  ; Patch104p @tweak commy2 09/10/2022 Tweak firing rotation animation speed.
+  ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -605,6 +605,7 @@ Object Nuke_ChinaHelixGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
+  ; Patch104p @tweak commy2 09/10/2022 Tweak firing rotation animation speed.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -623,19 +624,19 @@ Object Nuke_ChinaHelixGattlingCannon
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -658,19 +659,19 @@ Object Nuke_ChinaHelixGattlingCannon
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -333,6 +333,7 @@ Object Tank_ChinaHelixGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
+  ; Patch104p @tweak commy2 09/10/2022 Tweak firing rotation animation speed.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -351,19 +352,19 @@ Object Tank_ChinaHelixGattlingCannon
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -386,19 +387,19 @@ Object Tank_ChinaHelixGattlingCannon
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.1 0.1 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.2 0.2 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -333,7 +333,7 @@ Object Tank_ChinaHelixGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
-  ; Patch104p @tweak commy2 09/10/2022 Tweak firing rotation animation speed.
+  ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes


### PR DESCRIPTION
Refer to #1355. This is identical, but for Helix Gatling Cannon instead of Overlord Gatling Cannon.