### PR TITLE
Match Gattling barrel spin animation speeds with fire rates

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13552,7 +13552,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -13560,14 +13560,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -13575,14 +13575,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -13590,7 +13590,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13600,7 +13600,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -13608,14 +13608,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -13623,14 +13623,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -13638,7 +13638,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13649,7 +13649,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -13657,14 +13657,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -13672,14 +13672,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -13687,7 +13687,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13697,7 +13697,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -13705,14 +13705,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -13720,14 +13720,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -13735,7 +13735,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
@@ -21347,7 +21347,7 @@ Object Boss_TankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -21356,7 +21356,7 @@ Object Boss_TankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -21323,6 +21323,7 @@ Object Boss_TankGattling
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -21348,7 +21349,7 @@ Object Boss_TankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -21357,14 +21358,14 @@ Object Boss_TankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
@@ -21373,14 +21374,14 @@ Object Boss_TankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
@@ -21389,7 +21390,7 @@ Object Boss_TankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
@@ -21397,7 +21398,7 @@ Object Boss_TankGattling
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
@@ -21407,7 +21408,7 @@ Object Boss_TankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ;-----damaged attacking----------------------
@@ -21415,7 +21416,7 @@ Object Boss_TankGattling
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B REALLYDAMAGED ATTACKING
@@ -21424,14 +21425,14 @@ Object Boss_TankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
@@ -21440,14 +21441,14 @@ Object Boss_TankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
@@ -21456,7 +21457,7 @@ Object Boss_TankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -21464,7 +21465,7 @@ Object Boss_TankGattling
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -21474,7 +21475,7 @@ Object Boss_TankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13402,6 +13402,7 @@ Object Boss_GattlingCannon
   UpgradeCameo1           = Upgrade_ChinaChainGuns
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.95, 0.95, 1.90, 3.80 to match firing rate properly.
 
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -13552,7 +13553,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -13560,14 +13561,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -13575,14 +13576,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -13590,7 +13591,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13600,7 +13601,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -13608,14 +13609,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -13623,14 +13624,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -13638,7 +13639,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13649,7 +13650,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -13657,14 +13658,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -13672,14 +13673,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -13687,7 +13688,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13697,7 +13698,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -13705,14 +13706,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -13720,14 +13721,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -13735,7 +13736,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
@@ -13745,7 +13746,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
@@ -13753,14 +13754,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -13768,14 +13769,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -13783,7 +13784,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13793,7 +13794,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
       Model               = NBGattling_N
@@ -13801,14 +13802,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -13816,14 +13817,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -13831,7 +13832,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13842,7 +13843,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
       Model               = NBGattling_S
@@ -13850,14 +13851,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -13865,14 +13866,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -13880,7 +13881,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13890,7 +13891,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -13898,14 +13899,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -13913,14 +13914,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -13928,7 +13929,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13941,7 +13942,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
@@ -13949,14 +13950,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -13964,14 +13965,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -13979,7 +13980,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -13989,7 +13990,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
@@ -13997,14 +13998,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -14012,14 +14013,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -14027,7 +14028,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14036,7 +14037,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
@@ -14044,14 +14045,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -14059,14 +14060,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -14074,7 +14075,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14083,7 +14084,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -14091,14 +14092,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -14106,14 +14107,14 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -14121,7 +14122,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14135,7 +14136,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14145,7 +14146,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14154,7 +14155,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14164,7 +14165,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14173,7 +14174,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14183,7 +14184,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14195,7 +14196,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14205,7 +14206,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14214,7 +14215,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14224,7 +14225,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14233,7 +14234,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14243,7 +14244,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14254,7 +14255,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14264,7 +14265,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14273,7 +14274,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14283,7 +14284,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14292,7 +14293,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14302,7 +14303,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14313,7 +14314,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14323,7 +14324,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14332,7 +14333,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14342,7 +14343,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14351,7 +14352,7 @@ Object Boss_GattlingCannon
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14361,7 +14362,7 @@ Object Boss_GattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -16654,7 +16655,7 @@ Object Boss_InfantryColonelBurton
     ConditionState      = FIRING_A
       Animation         = AIHERO_SKL.AIHERO_ATA
       AnimationMode     = ONCE
-      AnimationSpeedFactorRange = 1.5 1.5
+      AnimationSpeedFactorRange = 1.9 1.9
       TransitionKey     = TRANS_FiringA
     End
 
@@ -16670,7 +16671,7 @@ Object Boss_InfantryColonelBurton
     ConditionState      = FIRING_A REALLYDAMAGED
       Animation         = AIHERO_SKL.AIHERO_IATA
       AnimationMode     = ONCE
-      AnimationSpeedFactorRange = 1.5 1.5
+      AnimationSpeedFactorRange = 1.9 1.9
       TransitionKey     = TRANS_FiringAInjured
     End
 
@@ -19226,7 +19227,7 @@ Object Boss_InfantryJarmenKell
       Animation         = UIHERO_SKL.UIHERO_ATA
       AnimationMode     = ONCE
       TransitionKey     = TRANS_FiringA
-      AnimationSpeedFactorRange = 1.5 1.5
+      AnimationSpeedFactorRange = 1.9 1.9
     End
     AliasConditionState = FIRING_B
 
@@ -19243,7 +19244,7 @@ Object Boss_InfantryJarmenKell
       Animation         = UIHERO_SKL.UIHERO_IATA2
       AnimationMode     = ONCE
       TransitionKey     = TRANS_FiringAInjured
-      AnimationSpeedFactorRange = 1.5 1.5
+      AnimationSpeedFactorRange = 1.9 1.9
     End
     AliasConditionState = FIRING_B REALLYDAMAGED
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -327,6 +327,7 @@ Object ChinaHelixGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
   ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.3, 0.3, 0.6, 1.2 to 0.38, 0.38, 0.76, 1.52 to match firing rate properly.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -345,25 +346,25 @@ Object ChinaHelixGattlingCannon
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -386,25 +387,25 @@ Object ChinaHelixGattlingCannon
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -326,6 +326,7 @@ Object ChinaHelixGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
+  ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -340,19 +341,25 @@ Object ChinaHelixGattlingCannon
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW
+    ConditionState        = ATTACKING
+      Model               = NVHelix_G
+      Animation           = NVHelix_G.NVHelix_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
@@ -375,19 +382,25 @@ Object ChinaHelixGattlingCannon
       ParticleSysBone     = SparkM01 SparksMedium
       ParticleSysBone     = SparkM02 SparksMedium
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = ATTACKING REALLYDAMAGED
+      Model               = NVHelix_GD
+      Animation           = NVHelix_GD.NVHelix_GD
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -461,6 +461,7 @@ Object ChinaTankOverlordGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
+  ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -475,13 +476,27 @@ Object ChinaTankOverlordGattlingCannon
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW
+    ConditionState        = ATTACKING
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -489,13 +504,13 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -503,7 +518,7 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -511,7 +526,7 @@ Object ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -536,13 +551,27 @@ Object ChinaTankOverlordGattlingCannon
       ParticleSysBone     = SparkM01 SparksMedium
       ParticleSysBone     = SparkM02 SparksMedium
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = ATTACKING REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -550,13 +579,13 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -564,7 +593,7 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -572,7 +601,7 @@ Object ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1806,6 +1806,7 @@ Object ChinaTankGattling
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -1831,7 +1832,7 @@ Object ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -1840,14 +1841,14 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
@@ -1856,14 +1857,14 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
@@ -1872,7 +1873,7 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
@@ -1880,7 +1881,7 @@ Object ChinaTankGattling
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
@@ -1890,7 +1891,7 @@ Object ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ;-----damaged attacking----------------------
@@ -1898,7 +1899,7 @@ Object ChinaTankGattling
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B REALLYDAMAGED ATTACKING
@@ -1907,14 +1908,14 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
@@ -1923,14 +1924,14 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
@@ -1939,7 +1940,7 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -1947,7 +1948,7 @@ Object ChinaTankGattling
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -1957,7 +1958,7 @@ Object ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1831,7 +1831,7 @@ Object ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -1840,7 +1840,7 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -462,6 +462,7 @@ Object ChinaTankOverlordGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
   ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.3, 0.3, 0.6, 1.2 to 0.38, 0.38, 0.76, 1.52 to match firing rate properly.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -480,7 +481,7 @@ Object ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NVOvrlrd_G
@@ -488,13 +489,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
@@ -502,13 +503,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
@@ -516,13 +517,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -532,7 +533,7 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -555,7 +556,7 @@ Object ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -563,13 +564,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -577,13 +578,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -591,13 +592,13 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -607,7 +608,7 @@ Object ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -32615,6 +32615,7 @@ Object ChinaGattlingCannon
   UpgradeCameo1           = Upgrade_ChinaChainGuns
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.95, 0.95, 1.90, 3.80 to match firing rate properly.
 
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -32765,7 +32766,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -32773,14 +32774,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -32788,14 +32789,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -32803,7 +32804,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -32813,7 +32814,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -32821,14 +32822,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -32836,14 +32837,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -32851,7 +32852,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -32862,7 +32863,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -32870,14 +32871,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -32885,14 +32886,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -32900,7 +32901,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -32910,7 +32911,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -32918,14 +32919,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -32933,14 +32934,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -32948,7 +32949,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
@@ -32958,7 +32959,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
@@ -32966,14 +32967,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -32981,14 +32982,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -32996,7 +32997,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -33006,7 +33007,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
       Model               = NBGattling_N
@@ -33014,14 +33015,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -33029,14 +33030,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -33044,7 +33045,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -33055,7 +33056,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
       Model               = NBGattling_S
@@ -33063,14 +33064,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -33078,14 +33079,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -33093,7 +33094,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -33103,7 +33104,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -33111,14 +33112,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -33126,14 +33127,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -33141,7 +33142,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -33154,7 +33155,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
@@ -33162,14 +33163,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -33177,14 +33178,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -33192,7 +33193,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -33202,7 +33203,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
@@ -33210,14 +33211,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -33225,14 +33226,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -33240,7 +33241,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -33249,7 +33250,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
@@ -33257,14 +33258,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -33272,14 +33273,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -33287,7 +33288,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -33296,7 +33297,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -33304,14 +33305,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -33319,14 +33320,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -33334,7 +33335,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -33348,7 +33349,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33358,7 +33359,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33367,7 +33368,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33377,7 +33378,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33386,7 +33387,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33396,7 +33397,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33408,7 +33409,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33418,7 +33419,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33427,7 +33428,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33437,7 +33438,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33446,7 +33447,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33456,7 +33457,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33467,7 +33468,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33477,7 +33478,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33486,7 +33487,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33496,7 +33497,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33505,7 +33506,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33515,7 +33516,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33526,7 +33527,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33536,7 +33537,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33545,7 +33546,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33555,7 +33556,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33564,7 +33565,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -33574,7 +33575,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -32765,7 +32765,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -32773,14 +32773,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -32788,14 +32788,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -32803,7 +32803,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -32813,7 +32813,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -32821,14 +32821,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -32836,14 +32836,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -32851,7 +32851,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -32862,7 +32862,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -32870,14 +32870,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -32885,14 +32885,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -32900,7 +32900,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -32910,7 +32910,7 @@ Object ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -32918,14 +32918,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -32933,14 +32933,14 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -32948,7 +32948,7 @@ Object ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2373,7 +2373,7 @@ Object Infa_ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -2382,7 +2382,7 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
@@ -11869,7 +11869,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -11877,14 +11877,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -11892,14 +11892,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -11907,7 +11907,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -11917,7 +11917,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -11925,14 +11925,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -11940,14 +11940,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -11955,7 +11955,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -11966,7 +11966,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -11974,14 +11974,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -11989,14 +11989,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -12004,7 +12004,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -12014,7 +12014,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -12022,14 +12022,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -12037,14 +12037,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -12052,7 +12052,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -11719,6 +11719,7 @@ Object Infa_ChinaGattlingCannon
   UpgradeCameo1           = Upgrade_ChinaChainGuns
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.95, 0.95, 1.90, 3.80 to match firing rate properly.
 
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -11869,7 +11870,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -11877,14 +11878,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -11892,14 +11893,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -11907,7 +11908,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -11917,7 +11918,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -11925,14 +11926,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -11940,14 +11941,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -11955,7 +11956,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -11966,7 +11967,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -11974,14 +11975,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -11989,14 +11990,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -12004,7 +12005,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -12014,7 +12015,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -12022,14 +12023,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -12037,14 +12038,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -12052,7 +12053,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
@@ -12062,7 +12063,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
@@ -12070,14 +12071,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -12085,14 +12086,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -12100,7 +12101,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -12110,7 +12111,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
       Model               = NBGattling_N
@@ -12118,14 +12119,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -12133,14 +12134,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -12148,7 +12149,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -12159,7 +12160,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
       Model               = NBGattling_S
@@ -12167,14 +12168,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -12182,14 +12183,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -12197,7 +12198,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -12207,7 +12208,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -12215,14 +12216,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -12230,14 +12231,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -12245,7 +12246,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -12258,7 +12259,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
@@ -12266,14 +12267,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -12281,14 +12282,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -12296,7 +12297,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -12306,7 +12307,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
@@ -12314,14 +12315,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -12329,14 +12330,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -12344,7 +12345,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -12353,7 +12354,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
@@ -12361,14 +12362,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -12376,14 +12377,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -12391,7 +12392,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -12400,7 +12401,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -12408,14 +12409,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -12423,14 +12424,14 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -12438,7 +12439,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -12452,7 +12453,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12462,7 +12463,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12471,7 +12472,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12481,7 +12482,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12490,7 +12491,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12500,7 +12501,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12512,7 +12513,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12522,7 +12523,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12531,7 +12532,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12541,7 +12542,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12550,7 +12551,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12560,7 +12561,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12571,7 +12572,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12581,7 +12582,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12590,7 +12591,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12600,7 +12601,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12609,7 +12610,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12619,7 +12620,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12630,7 +12631,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12640,7 +12641,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12649,7 +12650,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12659,7 +12660,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12668,7 +12669,7 @@ Object Infa_ChinaGattlingCannon
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -12678,7 +12679,7 @@ Object Infa_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2348,6 +2348,7 @@ Object Infa_ChinaTankGattling
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -2373,7 +2374,7 @@ Object Infa_ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -2382,14 +2383,14 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
@@ -2398,14 +2399,14 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
@@ -2414,7 +2415,7 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
@@ -2422,7 +2423,7 @@ Object Infa_ChinaTankGattling
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
@@ -2432,7 +2433,7 @@ Object Infa_ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ;-----damaged attacking----------------------
@@ -2440,7 +2441,7 @@ Object Infa_ChinaTankGattling
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B REALLYDAMAGED ATTACKING
@@ -2449,14 +2450,14 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
@@ -2465,14 +2466,14 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
@@ -2481,7 +2482,7 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -2489,7 +2490,7 @@ Object Infa_ChinaTankGattling
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -2499,7 +2500,7 @@ Object Infa_ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3894,7 +3894,7 @@ Object Nuke_ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -3903,7 +3903,7 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
@@ -14488,7 +14488,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -14496,14 +14496,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -14511,14 +14511,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -14526,7 +14526,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -14536,7 +14536,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -14544,14 +14544,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -14559,14 +14559,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -14574,7 +14574,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -14585,7 +14585,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -14593,14 +14593,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -14608,14 +14608,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -14623,7 +14623,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -14633,7 +14633,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -14641,14 +14641,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -14656,14 +14656,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -14671,7 +14671,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -607,6 +607,7 @@ Object Nuke_ChinaHelixGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
   ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.3, 0.3, 0.6, 1.2 to 0.38, 0.38, 0.76, 1.52 to match firing rate properly.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -625,25 +626,25 @@ Object Nuke_ChinaHelixGattlingCannon
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -666,25 +667,25 @@ Object Nuke_ChinaHelixGattlingCannon
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -17335,6 +17336,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
   ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.3, 0.3, 0.6, 1.2 to 0.38, 0.38, 0.76, 1.52 to match firing rate properly.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -17353,7 +17355,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NVOvrlrd_G
@@ -17361,13 +17363,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
@@ -17375,13 +17377,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
@@ -17389,13 +17391,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -17405,7 +17407,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -17428,7 +17430,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -17436,13 +17438,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -17450,13 +17452,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -17464,13 +17466,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -17480,7 +17482,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3869,6 +3869,7 @@ Object Nuke_ChinaTankGattling
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -3894,7 +3895,7 @@ Object Nuke_ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -3903,14 +3904,14 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
@@ -3919,14 +3920,14 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
@@ -3935,7 +3936,7 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
@@ -3943,7 +3944,7 @@ Object Nuke_ChinaTankGattling
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
@@ -3953,7 +3954,7 @@ Object Nuke_ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ;-----damaged attacking----------------------
@@ -3961,7 +3962,7 @@ Object Nuke_ChinaTankGattling
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B REALLYDAMAGED ATTACKING
@@ -3970,14 +3971,14 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
@@ -3986,14 +3987,14 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
@@ -4002,7 +4003,7 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -4010,7 +4011,7 @@ Object Nuke_ChinaTankGattling
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -4020,7 +4021,7 @@ Object Nuke_ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -14338,6 +14338,7 @@ Object Nuke_ChinaGattlingCannon
   UpgradeCameo1           = Upgrade_ChinaChainGuns
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.95, 0.95, 1.90, 3.80 to match firing rate properly.
 
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -14488,7 +14489,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -14496,14 +14497,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -14511,14 +14512,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -14526,7 +14527,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -14536,7 +14537,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -14544,14 +14545,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -14559,14 +14560,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -14574,7 +14575,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -14585,7 +14586,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -14593,14 +14594,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -14608,14 +14609,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -14623,7 +14624,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -14633,7 +14634,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -14641,14 +14642,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -14656,14 +14657,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -14671,7 +14672,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
@@ -14681,7 +14682,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
@@ -14689,14 +14690,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -14704,14 +14705,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -14719,7 +14720,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -14729,7 +14730,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
       Model               = NBGattling_N
@@ -14737,14 +14738,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -14752,14 +14753,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -14767,7 +14768,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -14778,7 +14779,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
       Model               = NBGattling_S
@@ -14786,14 +14787,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -14801,14 +14802,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -14816,7 +14817,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -14826,7 +14827,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -14834,14 +14835,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -14849,14 +14850,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -14864,7 +14865,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -14877,7 +14878,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
@@ -14885,14 +14886,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -14900,14 +14901,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -14915,7 +14916,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14925,7 +14926,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
@@ -14933,14 +14934,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -14948,14 +14949,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -14963,7 +14964,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14972,7 +14973,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
@@ -14980,14 +14981,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -14995,14 +14996,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -15010,7 +15011,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -15019,7 +15020,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -15027,14 +15028,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -15042,14 +15043,14 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -15057,7 +15058,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -15071,7 +15072,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15081,7 +15082,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15090,7 +15091,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15100,7 +15101,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15109,7 +15110,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15119,7 +15120,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15131,7 +15132,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15141,7 +15142,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15150,7 +15151,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15160,7 +15161,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15169,7 +15170,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15179,7 +15180,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15190,7 +15191,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15200,7 +15201,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15209,7 +15210,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15219,7 +15220,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15228,7 +15229,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15238,7 +15239,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15249,7 +15250,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15259,7 +15260,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15268,7 +15269,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15278,7 +15279,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15287,7 +15288,7 @@ Object Nuke_ChinaGattlingCannon
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -15297,7 +15298,7 @@ Object Nuke_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -606,6 +606,7 @@ Object Nuke_ChinaHelixGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
+  ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -620,19 +621,25 @@ Object Nuke_ChinaHelixGattlingCannon
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW
+    ConditionState        = ATTACKING
+      Model               = NVHelix_G
+      Animation           = NVHelix_G.NVHelix_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
@@ -655,19 +662,25 @@ Object Nuke_ChinaHelixGattlingCannon
       ParticleSysBone     = SparkM01 SparksMedium
       ParticleSysBone     = SparkM02 SparksMedium
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = ATTACKING REALLYDAMAGED
+      Model               = NVHelix_GD
+      Animation           = NVHelix_GD.NVHelix_GD
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
@@ -17321,6 +17334,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
+  ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -17335,13 +17349,27 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW
+    ConditionState        = ATTACKING
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -17349,13 +17377,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -17363,7 +17391,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -17371,7 +17399,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -17396,13 +17424,27 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       ParticleSysBone     = SparkM01 SparksMedium
       ParticleSysBone     = SparkM02 SparksMedium
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = ATTACKING REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -17410,13 +17452,13 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -17424,7 +17466,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -17432,7 +17474,7 @@ Object Nuke_ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4061,6 +4061,7 @@ Object Tank_ChinaTankGattling
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -4086,7 +4087,7 @@ Object Tank_ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -4095,14 +4096,14 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
@@ -4111,14 +4112,14 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
@@ -4127,7 +4128,7 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
@@ -4135,7 +4136,7 @@ Object Tank_ChinaTankGattling
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
@@ -4145,7 +4146,7 @@ Object Tank_ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ;-----damaged attacking----------------------
@@ -4153,7 +4154,7 @@ Object Tank_ChinaTankGattling
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B REALLYDAMAGED ATTACKING
@@ -4162,14 +4163,14 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
@@ -4178,14 +4179,14 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
@@ -4194,7 +4195,7 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -4202,7 +4203,7 @@ Object Tank_ChinaTankGattling
       Animation           = NVGattTank_D.NVGattTank_D
       AnimationMode       = LOOP
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
@@ -4212,7 +4213,7 @@ Object Tank_ChinaTankGattling
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -335,6 +335,7 @@ Object Tank_ChinaHelixGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
   ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.3, 0.3, 0.6, 1.2 to 0.38, 0.38, 0.76, 1.52 to match firing rate properly.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -353,25 +354,25 @@ Object Tank_ChinaHelixGattlingCannon
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -394,25 +395,25 @@ Object Tank_ChinaHelixGattlingCannon
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -3201,6 +3202,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
   ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.3, 0.3, 0.6, 1.2 to 0.38, 0.38, 0.76, 1.52 to match firing rate properly.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -3219,7 +3221,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NVOvrlrd_G
@@ -3227,13 +3229,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
@@ -3241,13 +3243,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
@@ -3255,13 +3257,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -3271,7 +3273,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -3294,7 +3296,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -3302,13 +3304,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -3316,13 +3318,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
      ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
@@ -3330,13 +3332,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -3346,7 +3348,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.2 1.2 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 1.52 1.52 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -13395,6 +13395,7 @@ Object Tank_ChinaGattlingCannon
   UpgradeCameo1           = Upgrade_ChinaChainGuns
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
+  ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.95, 0.95, 1.90, 3.80 to match firing rate properly.
 
   Draw                    = W3DModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -13545,7 +13546,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -13553,14 +13554,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -13568,14 +13569,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -13583,7 +13584,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13593,7 +13594,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -13601,14 +13602,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -13616,14 +13617,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -13631,7 +13632,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13642,7 +13643,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -13650,14 +13651,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -13665,14 +13666,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -13680,7 +13681,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13690,7 +13691,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -13698,14 +13699,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -13713,14 +13714,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -13728,7 +13729,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------
@@ -13738,7 +13739,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NBGattling
@@ -13746,14 +13747,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -13761,14 +13762,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -13776,7 +13777,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13786,7 +13787,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT ATTACKING
       Model               = NBGattling_N
@@ -13794,14 +13795,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -13809,14 +13810,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -13824,7 +13825,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13835,7 +13836,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW SNOW ATTACKING
       Model               = NBGattling_S
@@ -13843,14 +13844,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -13858,14 +13859,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -13873,7 +13874,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13883,7 +13884,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -13891,14 +13892,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -13906,14 +13907,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -13921,7 +13922,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.8 0.8 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.95 0.95 ;set this state to animate  s l o w l y
     End
 
 
@@ -13934,7 +13935,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NBGattling
@@ -13942,14 +13943,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
      ConditionState       = CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
      ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED ATTACKING
       Model               = NBGattling_D
@@ -13957,14 +13958,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NBGattling_E
@@ -13972,7 +13973,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -13982,7 +13983,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT ATTACKING
       Model               = NBGattling_N
@@ -13990,14 +13991,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED NIGHT ATTACKING
       Model               = NBGattling_DN
@@ -14005,14 +14006,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT ATTACKING
       Model               = NBGattling_EN
@@ -14020,7 +14021,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14029,7 +14030,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN SNOW ATTACKING
       Model               = NBGattling_S
@@ -14037,14 +14038,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW ATTACKING
       Model               = NBGattling_DS
@@ -14052,14 +14053,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING ; Patch104p @bugfix commy2 08/10/2022 Fix animation speed swapped in middle and fast mode.
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED SNOW ATTACKING
       Model               = NBGattling_ES
@@ -14067,7 +14068,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14076,7 +14077,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN NIGHT SNOW ATTACKING
       Model               = NBGattling_NS
@@ -14084,14 +14085,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN DAMAGED SNOW NIGHT ATTACKING
       Model               = NBGattling_DNS
@@ -14099,14 +14100,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED NIGHT SNOW ATTACKING
       Model               = NBGattling_ENS
@@ -14114,7 +14115,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 1.5 1.5 ;set this state to animate  medium-fast
+      AnimationSpeedFactorRange = 1.90 1.90 ;set this state to animate  medium-fast
     End
 
 
@@ -14128,7 +14129,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14138,7 +14139,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14147,7 +14148,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14157,7 +14158,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14166,7 +14167,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14176,7 +14177,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14188,7 +14189,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14198,7 +14199,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14207,7 +14208,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14217,7 +14218,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14226,7 +14227,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14236,7 +14237,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14247,7 +14248,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14257,7 +14258,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14266,7 +14267,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_DS ; Patch104p @bugfix commy2 08/10/2022 Fix wrong model in this state (was NBGattling_NS).
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14276,7 +14277,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14285,7 +14286,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14295,7 +14296,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14306,7 +14307,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14316,7 +14317,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14325,7 +14326,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14335,7 +14336,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14344,7 +14345,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
@@ -14354,7 +14355,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 3.0 3.0 ;set this state to animate  vryfst
+      AnimationSpeedFactorRange = 3.80 3.80 ;set this state to animate  vryfst
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -334,6 +334,7 @@ Object Tank_ChinaHelixGattlingCannon
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
+  ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -348,19 +349,25 @@ Object Tank_ChinaHelixGattlingCannon
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW
+    ConditionState        = ATTACKING
+      Model               = NVHelix_G
+      Animation           = NVHelix_G.NVHelix_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVHelix_G
       Animation           = NVHelix_G.NVHelix_G
       AnimationMode       = LOOP
@@ -383,19 +390,25 @@ Object Tank_ChinaHelixGattlingCannon
       ParticleSysBone     = SparkM01 SparksMedium
       ParticleSysBone     = SparkM02 SparksMedium
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = ATTACKING REALLYDAMAGED
+      Model               = NVHelix_GD
+      Animation           = NVHelix_GD.NVHelix_GD
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVHelix_GD
       Animation           = NVHelix_GD.NVHelix_GD
       AnimationMode       = LOOP
@@ -3187,6 +3200,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
   ; Patch104p @bugfix commy2 09/10/2022 Fix slow rotation in firing animation.
+  ; Patch104p @bugfix xezon 10/10/2022 Fix missing Gattling animation on first shot(s) by adding ATTACKING state.
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes
@@ -3201,13 +3215,27 @@ Object Tank_ChinaTankOverlordGattlingCannon
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW
+    ConditionState        = ATTACKING
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING
+      Model               = NVOvrlrd_G
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -3215,13 +3243,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -3229,7 +3257,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -3237,7 +3265,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -3262,13 +3290,27 @@ Object Tank_ChinaTankOverlordGattlingCannon
       ParticleSysBone     = SparkM01 SparksMedium
       ParticleSysBone     = SparkM02 SparksMedium
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = ATTACKING REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+      Model               = NVOvrlrd_GD
+      Animation           = NVOvrlrd_G.NVOvrlrd_G
+      AnimationMode       = LOOP
+      WeaponFireFXBone    = SECONDARY Muzzle
+      WeaponMuzzleFlash   = SECONDARY MuzzleFX
+      AnimationSpeedFactorRange = 0.30 0.30 ;set this state to animate  extemely sloowly
+    End
+    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -3276,13 +3318,13 @@ Object Tank_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.3 0.3 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED
+     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -3290,7 +3332,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.6 0.6 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -3298,7 +3340,7 @@ Object Tank_ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED
+    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4086,7 +4086,7 @@ Object Tank_ChinaTankGattling
       Model               = NVGattTank
       Animation           = NVGattTank.NVGattTank
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = USING_WEAPON_B ATTACKING
@@ -4095,7 +4095,7 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       WeaponFireFXBone    = SECONDARY Muzzle
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
@@ -13545,7 +13545,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING
       Model               = NBGattling
@@ -13553,14 +13553,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED
       Model               = NBGattling_D
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED
       Model               = NBGattling_D
@@ -13568,14 +13568,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
       Model               = NBGattling_E
@@ -13583,7 +13583,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13593,7 +13593,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_N
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT
       Model               = NBGattling_N
@@ -13601,14 +13601,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED NIGHT
       Model               = NBGattling_DN
@@ -13616,14 +13616,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT
       Model               = NBGattling_EN
@@ -13631,7 +13631,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13642,7 +13642,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_S
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING SNOW
       Model               = NBGattling_S
@@ -13650,14 +13650,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW
       Model               = NBGattling_DS
@@ -13665,14 +13665,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED SNOW
       Model               = NBGattling_ES
@@ -13680,7 +13680,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 
@@ -13690,7 +13690,7 @@ Object Tank_ChinaGattlingCannon
       Model               = NBGattling_NS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING NIGHT SNOW
       Model               = NBGattling_NS
@@ -13698,14 +13698,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING DAMAGED SNOW NIGHT
       Model               = NBGattling_DNS
@@ -13713,14 +13713,14 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
     ConditionState        = ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
       Animation           = NBGattling_A2.NBGattling_A2
       AnimationMode       = LOOP
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
     ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED NIGHT SNOW
       Model               = NBGattling_ENS
@@ -13728,7 +13728,7 @@ Object Tank_ChinaGattlingCannon
       AnimationMode       = LOOP
       WeaponFireFXBone    = SECONDARY Muzzle
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
-      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  s l o w l y
+      AnimationSpeedFactorRange = 0.5 0.5 ;set this state to animate  extemely sloowly
     End
 
 ;---------------- CONTINUOUS_FIRE_SLOW -----------------------


### PR DESCRIPTION
This change matches all Gattling barrel spin animation speeds with their respective fire rates.

This change has multiple commits and should be Merged with Rebase.

The new animation speeds were determined by observing the individual fire rates, barrel spins frame by frame and adjusting the animation speeds accordingly. Surely there is some math to it, but I did not check it.