### PR TITLE
Fix: Remove Boneless Effects From USA Supply Center (Day Maps Only)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -13229,6 +13229,7 @@ Object AirF_AmericaSupplyCenter
   ButtonImage            = SASupplyCntr
 
   ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -13245,32 +13246,12 @@ Object AirF_AmericaSupplyCenter
       Animation          = ABSupplyCT_D.ABSupplyCT_D
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE
       Model              = ABSupplyCT_E
       Animation          = ABSupplyCT_E.ABSupplyCT_E
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 
@@ -13286,32 +13267,12 @@ Object AirF_AmericaSupplyCenter
       Animation          = ABSupplyCT_DS.ABSupplyCT_DS
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE SNOW
       Model              = ABSupplyCT_ES
       Animation          = ABSupplyCT_ES.ABSupplyCT_ES
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -19493,6 +19493,7 @@ Object AmericaSupplyCenter
   ButtonImage            = SASupplyCntr
 
   ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -19509,32 +19510,12 @@ Object AmericaSupplyCenter
       Animation          = ABSupplyCT_D.ABSupplyCT_D
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE
       Model              = ABSupplyCT_E
       Animation          = ABSupplyCT_E.ABSupplyCT_E
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 
@@ -19550,32 +19531,12 @@ Object AmericaSupplyCenter
       Animation          = ABSupplyCT_DS.ABSupplyCT_DS
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE SNOW
       Model              = ABSupplyCT_ES
       Animation          = ABSupplyCT_ES.ABSupplyCT_ES
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -12912,6 +12912,7 @@ Object Lazr_AmericaSupplyCenter
   ButtonImage            = SASupplyCntr
 
   ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -12928,32 +12929,12 @@ Object Lazr_AmericaSupplyCenter
       Animation          = ABSupplyCT_D.ABSupplyCT_D
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE
       Model              = ABSupplyCT_E
       Animation          = ABSupplyCT_E.ABSupplyCT_E
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 
@@ -12969,32 +12950,12 @@ Object Lazr_AmericaSupplyCenter
       Animation          = ABSupplyCT_DS.ABSupplyCT_DS
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE SNOW
       Model              = ABSupplyCT_ES
       Animation          = ABSupplyCT_ES.ABSupplyCT_ES
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -12346,6 +12346,7 @@ Object SupW_AmericaSupplyCenter
   ButtonImage            = SASupplyCntr
 
   ; Patch104p @bugfix commy2 13/09/2021 Removed Supply Lines upgrade icon, since upgrade applies to Chinook, not Supply Center.
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -12362,32 +12363,12 @@ Object SupW_AmericaSupplyCenter
       Animation          = ABSupplyCT_D.ABSupplyCT_D
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE
       Model              = ABSupplyCT_E
       Animation          = ABSupplyCT_E.ABSupplyCT_E
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 
@@ -12403,32 +12384,12 @@ Object SupW_AmericaSupplyCenter
       Animation          = ABSupplyCT_DS.ABSupplyCT_DS
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
     End
      ConditionState      = REALLYDAMAGED RUBBLE SNOW
       Model              = ABSupplyCT_ES
       Animation          = ABSupplyCT_ES.ABSupplyCT_ES
       AnimationMode      = LOOP
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmolderingSmoke
-      ParticleSysBone    = Smoke06 SmolderingSmoke
-      ParticleSysBone    = Smoke01 SmolderingFire
-      ParticleSysBone    = Smoke02 SmolderingFire
-      ParticleSysBone    = Smoke03 SmolderingFire
-      ParticleSysBone    = Smoke04 SmolderingFire
-      ParticleSysBone    = Smoke05 SmolderingFire
-      ParticleSysBone    = Smoke06 SmolderingFire
     End
 
 


### PR DESCRIPTION
### 1.04

![Supply Center 1 04](https://user-images.githubusercontent.com/6576312/195983683-7f2aed80-3e70-4161-9db6-764193750be9.jpg)

- on day maps, there are 4 (damaged state) or 6 (badly damaged state) little fires with smoke pillars stacked on top of each other at the center of the building. The bones these effects are supposed to attach to do not exist. This is not a problem on Night maps (both Summer and Winter).

### patch:

- The effects from day maps without bones are removed.