### PR TITLE
Fix: Strategy Center Fan Animation Broken On Night Maps Unless Damaged

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -10727,6 +10727,9 @@ Object AirF_AmericaStrategyCenter
   ; *** ART Parameters ***
   SelectPortrait         = SAStrategyCenter_L
   ButtonImage            = SAStrategyCenter
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animation on night maps.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -10768,8 +10771,7 @@ Object AirF_AmericaStrategyCenter
     ConditionState = NIGHT
       Model              = ABStrategy_N
       Animation          = ABStrategy_N.ABStrategy_N
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED
       Model              = ABStrategy_DN
@@ -10786,8 +10788,7 @@ Object AirF_AmericaStrategyCenter
     ConditionState = NIGHT SNOW
       Model              = ABStrategy_NS
       Animation          = ABStrategy_NS.ABStrategy_NS
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED SNOW
       Model              = ABStrategy_DNS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -6222,6 +6222,9 @@ Object AmericaStrategyCenter
   ; *** ART Parameters ***
   SelectPortrait         = SAStrategyCenter_L
   ButtonImage            = SAStrategyCenter
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animation on night maps.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -6263,8 +6266,7 @@ Object AmericaStrategyCenter
     ConditionState = NIGHT
       Model              = ABStrategy_N
       Animation          = ABStrategy_N.ABStrategy_N
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED
       Model              = ABStrategy_DN
@@ -6281,8 +6283,7 @@ Object AmericaStrategyCenter
     ConditionState = NIGHT SNOW
       Model              = ABStrategy_NS
       Animation          = ABStrategy_NS.ABStrategy_NS
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED SNOW
       Model              = ABStrategy_DNS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -10412,6 +10412,9 @@ Object Lazr_AmericaStrategyCenter
   ; *** ART Parameters ***
   SelectPortrait         = SAStrategyCenter_L
   ButtonImage            = SAStrategyCenter
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animation on night maps.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -10453,8 +10456,7 @@ Object Lazr_AmericaStrategyCenter
     ConditionState = NIGHT
       Model              = ABStrategy_N
       Animation          = ABStrategy_N.ABStrategy_N
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED
       Model              = ABStrategy_DN
@@ -10471,8 +10473,7 @@ Object Lazr_AmericaStrategyCenter
     ConditionState = NIGHT SNOW
       Model              = ABStrategy_NS
       Animation          = ABStrategy_NS.ABStrategy_NS
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED SNOW
       Model              = ABStrategy_DNS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -9846,6 +9846,9 @@ Object SupW_AmericaStrategyCenter
   ; *** ART Parameters ***
   SelectPortrait         = SAStrategyCenter_L
   ButtonImage            = SAStrategyCenter
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animation on night maps.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -9887,8 +9890,7 @@ Object SupW_AmericaStrategyCenter
     ConditionState = NIGHT
       Model              = ABStrategy_N
       Animation          = ABStrategy_N.ABStrategy_N
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED
       Model              = ABStrategy_DN
@@ -9905,8 +9907,7 @@ Object SupW_AmericaStrategyCenter
     ConditionState = NIGHT SNOW
       Model              = ABStrategy_NS
       Animation          = ABStrategy_NS.ABStrategy_NS
-      AnimationMode      = ONCE_BACKWARDS
-      Flags              = START_FRAME_FIRST
+      AnimationMode      = LOOP
     End
     ConditionState = NIGHT DAMAGED SNOW
       Model              = ABStrategy_DNS


### PR DESCRIPTION
### 1.04

![strat center](https://user-images.githubusercontent.com/6576312/195985969-7e930938-ea99-4b13-a845-2bca1c4e0686.jpg)

- These fans are not animated on Night maps (both Summer and Winter), except when the building is damaged.

### patch

- The fans are always animated.