### PR TITLE
Fix: Remove Boneless Effects From USA Airfield (Day Maps Only)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -12029,6 +12029,9 @@ Object AirF_AmericaAirfield
   ; *** ART Parameters ***
   SelectPortrait         = SAACommand_L
   ButtonImage            = SAACommand
+
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+
   Draw = W3DModelDraw ModuleTag_01
 
     ExtraPublicBone = Runway1Parking1
@@ -12061,25 +12064,11 @@ Object AirF_AmericaAirfield
       Model              = ABArFrcCmd_D
       Animation          = ABArFrcCmd_D.ABArFrcCmd_D
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABArFrcCmd_E
       Animation          = ABArFrcCmd_E.ABArFrcCmd_E
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ConditionState       = SNOW
@@ -12091,25 +12080,11 @@ Object AirF_AmericaAirfield
       Model              = ABArFrcCmd_DS
       Animation          = ABArFrcCmd_DS.ABArFrcCmd_DS
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABArFrcCmd_ES
       Animation          = ABArFrcCmd_ES.ABArFrcCmd_ES
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ; night ******************************************

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7514,6 +7514,9 @@ Object AmericaAirfield
   ; *** ART Parameters ***
   SelectPortrait         = SAACommand_L
   ButtonImage            = SAACommand
+
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+
   Draw = W3DModelDraw ModuleTag_01
 
     ExtraPublicBone = Runway1Parking1
@@ -7546,25 +7549,11 @@ Object AmericaAirfield
       Model              = ABArFrcCmd_D
       Animation          = ABArFrcCmd_D.ABArFrcCmd_D
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABArFrcCmd_E
       Animation          = ABArFrcCmd_E.ABArFrcCmd_E
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ConditionState       = SNOW
@@ -7576,25 +7565,11 @@ Object AmericaAirfield
       Model              = ABArFrcCmd_DS
       Animation          = ABArFrcCmd_DS.ABArFrcCmd_DS
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABArFrcCmd_ES
       Animation          = ABArFrcCmd_ES.ABArFrcCmd_ES
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ; night ******************************************

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11707,6 +11707,9 @@ Object Lazr_AmericaAirfield
   ; *** ART Parameters ***
   SelectPortrait         = SAACommand_L
   ButtonImage            = SAACommand
+
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+
   Draw = W3DModelDraw ModuleTag_01
 
     ExtraPublicBone = Runway1Parking1
@@ -11739,25 +11742,11 @@ Object Lazr_AmericaAirfield
       Model              = ABArFrcCmd_D
       Animation          = ABArFrcCmd_D.ABArFrcCmd_D
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABArFrcCmd_E
       Animation          = ABArFrcCmd_E.ABArFrcCmd_E
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ConditionState       = SNOW
@@ -11769,25 +11758,11 @@ Object Lazr_AmericaAirfield
       Model              = ABArFrcCmd_DS
       Animation          = ABArFrcCmd_DS.ABArFrcCmd_DS
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABArFrcCmd_ES
       Animation          = ABArFrcCmd_ES.ABArFrcCmd_ES
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ; night ******************************************

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -11141,6 +11141,9 @@ Object SupW_AmericaAirfield
   ; *** ART Parameters ***
   SelectPortrait         = SAACommand_L
   ButtonImage            = SAACommand
+
+  ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+
   Draw = W3DModelDraw ModuleTag_01
 
     ExtraPublicBone = Runway1Parking1
@@ -11173,25 +11176,11 @@ Object SupW_AmericaAirfield
       Model              = ABArFrcCmd_D
       Animation          = ABArFrcCmd_D.ABArFrcCmd_D
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABArFrcCmd_E
       Animation          = ABArFrcCmd_E.ABArFrcCmd_E
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ConditionState       = SNOW
@@ -11203,25 +11192,11 @@ Object SupW_AmericaAirfield
       Model              = ABArFrcCmd_DS
       Animation          = ABArFrcCmd_DS.ABArFrcCmd_DS
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Fire01 SmolderingFire
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABArFrcCmd_ES
       Animation          = ABArFrcCmd_ES.ABArFrcCmd_ES
       AnimationMode      = LOOP
-      ParticleSysBone    = Smoke01 SmolderingSmoke
-      ParticleSysBone    = Smoke02 SmolderingSmoke
-      ParticleSysBone    = Smoke03 SmolderingSmoke
-      ParticleSysBone    = Smoke04 SmolderingSmoke
-      ParticleSysBone    = Smoke05 SmokeFactionLarge
-      ParticleSysBone    = Smoke06 SmokeFactionLarge
-      ParticleSysBone    = Fire01 SmolderingFire
-      ParticleSysBone    = Fire02 SmolderingFire
-      ParticleSysBone    = Fire03 FireFactionLarge
-      ParticleSysBone    = Spark01 SparksLarge
     End
 
     ; night ******************************************


### PR DESCRIPTION
### 1.04

![Airfield 1 04](https://user-images.githubusercontent.com/6576312/195987915-27c8e978-82e6-4afe-90e8-db19dd1dcb06.jpg)

- On day maps, there are multiple little fires, smoke and spark effects stacked on top of each other at the center of the airfiled. The bones these effects are supposed to attach to do not exist. This is not a problem on Night maps (both Summer and Winter).

### patch

- The effects from day maps without bones are removed.
