### PR TITLE
Fix: Control Rods Upgrade Icon Missing From Boss Reactor

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1438,6 +1438,9 @@ Object Boss_PowerPlant
   SelectPortrait         = SAPowerPlant_L
   ButtonImage            = SAPowerPlant
 
+  ; Patch104p @bugfix commy2 15/10/2022 Add missing upgrade icon for Control Rods.
+  UpgradeCameo1          = Upgrade_AmericaAdvancedControlRods
+
 ; ---- the building itself ------
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes


### PR DESCRIPTION
The Boss Reactor can be upgraded with Control Rods, but it has no upgrade icon like all the xUSA Reactors have.