### PR TITLE
Fix: China Barracks Fire Bowl Particles Spawn At Center Of Building When Damaged

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -10214,6 +10214,9 @@ Object Boss_Barracks
   ; *** ART Parameters ***
   SelectPortrait         = SNBarracks_L
   ButtonImage            = SNBarracks
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix bowl fire spawns at center of building when damaged.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -10228,14 +10231,14 @@ Object Boss_Barracks
 
     ConditionState = DAMAGED
       Model = NBBarracks_D
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_D.NBBarracks_D
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE
       Model = NBBarracks_E
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_E.NBBarracks_E
       AnimationMode = LOOP
     End
@@ -10251,14 +10254,14 @@ Object Boss_Barracks
 
     ConditionState = DAMAGED SNOW
       Model = NBBarracks_DS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DS.NBBarracks_DS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE SNOW
       Model = NBBarracks_ES
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ES.NBBarracks_ES
       AnimationMode = LOOP
     End
@@ -10274,14 +10277,14 @@ Object Boss_Barracks
 
     ConditionState = DAMAGED NIGHT
       Model = NBBarracks_DN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DN.NBBarracks_DN
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT
       Model = NBBarracks_EN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_EN.NBBarracks_EN
       AnimationMode = LOOP
     End
@@ -10296,14 +10299,14 @@ Object Boss_Barracks
 
     ConditionState = DAMAGED NIGHT SNOW
       Model = NBBarracks_DNS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DNS.NBBarracks_DNS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model = NBBarracks_ENS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ENS.NBBarracks_ENS
       AnimationMode = LOOP
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -25195,6 +25195,9 @@ Object ChinaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SNBarracks_L
   ButtonImage            = SNBarracks
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix bowl fire spawns at center of building when damaged.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -25209,14 +25212,14 @@ Object ChinaBarracks
 
     ConditionState = DAMAGED
       Model = NBBarracks_D
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_D.NBBarracks_D
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE
       Model = NBBarracks_E
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_E.NBBarracks_E
       AnimationMode = LOOP
     End
@@ -25232,14 +25235,14 @@ Object ChinaBarracks
 
     ConditionState = DAMAGED SNOW
       Model = NBBarracks_DS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DS.NBBarracks_DS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE SNOW
       Model = NBBarracks_ES
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ES.NBBarracks_ES
       AnimationMode = LOOP
     End
@@ -25255,14 +25258,14 @@ Object ChinaBarracks
 
     ConditionState = DAMAGED NIGHT
       Model = NBBarracks_DN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DN.NBBarracks_DN
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT
       Model = NBBarracks_EN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_EN.NBBarracks_EN
       AnimationMode = LOOP
     End
@@ -25277,14 +25280,14 @@ Object ChinaBarracks
 
     ConditionState = DAMAGED NIGHT SNOW
       Model = NBBarracks_DNS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DNS.NBBarracks_DNS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model = NBBarracks_ENS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ENS.NBBarracks_ENS
       AnimationMode = LOOP
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -9199,6 +9199,9 @@ Object Infa_ChinaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SNBarracks_L
   ButtonImage            = SNBarracks
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix bowl fire spawns at center of building when damaged.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -9213,14 +9216,14 @@ Object Infa_ChinaBarracks
 
     ConditionState = DAMAGED
       Model = NBBarracks_D
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_D.NBBarracks_D
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE
       Model = NBBarracks_E
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_E.NBBarracks_E
       AnimationMode = LOOP
     End
@@ -9236,14 +9239,14 @@ Object Infa_ChinaBarracks
 
     ConditionState = DAMAGED SNOW
       Model = NBBarracks_DS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DS.NBBarracks_DS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE SNOW
       Model = NBBarracks_ES
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ES.NBBarracks_ES
       AnimationMode = LOOP
     End
@@ -9259,14 +9262,14 @@ Object Infa_ChinaBarracks
 
     ConditionState = DAMAGED NIGHT
       Model = NBBarracks_DN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DN.NBBarracks_DN
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT
       Model = NBBarracks_EN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_EN.NBBarracks_EN
       AnimationMode = LOOP
     End
@@ -9281,14 +9284,14 @@ Object Infa_ChinaBarracks
 
     ConditionState = DAMAGED NIGHT SNOW
       Model = NBBarracks_DNS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DNS.NBBarracks_DNS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model = NBBarracks_ENS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ENS.NBBarracks_ENS
       AnimationMode = LOOP
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -10976,6 +10976,9 @@ Object Nuke_ChinaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SNBarracks_L
   ButtonImage            = SNBarracks
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix bowl fire spawns at center of building when damaged.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -10990,14 +10993,14 @@ Object Nuke_ChinaBarracks
 
     ConditionState = DAMAGED
       Model = NBBarracks_D
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_D.NBBarracks_D
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE
       Model = NBBarracks_E
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_E.NBBarracks_E
       AnimationMode = LOOP
     End
@@ -11013,14 +11016,14 @@ Object Nuke_ChinaBarracks
 
     ConditionState = DAMAGED SNOW
       Model = NBBarracks_DS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DS.NBBarracks_DS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE SNOW
       Model = NBBarracks_ES
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ES.NBBarracks_ES
       AnimationMode = LOOP
     End
@@ -11036,14 +11039,14 @@ Object Nuke_ChinaBarracks
 
     ConditionState = DAMAGED NIGHT
       Model = NBBarracks_DN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DN.NBBarracks_DN
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT
       Model = NBBarracks_EN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_EN.NBBarracks_EN
       AnimationMode = LOOP
     End
@@ -11058,14 +11061,14 @@ Object Nuke_ChinaBarracks
 
     ConditionState = DAMAGED NIGHT SNOW
       Model = NBBarracks_DNS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DNS.NBBarracks_DNS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model = NBBarracks_ENS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ENS.NBBarracks_ENS
       AnimationMode = LOOP
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -8935,6 +8935,9 @@ Object Tank_ChinaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SNBarracks_L
   ButtonImage            = SNBarracks
+
+  ; Patch104p @bugfix commy2 15/10/2022 Fix bowl fire spawns at center of building when damaged.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -8949,14 +8952,14 @@ Object Tank_ChinaBarracks
 
     ConditionState = DAMAGED
       Model = NBBarracks_D
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_D.NBBarracks_D
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE
       Model = NBBarracks_E
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_E.NBBarracks_E
       AnimationMode = LOOP
     End
@@ -8972,14 +8975,14 @@ Object Tank_ChinaBarracks
 
     ConditionState = DAMAGED SNOW
       Model = NBBarracks_DS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DS.NBBarracks_DS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE SNOW
       Model = NBBarracks_ES
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ES.NBBarracks_ES
       AnimationMode = LOOP
     End
@@ -8995,14 +8998,14 @@ Object Tank_ChinaBarracks
 
     ConditionState = DAMAGED NIGHT
       Model = NBBarracks_DN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DN.NBBarracks_DN
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT
       Model = NBBarracks_EN
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_EN.NBBarracks_EN
       AnimationMode = LOOP
     End
@@ -9017,14 +9020,14 @@ Object Tank_ChinaBarracks
 
     ConditionState = DAMAGED NIGHT SNOW
       Model = NBBarracks_DNS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire05 SmolderingFire
       Animation     = NBBarracks_DNS.NBBarracks_DNS
       AnimationMode = LOOP
     End
 
     ConditionState = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model = NBBarracks_ENS
-      ParticleSysBone= Fire01 SmolderingFire
+      ParticleSysBone= Fire06 SmolderingFire
       Animation     = NBBarracks_ENS.NBBarracks_ENS
       AnimationMode = LOOP
     End


### PR DESCRIPTION
### 1.04

![China Barracks Damaged](https://user-images.githubusercontent.com/6576312/196004662-bf498652-7879-4191-a01f-2bb93aef4d3f.jpg)

- Fire particles spawn outside of bowl at object center when damaged.

### patch

![China Barracks Damaged Fixed](https://user-images.githubusercontent.com/6576312/196004665-f0220755-2e71-45d3-a238-8e4442c4bdf8.jpg)

- Fire particles spawn inside bowl. No effects at building center.

Notes:

This happens, because the bone name inexplicably changes between damage states. Happens regardless of Day, Night, Snow or Summer.
