### PR TITLE
Fix: USA Power Plant Construction Fence Texture On Snow Night Maps

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -8719,6 +8719,7 @@ Object AirF_AmericaPowerPlant
   UpgradeCameo1          = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
   Draw = W3DModelDraw ModuleTag_01
@@ -9085,8 +9086,8 @@ Object AirF_AmericaPowerPlant
       ParticleSysBone = SparksS01 LiveWireSparks02
     End
     ConditionState    = SNOW NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model           = ABPwrPlant_A4S
-      Animation       = ABPwrPlant_A4S.ABPwrPlant_A4S
+      Model           = ABPwrPlant_A4SN
+      Animation       = ABPwrPlant_A4SN.ABPwrPlant_A4SN
       AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = UP_SNOWNIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1442,6 +1442,7 @@ Object Boss_PowerPlant
   UpgradeCameo1          = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
   Draw = W3DModelDraw ModuleTag_01
@@ -1808,8 +1809,8 @@ Object Boss_PowerPlant
       ParticleSysBone = SparksS01 LiveWireSparks02
     End
     ConditionState    = SNOW NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model           = ABPwrPlant_A4S
-      Animation       = ABPwrPlant_A4S.ABPwrPlant_A4S
+      Model           = ABPwrPlant_A4SN
+      Animation       = ABPwrPlant_A4SN.ABPwrPlant_A4SN
       AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = UP_SNOWNIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -4212,6 +4212,7 @@ Object AmericaPowerPlant
   UpgradeCameo1          = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
   Draw = W3DModelDraw ModuleTag_01
@@ -4578,8 +4579,8 @@ Object AmericaPowerPlant
       ParticleSysBone = SparksS01 LiveWireSparks02
     End
     ConditionState    = SNOW NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model           = ABPwrPlant_A4S
-      Animation       = ABPwrPlant_A4S.ABPwrPlant_A4S
+      Model           = ABPwrPlant_A4SN
+      Animation       = ABPwrPlant_A4SN.ABPwrPlant_A4SN
       AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = UP_SNOWNIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -8416,6 +8416,7 @@ Object Lazr_AmericaPowerPlant
   UpgradeCameo1 = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
   Draw = W3DModelDraw ModuleTag_01
@@ -8782,8 +8783,8 @@ Object Lazr_AmericaPowerPlant
       ParticleSysBone = SparksS01 LiveWireSparks02
     End
     ConditionState    = SNOW NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model           = ABPwrPlant_A4S
-      Animation       = ABPwrPlant_A4S.ABPwrPlant_A4S
+      Model           = ABPwrPlant_A4SN
+      Animation       = ABPwrPlant_A4SN.ABPwrPlant_A4SN
       AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = UP_SNOWNIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -16431,6 +16431,7 @@ Object SupW_AmericaPowerPlant
   UpgradeCameo1          = SupW_Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
   Draw = W3DModelDraw ModuleTag_01
@@ -16797,8 +16798,8 @@ Object SupW_AmericaPowerPlant
       ParticleSysBone = SparksS01 LiveWireSparks02
     End
     ConditionState    = SNOW NIGHT AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model           = ABPwrPlant_A4S
-      Animation       = ABPwrPlant_A4S.ABPwrPlant_A4S
+      Model           = ABPwrPlant_A4SN
+      Animation       = ABPwrPlant_A4SN.ABPwrPlant_A4SN
       AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = UP_SNOWNIGHT


### PR DESCRIPTION
### 1.04

![Power Plant Fence 1 04](https://user-images.githubusercontent.com/6576312/196006744-78439fbe-f63a-4555-8b27-0c32403105c5.jpg)

- The construction fence is very dark.

### patch

- The construction fence of the Power Plant uses the same texture as any other USA building construction fence.