### PR TITLE
Fix: USA Power Plant Missing Animation When Damaged On Day Maps

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -8719,6 +8719,7 @@ Object AirF_AmericaPowerPlant
   UpgradeCameo1          = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animations.
   ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
@@ -8734,10 +8735,14 @@ Object AirF_AmericaPowerPlant
     End
     ConditionState       = DAMAGED
       Model              = ABPWRPLANT_D
+      Animation          = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABPWRPLANT_E
+      Animation          = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -8756,6 +8761,8 @@ Object AirF_AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_D
+      Animation     = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -8766,6 +8773,8 @@ Object AirF_AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_E
+      Animation     = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -8843,10 +8852,14 @@ Object AirF_AmericaPowerPlant
     End
     ConditionState       = DAMAGED SNOW
       Model              = ABPWRPLANT_DS
+      Animation          = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABPWRPLANT_ES
+      Animation          = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -8866,6 +8879,8 @@ Object AirF_AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_DS
+      Animation     = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -8876,6 +8891,8 @@ Object AirF_AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_ES
+      Animation     = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1442,6 +1442,7 @@ Object Boss_PowerPlant
   UpgradeCameo1          = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animations.
   ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
@@ -1457,10 +1458,14 @@ Object Boss_PowerPlant
     End
     ConditionState       = DAMAGED
       Model              = ABPWRPLANT_D
+      Animation          = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABPWRPLANT_E
+      Animation          = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -1479,6 +1484,8 @@ Object Boss_PowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_D
+      Animation     = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -1489,6 +1496,8 @@ Object Boss_PowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_E
+      Animation     = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -1566,10 +1575,14 @@ Object Boss_PowerPlant
     End
     ConditionState       = DAMAGED SNOW
       Model              = ABPWRPLANT_DS
+      Animation          = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABPWRPLANT_ES
+      Animation          = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -1589,6 +1602,8 @@ Object Boss_PowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_DS
+      Animation     = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -1599,6 +1614,8 @@ Object Boss_PowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_ES
+      Animation     = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -4212,6 +4212,7 @@ Object AmericaPowerPlant
   UpgradeCameo1          = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animations.
   ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
@@ -4227,10 +4228,14 @@ Object AmericaPowerPlant
     End
     ConditionState       = DAMAGED
       Model              = ABPWRPLANT_D
+      Animation          = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABPWRPLANT_E
+      Animation          = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -4249,6 +4254,8 @@ Object AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_D
+      Animation     = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -4259,6 +4266,8 @@ Object AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_E
+      Animation     = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -4336,10 +4345,14 @@ Object AmericaPowerPlant
     End
     ConditionState       = DAMAGED SNOW
       Model              = ABPWRPLANT_DS
+      Animation          = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABPWRPLANT_ES
+      Animation          = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -4359,6 +4372,8 @@ Object AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_DS
+      Animation     = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -4369,6 +4384,8 @@ Object AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_ES
+      Animation     = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -8416,6 +8416,7 @@ Object Lazr_AmericaPowerPlant
   UpgradeCameo1 = Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animations.
   ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
@@ -8431,10 +8432,14 @@ Object Lazr_AmericaPowerPlant
     End
     ConditionState       = DAMAGED
       Model              = ABPWRPLANT_D
+      Animation          = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABPWRPLANT_E
+      Animation          = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -8453,6 +8458,8 @@ Object Lazr_AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_D
+      Animation     = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -8463,6 +8470,8 @@ Object Lazr_AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_E
+      Animation     = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -8540,10 +8549,14 @@ Object Lazr_AmericaPowerPlant
     End
     ConditionState       = DAMAGED SNOW
       Model              = ABPWRPLANT_DS
+      Animation          = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABPWRPLANT_ES
+      Animation          = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -8563,6 +8576,8 @@ Object Lazr_AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_DS
+      Animation     = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -8573,6 +8588,8 @@ Object Lazr_AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_ES
+      Animation     = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -16431,6 +16431,7 @@ Object SupW_AmericaPowerPlant
   UpgradeCameo1          = SupW_Upgrade_AmericaAdvancedControlRods
 
   ; Patch104p @bugfix commy2 15/10/2022 Remove effects without bones.
+  ; Patch104p @bugfix commy2 15/10/2022 Fix missing animations.
   ; Patch104p @bugfix commy2 15/10/2022 Fix construction fence texture on snow night maps.
 
 ; ---- the building itself ------
@@ -16446,10 +16447,14 @@ Object SupW_AmericaPowerPlant
     End
     ConditionState       = DAMAGED
       Model              = ABPWRPLANT_D
+      Animation          = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE
       Model              = ABPWRPLANT_E
+      Animation          = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -16468,6 +16473,8 @@ Object SupW_AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_D
+      Animation     = ABPWRPLANT_D.ABPWRPLANT_D
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -16478,6 +16485,8 @@ Object SupW_AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED
       Model = ABPWRPLANT_E
+      Animation     = ABPWRPLANT_E.ABPWRPLANT_E
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -16555,10 +16564,14 @@ Object SupW_AmericaPowerPlant
     End
     ConditionState       = DAMAGED SNOW
       Model              = ABPWRPLANT_DS
+      Animation          = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
     ConditionState       = REALLYDAMAGED RUBBLE SNOW
       Model              = ABPWRPLANT_ES
+      Animation          = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode      = LOOP
       ParticleSysBone    = Smoke01 SteamVent
     End
 
@@ -16578,6 +16591,8 @@ Object SupW_AmericaPowerPlant
     End
     ConditionState = DAMAGED POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_DS
+      Animation     = ABPWRPLANT_DS.ABPWRPLANT_DS
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02
@@ -16588,6 +16603,8 @@ Object SupW_AmericaPowerPlant
     End
     ConditionState = REALLYDAMAGED RUBBLE POWER_PLANT_UPGRADED SNOW
       Model = ABPWRPLANT_ES
+      Animation     = ABPWRPLANT_ES.ABPWRPLANT_ES
+      AnimationMode = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks02


### PR DESCRIPTION
### 1.04

- Reactor cylinders are not animated on Summer and Winter Day maps when damaged. They are however animated in other states, including at Night.

### patch

- Cylinders are always animated.

This does not fix the black texture (no alpha channel?) mentioned here: https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1259. That bug only happens on Snow (Day?) maps when UNDAMAGED.