### PR TITLE
Fix: Remove Floating Basket From Undamaged China War Factory On Snow Maps At Night

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -10950,6 +10950,7 @@ Object Boss_WarFactory
     ; night   SNOW
       ConditionState = NIGHT SNOW
       Model           = NBWarFact_NS
+      HideSubObject   = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState = DAMAGED NIGHT SNOW
       Model           = NBWarFact_DNS
@@ -11022,6 +11023,7 @@ Object Boss_WarFactory
       ;Animation          = NBWarFact_NS.NBWarFact_NS
       ;AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW DAMAGED
       Model              = NBWarFact_DNS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -28820,6 +28820,7 @@ Object ChinaWarFactory
     ; night   SNOW
       ConditionState = NIGHT SNOW
       Model           = NBWarFact_NS
+      HideSubObject   = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState = DAMAGED NIGHT SNOW
       Model           = NBWarFact_DNS
@@ -28892,6 +28893,7 @@ Object ChinaWarFactory
       ;Animation          = NBWarFact_NS.NBWarFact_NS
       ;AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW DAMAGED
       Model              = NBWarFact_DNS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -9913,6 +9913,7 @@ Object Infa_ChinaWarFactory
     ; night   SNOW
       ConditionState = NIGHT SNOW
       Model           = NBWarFact_NS
+      HideSubObject   = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState = DAMAGED NIGHT SNOW
       Model           = NBWarFact_DNS
@@ -9985,6 +9986,7 @@ Object Infa_ChinaWarFactory
       ;Animation          = NBWarFact_NS.NBWarFact_NS
       ;AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW DAMAGED
       Model              = NBWarFact_DNS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -11690,6 +11690,7 @@ Object Nuke_ChinaWarFactory
     ; night   SNOW
       ConditionState = NIGHT SNOW
       Model           = NBWarFact_NS
+      HideSubObject   = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState = DAMAGED NIGHT SNOW
       Model           = NBWarFact_DNS
@@ -11762,6 +11763,7 @@ Object Nuke_ChinaWarFactory
       ;Animation          = NBWarFact_NS.NBWarFact_NS
       ;AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW DAMAGED
       Model              = NBWarFact_DNS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -10747,6 +10747,7 @@ Object Tank_ChinaWarFactory
     ; night   SNOW
       ConditionState = NIGHT SNOW
       Model           = NBWarFact_NS
+      HideSubObject   = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState = DAMAGED NIGHT SNOW
       Model           = NBWarFact_DNS
@@ -10819,6 +10820,7 @@ Object Tank_ChinaWarFactory
       ;Animation          = NBWarFact_NS.NBWarFact_NS
       ;AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
+      HideSubObject      = Basket04 ; Patch104p @bugfix commy2 16/10/2022 Hide floating basket.
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW DAMAGED
       Model              = NBWarFact_DNS


### PR DESCRIPTION
### 1.04

![China War Factory 1 04 markings](https://user-images.githubusercontent.com/6576312/196029359-c1f0bd3d-7860-43b0-ac77-0d366723890e.jpg)

- There is a floating basket inside the China War Factory on Snow Night maps when undamaged (marking 2). It disappears when damaged.

### patch

- No floating baskets.