### PR TITLE
Fix: Factory Door Animation Damage Transitions

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -15493,7 +15493,7 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -15503,7 +15503,7 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -15513,7 +15513,7 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -15523,7 +15523,7 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -15534,7 +15534,7 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -15544,7 +15544,7 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -11569,7 +11569,7 @@ Object Boss_WarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -11580,7 +11580,7 @@ Object Boss_WarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
    End
    AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
    AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -11590,7 +11590,7 @@ Object Boss_WarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -11600,7 +11600,7 @@ Object Boss_WarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -11611,7 +11611,7 @@ Object Boss_WarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -11621,7 +11621,7 @@ Object Boss_WarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -11091,7 +11091,7 @@ Object Chem_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -11101,7 +11101,7 @@ Object Chem_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -11111,7 +11111,7 @@ Object Chem_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -11123,7 +11123,7 @@ Object Chem_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -11133,7 +11133,7 @@ Object Chem_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW NIGHT DOOR_1_CLOSING DAMAGED
@@ -11143,7 +11143,7 @@ Object Chem_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -11035,7 +11035,7 @@ Object Demo_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -11045,7 +11045,7 @@ Object Demo_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -11055,7 +11055,7 @@ Object Demo_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -11067,7 +11067,7 @@ Object Demo_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -11077,7 +11077,7 @@ Object Demo_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW NIGHT DOOR_1_CLOSING DAMAGED
@@ -11087,7 +11087,7 @@ Object Demo_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -26085,7 +26085,7 @@ Object AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -26095,7 +26095,7 @@ Object AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -26105,7 +26105,7 @@ Object AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -26115,7 +26115,7 @@ Object AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -26126,7 +26126,7 @@ Object AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -26136,7 +26136,7 @@ Object AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE
@@ -29439,7 +29439,7 @@ Object ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -29450,7 +29450,7 @@ Object ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
    End
    AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
    AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -29460,7 +29460,7 @@ Object ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -29470,7 +29470,7 @@ Object ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -29481,7 +29481,7 @@ Object ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -29491,7 +29491,7 @@ Object ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE
@@ -37508,7 +37508,7 @@ Object GLAArmsDealerNoHole
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -37518,7 +37518,7 @@ Object GLAArmsDealerNoHole
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -37528,7 +37528,7 @@ Object GLAArmsDealerNoHole
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -37540,7 +37540,7 @@ Object GLAArmsDealerNoHole
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -37550,7 +37550,7 @@ Object GLAArmsDealerNoHole
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW NIGHT DOOR_1_CLOSING DAMAGED
@@ -37560,7 +37560,7 @@ Object GLAArmsDealerNoHole
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -4400,7 +4400,7 @@ Object GC_Chem_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -4410,7 +4410,7 @@ Object GC_Chem_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -4420,7 +4420,7 @@ Object GC_Chem_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -4432,7 +4432,7 @@ Object GC_Chem_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -4442,7 +4442,7 @@ Object GC_Chem_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW NIGHT DOOR_1_CLOSING DAMAGED
@@ -4452,7 +4452,7 @@ Object GC_Chem_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -4279,7 +4279,7 @@ Object GC_Slth_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -4289,7 +4289,7 @@ Object GC_Slth_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -4299,7 +4299,7 @@ Object GC_Slth_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -4311,7 +4311,7 @@ Object GC_Slth_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -4321,7 +4321,7 @@ Object GC_Slth_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW NIGHT DOOR_1_CLOSING DAMAGED
@@ -4331,7 +4331,7 @@ Object GC_Slth_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -10532,7 +10532,7 @@ Object Infa_ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -10543,7 +10543,7 @@ Object Infa_ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
    End
    AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
    AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -10553,7 +10553,7 @@ Object Infa_ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -10563,7 +10563,7 @@ Object Infa_ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -10574,7 +10574,7 @@ Object Infa_ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -10584,7 +10584,7 @@ Object Infa_ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -15178,7 +15178,7 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -15188,7 +15188,7 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -15198,7 +15198,7 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -15208,7 +15208,7 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -15219,7 +15219,7 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -15229,7 +15229,7 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -12309,7 +12309,7 @@ Object Nuke_ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -12320,7 +12320,7 @@ Object Nuke_ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
    End
    AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
    AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -12330,7 +12330,7 @@ Object Nuke_ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -12340,7 +12340,7 @@ Object Nuke_ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -12351,7 +12351,7 @@ Object Nuke_ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -12361,7 +12361,7 @@ Object Nuke_ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -11736,7 +11736,7 @@ Object Slth_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -11746,7 +11746,7 @@ Object Slth_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -11756,7 +11756,7 @@ Object Slth_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -11768,7 +11768,7 @@ Object Slth_GLAArmsDealer
       Model           = UBArmDeal_A7
       Animation       = UBArmDeal_A7.UBArmDeal_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -11778,7 +11778,7 @@ Object Slth_GLAArmsDealer
       Model           = UBArmDeal_A7D
       Animation       = UBArmDeal_A7D.UBArmDeal_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW NIGHT DOOR_1_CLOSING DAMAGED
@@ -11788,7 +11788,7 @@ Object Slth_GLAArmsDealer
       Model           = UBArmDeal_A7E
       Animation       = UBArmDeal_A7E.UBArmDeal_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -14612,7 +14612,7 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -14622,7 +14622,7 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -14632,7 +14632,7 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -14642,7 +14642,7 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_A8
       Animation       = ABWarFact_A8.ABWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -14653,7 +14653,7 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_A8D
       Animation       = ABWarFact_A8D.ABWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -14663,7 +14663,7 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_A8E
       Animation       = ABWarFact_A8E.ABWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -11366,7 +11366,7 @@ Object Tank_ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -11377,7 +11377,7 @@ Object Tank_ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
    End
    AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
    AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -11387,7 +11387,7 @@ Object Tank_ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -11397,7 +11397,7 @@ Object Tank_ChinaWarFactory
       Model           = NBWarFact_A8
       Animation       = NBWarFact_A8.NBWarFact_A8
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -11408,7 +11408,7 @@ Object Tank_ChinaWarFactory
       Model           = NBWarFact_A8D
       Animation       = NBWarFact_A8D.NBWarFact_A8D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -11418,7 +11418,7 @@ Object Tank_ChinaWarFactory
       Model           = NBWarFact_A8E
       Animation       = NBWarFact_A8E.NBWarFact_A8E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 16/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE


### PR DESCRIPTION
Fixed door animations resetting when transitioning between damage states for vehicle production buildings (GLA Arms Dealer + China War Factory + USA War Factory).

## 1.04:
When the War Factory transitions between damage states, the door animation state is reset.

https://user-images.githubusercontent.com/11547761/196031878-4fa989b2-c5ec-4a87-b479-92e106172ba3.mp4

## Patch:
When the War Factory transitions between damage states, the door animation state is maintained.

https://user-images.githubusercontent.com/11547761/196031884-4bd62cc6-1994-4db5-b4e4-f99c2f1ec3e0.mp4