### PR TITLE
Fix: Building death effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -14558,7 +14558,7 @@ Object AirF_AmericaSupplyDropZone
   End
 
   Behavior                  = CreateObjectDie ModuleTag_08
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior             = FlammableUpdate ModuleTag_09

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -14568,7 +14568,7 @@ Object AirF_AmericaSupplyDropZone
   End
 
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
 
   Behavior = BaseRegenerateUpdate ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17243,7 +17243,7 @@ Object AirF_AmericaFireBase
   End
 
   Behavior             = FXListDie ModuleTag_10
-    DeathFX       = FX_StructureMediumDeath
+    DeathFX       = FX_StructureSmallDeath
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -15218,7 +15218,7 @@ Object AirF_AmericaBarracks
     ExemptStatus       = UNDER_CONSTRUCTION
   End
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
   Behavior = ProductionUpdate ModuleTag_11
     ; nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -16701,6 +16701,11 @@ Object AirF_AmericaPatriotBattery
   Behavior = DestroyDie ModuleTag_08
     ;nothing
   End
+
+  Behavior = CreateObjectDie ModuleTag_11
+    CreationList = OCL_TinyStructureDebris
+  End
+
   Behavior             = CreateObjectDie ModuleTag_09
     CreationList  = AirF_OCL_AmericanRangerDebris03
     ExemptStatus  = UNDER_CONSTRUCTION

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17258,7 +17258,7 @@ Object AirF_AmericaFireBase
   End
 
   Behavior                  = CreateObjectDie ModuleTag_13
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior = TransitionDamageFX ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -8898,7 +8898,7 @@ Object Boss_SpeakerTower
     ;<NO DATA>
   End
   Behavior        = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_ABPowerPlantExplode
+    CreationList  = OCL_ABSpeakerTowerDebris
   End
   Behavior        = FXListDie ModuleTag_09
     DeathFX       = FX_StructureTinyDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -8236,6 +8236,11 @@ Object Boss_NuclearMissileLauncher
     DeathFX       = FX_NukeGLA
   End
 
+  Behavior = FXListDie ModuleTag_22
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureMediumDeath
+  End
+
   Behavior = CommandSetUpgrade ModuleTag_25
     CommandSet = Boss_ChinaNuclearMissileCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -12437,6 +12437,11 @@ Object Boss_PatriotBattery
   Behavior = DestroyDie ModuleTag_08
     ;nothing
   End
+
+  Behavior = CreateObjectDie ModuleTag_11
+    CreationList = OCL_TinyStructureDebris
+  End
+
   Behavior             = CreateObjectDie ModuleTag_09
     CreationList  = Boss_OCL_AmericanRangerDebris03 ; @bugfix commy2 19/09/2021 Fix building spawning vanilla USA Rangers when destroyed.
     ExemptStatus  = UNDER_CONSTRUCTION

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -6692,7 +6692,8 @@ Object Boss_ScudStorm
   End
 
   Behavior        = FXListDie ModuleTag_19
-    DeathFX       = FX_BuildingDie
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX       = FX_StructureMediumDeath
   End
 
   Behavior = GenerateMinefieldBehavior     ModuleTag_20

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -13335,7 +13335,7 @@ Object Boss_Bunker
   End
 
   Behavior             = CreateObjectDie ModuleTag_13
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
   Behavior             = FXListDie ModuleTag_14
     DeathFX       = FX_StructureSmallDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -14461,7 +14461,7 @@ Object Boss_GattlingCannon
   End
 
   Behavior        = CreateObjectDie ModuleTag_11
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -6696,6 +6696,10 @@ Object Boss_ScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
+  Behavior  = CreateObjectDie ModuleTag_22
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Behavior = GenerateMinefieldBehavior     ModuleTag_20
     TriggeredBy           = Upgrade_ChinaMines
     MineName              = ChinaStandardMine

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -7296,7 +7296,7 @@ Object Chem_GLAPalace
   End
 
   Behavior             = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_SmallStructureDebris
+    CreationList  = OCL_LargeStructureDebris
   End
   Behavior             = FXListDie ModuleTag_09
     DeathFX       = FX_StructureMediumDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5693,6 +5693,10 @@ Object Chem_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
+  Behavior  = CreateObjectDie ModuleTag_20
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5689,7 +5689,8 @@ Object Chem_GLAScudStorm
   End
 
   Behavior        = FXListDie ModuleTag_19
-    DeathFX       = FX_BuildingDie
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX       = FX_StructureMediumDeath
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5693,7 +5693,7 @@ Object Chem_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior  = CreateObjectDie ModuleTag_20
+  Behavior  = CreateObjectDie ModuleTag_22
     CreationList = OCL_LargeStructureDebris
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -5005,7 +5005,8 @@ Object Demo_GLAScudStorm
   End
 
   Behavior        = FXListDie ModuleTag_19
-    DeathFX       = FX_BuildingDie
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX       = FX_StructureMediumDeath
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -7212,7 +7212,7 @@ Object Demo_GLAPalace
   End
 
   Behavior             = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_SmallStructureDebris
+    CreationList  = OCL_LargeStructureDebris
   End
   Behavior             = FXListDie ModuleTag_09
     DeathFX       = FX_StructureMediumDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -5009,6 +5009,10 @@ Object Demo_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
+  Behavior  = CreateObjectDie ModuleTag_20
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -5009,7 +5009,7 @@ Object Demo_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior  = CreateObjectDie ModuleTag_20
+  Behavior  = CreateObjectDie ModuleTag_22
     CreationList = OCL_LargeStructureDebris
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13559,7 +13559,7 @@ Object GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior  = CreateObjectDie ModuleTag_20
+  Behavior  = CreateObjectDie ModuleTag_22
     CreationList = OCL_LargeStructureDebris
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13559,6 +13559,10 @@ Object GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
+  Behavior  = CreateObjectDie ModuleTag_20
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -20837,7 +20837,7 @@ Object AmericaSupplyDropZone
   End
 
   Behavior                  = CreateObjectDie ModuleTag_08
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior             = FlammableUpdate ModuleTag_09

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -20842,7 +20842,7 @@ Object AmericaSupplyDropZone
   End
 
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
 
   Behavior = BaseRegenerateUpdate ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -15737,7 +15737,7 @@ Object ChinaSpeakerTower
     ;<NO DATA>
   End
   Behavior        = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_ABPowerPlantExplode
+    CreationList  = OCL_ABSpeakerTowerDebris
   End
   Behavior        = FXListDie ModuleTag_09
     DeathFX       = FX_StructureTinyDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -19450,7 +19450,13 @@ Object ChinaPowerPlant
   End
 
   Behavior             = FXListDie ModuleTag_16
+    ExemptStatus  = UNDER_CONSTRUCTION
     DeathFX       = FX_BuildingDie
+  End
+
+  Behavior = FXListDie ModuleTag_17
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureSmallDeath
   End
 
   Behavior = CommandSetUpgrade ModuleTag_25

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13555,7 +13555,8 @@ Object GLAScudStorm
   End
 
   Behavior        = FXListDie ModuleTag_19
-    DeathFX       = FX_BuildingDie
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX       = FX_StructureMediumDeath
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -15129,6 +15129,11 @@ Object ChinaNuclearMissileLauncher
     DeathFX       = FX_NukeGLA
   End
 
+  Behavior = FXListDie ModuleTag_22
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureMediumDeath
+  End
+
   Behavior = CommandSetUpgrade ModuleTag_25
     CommandSet = ChinaNuclearMissileCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -30908,6 +30908,11 @@ Object AmericaPatriotBattery
   Behavior = DestroyDie ModuleTag_08
     ;nothing
   End
+
+  Behavior = CreateObjectDie ModuleTag_11
+    CreationList = OCL_TinyStructureDebris
+  End
+
   Behavior             = CreateObjectDie ModuleTag_09
     CreationList  = OCL_AmericanRangerDebris03
     ExemptStatus  = UNDER_CONSTRUCTION

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -23621,7 +23621,7 @@ Object AmericaBarracks
     ExemptStatus       = UNDER_CONSTRUCTION
   End
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
   Behavior = ProductionUpdate ModuleTag_11
     ; nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -36575,7 +36575,7 @@ Object AmericaFireBase
   End
 
   Behavior             = FXListDie ModuleTag_10
-    DeathFX       = FX_StructureMediumDeath
+    DeathFX       = FX_StructureSmallDeath
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -18455,7 +18455,7 @@ Object GLAPalace
   End
 
   Behavior             = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_SmallStructureDebris
+    CreationList  = OCL_LargeStructureDebris
   End
   Behavior             = FXListDie ModuleTag_09
     DeathFX       = FX_StructureMediumDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -36600,7 +36600,7 @@ Object AmericaFireBase
   End
 
   Behavior                  = CreateObjectDie ModuleTag_13
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior = TransitionDamageFX ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -33724,7 +33724,7 @@ Object ChinaGattlingCannon
   End
 
   Behavior        = CreateObjectDie ModuleTag_11
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -32610,6 +32610,11 @@ Object ChinaPropagandaCenter
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>
   End
+
+  Behavior  = CreateObjectDie ModuleTag_13
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Behavior  = FXListDie ModuleTag_14
     DeathFX = FX_StructureMediumDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -31754,7 +31754,7 @@ Object ChinaBunker
   End
 
   Behavior             = CreateObjectDie ModuleTag_13
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
   Behavior             = FXListDie ModuleTag_14
     DeathFX       = FX_StructureSmallDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -8399,6 +8399,10 @@ Object GC_Chem_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
+  Behavior  = CreateObjectDie ModuleTag_20
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 71.0
   GeometryMinorRadius = 67.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -8395,7 +8395,8 @@ Object GC_Chem_GLAScudStorm
   End
 
   Behavior        = FXListDie ModuleTag_19
-    DeathFX       = FX_BuildingDie
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX       = FX_StructureMediumDeath
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -8399,7 +8399,7 @@ Object GC_Chem_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior  = CreateObjectDie ModuleTag_20
+  Behavior  = CreateObjectDie ModuleTag_22
     CreationList = OCL_LargeStructureDebris
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -3680,7 +3680,7 @@ Object GC_Chem_GLAPalace
   End
 
   Behavior             = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_SmallStructureDebris
+    CreationList  = OCL_LargeStructureDebris
   End
   Behavior             = FXListDie ModuleTag_09
     DeathFX       = FX_StructureMediumDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -8670,7 +8670,8 @@ Object GC_Slth_GLAScudStorm
   End
 
   Behavior        = FXListDie ModuleTag_19
-    DeathFX       = FX_BuildingDie
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX       = FX_StructureMediumDeath
   End
   Behavior = StealthUpdate ModuleTag_20
     StealthDelay                = 2000 ; msec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -8673,6 +8673,11 @@ Object GC_Slth_GLAScudStorm
     RequiredStatus = UNDER_CONSTRUCTION
     DeathFX       = FX_StructureMediumDeath
   End
+
+  Behavior  = CreateObjectDie ModuleTag_21
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Behavior = StealthUpdate ModuleTag_20
     StealthDelay                = 2000 ; msec
     StealthForbiddenConditions  = FIRING_SECONDARY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -5424,7 +5424,7 @@ Object GC_Slth_GLAPalace
   End
 
   Behavior             = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_SmallStructureDebris
+    CreationList  = OCL_LargeStructureDebris
   End
   Behavior             = FXListDie ModuleTag_09
     DeathFX       = FX_StructureMediumDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -8674,7 +8674,7 @@ Object GC_Slth_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior  = CreateObjectDie ModuleTag_21
+  Behavior  = CreateObjectDie ModuleTag_22
     CreationList = OCL_LargeStructureDebris
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -11675,6 +11675,11 @@ Object Infa_ChinaPropagandaCenter
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>
   End
+
+  Behavior  = CreateObjectDie ModuleTag_13
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Behavior  = FXListDie ModuleTag_14
     DeathFX = FX_StructureMediumDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -7431,7 +7431,7 @@ Object Infa_ChinaSpeakerTower
     ;<NO DATA>
   End
   Behavior        = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_ABPowerPlantExplode
+    CreationList  = OCL_ABSpeakerTowerDebris
   End
   Behavior        = FXListDie ModuleTag_09
     DeathFX       = FX_StructureTinyDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -14722,7 +14722,7 @@ Object Infa_ChinaBunker
   End
 
   Behavior             = CreateObjectDie ModuleTag_13
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
   Behavior             = FXListDie ModuleTag_14
     DeathFX       = FX_StructureSmallDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -6828,6 +6828,11 @@ Object Infa_ChinaNuclearMissileLauncher
     DeathFX       = FX_NukeGLA
   End
 
+  Behavior = FXListDie ModuleTag_22
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureMediumDeath
+  End
+
   Behavior = CommandSetUpgrade ModuleTag_25
     CommandSet = Infa_ChinaNuclearMissileCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -12780,7 +12780,7 @@ Object Infa_ChinaGattlingCannon
   End
 
   Behavior        = CreateObjectDie ModuleTag_11
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -8414,7 +8414,13 @@ Object Infa_ChinaPowerPlant
   End
 
   Behavior             = FXListDie ModuleTag_16
+    ExemptStatus  = UNDER_CONSTRUCTION
     DeathFX       = FX_BuildingDie
+  End
+
+  Behavior = FXListDie ModuleTag_17
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureSmallDeath
   End
 
   Behavior = CommandSetUpgrade ModuleTag_25

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14240,7 +14240,7 @@ Object Lazr_AmericaSupplyDropZone
   End
 
   Behavior                  = CreateObjectDie ModuleTag_08
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior             = FlammableUpdate ModuleTag_09

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -17024,6 +17024,11 @@ Object Lazr_AmericaPatriotBattery
   Behavior = DestroyDie ModuleTag_08
     ;nothing
   End
+
+  Behavior = CreateObjectDie ModuleTag_11
+    CreationList = OCL_TinyStructureDebris
+  End
+
   Behavior             = CreateObjectDie ModuleTag_09
     CreationList  = Lazr_OCL_AmericanRangerDebris03
     ExemptStatus  = UNDER_CONSTRUCTION

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14902,7 +14902,7 @@ Object Lazr_AmericaBarracks
     ExemptStatus       = UNDER_CONSTRUCTION
   End
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
   Behavior = ProductionUpdate ModuleTag_11
     ; nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -16367,7 +16367,7 @@ Object Lazr_AmericaFireBase
   End
 
   Behavior             = FXListDie ModuleTag_10
-    DeathFX       = FX_StructureMediumDeath
+    DeathFX       = FX_StructureSmallDeath
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14250,7 +14250,7 @@ Object Lazr_AmericaSupplyDropZone
   End
 
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
 
   Behavior = BaseRegenerateUpdate ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -16377,7 +16377,7 @@ Object Lazr_AmericaFireBase
   End
 
   Behavior                  = CreateObjectDie ModuleTag_13
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior = TransitionDamageFX ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -9202,7 +9202,7 @@ Object Nuke_ChinaSpeakerTower
     ;<NO DATA>
   End
   Behavior        = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_ABPowerPlantExplode
+    CreationList  = OCL_ABSpeakerTowerDebris
   End
   Behavior        = FXListDie ModuleTag_09
     DeathFX       = FX_StructureTinyDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -10185,7 +10185,13 @@ Object Nuke_ChinaPowerPlant
   End
 
   Behavior             = FXListDie ModuleTag_16
+    ExemptStatus  = UNDER_CONSTRUCTION
     DeathFX       = FX_BuildingDie
+  End
+
+  Behavior = FXListDie ModuleTag_17
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureSmallDeath
   End
 
   Behavior = CommandSetUpgrade ModuleTag_25

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -15393,7 +15393,7 @@ Object Nuke_ChinaGattlingCannon
   End
 
   Behavior        = CreateObjectDie ModuleTag_11
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -13423,7 +13423,7 @@ Object Nuke_ChinaBunker
   End
 
   Behavior             = CreateObjectDie ModuleTag_13
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
   Behavior             = FXListDie ModuleTag_14
     DeathFX       = FX_StructureSmallDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -8599,6 +8599,11 @@ Object Nuke_ChinaNuclearMissileLauncher
     DeathFX       = FX_NukeGLA
   End
 
+  Behavior = FXListDie ModuleTag_22
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureMediumDeath
+  End
+
   Behavior = CommandSetUpgrade ModuleTag_25
     CommandSet = Nuke_ChinaNuclearMissileCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -14288,6 +14288,11 @@ Object Nuke_ChinaPropagandaCenter
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>
   End
+
+  Behavior  = CreateObjectDie ModuleTag_13
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Behavior  = FXListDie ModuleTag_14
     DeathFX = FX_StructureMediumDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5739,7 +5739,8 @@ Object Slth_GLAScudStorm
   End
 
   Behavior        = FXListDie ModuleTag_19
-    DeathFX       = FX_BuildingDie
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX       = FX_StructureMediumDeath
   End
 
 ;  Behavior = GrantUpgradeCreate ModuleTag_900

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5743,6 +5743,10 @@ Object Slth_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
+  Behavior  = CreateObjectDie ModuleTag_20
+    CreationList = OCL_LargeStructureDebris
+  End
+
 ;  Behavior = GrantUpgradeCreate ModuleTag_900
 ;    UpgradeToGrant = Upgrade_GLACamoNetting
 ;  End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -7875,7 +7875,7 @@ Object Slth_GLAPalace
   End
 
   Behavior             = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_SmallStructureDebris
+    CreationList  = OCL_LargeStructureDebris
   End
   Behavior             = FXListDie ModuleTag_09
     DeathFX       = FX_StructureMediumDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5743,7 +5743,7 @@ Object Slth_GLAScudStorm
     DeathFX       = FX_StructureMediumDeath
   End
 
-  Behavior  = CreateObjectDie ModuleTag_20
+  Behavior  = CreateObjectDie ModuleTag_22
     CreationList = OCL_LargeStructureDebris
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -14336,7 +14336,7 @@ Object SupW_AmericaBarracks
     ExemptStatus       = UNDER_CONSTRUCTION
   End
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
   Behavior = ProductionUpdate ModuleTag_11
     ; nothing

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13674,7 +13674,7 @@ Object SupW_AmericaSupplyDropZone
   End
 
   Behavior                  = CreateObjectDie ModuleTag_08
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior             = FlammableUpdate ModuleTag_09

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -15813,6 +15813,11 @@ Object SupW_AmericaPatriotBattery
   Behavior = DestroyDie ModuleTag_09
     ;nothing
   End
+
+  Behavior = CreateObjectDie ModuleTag_11
+    CreationList = OCL_TinyStructureDebris
+  End
+
   Behavior             = FXListDie ModuleTag_10
     DeathFX       = FX_StructureTinyDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -16311,7 +16311,7 @@ Object SupW_AmericaFireBase
   End
 
   Behavior             = FXListDie ModuleTag_10
-    DeathFX       = FX_StructureMediumDeath
+    DeathFX       = FX_StructureSmallDeath
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -16326,7 +16326,7 @@ Object SupW_AmericaFireBase
   End
 
   Behavior                  = CreateObjectDie ModuleTag_13
-    CreationList       = OCL_LargeStructureDebris
+    CreationList       = OCL_SmallStructureDebris
   End
 
   Behavior = TransitionDamageFX ModuleTag_14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13684,7 +13684,7 @@ Object SupW_AmericaSupplyDropZone
   End
 
   Behavior                  = FXListDie ModuleTag_10
-    DeathFX            = FX_StructureMediumDeath
+    DeathFX            = FX_StructureSmallDeath
   End
 
   Behavior = BaseRegenerateUpdate ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -6501,6 +6501,11 @@ Object Tank_ChinaNuclearMissileLauncher
     DeathFX       = FX_NukeGLA
   End
 
+  Behavior = FXListDie ModuleTag_22
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureMediumDeath
+  End
+
   Behavior = CommandSetUpgrade ModuleTag_25
     CommandSet = Tank_ChinaNuclearMissileCommandSetUpgrade
     TriggeredBy = Upgrade_ChinaMines

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -8087,7 +8087,13 @@ Object Tank_ChinaPowerPlant
   End
 
   Behavior             = FXListDie ModuleTag_16
+    ExemptStatus  = UNDER_CONSTRUCTION
     DeathFX       = FX_BuildingDie
+  End
+
+  Behavior = FXListDie ModuleTag_17
+    RequiredStatus = UNDER_CONSTRUCTION
+    DeathFX = FX_StructureSmallDeath
   End
 
   Behavior = CommandSetUpgrade ModuleTag_25

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -13289,6 +13289,11 @@ Object Tank_ChinaPropagandaCenter
   Behavior = DestroyDie ModuleTag_12
     ;<NO DATA>
   End
+
+  Behavior  = CreateObjectDie ModuleTag_13
+    CreationList = OCL_LargeStructureDebris
+  End
+
   Behavior  = FXListDie ModuleTag_14
     DeathFX = FX_StructureMediumDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -14394,7 +14394,7 @@ Object Tank_ChinaGattlingCannon
   End
 
   Behavior        = CreateObjectDie ModuleTag_11
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
 
   Behavior = FlammableUpdate ModuleTag_12

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -7104,7 +7104,7 @@ Object Tank_ChinaSpeakerTower
     ;<NO DATA>
   End
   Behavior        = CreateObjectDie ModuleTag_08
-    CreationList  = OCL_ABPowerPlantExplode
+    CreationList  = OCL_ABSpeakerTowerDebris
   End
   Behavior        = FXListDie ModuleTag_09
     DeathFX       = FX_StructureTinyDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -12424,7 +12424,7 @@ Object Tank_ChinaBunker
   End
 
   Behavior             = CreateObjectDie ModuleTag_13
-    CreationList  = OCL_LargeStructureDebris
+    CreationList  = OCL_TinyStructureDebris
   End
   Behavior             = FXListDie ModuleTag_14
     DeathFX       = FX_StructureSmallDeath

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -3537,6 +3537,100 @@ ObjectCreationList OCL_ABTunnelNetworkDebris
 End
 
 
+; ----------------------------------------------
+ObjectCreationList OCL_ABSpeakerTowerDebris
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:8 Y:8 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-8 Y:-8 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-8 Y:8 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:8 Y:-8 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:8 Y:8 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-8 Y:-8 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-8 Y:8 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:8 Y:-8 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:20
+    Mass = 40
+    Count = 3
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:30
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+End
+
 ; ----------------------------------------------------------------------------
 ; GLA Death
 ; ----------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -2248,6 +2248,91 @@ ObjectCreationList OCL_SmallStructureDebris
 End
 
 ; ----------------------------------------------
+ObjectCreationList OCL_TinyStructureDebris
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:10 Y:10 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-10 Y:-10 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-10 Y:10 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:10 Y:-10 Z:5
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:10 Y:10 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-10 Y:-10 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:-10 Y:10 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10
+    Offset = X:10 Y:-10 Z:10
+    Mass = 40
+    Count = 2
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+  CreateDebris
+    ModelNames = ABPwrPlant_d11 ABPwrPlant_d12 ABPwrPlant_d13 ABPwrPlant_d14 ABPwrPlant_d15 ABPwrPlant_d16 ABPwrPlant_d17 ABPwrPlant_d18 ABPwrPlant_d19 ABPwrPlant_d20
+    Offset = X:0 Y:0 Z:15
+    Mass = 40
+    Count = 6
+    Disposition = SEND_IT_FLYING
+    DispositionIntensity = 3
+    BounceSound = BuildingDebris
+  End
+End
+
+; ----------------------------------------------
 ObjectCreationList OCL_ParticleUplinkDeathFinal
 ; SlowDeath treats two listings as an OR, so this combines the two it was using. OCL_ABPowerPlantExplode & OCL_AmericanRangerDebris06
   CreateObject


### PR DESCRIPTION
Applied a bunch of fixes to various building scaffold death effects, and tweaked some death effect sizes. The reason for the missing effects was due to the custom 'explosion' death replacements for the respective buildings, which are exempt from playing while `UNDER_CONSTRUCTION`. The equivalent effects for the `UNDER_CONSTRUCTION` condition were evidently overlooked.

- Scud Storms now play an appropriate effect when the scaffold is cancelled.
- Nuclear Reactors now play an appropriate effect when the scaffold is cancelled.
- Nuclear Silos now play an appropriate effect when the scaffold is cancelled.
- Reduced the size of America Barracks death effects (medium → small).
- Reduced the size of Firebase death effects (medium → small).
- Reduced the size of Supply Drop Zone death effects (medium → small).

## 1.04:
When the Scud Storm scaffold is cancelled, there is no proper effect.

https://user-images.githubusercontent.com/11547761/196043627-d2a31e85-6cab-44ee-a114-bf0b0534d6f9.mp4

## Patch:
When the Scud Storm scaffold is cancelled, there is a proper effect.

https://user-images.githubusercontent.com/11547761/196043635-8ccd21d2-1a08-45bf-9b38-0c643fbee5af.mp4