### PR TITLE
Fix: America War Factory Smoke Coming From Center Of Building, Spawn Smoke When Constructing Only

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -15204,16 +15204,17 @@ Object AirF_AmericaWarFactory
   SelectPortrait = SACWeaponsfact_L
   ButtonImage            = SACWeaponsfact
 
+  ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
+  ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day **************************************************
-    DefaultConditionState
+    ConditionState = NONE
       Model           = ABWarFact
       Animation       = ABWarFact.ABWarFact
       AnimationMode   = LOOP
-      ParticleSysBone = Smoke01 SteamVent
-      ParticleSysBone = Smoke02 SteamVent
     End
     ConditionState = DAMAGED
       Model           = ABWarFact_D
@@ -15226,6 +15227,26 @@ Object AirF_AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING
+      Model           = ABWarFact
+      Animation       = ABWarFact.ABWarFact
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED
+      Model           = ABWarFact_D
+      Animation       = ABWarFact_D.ABWarFact_D
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+      Model           = ABWarFact_E
+      Animation       = ABWarFact_E.ABWarFact_E
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night *************************************************
     ConditionState = NIGHT
@@ -15242,6 +15263,27 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_EN
       Animation       = ABWarFact_EN.ABWarFact_EN
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT
+      Model           = ABWarFact_N
+      Animation       = ABWarFact_N.ABWarFact_N
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT
+      Model           = ABWarFact_DN
+      Animation       = ABWarFact_DN.ABWarFact_DN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT
+      Model           = ABWarFact_EN
+      Animation       = ABWarFact_EN.ABWarFact_EN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ; snow *************************************************
@@ -15261,6 +15303,26 @@ Object AirF_AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING SNOW
+      Model           = ABWarFact_S
+      Animation       = ABWarFact_S.ABWarFact_S
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED SNOW
+      Model           = ABWarFact_DS
+      Animation       = ABWarFact_DS.ABWarFact_DS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE SNOW
+      Model           = ABWarFact_ES
+      Animation       = ABWarFact_ES.ABWarFact_ES
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night snow *************************************************
     ConditionState = NIGHT SNOW
@@ -15277,6 +15339,27 @@ Object AirF_AmericaWarFactory
       Model           = ABWarFact_ENS
       Animation       = ABWarFact_ENS.ABWarFact_ENS
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT SNOW
+      Model           = ABWarFact_NS
+      Animation       = ABWarFact_NS.ABWarFact_NS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT SNOW
+      Model           = ABWarFact_DNS
+      Animation       = ABWarFact_DNS.ABWarFact_DNS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT SNOW
+      Model           = ABWarFact_ENS
+      Animation       = ABWarFact_ENS.ABWarFact_ENS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ;**************************************************************************************************************************

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -25799,16 +25799,17 @@ Object AmericaWarFactory
   SelectPortrait = SACWeaponsfact_L
   ButtonImage            = SACWeaponsfact
 
+  ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
+  ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day **************************************************
-    DefaultConditionState
+    ConditionState = NONE
       Model           = ABWarFact
       Animation       = ABWarFact.ABWarFact
       AnimationMode   = LOOP
-      ParticleSysBone = Smoke01 SteamVent
-      ParticleSysBone = Smoke02 SteamVent
     End
     ConditionState = DAMAGED
       Model           = ABWarFact_D
@@ -25821,6 +25822,26 @@ Object AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING
+      Model           = ABWarFact
+      Animation       = ABWarFact.ABWarFact
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED
+      Model           = ABWarFact_D
+      Animation       = ABWarFact_D.ABWarFact_D
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+      Model           = ABWarFact_E
+      Animation       = ABWarFact_E.ABWarFact_E
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night *************************************************
     ConditionState = NIGHT
@@ -25837,6 +25858,27 @@ Object AmericaWarFactory
       Model           = ABWarFact_EN
       Animation       = ABWarFact_EN.ABWarFact_EN
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT
+      Model           = ABWarFact_N
+      Animation       = ABWarFact_N.ABWarFact_N
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT
+      Model           = ABWarFact_DN
+      Animation       = ABWarFact_DN.ABWarFact_DN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT
+      Model           = ABWarFact_EN
+      Animation       = ABWarFact_EN.ABWarFact_EN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ; snow *************************************************
@@ -25856,6 +25898,26 @@ Object AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING SNOW
+      Model           = ABWarFact_S
+      Animation       = ABWarFact_S.ABWarFact_S
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED SNOW
+      Model           = ABWarFact_DS
+      Animation       = ABWarFact_DS.ABWarFact_DS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE SNOW
+      Model           = ABWarFact_ES
+      Animation       = ABWarFact_ES.ABWarFact_ES
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night snow *************************************************
     ConditionState = NIGHT SNOW
@@ -25872,6 +25934,27 @@ Object AmericaWarFactory
       Model           = ABWarFact_ENS
       Animation       = ABWarFact_ENS.ABWarFact_ENS
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT SNOW
+      Model           = ABWarFact_NS
+      Animation       = ABWarFact_NS.ABWarFact_NS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT SNOW
+      Model           = ABWarFact_DNS
+      Animation       = ABWarFact_DNS.ABWarFact_DNS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT SNOW
+      Model           = ABWarFact_ENS
+      Animation       = ABWarFact_ENS.ABWarFact_ENS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ;**************************************************************************************************************************

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14889,16 +14889,17 @@ Object Lazr_AmericaWarFactory
   SelectPortrait = SACWeaponsfact_L
   ButtonImage            = SACWeaponsfact
 
+  ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
+  ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day **************************************************
-    DefaultConditionState
+    ConditionState = NONE
       Model           = ABWarFact
       Animation       = ABWarFact.ABWarFact
       AnimationMode   = LOOP
-      ParticleSysBone = Smoke01 SteamVent
-      ParticleSysBone = Smoke02 SteamVent
     End
     ConditionState = DAMAGED
       Model           = ABWarFact_D
@@ -14911,6 +14912,26 @@ Object Lazr_AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING
+      Model           = ABWarFact
+      Animation       = ABWarFact.ABWarFact
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED
+      Model           = ABWarFact_D
+      Animation       = ABWarFact_D.ABWarFact_D
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+      Model           = ABWarFact_E
+      Animation       = ABWarFact_E.ABWarFact_E
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night *************************************************
     ConditionState = NIGHT
@@ -14927,6 +14948,27 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_EN
       Animation       = ABWarFact_EN.ABWarFact_EN
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT
+      Model           = ABWarFact_N
+      Animation       = ABWarFact_N.ABWarFact_N
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT
+      Model           = ABWarFact_DN
+      Animation       = ABWarFact_DN.ABWarFact_DN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT
+      Model           = ABWarFact_EN
+      Animation       = ABWarFact_EN.ABWarFact_EN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ; snow *************************************************
@@ -14946,6 +14988,26 @@ Object Lazr_AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING SNOW
+      Model           = ABWarFact_S
+      Animation       = ABWarFact_S.ABWarFact_S
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED SNOW
+      Model           = ABWarFact_DS
+      Animation       = ABWarFact_DS.ABWarFact_DS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE SNOW
+      Model           = ABWarFact_ES
+      Animation       = ABWarFact_ES.ABWarFact_ES
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night snow *************************************************
     ConditionState = NIGHT SNOW
@@ -14962,6 +15024,27 @@ Object Lazr_AmericaWarFactory
       Model           = ABWarFact_ENS
       Animation       = ABWarFact_ENS.ABWarFact_ENS
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT SNOW
+      Model           = ABWarFact_NS
+      Animation       = ABWarFact_NS.ABWarFact_NS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT SNOW
+      Model           = ABWarFact_DNS
+      Animation       = ABWarFact_DNS.ABWarFact_DNS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT SNOW
+      Model           = ABWarFact_ENS
+      Animation       = ABWarFact_ENS.ABWarFact_ENS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ;**************************************************************************************************************************

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -14323,16 +14323,17 @@ Object SupW_AmericaWarFactory
   SelectPortrait = SACWeaponsfact_L
   ButtonImage            = SACWeaponsfact
 
+  ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
+  ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day **************************************************
-    DefaultConditionState
+    ConditionState = NONE
       Model           = ABWarFact
       Animation       = ABWarFact.ABWarFact
       AnimationMode   = LOOP
-      ParticleSysBone = Smoke01 SteamVent
-      ParticleSysBone = Smoke02 SteamVent
     End
     ConditionState = DAMAGED
       Model           = ABWarFact_D
@@ -14345,6 +14346,26 @@ Object SupW_AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING
+      Model           = ABWarFact
+      Animation       = ABWarFact.ABWarFact
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED
+      Model           = ABWarFact_D
+      Animation       = ABWarFact_D.ABWarFact_D
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+      Model           = ABWarFact_E
+      Animation       = ABWarFact_E.ABWarFact_E
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night *************************************************
     ConditionState = NIGHT
@@ -14361,6 +14382,27 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_EN
       Animation       = ABWarFact_EN.ABWarFact_EN
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT
+      Model           = ABWarFact_N
+      Animation       = ABWarFact_N.ABWarFact_N
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT
+      Model           = ABWarFact_DN
+      Animation       = ABWarFact_DN.ABWarFact_DN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT
+      Model           = ABWarFact_EN
+      Animation       = ABWarFact_EN.ABWarFact_EN
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ; snow *************************************************
@@ -14380,6 +14422,26 @@ Object SupW_AmericaWarFactory
       AnimationMode   = LOOP
     End
 
+    ConditionState = ACTIVELY_CONSTRUCTING SNOW
+      Model           = ABWarFact_S
+      Animation       = ABWarFact_S.ABWarFact_S
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED SNOW
+      Model           = ABWarFact_DS
+      Animation       = ABWarFact_DS.ABWarFact_DS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE SNOW
+      Model           = ABWarFact_ES
+      Animation       = ABWarFact_ES.ABWarFact_ES
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+    End
 
     ; night snow *************************************************
     ConditionState = NIGHT SNOW
@@ -14396,6 +14458,27 @@ Object SupW_AmericaWarFactory
       Model           = ABWarFact_ENS
       Animation       = ABWarFact_ENS.ABWarFact_ENS
       AnimationMode   = LOOP
+    End
+
+    ConditionState = ACTIVELY_CONSTRUCTING NIGHT SNOW
+      Model           = ABWarFact_NS
+      Animation       = ABWarFact_NS.ABWarFact_NS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING DAMAGED NIGHT SNOW
+      Model           = ABWarFact_DNS
+      Animation       = ABWarFact_DNS.ABWarFact_DNS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
+    End
+    ConditionState = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE NIGHT SNOW
+      Model           = ABWarFact_ENS
+      Animation       = ABWarFact_ENS.ABWarFact_ENS
+      AnimationMode   = LOOP
+      ParticleSysBone = Smoke01 SteamVent
     End
 
     ;**************************************************************************************************************************


### PR DESCRIPTION
### 1.04

![shot_20221016_175323_1](https://user-images.githubusercontent.com/6576312/196045438-86981184-937c-48fa-806e-4f109f64cbb1.jpg)
![shot_20221016_175349_2](https://user-images.githubusercontent.com/6576312/196045445-4f9b90d9-56d2-4ec7-9afd-76579f18b690.jpg)
![shot_20221016_175736_1](https://user-images.githubusercontent.com/6576312/196045449-c68bfe01-ef64-445f-8f98-18b31762c03e.jpg)

- Smoke spawns from center of 0% scaffold (2 particle sources on top of each other in fact)
- Smoke spawns while the building is being constructed (what?), and it spawns where the chimney will end, not where it is.
- In badly damaged state, because one chimney has collapsed and the corresponding particle bone is deleted, one smoke source spawns at the center of the object.

### patch

- Smoke spawns only when building a unit or upgrade.
- Smoke no longer spawns from center of object in badly damaged state.