### PR TITLE
Change: Reduce Supply Drop Zone crate count from 6 to 3

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -549,7 +549,7 @@ Object SupplyDropZoneCrate
   KindOf = PARACHUTABLE CRATE INERT
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
-    MoneyProvided = 250
+    MoneyProvided = 500 ; Patch104p @tweak from 250
     UpgradedBoost = UpgradeType:Upgrade_AmericaSupplyLines  Boost:25
     BuildingPickup = Yes
     ;ExecuteFX = FX_CratePickup

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6596,6 +6596,7 @@ End
 
 
 ; Patch104p @performance hanfield commy2 06/08/2022 Do not attack SDZ plane for performance in spam games.
+; Patch104p @performance xezon 18/10/2022 Drop 3 crates worth 500$ each instead of 6 worth 250$ each to reduce world object count.
 ; -----------------------------------------------------------------------------
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_AmericaSupplyDropZoneCrateDrop
@@ -6605,12 +6606,12 @@ ObjectCreationList OCL_AmericaSupplyDropZoneCrateDrop
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-5
-    DropDelay = 350
+    DropDelay = 500 ; Patch104p @tweak from 350
     PutInContainer = AmericaCrateParachute
-    Payload = SupplyDropZoneCrate 6
+    Payload = SupplyDropZoneCrate 3 ; Patch104p @tweak from 6
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     ; up on the target instead of parachuting to the spot below their drop point.
-    DeliveryDistance = 410
+    DeliveryDistance = 350 ; Patch104p @tweak from 410
   End
 End
 


### PR DESCRIPTION
This change reduces the Supply Drop Zone crate count from 6 to 3. The value per crate increases from 250 to 500. For gameplay this should make no difference. The Supply Drop is no player controlled event. The first crate of 3 will fall down a bit later than the first crate of 6, but the last crate of 3 drops earlier than the last crate of 6.

I calculated the new drop distance with

410 * (1 - (1 - ((500 * 3) / (350 * 6))) * 0.5) = 351.4

The reduced crate count spams less sounds and spawns less world objects, which incurs less performance cost.

## Original

https://user-images.githubusercontent.com/4720891/196511579-9352fbaf-3d4f-41e2-8a33-9edfaa058c1e.mp4

## Patched

https://user-images.githubusercontent.com/4720891/196511663-a1092549-dab2-4e56-9719-6184c6f10cb3.mp4

## Rationale

Less world objects impose less cost in the game world. As illustrated above, the reduced crate count causes boxes to intersect less and spawn less sounds. Originally the sounds could not even keep up with the amount, as some parachute and cash sounds would be swallowed by the short interval. Additionally the new 3 boxes fly more gentle to the center of the Supply Drop Zone than some of the original ones which may land on the outer edges.