### PR TITLE
Change: Reduce particle count of AmericaJetCargoPlane_SupplyDropZone

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -2513,6 +2513,7 @@ Object AmericaJetCargoPlane
 End
 
 ; Patch104p @performance hanfield commy2 06/08/2022 A harmless plane that can not be attacked.
+; Patch104p @performance xezon 18/10/2022 Reduce particle count for this plane.
 ;------------------------------------------------------------------------------
 Object AmericaJetCargoPlane_SupplyDropZone
 
@@ -2522,10 +2523,10 @@ Object AmericaJetCargoPlane_SupplyDropZone
       Model            = AVCargoPln
       Animation       = AVCargoPln.AVCargoPln
       AnimationMode   = LOOP
-      ParticleSysBone = Propeller01 JetBlackTrailThin
-      ParticleSysBone = Propeller02 JetBlackTrailThin
-      ParticleSysBone = Propeller03 JetBlackTrailThin
-      ParticleSysBone = Propeller04 JetBlackTrailThin
+      ;ParticleSysBone = Propeller01 JetBlackTrailThin
+      ;ParticleSysBone = Propeller02 JetBlackTrailThin
+      ;ParticleSysBone = Propeller03 JetBlackTrailThin
+      ;ParticleSysBone = Propeller04 JetBlackTrailThin
       ParticleSysBone = WingTip01 JetContrailThin
       ParticleSysBone = WingTip02 JetContrailThin
     End


### PR DESCRIPTION
This change removes the black smoke trails from all 4 propellers on Supply Drop Zone plane. Only the contrails on the wing tips remain. This will render it a bit cheaper.