### PR TITLE
Change: Animate China War Factory Crane When Repairing Instead Of When Constructing

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -10921,6 +10921,7 @@ Object Boss_WarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Remove effects without bones.
   ; Patch104p @bugfix commy2 16/10/2022 Fix conveyor belt and construction crane animations.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw                = W3DModelDraw ModuleTag_01
@@ -11083,7 +11084,7 @@ Object Boss_WarFactory
 
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw                   = W3DModelDraw ModuleTag_02
     OkToChangeModelColor = Yes
 
@@ -11106,44 +11107,44 @@ Object Boss_WarFactory
       TransitionKey      = TRANS_IdleReallyDamaged
     End
 
-    TransitionState      = TRANS_Constructing TRANS_Idle
+    TransitionState      = TRANS_Repairing TRANS_Idle
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState      = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState      = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
 
-    ConditionState       = ACTIVELY_CONSTRUCTING
+    ConditionState       = DOCKING_ACTIVE
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_Constructing
+      TransitionKey      = TRANS_Repairing
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState       = DOCKING_ACTIVE DAMAGED
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingDamaged
+      TransitionKey      = TRANS_RepairingDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState       = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingReallyDamaged
+      TransitionKey      = TRANS_RepairingReallyDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -28808,6 +28808,7 @@ Object ChinaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Remove effects without bones.
   ; Patch104p @bugfix commy2 16/10/2022 Fix conveyor belt and construction crane animations.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw                = W3DModelDraw ModuleTag_01
@@ -28970,7 +28971,7 @@ Object ChinaWarFactory
 
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw                   = W3DModelDraw ModuleTag_02
     OkToChangeModelColor = Yes
 
@@ -28993,44 +28994,44 @@ Object ChinaWarFactory
       TransitionKey      = TRANS_IdleReallyDamaged
     End
 
-    TransitionState      = TRANS_Constructing TRANS_Idle
+    TransitionState      = TRANS_Repairing TRANS_Idle
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState      = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState      = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
 
-    ConditionState       = ACTIVELY_CONSTRUCTING
+    ConditionState       = DOCKING_ACTIVE
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_Constructing
+      TransitionKey      = TRANS_Repairing
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState       = DOCKING_ACTIVE DAMAGED
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingDamaged
+      TransitionKey      = TRANS_RepairingDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState       = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingReallyDamaged
+      TransitionKey      = TRANS_RepairingReallyDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -9874,6 +9874,7 @@ Object Infa_ChinaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Remove effects without bones.
   ; Patch104p @bugfix commy2 16/10/2022 Fix conveyor belt and construction crane animations.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw                = W3DModelDraw ModuleTag_01
@@ -10036,7 +10037,7 @@ Object Infa_ChinaWarFactory
 
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw                   = W3DModelDraw ModuleTag_02
     OkToChangeModelColor = Yes
 
@@ -10059,44 +10060,44 @@ Object Infa_ChinaWarFactory
       TransitionKey      = TRANS_IdleReallyDamaged
     End
 
-    TransitionState      = TRANS_Constructing TRANS_Idle
+    TransitionState      = TRANS_Repairing TRANS_Idle
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState      = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState      = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
 
-    ConditionState       = ACTIVELY_CONSTRUCTING
+    ConditionState       = DOCKING_ACTIVE
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_Constructing
+      TransitionKey      = TRANS_Repairing
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState       = DOCKING_ACTIVE DAMAGED
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingDamaged
+      TransitionKey      = TRANS_RepairingDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState       = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingReallyDamaged
+      TransitionKey      = TRANS_RepairingReallyDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -11651,6 +11651,7 @@ Object Nuke_ChinaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Remove effects without bones.
   ; Patch104p @bugfix commy2 16/10/2022 Fix conveyor belt and construction crane animations.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw                = W3DModelDraw ModuleTag_01
@@ -11813,7 +11814,7 @@ Object Nuke_ChinaWarFactory
 
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw                   = W3DModelDraw ModuleTag_02
     OkToChangeModelColor = Yes
 
@@ -11836,44 +11837,44 @@ Object Nuke_ChinaWarFactory
       TransitionKey      = TRANS_IdleReallyDamaged
     End
 
-    TransitionState      = TRANS_Constructing TRANS_Idle
+    TransitionState      = TRANS_Repairing TRANS_Idle
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState      = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState      = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
 
-    ConditionState       = ACTIVELY_CONSTRUCTING
+    ConditionState       = DOCKING_ACTIVE
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_Constructing
+      TransitionKey      = TRANS_Repairing
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState       = DOCKING_ACTIVE DAMAGED
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingDamaged
+      TransitionKey      = TRANS_RepairingDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState       = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingReallyDamaged
+      TransitionKey      = TRANS_RepairingReallyDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -10708,6 +10708,7 @@ Object Tank_ChinaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Remove effects without bones.
   ; Patch104p @bugfix commy2 16/10/2022 Fix conveyor belt and construction crane animations.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw                = W3DModelDraw ModuleTag_01
@@ -10870,7 +10871,7 @@ Object Tank_ChinaWarFactory
 
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw                   = W3DModelDraw ModuleTag_02
     OkToChangeModelColor = Yes
 
@@ -10893,44 +10894,44 @@ Object Tank_ChinaWarFactory
       TransitionKey      = TRANS_IdleReallyDamaged
     End
 
-    TransitionState      = TRANS_Constructing TRANS_Idle
+    TransitionState      = TRANS_Repairing TRANS_Idle
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState      = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState      = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState      = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
       Flags              = MAINTAIN_FRAME_ACROSS_STATES
     End
 
-    ConditionState       = ACTIVELY_CONSTRUCTING
+    ConditionState       = DOCKING_ACTIVE
       Model              = NBWarFact_A2
       Animation          = NBWarFact_A2.NBWarFact_A2
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_Constructing
+      TransitionKey      = TRANS_Repairing
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState       = DOCKING_ACTIVE DAMAGED
       Model              = NBWarFact_A2D
       Animation          = NBWarFact_A2D.NBWarFact_A2D
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingDamaged
+      TransitionKey      = TRANS_RepairingDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState       = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState       = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model              = NBWarFact_A2E
       Animation          = NBWarFact_A2E.NBWarFact_A2E
       AnimationMode      = ONCE
-      TransitionKey      = TRANS_ConstructingReallyDamaged
+      TransitionKey      = TRANS_RepairingReallyDamaged
       Flags              = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
 


### PR DESCRIPTION
### 1.04

- Crane on War Factory moves while building a unit.

### patch

- Crane on War Factory moves while repairing a unit instead.
- You can still tell if a unit is being build, because the baskets filled with molten metal are animated.