### PR TITLE
Change: Animate USA War Factory Crane When Repairing Instead Of When Constructing

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -15213,6 +15213,7 @@ Object AirF_AmericaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
   ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
@@ -15632,7 +15633,7 @@ Object AirF_AmericaWarFactory
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw = W3DModelDraw ModuleTag_03
     ; -----------------------------------------------------------
     OkToChangeModelColor = Yes
@@ -15657,19 +15658,19 @@ Object AirF_AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    TransitionState   = TRANS_Constructing TRANS_Idle
+    TransitionState   = TRANS_Repairing TRANS_Idle
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState   = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState   = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
@@ -15677,25 +15678,25 @@ Object AirF_AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    ConditionState    = ACTIVELY_CONSTRUCTING
+    ConditionState    = DOCKING_ACTIVE
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_Constructing
+      TransitionKey   = TRANS_Repairing
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState    = DOCKING_ACTIVE DAMAGED
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingDamaged
+      TransitionKey   = TRANS_RepairingDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState    = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingReallyDamaged
+      TransitionKey   = TRANS_RepairingReallyDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
     ; -----------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -25808,6 +25808,7 @@ Object AmericaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
   ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
@@ -26227,7 +26228,7 @@ Object AmericaWarFactory
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw = W3DModelDraw ModuleTag_03
     ; -----------------------------------------------------------
     OkToChangeModelColor = Yes
@@ -26252,19 +26253,19 @@ Object AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    TransitionState   = TRANS_Constructing TRANS_Idle
+    TransitionState   = TRANS_Repairing TRANS_Idle
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState   = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState   = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
@@ -26272,25 +26273,25 @@ Object AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    ConditionState    = ACTIVELY_CONSTRUCTING
+    ConditionState    = DOCKING_ACTIVE
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_Constructing
+      TransitionKey   = TRANS_Repairing
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState    = DOCKING_ACTIVE DAMAGED
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingDamaged
+      TransitionKey   = TRANS_RepairingDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState    = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingReallyDamaged
+      TransitionKey   = TRANS_RepairingReallyDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
     ; -----------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14898,6 +14898,7 @@ Object Lazr_AmericaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
   ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
@@ -15317,7 +15318,7 @@ Object Lazr_AmericaWarFactory
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw = W3DModelDraw ModuleTag_03
     ; -----------------------------------------------------------
     OkToChangeModelColor = Yes
@@ -15342,19 +15343,19 @@ Object Lazr_AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    TransitionState   = TRANS_Constructing TRANS_Idle
+    TransitionState   = TRANS_Repairing TRANS_Idle
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState   = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState   = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
@@ -15362,25 +15363,25 @@ Object Lazr_AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    ConditionState    = ACTIVELY_CONSTRUCTING
+    ConditionState    = DOCKING_ACTIVE
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_Constructing
+      TransitionKey   = TRANS_Repairing
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState    = DOCKING_ACTIVE DAMAGED
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingDamaged
+      TransitionKey   = TRANS_RepairingDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState    = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingReallyDamaged
+      TransitionKey   = TRANS_RepairingReallyDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
     ; -----------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -14332,6 +14332,7 @@ Object SupW_AmericaWarFactory
 
   ; Patch104p @bugfix commy2 16/10/2022 Fix smoke column emerging from center of building when badly damaged or 0% scaffold.
   ; Patch104p @change commy2 16/10/2022 Make smoke spawn from chimney only when building vehicles or upgrades.
+  ; Patch104p @change commy2 19/10/2022 Make crane animation only play while repairing.
 
   ; ------------ the main factory itself -----------------
   Draw = W3DModelDraw ModuleTag_01
@@ -14751,7 +14752,7 @@ Object SupW_AmericaWarFactory
     AliasConditionState  = SOLD NIGHT SNOW REALLYDAMAGED
   End
 
-  ; ------------------ the construction crane ------------
+  ; ------------------ the repair crane ------------
   Draw = W3DModelDraw ModuleTag_03
     ; -----------------------------------------------------------
     OkToChangeModelColor = Yes
@@ -14776,19 +14777,19 @@ Object SupW_AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    TransitionState   = TRANS_Constructing TRANS_Idle
+    TransitionState   = TRANS_Repairing TRANS_Idle
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingDamaged TRANS_IdleDamaged
+    TransitionState   = TRANS_RepairingDamaged TRANS_IdleDamaged
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
       Flags           = MAINTAIN_FRAME_ACROSS_STATES
     End
-    TransitionState   = TRANS_ConstructingReallyDamaged TRANS_IdleReallyDamaged
+    TransitionState   = TRANS_RepairingReallyDamaged TRANS_IdleReallyDamaged
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
@@ -14796,25 +14797,25 @@ Object SupW_AmericaWarFactory
     End
 
     ; -----------------------------------------------------------
-    ConditionState    = ACTIVELY_CONSTRUCTING
+    ConditionState    = DOCKING_ACTIVE
       Model           = ABWarFact_A3
       Animation       = ABWarFact_A3.ABWarFact_A3
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_Constructing
+      TransitionKey   = TRANS_Repairing
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING DAMAGED
+    ConditionState    = DOCKING_ACTIVE DAMAGED
       Model           = ABWarFact_A3D
       Animation       = ABWarFact_A3D.ABWarFact_A3D
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingDamaged
+      TransitionKey   = TRANS_RepairingDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
-    ConditionState    = ACTIVELY_CONSTRUCTING REALLYDAMAGED RUBBLE
+    ConditionState    = DOCKING_ACTIVE REALLYDAMAGED RUBBLE
       Model           = ABWarFact_A3E
       Animation       = ABWarFact_A3E.ABWarFact_A3E
       AnimationMode   = ONCE
-      TransitionKey   = TRANS_ConstructingReallyDamaged
+      TransitionKey   = TRANS_RepairingReallyDamaged
       Flags           = MAINTAIN_FRAME_ACROSS_STATES RESTART_ANIM_WHEN_COMPLETE
     End
     ; -----------------------------------------------------------


### PR DESCRIPTION
### 1.04

- Crane on War Factory moves while building a unit.

### patch

- Crane on War Factory moves while repairing a unit instead.
- You can still tell if a unit is being build, because it produces smoke from the chimney.