### PR TITLE
Fix: China Power Plant Particle Effect Issues And Remove Effects Without Bones

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -18542,7 +18542,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -18579,7 +18579,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -18607,7 +18607,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -18644,7 +18644,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -18677,7 +18677,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -18720,7 +18720,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -18753,7 +18753,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -18796,7 +18796,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -18520,6 +18520,10 @@ Object ChinaPowerPlant
   ; *** ART Parameters ***
   SelectPortrait         = SNReactor_L
   ButtonImage            = SNReactor
+
+  ; Patch104p @bugfix commy2 20/10/2022 Remove sparks when badly damaged without overcharging on day maps.
+  ; Patch104p @bugfix commy2 20/10/2022 Remove effects without bones and fix some particle effect inconsistencies between day and night maps.
+
   ;day
   Draw                = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -18530,27 +18534,18 @@ Object ChinaPowerPlant
     End
     ConditionState    = DAMAGED
       Model           = NBPwrPlant_D
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -18571,11 +18566,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_D
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -18588,12 +18579,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -18613,27 +18599,18 @@ Object ChinaPowerPlant
     End
     ConditionState    = DAMAGED SNOW
       Model           = NBPwrPlant_DS
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE SNOW
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -18654,11 +18631,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_DS
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -18671,12 +18644,7 @@ Object ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -18701,11 +18669,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model           = NBPwrPlant_ENS
@@ -18713,12 +18677,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -18746,11 +18705,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -18765,12 +18720,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -18795,11 +18745,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBPwrPlant_EN
@@ -18807,12 +18753,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -18840,11 +18781,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -18859,12 +18796,7 @@ Object ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -7578,6 +7578,10 @@ Object Infa_ChinaPowerPlant
   ; *** ART Parameters ***
   SelectPortrait         = SNReactor_L
   ButtonImage            = SNReactor
+
+  ; Patch104p @bugfix commy2 20/10/2022 Remove sparks when badly damaged without overcharging on day maps.
+  ; Patch104p @bugfix commy2 20/10/2022 Remove effects without bones and fix some particle effect inconsistencies between day and night maps.
+
   ;day
   Draw                = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -7588,27 +7592,18 @@ Object Infa_ChinaPowerPlant
     End
     ConditionState    = DAMAGED
       Model           = NBPwrPlant_D
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -7629,11 +7624,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_D
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7646,12 +7637,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7671,27 +7657,18 @@ Object Infa_ChinaPowerPlant
     End
     ConditionState    = DAMAGED SNOW
       Model           = NBPwrPlant_DS
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE SNOW
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -7712,11 +7689,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_DS
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7729,12 +7702,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7759,11 +7727,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model           = NBPwrPlant_ENS
@@ -7771,12 +7735,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7804,11 +7763,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7823,12 +7778,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7853,11 +7803,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBPwrPlant_EN
@@ -7865,12 +7811,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7898,11 +7839,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7917,12 +7854,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -7600,7 +7600,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7637,7 +7637,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7665,7 +7665,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7702,7 +7702,7 @@ Object Infa_ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7735,7 +7735,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7778,7 +7778,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7811,7 +7811,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7854,7 +7854,7 @@ Object Infa_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -9355,6 +9355,10 @@ Object Nuke_ChinaPowerPlant
   ; *** ART Parameters ***
   SelectPortrait         = SNAdvReactor_L
   ButtonImage            = SNAdvReactor
+
+  ; Patch104p @bugfix commy2 20/10/2022 Remove sparks when badly damaged without overcharging on day maps.
+  ; Patch104p @bugfix commy2 20/10/2022 Remove effects without bones and fix some particle effect inconsistencies between day and night maps.
+
   ;day
   Draw                = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -9365,27 +9369,18 @@ Object Nuke_ChinaPowerPlant
     End
     ConditionState    = DAMAGED
       Model           = NBPwrPtI_D
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE
       Model           = NBPwrPtI_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -9406,11 +9401,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_D
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9423,12 +9414,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -9448,27 +9434,18 @@ Object Nuke_ChinaPowerPlant
     End
     ConditionState    = DAMAGED SNOW
       Model           = NBPwrPtI_DS
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE SNOW
       Model           = NBPwrPtI_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -9489,11 +9466,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_DS
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9506,12 +9479,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -9536,11 +9504,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model           = NBPwrPtI_ENS
@@ -9548,12 +9512,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -9581,11 +9540,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9600,12 +9555,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -9630,11 +9580,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBPwrPtI_EN
@@ -9642,12 +9588,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -9675,11 +9616,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9694,12 +9631,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -9377,7 +9377,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -9414,7 +9414,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -9442,7 +9442,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -9479,7 +9479,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -9512,7 +9512,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -9555,7 +9555,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -9588,7 +9588,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -9631,7 +9631,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -7335,7 +7335,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7372,7 +7372,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7400,7 +7400,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7437,7 +7437,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7470,7 +7470,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7513,7 +7513,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7546,7 +7546,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7589,7 +7589,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke06 SmolderingSmoke
+      ParticleSysBone = Smoke06 FireFactionMedium
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -7313,6 +7313,10 @@ Object Tank_ChinaPowerPlant
   ; *** ART Parameters ***
   SelectPortrait         = SNReactor_L
   ButtonImage            = SNReactor
+
+  ; Patch104p @bugfix commy2 20/10/2022 Remove sparks when badly damaged without overcharging on day maps.
+  ; Patch104p @bugfix commy2 20/10/2022 Remove effects without bones and fix some particle effect inconsistencies between day and night maps.
+
   ;day
   Draw                = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -7323,27 +7327,18 @@ Object Tank_ChinaPowerPlant
     End
     ConditionState    = DAMAGED
       Model           = NBPwrPlant_D
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -7364,11 +7359,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_D
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7381,12 +7372,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_E
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7406,27 +7392,18 @@ Object Tank_ChinaPowerPlant
     End
     ConditionState    = DAMAGED SNOW
       Model           = NBPwrPlant_DS
-      ParticleSysBone = Smoke01 SteamLarge
-      ParticleSysBone = Smoke02 SteamMedium
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
+      ParticleSysBone = Smoke01 SteamVent
+      ParticleSysBone = Smoke02 SteamVent
       ParticleSysBone = Smoke06 FireFactionLarge
-      ParticleSysBone = Fire01  SmolderingFire
     End
     ConditionState    = REALLYDAMAGED RUBBLE SNOW
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
-      ParticleSysBone = Spark01 SparksLarge
-      ParticleSysBone = Spark02 SparksMedium
-      ParticleSysBone = Spark03 SparksSmall
+      ParticleSysBone = Spark01 LiveWireSparks
+      ParticleSysBone = Spark02 LiveWireSparks
+      ParticleSysBone = Spark03 LiveWireSparks
       ParticleSysBone = Spark04 LiveWireSparks
     End
 
@@ -7447,11 +7424,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_DS
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7464,12 +7437,7 @@ Object Tank_ChinaPowerPlant
       Model           = NBPwrPlant_ES
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7494,11 +7462,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT SNOW
       Model           = NBPwrPlant_ENS
@@ -7506,12 +7470,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7539,11 +7498,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7558,12 +7513,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge
@@ -7588,11 +7538,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
       Model           = NBPwrPlant_EN
@@ -7600,12 +7546,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 LiveWireSparks
       ParticleSysBone = Spark02 LiveWireSparks
       ParticleSysBone = Spark03 LiveWireSparks
@@ -7633,11 +7574,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
-      ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
+      ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -7652,12 +7589,7 @@ Object Tank_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
-      ParticleSysBone = Smoke03 SmolderingSmoke
-      ParticleSysBone = Smoke04 SmolderingSmoke
-      ParticleSysBone = Smoke05 SmolderingSmoke
       ParticleSysBone = Smoke06 SmolderingSmoke
-      ParticleSysBone = Fire01  SmolderingFire
-      ParticleSysBone = Fire02  SmolderingFire
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksLarge


### PR DESCRIPTION
### 1.04

![China Power Plant 1 04](https://user-images.githubusercontent.com/6576312/196812794-b837d25d-1d71-4d3e-be20-d5a2182733bd.jpg)

- Overcharging sparks are shown while badly damaged, even when not Overcharging (not visible in image). This also only happens on day maps.
- Smoke and fire effects at center of building in damaged and badly damaged states due to effects on non-existing bones.
- Chimney smoke reduced/very white in damaged states. Only happens on day maps and also stops while Overcharging.
- Chimney fire missing on night maps.
- Chimney fire missing in badly damaged states. This may be intentional, as another fire breaks out on the small building.

---

![Nuke Power Plant 1 04](https://user-images.githubusercontent.com/6576312/196812811-52249451-380d-4f39-b22a-971efef85267.jpg)

- Nuke variant has no smoke over small chimneys. Bones exist and smoke is shown in portrait art.

---

Existing bones:
```
All
    Smoke01/02
    Spark01-07

All D/E
    Smoke06

Nuke _/N/S/NS:
    Smoke03 (thin little chimney)
    Smoke04 (thick little chimney)

Nuke D/DN/DS/DNS:
    Smoke03 (thin little chimney)
```

<details><summary>*click for script*</summary>

```py
import re
from pathlib import Path

files = list(Path(".").glob("*.W3D"))

bones = [
    rb"FIRE\d\d",
    rb"SMOKE\d\d",
    rb"SPARK\d\d",
]

patterns = [re.compile(b) for b in bones]

for file in files:
    print(file)

    with open(file, "rb") as f:
        data = f.read()

    for pattern in patterns:
        for match in pattern.finditer(data):
            start, end = match.span()
            print("\t" + data[start: end].decode())

    print()
```

</details>

### patch

- Overcharge particles only shown when overcharging.
- No effects emerging from center of building.
- Big fire in damaged state shown on all maps. Smoke column not reduced on some maps either.
- No inexplicable differences between normal and Overcharging mode.