### PR TITLE
Add: Smoke Pillars To Small Chimneys On Nuke General Power Plant

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -9378,6 +9378,7 @@ Object Nuke_ChinaPowerPlant
 
   ; Patch104p @bugfix commy2 20/10/2022 Remove sparks when badly damaged without overcharging on day maps.
   ; Patch104p @bugfix commy2 20/10/2022 Remove effects without bones and fix some particle effect inconsistencies between day and night maps.
+  ; Patch104p @bugfix commy2 20/10/2022 Add smoke to little chimneys.
 
   ;day
   Draw                = W3DModelDraw ModuleTag_01
@@ -9386,11 +9387,14 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
     End
     ConditionState    = DAMAGED
       Model           = NBPwrPtI_D
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE
@@ -9409,6 +9413,8 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9421,6 +9427,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_D
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
@@ -9451,11 +9458,14 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_S
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
     End
     ConditionState    = DAMAGED SNOW
       Model           = NBPwrPtI_DS
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE SNOW
@@ -9474,6 +9484,8 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_S
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9486,6 +9498,7 @@ Object Nuke_ChinaPowerPlant
       Model           = NBPwrPtI_DS
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
@@ -9517,6 +9530,8 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
     End
     ConditionState    = NIGHT DAMAGED SNOW
       Model           = NBPwrPtI_DNS
@@ -9524,6 +9539,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT SNOW
@@ -9546,6 +9562,8 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9560,6 +9578,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
@@ -9593,6 +9612,8 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
     End
     ConditionState    = NIGHT DAMAGED
       Model           = NBPwrPtI_DN
@@ -9600,6 +9621,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
     End
     ConditionState    = REALLYDAMAGED RUBBLE NIGHT
@@ -9622,6 +9644,8 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
+      ParticleSysBone = Smoke04 SteamLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge
       ParticleSysBone = Spark03 SparksMedium
@@ -9636,6 +9660,7 @@ Object Nuke_ChinaPowerPlant
       AnimationMode   = LOOP
       ParticleSysBone = Smoke01 SteamVent
       ParticleSysBone = Smoke02 SteamVent
+      ParticleSysBone = Smoke03 SteamMedium
       ParticleSysBone = Smoke06 FireFactionLarge
       ParticleSysBone = Spark01 SparksLarge
       ParticleSysBone = Spark02 SparksLarge


### PR DESCRIPTION
- merge after https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1395

### 1.04

- Smoke from small chimneys on portrait art, but not on model

### patch

- Smoke on model and portrait

Notes:

Small thick chimney is missing the bone in damaged state. Assume it is "broken" (meaning: the building, not the model). Badly damaged state chimneys are missing or collapsed, so no effects either.