### PR TITLE
Fix: Command Center Door Animation Damage Transitions

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7783,25 +7783,25 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING DAMAGED
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
 
@@ -7809,13 +7809,13 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_WAITING_OPEN
       Model           = ABBtCmdHQ_A7
@@ -7956,7 +7956,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -7966,7 +7966,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -7976,7 +7976,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -7986,7 +7986,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -7996,7 +7996,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -8006,7 +8006,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7845,6 +7845,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_AC
       Animation       = ABBtCmdHQ_AC.ABBtCmdHQ_AC
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT
     AliasConditionState = SNOW
@@ -7854,6 +7855,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_ACD
       Animation       = ABBtCmdHQ_ACD.ABBtCmdHQ_ACD
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DAMAGED
     AliasConditionState = SNOW DAMAGED
@@ -7863,6 +7865,7 @@ Object AirF_AmericaCommandCenter
       Model           = ABBtCmdHQ_ACE
       Animation       = ABBtCmdHQ_ACE.ABBtCmdHQ_ACE
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -557,21 +557,21 @@ Object Boss_CommandCenter
       Model             = NBConYard_A2
       Animation         = NBConYard_A2.NBConYard_A2
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING DAMAGED RADAR_UPGRADED
       Model             = NBConYard_A2D
       Animation         = NBConYard_A2D.NBConYard_A2D
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING REALLYDAMAGED RUBBLE RADAR_UPGRADED
       Model             = NBConYard_A2E
       Animation         = NBConYard_A2E.NBConYard_A2E
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_UPGRADED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1041,7 +1041,7 @@ Object Boss_CommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
@@ -1052,7 +1052,7 @@ Object Boss_CommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
@@ -1063,7 +1063,7 @@ Object Boss_CommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -1074,7 +1074,7 @@ Object Boss_CommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
@@ -1085,7 +1085,7 @@ Object Boss_CommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
@@ -1096,7 +1096,7 @@ Object Boss_CommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -649,6 +649,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_AC
       Animation       = ABBtCmdHQ_AC.ABBtCmdHQ_AC
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT
     AliasConditionState = SNOW
@@ -658,6 +659,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_ACD
       Animation       = ABBtCmdHQ_ACD.ABBtCmdHQ_ACD
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DAMAGED
     AliasConditionState = SNOW DAMAGED
@@ -667,6 +669,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_ACE
       Animation       = ABBtCmdHQ_ACE.ABBtCmdHQ_ACE
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -3839,7 +3839,7 @@ Object ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
@@ -3850,7 +3850,7 @@ Object ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
@@ -3861,7 +3861,7 @@ Object ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -3872,7 +3872,7 @@ Object ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
@@ -3883,7 +3883,7 @@ Object ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
@@ -3894,7 +3894,7 @@ Object ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -587,25 +587,25 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING DAMAGED
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
 
@@ -613,13 +613,13 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_WAITING_OPEN
       Model           = ABBtCmdHQ_A7
@@ -760,7 +760,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -770,7 +770,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -780,7 +780,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -790,7 +790,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -800,7 +800,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -810,7 +810,7 @@ Object AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -3358,21 +3358,21 @@ Object ChinaCommandCenter
       Model             = NBConYard_A2
       Animation         = NBConYard_A2.NBConYard_A2
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING DAMAGED RADAR_UPGRADED
       Model             = NBConYard_A2D
       Animation         = NBConYard_A2D.NBConYard_A2D
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING REALLYDAMAGED RUBBLE RADAR_UPGRADED
       Model             = NBConYard_A2E
       Animation         = NBConYard_A2E.NBConYard_A2E
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_UPGRADED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -3982,7 +3982,7 @@ Object Infa_ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
@@ -3993,7 +3993,7 @@ Object Infa_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
@@ -4004,7 +4004,7 @@ Object Infa_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -4015,7 +4015,7 @@ Object Infa_ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
@@ -4026,7 +4026,7 @@ Object Infa_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
@@ -4037,7 +4037,7 @@ Object Infa_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -3498,21 +3498,21 @@ Object Infa_ChinaCommandCenter
       Model             = NBConYard_A2
       Animation         = NBConYard_A2.NBConYard_A2
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING DAMAGED RADAR_UPGRADED
       Model             = NBConYard_A2D
       Animation         = NBConYard_A2D.NBConYard_A2D
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING REALLYDAMAGED RUBBLE RADAR_UPGRADED
       Model             = NBConYard_A2E
       Animation         = NBConYard_A2E.NBConYard_A2E
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_UPGRADED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -7501,25 +7501,25 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING DAMAGED
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
 
@@ -7527,13 +7527,13 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_WAITING_OPEN
       Model           = ABBtCmdHQ_A7
@@ -7674,7 +7674,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -7684,7 +7684,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -7694,7 +7694,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -7704,7 +7704,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -7714,7 +7714,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -7724,7 +7724,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -7563,6 +7563,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_AC
       Animation       = ABBtCmdHQ_AC.ABBtCmdHQ_AC
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT
     AliasConditionState = SNOW
@@ -7572,6 +7573,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_ACD
       Animation       = ABBtCmdHQ_ACD.ABBtCmdHQ_ACD
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DAMAGED
     AliasConditionState = SNOW DAMAGED
@@ -7581,6 +7583,7 @@ Object Lazr_AmericaCommandCenter
       Model           = ABBtCmdHQ_ACE
       Animation       = ABBtCmdHQ_ACE.ABBtCmdHQ_ACE
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -5769,7 +5769,7 @@ Object Nuke_ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
@@ -5780,7 +5780,7 @@ Object Nuke_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
@@ -5791,7 +5791,7 @@ Object Nuke_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -5802,7 +5802,7 @@ Object Nuke_ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
@@ -5813,7 +5813,7 @@ Object Nuke_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
@@ -5824,7 +5824,7 @@ Object Nuke_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -5285,21 +5285,21 @@ Object Nuke_ChinaCommandCenter
       Model             = NBConYard_A2
       Animation         = NBConYard_A2.NBConYard_A2
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING DAMAGED RADAR_UPGRADED
       Model             = NBConYard_A2D
       Animation         = NBConYard_A2D.NBConYard_A2D
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING REALLYDAMAGED RUBBLE RADAR_UPGRADED
       Model             = NBConYard_A2E
       Animation         = NBConYard_A2E.NBConYard_A2E
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_UPGRADED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7971,25 +7971,25 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING DAMAGED
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_OPENING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
 
@@ -7997,13 +7997,13 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_CLOSING REALLYDAMAGED RUBBLE
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     ConditionState    = DOOR_1_WAITING_OPEN
       Model           = ABBtCmdHQ_A7
@@ -8144,7 +8144,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
     AliasConditionState = SNOW DOOR_1_OPENING
@@ -8154,7 +8154,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
     AliasConditionState = SNOW DOOR_1_OPENING DAMAGED
@@ -8164,7 +8164,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -8174,7 +8174,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7
       Animation       = ABBtCmdHQ_A7.ABBtCmdHQ_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
     AliasConditionState = SNOW DOOR_1_CLOSING
@@ -8184,7 +8184,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7D
       Animation       = ABBtCmdHQ_A7D.ABBtCmdHQ_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
     AliasConditionState = SNOW DOOR_1_CLOSING DAMAGED
@@ -8194,7 +8194,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_A7E
       Animation       = ABBtCmdHQ_A7E.ABBtCmdHQ_A7E
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -8033,6 +8033,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_AC
       Animation       = ABBtCmdHQ_AC.ABBtCmdHQ_AC
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT
     AliasConditionState = SNOW
@@ -8042,6 +8043,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_ACD
       Animation       = ABBtCmdHQ_ACD.ABBtCmdHQ_ACD
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT DAMAGED
     AliasConditionState = SNOW DAMAGED
@@ -8051,6 +8053,7 @@ Object SupW_AmericaCommandCenter
       Model           = ABBtCmdHQ_ACE
       Animation       = ABBtCmdHQ_ACE.ABBtCmdHQ_ACE
       AnimationMode   = LOOP
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
     AliasConditionState = NIGHT REALLYDAMAGED RUBBLE
     AliasConditionState = SNOW REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16803,7 +16803,7 @@ Object Tank_ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING
@@ -16814,7 +16814,7 @@ Object Tank_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING DAMAGED
@@ -16825,7 +16825,7 @@ Object Tank_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE
-      Flags           = START_FRAME_FIRST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorOpeningTime
     End
     AliasConditionState = NIGHT DOOR_1_OPENING REALLYDAMAGED RUBBLE
@@ -16836,7 +16836,7 @@ Object Tank_ChinaCommandCenter
       Model           = NBConYard_A7
       Animation       = NBConYard_A7.NBConYard_A7
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING
@@ -16847,7 +16847,7 @@ Object Tank_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING DAMAGED
@@ -16858,7 +16858,7 @@ Object Tank_ChinaCommandCenter
       Model           = NBConYard_A7D
       Animation       = NBConYard_A7D.NBConYard_A7D
       AnimationMode   = ONCE_BACKWARDS
-      Flags           = START_FRAME_LAST
+      Flags           = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
       AnimationSpeedFactorRange = 2.0 2.0 ; Patch104p @tweak Match animation with DoorClosingTime
     End
     AliasConditionState = NIGHT DOOR_1_CLOSING REALLYDAMAGED RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16319,21 +16319,21 @@ Object Tank_ChinaCommandCenter
       Model             = NBConYard_A2
       Animation         = NBConYard_A2.NBConYard_A2
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING DAMAGED RADAR_UPGRADED
       Model             = NBConYard_A2D
       Animation         = NBConYard_A2D.NBConYard_A2D
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_EXTENDING REALLYDAMAGED RUBBLE RADAR_UPGRADED
       Model             = NBConYard_A2E
       Animation         = NBConYard_A2E.NBConYard_A2E
       AnimationMode     = ONCE
-      Flags             = START_FRAME_FIRST
+      Flags             = MAINTAIN_FRAME_ACROSS_STATES ; Patch104p @bugfix Stubbjax 20/10/2022 Fixed animation transition between damage states.
     End
 
     ConditionState      = RADAR_UPGRADED


### PR DESCRIPTION
Fixed door animations resetting when transitioning between damage states for the China and USA Command Centers. Also fixed the radars resetting their animations as well.

The below footage demonstrates the doors of both Command Centers seamlessly opening and closing while transitioning between damage states (+ USA satellite dish).

https://user-images.githubusercontent.com/11547761/196996231-6d1a7c85-00d4-4ea9-afbb-a9d6f762b77b.mp4

https://user-images.githubusercontent.com/11547761/196996251-9e6789d5-ad18-4723-a410-d982dc8bdea1.mp4

One strange thing to note is that it appears the USA Command Centers each have a duplicate door entry, which likely means they are being rendered / processed twice (and changing both of them was necessary to solve the respective animation issue, rather than one or the other). Further investigation may be required.