### PR TITLE
Change: Winged aircraft no longer returns to the Airfield after 10 seconds

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -1778,7 +1778,7 @@ Object AirF_AmericaJetAurora
     AttackLocomotorPersistTime  = 100    ; we start slowing down almost immediately
     AttackersMissPersistTime    = 2000   ; but remain untargetable fer a bit longer
     ReturnForAmmoLocomotorType  = SET_SLUGGISH
-    ReturnToBaseIdleTime        = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime        = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL      AuroraJetLocomotor
   Locomotor = SET_SUPERSONIC  AuroraJetSupersonicLocomotor
@@ -2020,7 +2020,7 @@ Object AirF_AmericaJetStealthFighter
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause           = 500
     MinHeight              = 5
-    ReturnToBaseIdleTime   = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime   = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Behavior = ExperienceScalarUpgrade ModuleTag_08
@@ -17997,7 +17997,7 @@ Object AirF_AmericaJetRaptor
     TakeoffPause              = 500
     MinHeight                 = 5
     ParkingOffset             = 3             ; scooch it a little forward so the tail doesn't hit the doors
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL RaptorJetLocomotor
   Locomotor = SET_TAXIING BasicJetTaxiLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -700,7 +700,7 @@ Object AmericaJetRaptor
     TakeoffPause              = 500
     MinHeight                 = 5
     ParkingOffset             = 3             ; scooch it a little forward so the tail doesn't hit the doors
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL RaptorJetLocomotor
   Locomotor = SET_TAXIING BasicJetTaxiLocomotor
@@ -940,7 +940,7 @@ Object AmericaJetAircraftCarrierRaptor
     TakeoffPause              = 500
     MinHeight                 = 5
     ParkingOffset             = 3             ; scooch it a little forward so the tail doesn't hit the doors
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
     AutoAcquireEnemiesWhenIdle = YES ATTACK_BUILDINGS
   End
   Locomotor = SET_NORMAL RaptorJetLocomotor
@@ -1363,7 +1363,7 @@ Object AmericaJetAurora
     AttackLocomotorPersistTime  = 100    ; we start slowing down almost immediately
     AttackersMissPersistTime    = 2000   ; but remain untargetable fer a bit longer
     ReturnForAmmoLocomotorType  = SET_SLUGGISH
-    ReturnToBaseIdleTime        = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime        = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL      AuroraJetLocomotor
   Locomotor = SET_SUPERSONIC  AuroraJetSupersonicLocomotor
@@ -1598,7 +1598,7 @@ Object AmericaJetStealthFighter
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause           = 500
     MinHeight              = 5
-    ReturnToBaseIdleTime   = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime   = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Behavior = ExperienceScalarUpgrade ModuleTag_08

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15637,7 +15637,7 @@ Object Boss_JetAurora
     AttackLocomotorPersistTime  = 100    ; we start slowing down almost immediately
     AttackersMissPersistTime    = 2000   ; but remain untargetable fer a bit longer
     ReturnForAmmoLocomotorType  = SET_SLUGGISH
-    ReturnToBaseIdleTime        = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime        = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL      AuroraJetLocomotor
   Locomotor = SET_SUPERSONIC  AuroraJetSupersonicLocomotor
@@ -16212,7 +16212,7 @@ Object Boss_JetMIG
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause              = 500
     MinHeight                 = 5
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Locomotor = SET_NORMAL MIGLocomotor
@@ -16489,7 +16489,7 @@ Object Boss_JetRaptor
     TakeoffPause              = 500
     MinHeight                 = 5
     ParkingOffset             = 3             ; scooch it a little forward so the tail doesn't hit the doors
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL RaptorJetLocomotor
   Locomotor = SET_TAXIING BasicJetTaxiLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -829,7 +829,7 @@ Object ChinaJetMIG
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause              = 500
     MinHeight                 = 5
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Locomotor = SET_NORMAL MIGLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -171,7 +171,7 @@ Object ChinaJetMIG_CinematicVersion
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause              = 500
     MinHeight                 = 5
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Locomotor = SET_NORMAL MIGLocomotor
@@ -2616,7 +2616,7 @@ Object CINE_ChinaJetMIG
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause              = 500
     MinHeight                 = 5
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Locomotor = SET_NORMAL CINE_MIGLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -171,7 +171,7 @@ Object Infa_ChinaJetMIG
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause              = 500
     MinHeight                 = 5
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Locomotor = SET_NORMAL MIGLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -702,7 +702,7 @@ Object Lazr_AmericaJetRaptor
     TakeoffPause              = 500
     MinHeight                 = 5
     ParkingOffset             = 3             ; scooch it a little forward so the tail doesn't hit the doors
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL RaptorJetLocomotor
   Locomotor = SET_TAXIING BasicJetTaxiLocomotor
@@ -1121,7 +1121,7 @@ Object Lazr_AmericaJetAurora
     AttackLocomotorPersistTime  = 100    ; we start slowing down almost immediately
     AttackersMissPersistTime    = 2000   ; but remain untargetable fer a bit longer
     ReturnForAmmoLocomotorType  = SET_SLUGGISH
-    ReturnToBaseIdleTime        = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime        = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL      AuroraJetLocomotor
   Locomotor = SET_SUPERSONIC  AuroraJetSupersonicLocomotor
@@ -1356,7 +1356,7 @@ Object Lazr_AmericaJetStealthFighter
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause           = 500
     MinHeight              = 5
-    ReturnToBaseIdleTime   = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime   = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Behavior = ExperienceScalarUpgrade ModuleTag_08

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1117,7 +1117,7 @@ Object Nuke_ChinaJetMIG
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause              = 500
     MinHeight                 = 5
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Locomotor = SET_NORMAL MIGLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -1179,7 +1179,7 @@ Object SupW_AmericaJetRaptor
     TakeoffPause              = 500
     MinHeight                 = 5
     ParkingOffset             = 3             ; scooch it a little forward so the tail doesn't hit the doors
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL RaptorJetLocomotor
   Locomotor = SET_TAXIING BasicJetTaxiLocomotor
@@ -1598,7 +1598,7 @@ Object SupW_AmericaJetAurora
     AttackLocomotorPersistTime  = 100    ; we start slowing down almost immediately
     AttackersMissPersistTime    = 2000   ; but remain untargetable fer a bit longer
     ReturnForAmmoLocomotorType  = SET_SLUGGISH
-    ReturnToBaseIdleTime        = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime        = 0         ; if idle for this long, return to base, even if not out of ammo
   End
   Locomotor = SET_NORMAL      AuroraJetLocomotor
   Locomotor = SET_SUPERSONIC  AuroraJetSupersonicLocomotor
@@ -1833,7 +1833,7 @@ Object SupW_AmericaJetStealthFighter
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause           = 500
     MinHeight              = 5
-    ReturnToBaseIdleTime   = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime   = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Behavior = ExperienceScalarUpgrade ModuleTag_08

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -847,7 +847,7 @@ Object Tank_ChinaJetMIG
     TakeoffDistForMaxLift     = 0%   ; larger numbers give more lift sooner when taking off
     TakeoffPause              = 500
     MinHeight                 = 5
-    ReturnToBaseIdleTime      = 10000         ; if idle for this long, return to base, even if not out of ammo
+    ReturnToBaseIdleTime      = 0         ; if idle for this long, return to base, even if not out of ammo
   End
 
   Locomotor = SET_NORMAL MIGLocomotor


### PR DESCRIPTION
This change improves the control over air planes. Players can leave airplanes idle for an unlimited amount of time. Idle planes will no longer return to the airfield after 10 seconds unless ordered so or out of ammo. The guard mode functionality of airplanes is unchanged.

## Rationale

Players are no longer punished for the lack of plane babysitting. Instead players can invest their attention into more meaningful tasks in a given match.