### PR TITLE
Fix: Streamline drift velocity of prominent smoke and steam particles

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -2877,7 +2877,7 @@ ParticleSystem Steam
   BurstDelay = 1.00 1.00
   BurstCount = 2.00 2.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.20 Y:0.40 Z:0.10
+  DriftVelocity = X:0.15 Y:0.25 Z:0.10 ; Patch104p @tweak from X:0.20 Y:0.40 Z:0.10 based on SteamVent
   VelocityType = ORTHO
   VelOrthoX = -0.10 0.10
   VelOrthoY = -0.10 0.10
@@ -14668,7 +14668,7 @@ ParticleSystem DozerSmokeLight
   BurstDelay = 2.00 5.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.20 Y:0.40 Z:0.10
+  DriftVelocity = X:0.075 Y:0.125 Z:0.20 ; Patch104p @tweak from X:0.20 Y:0.40 Z:0.10 based on SteamVent
   VelocityType = ORTHO
   VelOrthoX = -0.03 0.03
   VelOrthoY = -0.03 0.03
@@ -14841,7 +14841,7 @@ ParticleSystem SteamVentNight
   BurstDelay = 3.00 3.00
   BurstCount = 3.00 3.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.10 Y:0.20 Z:0.20
+  DriftVelocity = X:0.15 Y:0.25 Z:0.20 ; Patch104p @tweak from X:0.10 Y:0.20 Z:0.20 based on SteamVent
   VelocityType = OUTWARD
   VelOutward = 0.00 1.50
   VelOutwardOther = 1.00 1.00
@@ -15292,7 +15292,7 @@ ParticleSystem DozerSmokeHeavy
   BurstDelay = 1.00 2.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.20 Y:0.40 Z:0.10
+  DriftVelocity = X:0.075 Y:0.125 Z:0.20 ; Patch104p @tweak from X:0.20 Y:0.40 Z:0.10 based on SteamVent
   VelocityType = ORTHO
   VelOrthoX = -0.07 0.07
   VelOrthoY = -0.07 0.07
@@ -25447,7 +25447,7 @@ ParticleSystem SteamLarge
   BurstDelay = 1.00 1.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.00 Y:0.00 Z:0.50
+  DriftVelocity = X:0.24 Y:0.40 Z:0.50 ; Patch104p @tweak from X:0.00 Y:0.00 Z:0.50 based on SteamVent
   VelocityType = ORTHO
   VelOrthoX = -0.20 0.20
   VelOrthoY = -0.20 0.20
@@ -30496,7 +30496,7 @@ ParticleSystem SmolderingSmokeHuge
   BurstDelay = 0.00 3.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:-0.05 Y:0.15 Z:0.03
+  DriftVelocity = X:0.09 Y:0.15 Z:0.05 ; Patch104p from X:-0.05 Y:0.15 Z:0.03 based on SteamVent
   VelocityType = OUTWARD
   VelOutward = 0.10 0.10
   VelOutwardOther = 0.00 0.00
@@ -31114,7 +31114,7 @@ ParticleSystem SmolderingSmokeLarge
   BurstDelay = 0.00 3.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:-0.05 Y:0.10 Z:0.05
+  DriftVelocity = X:0.09 Y:0.15 Z:0.05 ; Patch104p from X:-0.05 Y:0.10 Z:0.05 based on SteamVent
   VelocityType = OUTWARD
   VelOutward = 0.10 0.10
   VelOutwardOther = 0.00 0.00
@@ -32080,7 +32080,7 @@ ParticleSystem SmolderingSmoke
   BurstDelay = 5.00 10.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:-0.05 Y:0.10 Z:0.05
+  DriftVelocity = X:0.09 Y:0.15 Z:0.05 ; Patch104p from X:-0.05 Y:0.10 Z:0.05 based on SteamVent
   VelocityType = OUTWARD
   VelOutward = 0.10 0.10
   VelOutwardOther = 0.00 0.00
@@ -36413,7 +36413,7 @@ ParticleSystem SteamMedium
   BurstDelay = 2.00 2.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.00 Y:0.00 Z:0.50
+  DriftVelocity = X:0.12 Y:0.20 Z:0.50 ; Patch104p @tweak from X:0.00 Y:0.00 Z:0.50 based on SteamVent
   VelocityType = ORTHO
   VelOrthoX = -0.10 0.10
   VelOrthoY = -0.10 0.10
@@ -60355,7 +60355,7 @@ ParticleSystem SteamSmall
   BurstDelay = 3.00 5.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.00 Y:0.00 Z:0.10
+  DriftVelocity = X:0.06 Y:0.10 Z:0.10 ; Patch104p @tweak from X:0.00 Y:0.00 Z:0.10 based on SteamVent
   VelocityType = ORTHO
   VelOrthoX = -0.05 0.05
   VelOrthoY = -0.05 0.05
@@ -60413,7 +60413,7 @@ ParticleSystem SmolderingSmokeTower
   BurstDelay = 5.00 10.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:-0.05 Y:0.10 Z:0.05
+  DriftVelocity = X:0.09 Y:0.15 Z:0.05 ; Patch104p from X:-0.05 Y:0.10 Z:0.05 based on SteamVent
   VelocityType = OUTWARD
   VelOutward = 0.10 0.10
   VelOutwardOther = 0.00 0.00
@@ -64233,7 +64233,7 @@ ParticleSystem SteamBurst
   BurstDelay = 9999.00 9999.00
   BurstCount = 20.00 25.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.10 Y:0.10 Z:0.10
+  DriftVelocity = X:0.06 Y:0.10 Z:0.10 ; Patch104p @tweak from X:0.10 Y:0.10 Z:0.10 based on SteamVent
   VelocityType = ORTHO
   VelOrthoX = -0.10 0.10
   VelOrthoY = -0.10 0.10


### PR DESCRIPTION
Smoke and steam particle drift velocity is not consistent. I streamlined the prominent ones based on SteamVent velocity. It drift into similar direction of where clouds move.

Dozer smoke drifted way too much sideways.

Smoldering smoke drifted into opposite direction of Steam.

Some steams had no drift velocity.

There likely are still some inconsistent ones left over, but it is unclear to me how to find all relevant static ones.

![shot_20221022_142251_2](https://user-images.githubusercontent.com/4720891/197339056-74190042-c411-4cf3-a865-92124376b0b7.jpg)
