### PR TITLE
Change: Patriot Missile Battery standardisation

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -16525,7 +16525,7 @@ Object AirF_AmericaPatriotBattery
   Prerequisites
     Object = AirF_AmericaPowerPlant
   End
-  BuildCost        = 1000
+  BuildCost        = 900
   BuildTime        = 25.0           ; in seconds
   EnergyProduction = -3
   WeaponSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -12202,7 +12202,7 @@ Object Boss_PatriotBattery
   Prerequisites
     Object = Boss_Barracks
   End
-  BuildCost        = 1000
+  BuildCost        = 900
   BuildTime        = 25.0           ; in seconds
   EnergyProduction = -3
   WeaponSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -30625,7 +30625,7 @@ Object AmericaPatriotBattery
   Prerequisites
     Object = AmericaPowerPlant
   End
-  BuildCost        = 1000
+  BuildCost        = 900
   BuildTime        = 25.0           ; in seconds
   EnergyProduction = -3
   WeaponSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2052,7 +2052,6 @@ Weapon PatriotMissileAssistWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
-  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes
@@ -6694,7 +6693,6 @@ Weapon Lazr_PatriotMissileAssistWeapon
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
-  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes
@@ -7665,7 +7663,6 @@ Weapon SupW_PatriotMissileAssistWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
-  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1980,7 +1980,7 @@ Weapon PatriotMissileWeapon
   PrimaryDamage               = 30.0
   PrimaryDamageRadius         = 5.0
   ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
-  AttackRange                 = 225.0
+  AttackRange                 = 275.0
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
   WeaponSpeed                 = 1             ; locomotor specifies speed.
@@ -2009,7 +2009,7 @@ Weapon PatriotMissileWeaponAir
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
   ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
-  AttackRange                 = 350.0
+  AttackRange                 = 400.0
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
   WeaponSpeed                 = 600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2052,6 +2052,7 @@ Weapon PatriotMissileAssistWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes
@@ -6693,6 +6694,7 @@ Weapon Lazr_PatriotMissileAssistWeapon
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes
@@ -7663,6 +7665,7 @@ Weapon SupW_PatriotMissileAssistWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100    ; If I haven't fired in this long, I will reload on my own (rather than only after the last one is fired)
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1979,7 +1979,7 @@ End
 Weapon PatriotMissileWeapon
   PrimaryDamage               = 30.0
   PrimaryDamageRadius         = 5.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 225.0
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
@@ -2008,7 +2008,7 @@ End
 Weapon PatriotMissileWeaponAir
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 350.0
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
@@ -2038,7 +2038,7 @@ End
 Weapon PatriotMissileAssistWeapon
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range
   DamageType                  = EXPLOSION          ; ignored for projectile weapons
   DeathType                   = EXPLODED
@@ -7649,7 +7649,7 @@ End
 Weapon SupW_PatriotMissileAssistWeapon
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
+  ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range
   DamageType                  = EXPLOSION          ; ignored for projectile weapons
   DeathType                   = EXPLODED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2006,7 +2006,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon PatriotMissileWeaponAir
-  PrimaryDamage               = 25.0
+  PrimaryDamage               = 30.0
   PrimaryDamageRadius         = 5.0
   ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 400.0
@@ -2036,7 +2036,7 @@ End
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 Weapon PatriotMissileAssistWeapon
-  PrimaryDamage               = 25.0
+  PrimaryDamage               = 30.0
   PrimaryDamageRadius         = 5.0
   ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range
@@ -7613,7 +7613,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon SupW_PatriotMissileWeaponAir
-  PrimaryDamage               = 30.0
+  PrimaryDamage               = 15.0
   PrimaryDamageRadius         = 5.0
   ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 400.0
@@ -7647,7 +7647,7 @@ End
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 Weapon SupW_PatriotMissileAssistWeapon
-  PrimaryDamage               = 25.0
+  PrimaryDamage               = 15.0
   PrimaryDamageRadius         = 5.0
   ScatterRadiusVsInfantry     = 5.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1989,7 +1989,7 @@ Weapon PatriotMissileWeapon
   FireSound                   = PatriotBatteryWeapon
   FireFX                      = FX_BuggyMissileIgnition
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots           = 250                   ; time between shots, msec
+  DelayBetweenShots           = 100                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
@@ -2018,7 +2018,7 @@ Weapon PatriotMissileWeaponAir
   FireFX                      = FX_BuggyMissileIgnition
   FireSound                   = PatriotBatteryWeapon
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots           = 250                   ; time between shots, msec
+  DelayBetweenShots           = 100                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
@@ -2048,7 +2048,7 @@ Weapon PatriotMissileAssistWeapon
   FireFX                      = FX_BuggyMissileIgnition
   FireSound                   = PatriotBatteryWeapon
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots           = 250                   ; time between shots, msec
+  DelayBetweenShots           = 100                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
@@ -7659,7 +7659,7 @@ Weapon SupW_PatriotMissileAssistWeapon
   FireFX                      = FX_BuggyMissileIgnition
   FireSound                   = PatriotBatteryWeapon
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots           = 250                   ; time between shots, msec
+  DelayBetweenShots           = 100                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes


### PR DESCRIPTION
* Relevant to #1178
* Relevant to #1580
* Relevant to #1755

This change standardises a lot of inconsistencies between missile-based Patriot Batteries, and improves the standard Patriot Battery so that it shares the same price, range and shot delay as the EMP variant.

Other inconsistencies have also been addressed, such as the EMP assist weapon firing slower and both the assist and air weapons doing more or different damage. The scatter radius vs infantry and assist weapon idle reloads are now standardised as well.

The primary adjustments to the vanilla Patriot to consider are the -$100 price, +50 range, -0.15s shot delay, and +5 air/assist damage. And for the EMP variant; the -15 air damage, -10 assist damage and -0.15s assist shot delay. This set of changes should make standard Patriots a little more useful and bring both structures' outputs more in line with player expectations.

Before:

| | Standard Patriot | EMP Patriot
-- | -- | --
Build cost | 1000 | 900
Ground range | 225 | 275
Ground damage | 4 x 30 | 4 x 15
Ground reload | 4 x 0.25s | 4 x 0.1s
Air range | 350 | 400
Air damage | 4 x 25 | 4 x 30
Air reload | 4 x 0.25s | 4 x 0.1s
Assist range | 450 | 450
Assist damage | 4 x 25 | 4 x 25
Assist reload | 4 x 0.25s | 4 x 0.25s

After:

| | Standard Patriot | EMP Patriot
-- | -- | --
Build cost | 900 | 900
Ground range | 275 | 275
Ground damage | 4 x 30 | 4 x 15
Ground reload | 4 x 0.1s | 4 x 0.1s
Air range | 400 | 400
Air damage | 4 x 30 | 4 x 15
Air reload | 4 x 0.1s | 4 x 0.1s
Assist range | 450 | 450
Assist damage | 4 x 30 | 4 x 15
Assist reload | 4 x 0.1s | 4 x 0.1s

Closes #897.