### PR TITLE
Change: Remove Supply Drop Zone select sound from TechRepairPad, TechRepairBay, TechRadioStation

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -436,6 +436,7 @@ Object TechReinforcementPad
   End
   ; Patch104p @bugfix commy2 11/09/2021 Removed experience yield when destroying this enemy controlled tech building.
   ;ExperienceValue     = 200 200 200 200  ; Experience point value at each level
+
   ; *** AUDIO Parameters ***
   VoiceSelect = SupplyDropZoneSelect
 
@@ -667,8 +668,10 @@ Object TechRepairPad
   ;ExperienceValue     = 200 200 200 200  ; Experience point value at each level
  ;**FIX**?
  ;CommandSet          = TechReinforcementPadCommandSet
+
+  ; Patch104p @tweak Disable select sound.
   ; *** AUDIO Parameters ***
-  VoiceSelect = SupplyDropZoneSelect
+  ;VoiceSelect = SupplyDropZoneSelect
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
@@ -895,8 +898,10 @@ Object TechRepairbay
   End
   ; Patch104p @bugfix commy2 11/09/2021 Removed experience yield when destroying this enemy controlled tech building.
   ;ExperienceValue     = 200 200 200 200  ; Experience point value at each level
+
+  ; Patch104p @tweak Disable select sound.
   ; *** AUDIO Parameters ***
-  VoiceSelect = SupplyDropZoneSelect
+  ;VoiceSelect = SupplyDropZoneSelect
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
@@ -1131,8 +1136,9 @@ Object TechRadioStation
     DamageFX          = StructureDamageFXNoShake
   End
 
+  ; Patch104p @tweak Disable select sound.
   ; *** AUDIO Parameters ***
-  VoiceSelect = SupplyDropZoneSelect
+  ;VoiceSelect = SupplyDropZoneSelect
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop


### PR DESCRIPTION
This this change, all tech buildings except TechReinforcementPad have no select sound.