### PR TITLE
Fix: Dragon Tanks can now force fire close Allies, Neutral targets with their primary weapon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -3321,14 +3321,16 @@ Locomotor PatriotMissileLocomotor
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix Stubbjax 03/11/2022 Changes MaxThrustAngle from 1 to fix flame projectiles not hitting targets on different terrain elevation.
+; Patch104p @bugfix Stubbjax 03/11/2022 Changes TurnRate from 5 to prevent flames from curving to followed targets.
 Locomotor DragonTankFlameLocomotor
   Surfaces = AIR
   Speed = 300               ; in dist/sec
   MinSpeed = 120            ; in dist/sec. (THRUST items must have nonzero minspeeds!)
   Acceleration = 2160       ; in dist/(sec^2)
   Braking = 0               ; in dist/(sec^2)
-  TurnRate = 5            ; in degrees/sec
-  MaxThrustAngle = 30       ; in degrees (NOT degrees/sec) ; Patch104p @bugfix Stubbjax 03/11/2022 Fixed flame projectiles not hitting targets on different terrain heights / angles.
+  TurnRate = 0            ; in degrees/sec
+  MaxThrustAngle = 30       ; in degrees (NOT degrees/sec) 
   AllowAirborneMotiveForce = Yes
   Appearance = THRUST
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -3328,7 +3328,7 @@ Locomotor DragonTankFlameLocomotor
   Acceleration = 2160       ; in dist/(sec^2)
   Braking = 0               ; in dist/(sec^2)
   TurnRate = 5            ; in degrees/sec
-  MaxThrustAngle = 1       ; in degrees (NOT degrees/sec)
+  MaxThrustAngle = 30       ; in degrees (NOT degrees/sec) ; Patch104p @bugfix Stubbjax 03/11/2022 Fixed flame projectiles not hitting targets on different terrain heights / angles.
   AllowAirborneMotiveForce = Yes
   Appearance = THRUST
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4046,7 +4046,7 @@ Object DragonTankFlameProjectile
     AllowCollideForce = No  ; flames collide, but never apply forces when they do so
   End
   Behavior = MissileAIUpdate ModuleTag_05
-    TryToFollowTarget = Yes ; Patch104p @bugfix Stubbjax 03/11/2022 Fixed flame projectiles not hitting targets in close proximity.
+    TryToFollowTarget = Yes ; Patch104p @bugfix Stubbjax 03/11/2022 From No to fix flame projectiles not hitting targets in close proximity.
     FuelLifetime = 350
     DetonateOnNoFuel = Yes
     InitialVelocity = 120                ; in dist/sec
@@ -4141,7 +4141,7 @@ Object DragonTankFlameProjectileUpgraded
     AllowCollideForce = No  ; flames collide, but never apply forces when they do so
   End
   Behavior = MissileAIUpdate ModuleTag_05
-    TryToFollowTarget = Yes ; Patch104p @bugfix Stubbjax 03/11/2022 Fixed flame projectiles not hitting targets in close proximity.
+    TryToFollowTarget = Yes ; Patch104p @bugfix Stubbjax 03/11/2022 From No to fix flame projectiles not hitting targets in close proximity.
     FuelLifetime = 350
     DetonateOnNoFuel = Yes
     InitialVelocity = 120                ; in dist/sec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4046,7 +4046,7 @@ Object DragonTankFlameProjectile
     AllowCollideForce = No  ; flames collide, but never apply forces when they do so
   End
   Behavior = MissileAIUpdate ModuleTag_05
-    TryToFollowTarget = No
+    TryToFollowTarget = Yes ; Patch104p @bugfix Stubbjax 03/11/2022 Fixed flame projectiles not hitting targets in close proximity.
     FuelLifetime = 350
     DetonateOnNoFuel = Yes
     InitialVelocity = 120                ; in dist/sec
@@ -4141,7 +4141,7 @@ Object DragonTankFlameProjectileUpgraded
     AllowCollideForce = No  ; flames collide, but never apply forces when they do so
   End
   Behavior = MissileAIUpdate ModuleTag_05
-    TryToFollowTarget = No
+    TryToFollowTarget = Yes ; Patch104p @bugfix Stubbjax 03/11/2022 Fixed flame projectiles not hitting targets in close proximity.
     FuelLifetime = 350
     DetonateOnNoFuel = Yes
     InitialVelocity = 120                ; in dist/sec


### PR DESCRIPTION
* Closes TheSuperHackers/GeneralsGamePatch#1589

## 1.04:
The projectile travels through units in close proximity.

https://user-images.githubusercontent.com/11547761/199525027-88273bd9-89b8-4d18-9a06-8cf769b60880.mp4

## Patch:
The projectile collides with units in close proximity.

https://user-images.githubusercontent.com/11547761/199525042-589595a5-3dd9-4508-b82f-5d76e0bff464.mp4

There is also a discrepancy between the minimum range of the Black Napalm and standard flame weapons, which is a question of design and needs further discussion.
```
Weapon DragonTankFlameWeapon
  MinimumAttackRange = 0; 10.0
End
```
```
Weapon DragonTankFlameWeaponUpgraded
  MinimumAttackRange = 10.0
End
```