### PR TITLE
Fix: Missing construction sounds

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -11763,9 +11763,6 @@ Object AirF_AmericaStrategyCenter
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly, will revisit. (mp) StrategyCenter_TurretMoveLoop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -16560,9 +16560,6 @@ Object AirF_AmericaPatriotBattery
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17098,9 +17098,6 @@ Object AirF_AmericaFireBase
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -6511,9 +6511,6 @@ Object Boss_ScudStorm
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -14634,9 +14634,6 @@ Object Boss_GattlingCannon
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
     VoiceRapidFire        = NoSound
-  End
-
-  UnitSpecificSounds
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly (mdp) TurretMoveLoopLoud
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -12237,9 +12237,6 @@ Object Boss_PatriotBattery
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5608,9 +5608,6 @@ Object Chem_GLAScudStorm
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -4937,9 +4937,6 @@ Object Demo_GLAScudStorm
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -30657,9 +30657,6 @@ Object AmericaPatriotBattery
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7255,9 +7255,6 @@ Object AmericaStrategyCenter
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly, will revisit. (mp) StrategyCenter_TurretMoveLoop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -36714,9 +36714,6 @@ Object AmericaFireBase
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13349,9 +13349,6 @@ Object GLAScudStorm
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -33846,9 +33846,6 @@ Object ChinaGattlingCannon
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
     VoiceRapidFire        = NoSound
-  End
-
-  UnitSpecificSounds
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly (mdp) TurretMoveLoopLoud
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -8314,9 +8314,6 @@ Object GC_Chem_GLAScudStorm
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -8589,9 +8589,6 @@ Object GC_Slth_GLAScudStorm
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -13068,9 +13068,6 @@ Object Infa_ChinaGattlingCannon
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
     VoiceRapidFire        = NoSound
-  End
-
-  UnitSpecificSounds
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly (mdp) TurretMoveLoopLoud
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -16220,9 +16220,6 @@ Object Lazr_AmericaFireBase
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11448,9 +11448,6 @@ Object Lazr_AmericaStrategyCenter
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly, will revisit. (mp) StrategyCenter_TurretMoveLoop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -16881,9 +16881,6 @@ Object Lazr_AmericaPatriotBattery
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -15726,9 +15726,6 @@ Object Nuke_ChinaGattlingCannon
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
     VoiceRapidFire        = NoSound
-  End
-
-  UnitSpecificSounds
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly (mdp) TurretMoveLoopLoud
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -5658,9 +5658,6 @@ Object Slth_GLAScudStorm
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -15784,9 +15784,6 @@ Object SupW_AmericaPatriotBattery
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -16276,9 +16276,6 @@ Object SupW_AmericaFireBase
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
   ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop = NoSound ;These aren't playing properly, will revisit (mp) TurretMoveLoopLoud

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -10992,9 +10992,6 @@ Object SupW_AmericaStrategyCenter
 
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
-  End
-
-  UnitSpecificSounds
     ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly, will revisit. (mp) StrategyCenter_TurretMoveLoop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -14788,9 +14788,6 @@ Object Tank_ChinaGattlingCannon
   UnitSpecificSounds
     UnderConstruction     = UnderConstructionLoop
     VoiceRapidFire        = NoSound
-  End
-
-  UnitSpecificSounds
     TurretMoveStart = NoSound
     TurretMoveLoop  = NoSound ;These aren't playing properly (mdp) TurretMoveLoopLoud
   End


### PR DESCRIPTION
Fixed missing under-construction sound loops for the following structures:

- Scud Storm
- Strategy Center
- Patriot Battery
- Gattling Cannon
- Firebase

These structures had duplicate `UnitSpecificSounds` entries, the latter of which overwrote the former. This resulted in 'silent' construction for the respective structures, which can be compared in the 1.04 footage below:

https://user-images.githubusercontent.com/11547761/199902401-55c15528-d6b0-4441-987a-35627f470f0c.mp4

I wonder if anyone ever noticed this.