### PR TITLE
Change: Remove duplicate fields

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -297,7 +297,6 @@ Armor ToxinTruckArmor ;TruckArmor that is immune to poison
   Armor = SMALL_ARMS        50%
   Armor = GATTLING          50%    ;resistant to gattling tank
   Armor = COMANCHE_VULCAN   50%
-  Armor = INFANTRY_MISSILE  50%
   Armor = POISON            0%    ;IMMUNE! It spews poison :)
   Armor = RADIATION         0%
   Armor = MICROWAVE         0%
@@ -321,7 +320,6 @@ Armor DragonTankArmor
   Armor = COMANCHE_VULCAN   25%
   Armor = FLAME              0%
   Armor = RADIATION         50%      ;Radiation does less damage to tanks.
-  Armor = MICROWAVE          0%
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = MICROWAVE         0%
   Armor = SNIPER            0%
@@ -361,7 +359,6 @@ Armor AirplaneArmor
   Armor = LASER             0%    ;lasers are anti-personel and anti-projectile only (for point defense laser)
   Armor = HAZARD_CLEANUP    0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT        0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER         0%    ;Capture type weapons are effective only against infantry.
   Armor = JET_MISSILES      25%   ;aircraft do less damage to one another in the skies.
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION         25%    ;Radiation does a little damage, just for balance reasons.
@@ -388,7 +385,6 @@ Armor CountermeasuresAirplaneArmor
   Armor = LASER             0%
   Armor = HAZARD_CLEANUP    0%
   Armor = KILL_PILOT        0%
-  Armor = SURRENDER         0%
   Armor = JET_MISSILES      25%
   Armor = POISON            25%
   Armor = RADIATION         25%
@@ -417,7 +413,6 @@ Armor SpectreGunshipArmor
   Armor = LASER             0%    ;lasers are anti-personel and anti-projectile only (for point defense laser)
   Armor = HAZARD_CLEANUP    0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT        0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER         0%    ;Capture type weapons are effective only against infantry.
   Armor = JET_MISSILES      25%   ;aircraft do less damage to one another in the skies.
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION         25%    ;Radiation does a little damage, just for balance reasons.
@@ -442,7 +437,6 @@ Armor CountermeasuresSpectreGunshipArmor
   Armor = LASER             0%
   Armor = HAZARD_CLEANUP    0%
   Armor = KILL_PILOT        0%
-  Armor = SURRENDER         0%
   Armor = JET_MISSILES      25%
   Armor = POISON            25%
   Armor = RADIATION         25%
@@ -471,7 +465,6 @@ Armor ComancheArmor
   Armor = HEALING           100%
   Armor = HAZARD_CLEANUP    0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT        0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER         0%    ;Capture type weapons are effective only against infantry.
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION         25%    ;Radiation does a little damage, just for balance reasons.
   Armor = MICROWAVE         0%
@@ -496,7 +489,6 @@ Armor CountermeasuresComancheArmor
   Armor = HEALING           100%
   Armor = HAZARD_CLEANUP    0%
   Armor = KILL_PILOT        0%
-  Armor = SURRENDER         0%
   Armor = POISON            25%
   Armor = RADIATION         25%
   Armor = MICROWAVE         0%
@@ -767,7 +759,6 @@ End
 
 Armor WallArmor
   Armor = DEFAULT           100%    ; this sets the level for all nonspecified damage types
-  Armor = SURRENDER         0%      ; buildings are immune to normal damage from STUN weapons.
   Armor = SMALL_ARMS        6%
   Armor = GATTLING          6%    ;resistant to gattling tank
   Armor = COMANCHE_VULCAN   6%
@@ -849,9 +840,6 @@ Armor BattleBusTruckArmor
   Armor = HAZARD_CLEANUP       0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT         100%    ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER            0%    ;Capture type weapons are effective only against infantry.
-  Armor = SUBDUAL_MISSILE      0%
-  Armor = SUBDUAL_VEHICLE    100%
-  Armor = SUBDUAL_BUILDING     0%
   Armor = RADIATION           50%    ;Radiation does less damage to tanks.
   Armor = SUBDUAL_MISSILE      0%
   Armor = SUBDUAL_VEHICLE    100%
@@ -905,9 +893,6 @@ Armor BattleBusTruckArmorPlusOne
   Armor = HAZARD_CLEANUP       0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT         100%    ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER            0%    ;Capture type weapons are effective only against infantry.
-  Armor = SUBDUAL_MISSILE      0%
-  Armor = SUBDUAL_VEHICLE     90%
-  Armor = SUBDUAL_BUILDING     0%
   Armor = RADIATION           45%    ;Radiation does less damage to tanks.
   Armor = SUBDUAL_MISSILE      0%
   Armor = SUBDUAL_VEHICLE     90%
@@ -962,9 +947,6 @@ Armor BattleBusTruckArmorPlusTwo
   Armor = HAZARD_CLEANUP       0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT         100%    ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER            0%    ;Capture type weapons are effective only against infantry.
-  Armor = SUBDUAL_MISSILE      0%
-  Armor = SUBDUAL_VEHICLE     80%
-  Armor = SUBDUAL_BUILDING     0%
   Armor = RADIATION           40%    ;Radiation does less damage to tanks.
   Armor = SUBDUAL_MISSILE      0%
   Armor = SUBDUAL_VEHICLE     80%
@@ -1082,7 +1064,6 @@ Armor AFG_ComancheArmor
   Armor = HEALING           100%
   Armor = HAZARD_CLEANUP      0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT          0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER           0%    ;Capture type weapons are effective only against infantry.
   Armor = POISON             25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION          25%    ;Radiation does a little damage, just for balance reasons.
   Armor = MICROWAVE           0%
@@ -1107,7 +1088,6 @@ Armor AFG_CountermeasuresComancheArmor
   Armor = HEALING            90%
   Armor = HAZARD_CLEANUP      0%
   Armor = KILL_PILOT          0%
-  Armor = SURRENDER           0%
   Armor = POISON             25%
   Armor = RADIATION          25%
   Armor = MICROWAVE           0%

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -118,7 +118,6 @@ CommandButton Command_FireParticleUplinkCannon
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannon
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
@@ -131,7 +130,6 @@ CommandButton Command_FireParticleUplinkCannonFromShortcut
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannonShortcut
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
@@ -6995,7 +6993,6 @@ CommandButton SupW_Command_FireParticleUplinkCannon
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannon
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
@@ -7008,7 +7005,6 @@ CommandButton SupW_Command_FireParticleUplinkCannonFromShortcut
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannonShortcut
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2795,7 +2795,6 @@ CommandSet Slth_GLAInfantryHijackerCommandSet
 End
 
 CommandSet Slth_GLAVehicleBattleBusCommandSet
-  1  = Slth_Command_DisguiseAsVehicle
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7836,8 +7836,6 @@ Object AirF_AmericaCommandCenter
     End
   End
 
-  PlacementViewAngle  = -135
-
   ; ------------ Radar Extending -----------------
   Draw                = W3DModelDraw ModuleTag_03
     ConditionState    = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4555,7 +4555,6 @@ Object AirF_AmericaInfantryPathfinder
   VoiceFear = PathfinderVoiceFear
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
-  VoiceFear = PathfinderVoiceFear
 
   UnitSpecificSounds
     VoiceCreate          = PathfinderVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -294,8 +294,6 @@ Object CINE_U06_CruiseMissileFLY
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -1946,7 +1946,6 @@ Object CINE_AmericanInfantryPathfinder
   VoiceFear = PathfinderVoiceFear
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
-  VoiceFear = PathfinderVoiceFear
 
   UnitSpecificSounds
     VoiceCreate          = PathfinderVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1805,7 +1805,6 @@ Object AmericaInfantryPathfinder
   VoiceFear = PathfinderVoiceFear
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
-  VoiceFear = PathfinderVoiceFear
 
   UnitSpecificSounds
     VoiceCreate          = PathfinderVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -16139,8 +16139,6 @@ Object Boss_JetMIG
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18122,7 +18122,6 @@ Object Boss_InfantryBlackLotus
   BuildCost             = 1500
   BuildTime             = 20.0          ;in seconds
   MaxSimultaneousOfType = 1
-  CommandSet            = ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -6689,8 +6689,6 @@ Object Boss_NuclearMissileLauncher
   ; *** ART Parameters ***
   SelectPortrait         = SNNukeMisl_L
   ButtonImage            = SNNukeMisl
-  SelectPortrait = SNNukeMisl_L
-  ButtonImage            = SNNukeMisl
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17735,7 +17735,6 @@ Object Boss_InfantryPathfinder
   VoiceFear = PathfinderVoiceFear
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
-  VoiceFear = PathfinderVoiceFear
 
   UnitSpecificSounds
     VoiceCreate          = PathfinderVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -611,7 +611,6 @@ Object Boss_CommandCenter
     End
 
   End
-  PlacementViewAngle = -135
 
   ; ------------ construction-zone fence -----------------
   Draw                = W3DModelDraw ModuleTag_03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -875,8 +875,6 @@ Object ChinaJetMIG
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -203,8 +203,6 @@ Object ChinaJetMIG_CinematicVersion
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End
@@ -2648,8 +2646,6 @@ Object CINE_ChinaJetMIG
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -3094,7 +3094,6 @@ Object CINE_ChinaInfantryBlackLotus
   BuildCost             = 1500
   BuildTime             = 20.0          ;in seconds
   MaxSimultaneousOfType = 1
-  CommandSet            = ChinaInfantryBlackLotusCommandSet
 
   ExperienceValue       = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired    = 0 150 450 900  ;Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -655,7 +655,6 @@ Object ChinaInfantryBlackLotus
   BuildCost             = 1500
   BuildTime             = 20.0          ;in seconds
   MaxSimultaneousOfType = 1
-  CommandSet            = ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
@@ -16946,7 +16946,6 @@ Object MogadishuWell
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Prop
   EditorSorting   = MISC_MAN_MADE
-  KindOf = IMMOBILE CAN_SEE_THROUGH_STRUCTURE
   ArmorSet
     Conditions      = None
     Armor           = StructureArmor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
@@ -16959,7 +16959,6 @@ Object MogadishuWell
     MaxHealth       = 100.0
     InitialHealth   = 100.0
   End
-  Shadow          = SHADOW_VOLUME
 
   Behavior = TransitionDamageFX ModuleTag_06
     ;-------------DESIGNED FOR SMALL SIZED CIVILIAN BUILDING TRANSITIONS-------------------
@@ -38046,7 +38045,6 @@ Object EgyptianPyramidLarge
     MaxHealth       = 100000.0
     InitialHealth   = 100000.0
   End
-  Shadow          = SHADOW_VOLUME
 
   Behavior = DestroyDie ModuleTag_09
     DeathTypes = ALL
@@ -38096,7 +38094,6 @@ Object EgyptianPyramidSmall
     MaxHealth       = 100000.0
     InitialHealth   = 100000.0
   End
-  Shadow          = SHADOW_VOLUME
 
   Behavior = DestroyDie ModuleTag_09
     DeathTypes = ALL
@@ -38146,7 +38143,6 @@ Object EgyptianSphinx
     MaxHealth       = 100000.0
     InitialHealth   = 100000.0
   End
-  Shadow          = SHADOW_VOLUME
 
   Behavior = DestroyDie ModuleTag_09
     DeathTypes = ALL

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianProp.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianProp.ini
@@ -6070,7 +6070,6 @@ Object WaterStorageTank01
  ;   DeathFX = FX_PropCrush
  ; End
 
-  Shadow          = SHADOW_VOLUME
   Geometry              = CYLINDER
   GeometryMajorRadius   = 46.0
   GeometryHeight        = 41.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianProp.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianProp.ini
@@ -9453,7 +9453,6 @@ Object GreekRuin01
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Prop
   EditorSorting   = MISC_MAN_MADE
-  KindOf = IMMOBILE CAN_SEE_THROUGH_STRUCTURE
   ArmorSet
     Conditions      = None
     Armor           = StructureArmor
@@ -9517,7 +9516,6 @@ Object GreekRuin02
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Prop
   EditorSorting   = MISC_MAN_MADE
-  KindOf = IMMOBILE CAN_SEE_THROUGH_STRUCTURE
   ArmorSet
     Conditions      = None
     Armor           = StructureArmor
@@ -9581,7 +9579,6 @@ Object GreekRuin03
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Prop
   EditorSorting   = MISC_MAN_MADE
-  KindOf = IMMOBILE CAN_SEE_THROUGH_STRUCTURE
   ArmorSet
     Conditions      = None
     Armor           = StructureArmor
@@ -9645,7 +9642,6 @@ Object GreekRuin04
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Prop
   EditorSorting   = MISC_MAN_MADE
-  KindOf = IMMOBILE CAN_SEE_THROUGH_STRUCTURE
   ArmorSet
     Conditions      = None
     Armor           = StructureArmor
@@ -9777,7 +9773,6 @@ Object GLA_StatueSm
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:Prop
   EditorSorting   = MISC_MAN_MADE
-  KindOf = IMMOBILE CAN_SEE_THROUGH_STRUCTURE
   ArmorSet
     Conditions      = None
     Armor           = StructureArmor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -5196,8 +5196,6 @@ Object Humvee1
   CommandSet      = AmericaVehicleHumveeCommandSet
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 150 450 900  ;Experience points needed to gain each level
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   IsTrainable = Yes             ;Can gain experience
   CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -9030,9 +9028,6 @@ Object UNSoldier
 
   ; ***DESIGN parameters ***
   Side = Civilian
-  EditorSorting = INFANTRY
-  TransportSlotCount = 1
-
   DisplayName      = OBJECT:UNSoldier
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -641,8 +641,6 @@ Object AmericaCommandCenter
     End
   End
 
-  PlacementViewAngle  = -135
-
   ; ------------ Radar Extending -----------------
   Draw                = W3DModelDraw ModuleTag_03
     ConditionState    = None
@@ -3412,7 +3410,6 @@ Object ChinaCommandCenter
     End
 
   End
-  PlacementViewAngle = -135
 
   ; ------------ construction-zone fence -----------------
   Draw                = W3DModelDraw ModuleTag_03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -13555,8 +13555,6 @@ Object ChinaNuclearMissileLauncher
   ; *** ART Parameters ***
   SelectPortrait         = SNNukeMisl_L
   ButtonImage            = SNNukeMisl
-  SelectPortrait = SNNukeMisl_L
-  ButtonImage            = SNNukeMisl
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -1495,7 +1495,6 @@ Object GC_Slth_GLAInfantrySniper
   VoiceFear = PathfinderVoiceFear
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
-  VoiceFear = PathfinderVoiceFear
 
   UnitSpecificSounds
     VoiceCreate          = PathfinderVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -3551,7 +3551,6 @@ Object Infa_ChinaCommandCenter
     End
 
   End
-  PlacementViewAngle = -135
 
   ; ------------ construction-zone fence -----------------
   Draw                = W3DModelDraw ModuleTag_03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -5457,8 +5457,6 @@ Object Infa_ChinaNuclearMissileLauncher
   ; *** ART Parameters ***
   SelectPortrait         = SNNukeMisl_L
   ButtonImage            = SNNukeMisl
-  SelectPortrait = SNNukeMisl_L
-  ButtonImage            = SNNukeMisl
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -203,8 +203,6 @@ Object Infa_ChinaJetMIG
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -7554,8 +7554,6 @@ Object Lazr_AmericaCommandCenter
     End
   End
 
-  PlacementViewAngle  = -135
-
   ; ------------ Radar Extending -----------------
   Draw                = W3DModelDraw ModuleTag_03
     ConditionState    = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4095,7 +4095,6 @@ Object Lazr_AmericaInfantryPathfinder
   VoiceFear = PathfinderVoiceFear
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
-  VoiceFear = PathfinderVoiceFear
 
   UnitSpecificSounds
     VoiceCreate          = PathfinderVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -7247,8 +7247,6 @@ Object Nuke_ChinaNuclearMissileLauncher
   ; *** ART Parameters ***
   SelectPortrait         = SNNukeMisl_L
   ButtonImage            = SNNukeMisl
-  SelectPortrait = SNNukeMisl_L
-  ButtonImage            = SNNukeMisl
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2062,7 +2062,6 @@ Object Nuke_ChinaInfantryBlackLotus
   BuildCost             = 1600
   BuildTime             = 20.0          ;in seconds
   MaxSimultaneousOfType = 1
-  CommandSet            = Nuke_ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1163,8 +1163,6 @@ Object Nuke_ChinaJetMIG
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -5351,7 +5351,6 @@ Object Nuke_ChinaCommandCenter
     End
 
   End
-  PlacementViewAngle = -135
 
   ; ------------ construction-zone fence -----------------
   Draw                = W3DModelDraw ModuleTag_03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4579,7 +4579,6 @@ Object SupW_AmericaInfantryPathfinder
   VoiceFear = PathfinderVoiceFear
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
-  VoiceFear = PathfinderVoiceFear
 
   UnitSpecificSounds
     VoiceCreate          = PathfinderVoiceCreate

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -8024,8 +8024,6 @@ Object SupW_AmericaCommandCenter
     End
   End
 
-  PlacementViewAngle  = -135
-
   ; ------------ Radar Extending -----------------
   Draw                = W3DModelDraw ModuleTag_03
     ConditionState    = None

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2677,7 +2677,6 @@ Object SpecialEffectsTrainCrashObject
 
   ; *** ART Parameters ***
   IsBridge            = Yes
-  KindOf              = SELECTABLE IMMOBILE BRIDGE
   Draw                = W3DModelDraw ModuleTag_01
     ParticlesAttachedToAnimatedBones = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -16343,7 +16343,6 @@ Object Tank_ChinaCommandCenter
     End
 
   End
-  PlacementViewAngle = -135
 
   ; ------------ construction-zone fence -----------------
   Draw                = W3DModelDraw ModuleTag_03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -893,8 +893,6 @@ Object Tank_ChinaJetMIG
   GeometryMinorRadius      = 7.0
   GeometryHeight           = 5.0
   Shadow                   = SHADOW_VOLUME
-
-  Shadow = SHADOW_VOLUME
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -1792,7 +1792,6 @@ Object Tank_ChinaInfantryBlackLotus
   BuildCost             = 1875
   BuildTime             = 20.0          ;in seconds
   MaxSimultaneousOfType = 1
-  CommandSet            = Tank_ChinaInfantryBlackLotusCommandSet
 
   ; Patch104p @balance commy2 25/09/2021 Reduce XP required to level up and granted when killed.
   ; Patch104p @balance xezon 01/08/2022 Further reduce XP required to level up so it compares better with Jarmen Kell.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5235,8 +5235,6 @@ Object Tank_ChinaNuclearMissileLauncher
   ; *** ART Parameters ***
   SelectPortrait         = SNNukeMisl_L
   ButtonImage            = SNNukeMisl
-  SelectPortrait = SNNukeMisl_L
-  ButtonImage            = SNNukeMisl
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     ; day

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -125,7 +125,6 @@ End
 
 AudioEvent ExplosionDirt
   Sounds      = gexpdira gexpdirb gexpdirc
-  Priority    = LOW
   Control     = interrupt random
   Limit       = 2
   VolumeShift = -10
@@ -493,7 +492,6 @@ End
 
 AudioEvent NeutronMissileRelease
   Sounds      =  bneutlau
-  Priority    = high
   Volume      = 90
   Priority    = normal
   Type        = world shrouded everyone
@@ -1914,7 +1912,6 @@ End
 AudioEvent VehicleImpactLight
   Sounds = gvehimpa gvehimpb gvehimpc gvehimpd gvehimpe gvehimpf gvehimpg gvehimph gvehimpi
   Control = random interrupt
-  Priority = low
   Limit = 3
   PitchShift = -5 5
   VolumeShift = -10
@@ -2229,7 +2226,6 @@ End
 
 AudioEvent ExplosionNeutron
   Sounds = sneutexp
-  Priority   = high
   Control = interrupt
   Limit = 1
   Volume = 110
@@ -2503,7 +2499,6 @@ End
 AudioEvent MigJetNapalmWeapon
   Sounds      = vmigweaa vmigweab
   Control     = interrupt random
-  Priority    = low
   Volume      = 70
   PitchShift  = -10 10
   Limit       = 3
@@ -2573,7 +2568,6 @@ End
 AudioEvent HumveeWeaponTOW
   Sounds = vhumwe2a vhumwe2b vhumwe2c vhumwe2d
   Control = interrupt random
-  Priority = low
   Limit= 3
   VolumeShift = -20
   PitchShift = -10 10
@@ -3487,7 +3481,6 @@ End
 AudioEvent ParticleUplinkCannon_PowerupSoundLoop
   Sounds      = sparlo1b sparlo1c
   Attack      = sparlo1a
-  Control     = random
   Control     = loop all random
   MinRange    = 100
   MaxRange    = 500
@@ -3701,7 +3694,6 @@ AudioEvent ColonelBurtonWeapon
   Sounds = icolweaa icolweab
   Control = random
   Limit = 2
-  Priority = normal
   PitchShift = -5 5
   VolumeShift = -10
   Volume = 100
@@ -3742,7 +3734,6 @@ AudioEvent BlackLotusPrepLoop
   Sounds      = ihaclo2a ihaclo2b ihaclo2c
   Attack      = ihaclo1a
   Decay       = ihaclo3a
-  Priority    = LOW
   Volume      = 50
   VolumeShift = -10
   PitchShift  = -10  10
@@ -3774,7 +3765,6 @@ AudioEvent HackerPrepLoop
   Sounds      = ihaclo2a ihaclo2b ihaclo2c
   Attack      = ihaclo1a
   Decay       = ihaclo3a
-  Priority    = LOW
   Volume      = 50
   VolumeShift = -10
   PitchShift  = -10  10
@@ -4145,7 +4135,6 @@ AudioEvent ExplosionAnthraxBomb
   Volume = 120
   MinVolume = 80
   Limit = 3
-  Priority = critical
   MinRange = 500
   MaxRange = 5000
   Priority    = high

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -608,7 +608,6 @@ Upgrade Upgrade_GLAArmTheMob
   BuildTime          = 30.0
   BuildCost          = 1000
   ButtonImage        = SSArmMob
-  ResearchSound      = AngryMobVoiceUpgradeArmTheMobCrowd
   ResearchSound      = AngryMobVoiceUpgradeArmTheMob
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -636,7 +636,6 @@ End
 
 AudioEvent AuroraBomberVoiceCreate
   Sounds = vaurseg
-  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f gradio1g
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control= random

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6586,7 +6586,6 @@ Weapon Lazr_CrusaderTankGun
   LaserBoneName           = TurretMS01
   FireFX                  = Lazr_WeaponFX_LaserCrusader
   RadiusDamageAffects     = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots       = 2300               ; time between shots, msec
   ClipSize                = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime          = 0              ; how long to reload a Clip, msec
   ProjectileCollidesWith  = STRUCTURES WALLS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -624,7 +624,6 @@ Weapon HumveeMissileWeapon
   DamageType = EXPLOSION          ; ignored for projectile weapons
   DeathType = EXPLODED
   WeaponSpeed = 600               ; ignored for projectile weapons
-  ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
   ProjectileObject = HumveeMissile
   ProjectileExhaust = TowMissileExhaust
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
@@ -653,7 +652,6 @@ Weapon HumveeMissileWeaponAir
   DamageType = EXPLOSION          ; ignored for projectile weapons
   DeathType = EXPLODED
   WeaponSpeed = 600               ; ignored for projectile weapons
-  ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
   ProjectileObject            = PatriotMissile
   ProjectileExhaust = MissileExhaust
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
@@ -701,7 +699,6 @@ Weapon HellfireMissileWeapon
   DamageType = EXPLOSION          ; ignored for projectile weapons
   DeathType = EXPLODED
   WeaponSpeed = 600               ; ignored for projectile weapons
-  ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
   ProjectileObject = MissileDefenderMissile
   ProjectileExhaust = MissileDefenderMissileExhaust
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS


### PR DESCRIPTION
Removed duplicate fields from various objects / definitions. Only assessed parent fields, not children. The former field was always removed, unless the value was identical, in which case the field with the worse / less consistent formatting was removed.

Note: Did not address the duplicate `ExperienceValue` fields of SpectreGunship, SpectreGunship1, SpectreGunship2, SpectreGunship3 and A10Thunderbolt. Also did not address duplicate `RadarPriority` fields of AngryMobNexus. The original values for the respective fields look more correct than the duplicate / used values and are better addressed separately.