### PR TITLE
Change: Add garrison audio to the Barracks

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -15038,8 +15038,8 @@ Object AirF_AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -15038,6 +15038,8 @@ Object AirF_AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -10711,6 +10711,8 @@ Object Boss_Barracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -10711,8 +10711,8 @@ Object Boss_Barracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -9564,6 +9564,8 @@ Object Chem_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -9564,8 +9564,8 @@ Object Chem_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -9484,6 +9484,8 @@ Object Demo_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -9484,8 +9484,8 @@ Object Demo_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -23372,6 +23372,8 @@ Object AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No
@@ -24123,6 +24125,8 @@ Object GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No
@@ -25563,6 +25567,8 @@ Object ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -23372,8 +23372,8 @@ Object AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No
@@ -24125,8 +24125,8 @@ Object GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No
@@ -25567,8 +25567,8 @@ Object ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -2773,8 +2773,8 @@ Object GC_Chem_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -2773,6 +2773,8 @@ Object GC_Chem_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -2378,6 +2378,8 @@ Object GC_Slth_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -2378,8 +2378,8 @@ Object GC_Slth_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -9733,6 +9733,8 @@ Object Infa_ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -9733,8 +9733,8 @@ Object Infa_ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14722,8 +14722,8 @@ Object Lazr_AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14722,6 +14722,8 @@ Object Lazr_AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -11549,8 +11549,8 @@ Object Nuke_ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -11549,6 +11549,8 @@ Object Nuke_ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -10181,6 +10181,8 @@ Object Slth_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -10181,8 +10181,8 @@ Object Slth_GLABarracks
   Behavior = HealContain ModuleTag_05
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -14266,6 +14266,8 @@ Object SupW_AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -14266,8 +14266,8 @@ Object SupW_AmericaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -9513,8 +9513,8 @@ Object Tank_ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
-    EnterSound          = GarrisonEnter
-    ExitSound           = GarrisonExit
+    EnterSound          = GarrisonEnter ; Patch104p @bugfix Stubbjax 05/11/2022 Added enter sound to the Barracks.
+    ExitSound           = GarrisonExit ; Patch104p @bugfix Stubbjax 05/11/2022 Added exit sound to the Barracks.
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -9513,6 +9513,8 @@ Object Tank_ChinaBarracks
   Behavior = HealContain ModuleTag_06
     ContainMax          = 10 ;way bigger than the # of objects we can have
     TimeForFullHeal     = 2000   ;(in milliseconds)
+    EnterSound          = GarrisonEnter
+    ExitSound           = GarrisonExit
     AllowInsideKindOf   = INFANTRY
     AllowAlliesInside   = Yes
     AllowNeutralInside  = No


### PR DESCRIPTION
Injured infantry units that would enter the Barracks in 1.04 played no audio whatsoever. This change adds enter / exit sound effects in order to provide feedback to the player and standardises the enter / exit feedback with other structures in the game.

https://user-images.githubusercontent.com/11547761/200110800-88175919-fb07-4895-b9e5-27a8a8a5863d.mp4