### PR TITLE
Change: Removed duplicate cursor name fields from the particle cannon launch command buttons.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -118,7 +118,6 @@ CommandButton Command_FireParticleUplinkCannon
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannon
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
@@ -131,7 +130,6 @@ CommandButton Command_FireParticleUplinkCannonFromShortcut
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannonShortcut
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
@@ -6995,7 +6993,6 @@ CommandButton SupW_Command_FireParticleUplinkCannon
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannon
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
@@ -7008,7 +7005,6 @@ CommandButton SupW_Command_FireParticleUplinkCannonFromShortcut
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannonShortcut
   ButtonImage       = SSParticleFire
-  CursorName        = LaserGuidedMissiles
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon


### PR DESCRIPTION
The `LaserGuidedMissiles` cursor is clearly incorrect, and is overridden by `ParticleUplinkCannon`.