### PR TITLE
Change: Removed a duplicate attack field from the Aurora Bomber creation audio event.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -636,7 +636,6 @@ End
 
 AudioEvent AuroraBomberVoiceCreate
   Sounds = vaurseg
-  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f gradio1g
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control= random


### PR DESCRIPTION
The `gradio1g` audio that is referenced by the former value does not exist.