### PR TITLE
Change: Removed a duplicate delay between shots field from the Laser Crusader's weapon.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6589,7 +6589,6 @@ Weapon Lazr_CrusaderTankGun
   LaserBoneName           = TurretMS01
   FireFX                  = Lazr_WeaponFX_LaserCrusader
   RadiusDamageAffects     = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots       = 2300               ; time between shots, msec
   ClipSize                = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime          = 0              ; how long to reload a Clip, msec
   ProjectileCollidesWith  = STRUCTURES WALLS


### PR DESCRIPTION
The latter value of `2000` is / was always used.