### PR TITLE
Change: Removed a duplicate research sound field from the Arm the Mob upgrade.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -608,7 +608,6 @@ Upgrade Upgrade_GLAArmTheMob
   BuildTime          = 30.0
   BuildCost          = 1000
   ButtonImage        = SSArmMob
-  ResearchSound      = AngryMobVoiceUpgradeArmTheMobCrowd
   ResearchSound      = AngryMobVoiceUpgradeArmTheMob
 End
 


### PR DESCRIPTION
`AngryMobVoiceUpgradeArmTheMobCrowd` references a missing audio file that does not exist, `iangupg`. Removing the latter and valid `AngryMobVoiceUpgradeArmTheMob` research sound will thus result in silence when the upgrade is researched in game. `AngryMobVoiceUpgradeArmTheMobCrowd` is not used anywhere else, and could probably also be deleted if desired.