### PR TITLE
Change: Removed a duplicate command set item field from the GLA Stealth General's Battle Bus.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2795,7 +2795,6 @@ CommandSet Slth_GLAInfantryHijackerCommandSet
 End
 
 CommandSet Slth_GLAVehicleBattleBusCommandSet
-  1  = Slth_Command_DisguiseAsVehicle
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit


### PR DESCRIPTION
This button is overridden, and also nonfunctional if placed in a valid slot such as `10`.