### PR TITLE
Change: Removed duplicate armour fields from various armour sets.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -297,7 +297,6 @@ Armor ToxinTruckArmor ;TruckArmor that is immune to poison
   Armor = SMALL_ARMS        50%
   Armor = GATTLING          50%    ;resistant to gattling tank
   Armor = COMANCHE_VULCAN   50%
-  Armor = INFANTRY_MISSILE  50%
   Armor = POISON            0%    ;IMMUNE! It spews poison :)
   Armor = RADIATION         0%
   Armor = MICROWAVE         0%
@@ -321,7 +320,6 @@ Armor DragonTankArmor
   Armor = COMANCHE_VULCAN   25%
   Armor = FLAME              0%
   Armor = RADIATION         50%      ;Radiation does less damage to tanks.
-  Armor = MICROWAVE          0%
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = MICROWAVE         0%
   Armor = SNIPER            0%
@@ -361,7 +359,6 @@ Armor AirplaneArmor
   Armor = LASER             0%    ;lasers are anti-personel and anti-projectile only (for point defense laser)
   Armor = HAZARD_CLEANUP    0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT        0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER         0%    ;Capture type weapons are effective only against infantry.
   Armor = JET_MISSILES      25%   ;aircraft do less damage to one another in the skies.
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION         25%    ;Radiation does a little damage, just for balance reasons.
@@ -388,7 +385,6 @@ Armor CountermeasuresAirplaneArmor
   Armor = LASER             0%
   Armor = HAZARD_CLEANUP    0%
   Armor = KILL_PILOT        0%
-  Armor = SURRENDER         0%
   Armor = JET_MISSILES      25%
   Armor = POISON            25%
   Armor = RADIATION         25%
@@ -417,7 +413,6 @@ Armor SpectreGunshipArmor
   Armor = LASER             0%    ;lasers are anti-personel and anti-projectile only (for point defense laser)
   Armor = HAZARD_CLEANUP    0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT        0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER         0%    ;Capture type weapons are effective only against infantry.
   Armor = JET_MISSILES      25%   ;aircraft do less damage to one another in the skies.
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION         25%    ;Radiation does a little damage, just for balance reasons.
@@ -442,7 +437,6 @@ Armor CountermeasuresSpectreGunshipArmor
   Armor = LASER             0%
   Armor = HAZARD_CLEANUP    0%
   Armor = KILL_PILOT        0%
-  Armor = SURRENDER         0%
   Armor = JET_MISSILES      25%
   Armor = POISON            25%
   Armor = RADIATION         25%
@@ -471,7 +465,6 @@ Armor ComancheArmor
   Armor = HEALING           100%
   Armor = HAZARD_CLEANUP    0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT        0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER         0%    ;Capture type weapons are effective only against infantry.
   Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION         25%    ;Radiation does a little damage, just for balance reasons.
   Armor = MICROWAVE         0%
@@ -496,7 +489,6 @@ Armor CountermeasuresComancheArmor
   Armor = HEALING           100%
   Armor = HAZARD_CLEANUP    0%
   Armor = KILL_PILOT        0%
-  Armor = SURRENDER         0%
   Armor = POISON            25%
   Armor = RADIATION         25%
   Armor = MICROWAVE         0%
@@ -767,7 +759,6 @@ End
 
 Armor WallArmor
   Armor = DEFAULT           100%    ; this sets the level for all nonspecified damage types
-  Armor = SURRENDER         0%      ; buildings are immune to normal damage from STUN weapons.
   Armor = SMALL_ARMS        6%
   Armor = GATTLING          6%    ;resistant to gattling tank
   Armor = COMANCHE_VULCAN   6%
@@ -849,9 +840,6 @@ Armor BattleBusTruckArmor
   Armor = HAZARD_CLEANUP       0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT         100%    ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER            0%    ;Capture type weapons are effective only against infantry.
-  Armor = SUBDUAL_MISSILE      0%
-  Armor = SUBDUAL_VEHICLE    100%
-  Armor = SUBDUAL_BUILDING     0%
   Armor = RADIATION           50%    ;Radiation does less damage to tanks.
   Armor = SUBDUAL_MISSILE      0%
   Armor = SUBDUAL_VEHICLE    100%
@@ -905,9 +893,6 @@ Armor BattleBusTruckArmorPlusOne
   Armor = HAZARD_CLEANUP       0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT         100%    ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER            0%    ;Capture type weapons are effective only against infantry.
-  Armor = SUBDUAL_MISSILE      0%
-  Armor = SUBDUAL_VEHICLE     90%
-  Armor = SUBDUAL_BUILDING     0%
   Armor = RADIATION           45%    ;Radiation does less damage to tanks.
   Armor = SUBDUAL_MISSILE      0%
   Armor = SUBDUAL_VEHICLE     90%
@@ -962,9 +947,6 @@ Armor BattleBusTruckArmorPlusTwo
   Armor = HAZARD_CLEANUP       0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT         100%    ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER            0%    ;Capture type weapons are effective only against infantry.
-  Armor = SUBDUAL_MISSILE      0%
-  Armor = SUBDUAL_VEHICLE     80%
-  Armor = SUBDUAL_BUILDING     0%
   Armor = RADIATION           40%    ;Radiation does less damage to tanks.
   Armor = SUBDUAL_MISSILE      0%
   Armor = SUBDUAL_VEHICLE     80%
@@ -1082,7 +1064,6 @@ Armor AFG_ComancheArmor
   Armor = HEALING           100%
   Armor = HAZARD_CLEANUP      0%    ;Not harmed by cleaning weapons
   Armor = KILL_PILOT          0%    ;Jarmen Kell uses against vehicles only.
-  Armor = SURRENDER           0%    ;Capture type weapons are effective only against infantry.
   Armor = POISON             25%    ;Poison does a little damage, just for balance reasons.
   Armor = RADIATION          25%    ;Radiation does a little damage, just for balance reasons.
   Armor = MICROWAVE           0%
@@ -1107,7 +1088,6 @@ Armor AFG_CountermeasuresComancheArmor
   Armor = HEALING            90%
   Armor = HAZARD_CLEANUP      0%
   Armor = KILL_PILOT          0%
-  Armor = SURRENDER           0%
   Armor = POISON             25%
   Armor = RADIATION          25%
   Armor = MICROWAVE           0%


### PR DESCRIPTION
All of these are duplicates with the exception of the `INFANTRY_MISSILE` value of `50%` for the Toxin Tractor, which is / was always overridden with the subsequent value of `20%`, which directly matches its counterpart, the Dragon Tank.