### PR TITLE
Change: Remove AIRCRAFT_PATH_AROUND from small non cinematic structures

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianBuilding.ini
@@ -222,7 +222,8 @@ Object BaghdadVictoryMemorial01
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf                = STRUCTURE SELECTABLE IMMOBILE AIRCRAFT_PATH_AROUND
+  ; Patch104p @tweak Remove AIRCRAFT_PATH_AROUND to avoid circling planes.
+  KindOf                = STRUCTURE SELECTABLE IMMOBILE
   Body                  = ActiveBody ModuleTag_02
     MaxHealth       = 2000.0
     InitialHealth   = 2000.0
@@ -279,7 +280,8 @@ Object BaghdadVictoryMemorial02
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf                = STRUCTURE SELECTABLE IMMOBILE AIRCRAFT_PATH_AROUND
+  ; Patch104p @tweak Remove AIRCRAFT_PATH_AROUND to avoid circling planes.
+  KindOf                = STRUCTURE SELECTABLE IMMOBILE
   Body                  = ActiveBody ModuleTag_02
     MaxHealth       = 2000.0
     InitialHealth   = 2000.0
@@ -7053,7 +7055,8 @@ Object EnglishTVStatio
 
   ; *** ENGINEERING Parameters ***
   RadarPriority       = STRUCTURE
-  KindOf              = STRUCTURE SELECTABLE IMMOBILE AIRCRAFT_PATH_AROUND
+  ; Patch104p @tweak Remove AIRCRAFT_PATH_AROUND to avoid circling planes.
+  KindOf              = STRUCTURE SELECTABLE IMMOBILE
   Body                = StructureBody ModuleTag_02
     MaxHealth       = 2000.0
     InitialHealth   = 2000.0
@@ -10506,7 +10509,8 @@ Object StanWatchTowerTall
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf                = STRUCTURE SELECTABLE IMMOBILE AIRCRAFT_PATH_AROUND
+  ; Patch104p @tweak Remove AIRCRAFT_PATH_AROUND to avoid circling planes.
+  KindOf                = STRUCTURE SELECTABLE IMMOBILE
   Body                  = StructureBody ModuleTag_02
     MaxHealth       = 500.0
     InitialHealth   = 500.0
@@ -13920,7 +13924,8 @@ Object WaterPlant
   End
 
   ; *** ENGINEERING Parameters ***
-  KindOf                = STRUCTURE SELECTABLE IMMOBILE AIRCRAFT_PATH_AROUND
+  ; Patch104p @tweak Remove AIRCRAFT_PATH_AROUND to avoid circling planes.
+  KindOf                = STRUCTURE SELECTABLE IMMOBILE
   Body                  = StructureBody ModuleTag_02
     MaxHealth       = 2000.0
     InitialHealth   = 2000.0


### PR DESCRIPTION
Partly addresses
* #676

This change removes AIRCRAFT_PATH_AROUND KindOf from non cinematic structures. This avoids plane collision avoidance logic.

The following structures are affected

* BaghdadVictoryMemorial01
* BaghdadVictoryMemorial02
* ~~EuropeanMuseum~~
* ~~AsianTVStation~~
* EnglishTVStatio
* ~~AsianBank~~
* StanWatchTowerTall
* WaterPlant
* ~~EuroHighrise~~
* ~~BaikonurRocketPad~~
* ~~BaikonurRocketPad_C~~
* ~~OceanConventionCenter~~
* ~~AsianSkyScraper01~~
* ~~AsianMegaHotel01~~
* ~~AsianOffice02~~
* ~~InternationalHotel01~~
* ~~BioRocketPad_C~~
