### PR TITLE
Change: Reduced poison damage received by Dragon Tanks from 25% to 20%.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -320,7 +320,7 @@ Armor DragonTankArmor
   Armor = COMANCHE_VULCAN   25%
   Armor = FLAME              0%
   Armor = RADIATION         50%      ;Radiation does less damage to tanks.
-  Armor = POISON            25%    ;Poison does a little damage, just for balance reasons.
+  Armor = POISON            20%    ;Poison does a little damage, just for balance reasons.
   Armor = MICROWAVE         0%
   Armor = SNIPER            0%
   Armor = MELEE             0%    ;tanks don't generally take much damage other than paint damage from MELEE weapons

--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -320,7 +320,7 @@ Armor DragonTankArmor
   Armor = COMANCHE_VULCAN   25%
   Armor = FLAME              0%
   Armor = RADIATION         50%      ;Radiation does less damage to tanks.
-  Armor = POISON            20%    ;Poison does a little damage, just for balance reasons.
+  Armor = POISON            20%    ;Poison does a little damage, just for balance reasons. ; Patch104p @balance Stubbjax 06/11/2022 Reduced poison damage received by Dragon Tanks from 25% to 20%.
   Armor = MICROWAVE         0%
   Armor = SNIPER            0%
   Armor = MELEE             0%    ;tanks don't generally take much damage other than paint damage from MELEE weapons


### PR DESCRIPTION
In 1.04, Dragon Tanks take 25% damage from `POISON`. Reducing this to 20% is a subtle and effective way to take some of the edge off of Toxin Tunnel Networks for all China factions. China has a tough time dealing with GLA Toxin General in 1.04, particularly due to the massive DPS bonus that Toxin Tunnel Networks have over standard Tunnel Networks. This is a serious design issue, as Dragon Tanks are hard counters to Tunnel Networks, and their weakness to Toxin Tunnel Networks doesn't leave China with many options without incurring losses.

A damage reduction from 25% to 20% (a 20% reduction) is just enough for a Dragon Tank to destroy a Toxin Tunnel Network under the right conditions, with critical health remaining. The resistance from other sources such as Toxin Rebels and Anthrax Bombs would also be a welcome bonus.

Here's a demonstration of a 20% `POISON` damage modifier applied to `DragonTankArmor`, rather than 1.04's 25%. Note that no Tunnel Defenders are present, which is necessary for the Dragon to have any hope of coming out on top.

https://user-images.githubusercontent.com/11547761/192110854-a8dfc2f1-f5d9-43e5-a4b8-f16937f713a2.mp4

After the change, a Dragon Tank with Black Napalm can _just_ manage to kill a Toxin Tunnel Network from directly behind if the flame wall is correctly positioned, no Tunnel Defenders are present or extra damage is sustained, no repairing occurs, and both begin at maximum health.

Standard Napalm can _just_ succeed from the back - though it is a mutual destruction. It took about five attempts to achieve, so it's pretty situational. The reaction time of tunnels likely creates a lot of variance (seems like they might be checking for targets every ~500ms). Black Napalm can reliably _just_ succeed from the front.

https://user-images.githubusercontent.com/11547761/192126021-9573d49c-6170-4dd6-8137-b60215f38e14.mp4

Closes #1269.