### PR TITLE
Fix: Tank Hunter Plays Wrong Animation When Blown Up

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18379,6 +18379,8 @@ Object Boss_InfantryTankHunter
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 06/11/2022 Fixed exploded death animation.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -18443,7 +18445,6 @@ Object Boss_InfantryTankHunter
       AnimationMode     = ONCE
       TransitionKey     = TRANS_Dying
     End
-    AliasConditionState = DYING RUBBLE
 
     TransitionState     = TRANS_Dying TRANS_Flailing
       Animation         = NIMSST_SKL.NIMSST_ADTD1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -875,6 +875,8 @@ Object ChinaInfantryTankHunter
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 06/11/2022 Fixed exploded death animation.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -939,7 +941,6 @@ Object ChinaInfantryTankHunter
       AnimationMode     = ONCE
       TransitionKey     = TRANS_Dying
     End
-    AliasConditionState = DYING RUBBLE
 
     TransitionState     = TRANS_Dying TRANS_Flailing
       Animation         = NIMSST_SKL.NIMSST_ADTD1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -920,6 +920,8 @@ Object Infa_ChinaInfantryTankHunter
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 06/11/2022 Fixed exploded death animation.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -984,7 +986,6 @@ Object Infa_ChinaInfantryTankHunter
       AnimationMode     = ONCE
       TransitionKey     = TRANS_Dying
     End
-    AliasConditionState = DYING RUBBLE
 
     TransitionState     = TRANS_Dying TRANS_Flailing
       Animation         = NIMSST_SKL.NIMSST_ADTD1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2279,6 +2279,8 @@ Object Nuke_ChinaInfantryTankHunter
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 06/11/2022 Fixed exploded death animation.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -2343,7 +2345,6 @@ Object Nuke_ChinaInfantryTankHunter
       AnimationMode     = ONCE
       TransitionKey     = TRANS_Dying
     End
-    AliasConditionState = DYING RUBBLE
 
     TransitionState     = TRANS_Dying TRANS_Flailing
       Animation         = NIMSST_SKL.NIMSST_ADTD1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2009,6 +2009,8 @@ Object Tank_ChinaInfantryTankHunter
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix commy2 06/11/2022 Fixed exploded death animation.
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -2073,7 +2075,6 @@ Object Tank_ChinaInfantryTankHunter
       AnimationMode     = ONCE
       TransitionKey     = TRANS_Dying
     End
-    AliasConditionState = DYING RUBBLE
 
     TransitionState     = TRANS_Dying TRANS_Flailing
       Animation         = NIMSST_SKL.NIMSST_ADTD1


### PR DESCRIPTION
### 1.04

- When blown up (killed by EXPLODED death type weapons), the Tank Hunter plays the normal death animation. The corpse is still flung into the air, which looks bad.

### patch

- The Tank Hunter plays the "blown up" animation when blown up and flung into the air

Note:

- This is not an issue in CCG
- `DYING RUBBLE` alias is superfluous here and not used by e.g. Red Guard. `DYING RUBBLE` clobbers `DYING EXPLODED_BOUNCING`, because when blown up, the object matches both flags in both states.
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1451