### PR TITLE
Fix: Hacker Screams With Red Guard Voice When Killed

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -103,7 +103,7 @@ End
 ; ----------------------------------------------
 FXList FX_HackerDie
   Sound
-    Name = RedGuardVoiceDie
+    Name = HackerVoiceDie ; Patch104p @bugfix commy2 07/11/2022 Fix Hacker effect using Red Guard sound files.
   End
 End
 


### PR DESCRIPTION
### 1.04

- When a Hacker is killed, it plays the same audio file as when a Red Guard is killed.

### patch

- When a Hacker is killed, a unique audio file is played that matches the Hackers voice in other voice effects.

Notes: 
- This issue was introduced in ZH and does not exist in CCG
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1454