### PR TITLE
Change: Reduce the Strategy Center's stealth detection range and S&D vision bonus

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -11824,7 +11824,7 @@ Object AirF_AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 2.0
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -11857,7 +11857,7 @@ Object AirF_AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  500    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -11824,7 +11824,7 @@ Object AirF_AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5 ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 2.0 to 1.5.
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO
@@ -11857,7 +11857,7 @@ Object AirF_AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing! ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 500 to 350.
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7316,7 +7316,7 @@ Object AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5 ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 2.0 to 1.5.
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO
@@ -7346,7 +7346,7 @@ Object AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing! ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 500 to 350.
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7316,7 +7316,7 @@ Object AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 2.0
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7346,7 +7346,7 @@ Object AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  500    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11542,7 +11542,7 @@ Object Lazr_AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  500    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11509,7 +11509,7 @@ Object Lazr_AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5 ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 2.0 to 1.5.
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO
@@ -11542,7 +11542,7 @@ Object Lazr_AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing! ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 500 to 350.
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11509,7 +11509,7 @@ Object Lazr_AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 2.0
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -11053,7 +11053,7 @@ Object SupW_AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 2.0
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -11053,7 +11053,7 @@ Object SupW_AmericaStrategyCenter
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 
     ;Building bonuses granted based on battle plan mode.
-    StrategyCenterSearchAndDestroySightRangeScalar = 1.5
+    StrategyCenterSearchAndDestroySightRangeScalar = 1.5 ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 2.0 to 1.5.
     StrategyCenterSearchAndDestroyDetectsStealth   = Yes
     StrategyCenterHoldTheLineMaxHealthScalar       = 2.0
     StrategyCenterHoldTheLineMaxHealthChangeType   = PRESERVE_RATIO
@@ -11086,7 +11086,7 @@ Object SupW_AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing! ; Patch104p @tweak Stubbjax 08/11/2022 Reduced from 500 to 350.
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -11086,7 +11086,7 @@ Object SupW_AmericaStrategyCenter
   Behavior = StealthDetectorUpdate ModuleTag_16
     DetectionRate       = 500   ; how often to rescan for stealthed things in my sight (msec)
     InitiallyDisabled   = Yes   ; only will be active when search & destroy plan active.
-    DetectionRange     =  500    ;Dustin, enable this for independant balancing!
+    DetectionRange     =  350    ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End


### PR DESCRIPTION
As all heroes (now) have a sight range of 400, options for reacting to a Strategy Center's presence before being detected are incredibly limited. Not only this, but the structure's extensive stealth detection range over the owner's entire base effectively renders heroes useless - on top of the substantial range bonus that Search and Destroy provides. Reducing the stealth detection range is a reasonable way to counterbalance the incredible effectiveness of S&D without directly affecting the bonus itself.

A range reduction could also have some additional benefits / implications, such as the increased importance and skill involved in Strategy Center placement - it makes sense that there would be some _strategy_ involved in placing the Strategy Center, after all. In 1.04, players can practically place the structure down anywhere and be covered, but with a reduced stealth detection range, the building's location might have to be more carefully considered. This would also somewhat increase the prospect of stealth / guerilla tactics for opponents and diversify strategies a bit more. It may even increase the utility of Sentry Drones (and Spy Drones - for opposing USAs as well), and it could certainly benefit / reward players who actively pursue stealth detection / awareness, which is far more meaningful than having it handed to them on a silver platter. A stealth detection range of 350 provides enough leeway for heroes to react accordingly, and affords heroes and other stealth units greater manoeuvrability around an opponent's base.

Another thing to note is the Strategy Center's extreme shroud-clearing range of 400 → 800 (×2) under the effects of Search and Destroy, and is another unnecessary advantage that discounts map awareness. The ×2 scalar has been reduced to ×1.5, resulting in a more palatable range of 400 → 600. This was preferred over reducing the default vision of 400 to 300 due to the Bombardment cannon's weapon range of 400.

To summarise, the proposed changes are:
- Reduce the Strategy Center's S&D stealth detection range from 500 to 350
- Reduce the Strategy Center's S&D vision bonus from ×2 (800) to ×1.5 (600)

I believe both of these changes would be fairly subtle and unlikely to be noticed by the majority of players.

![image](https://user-images.githubusercontent.com/11547761/199488314-27fe7400-4c3f-4e92-b6b5-6bece8b0f4cb.png)

Originally discussed in #1212.

# Tests

After some extensive testing, it seems as though there is a mismatch between the detection and shroud reveal ranges. Despite Black Lotus's shroud range of 400 and the Strategy Center's stealth detection range of 500, it seems as though the two are roughly equal during gameplay, as seen in the footage below. It is unclear whether this should impact the suggested range of 350, as a large component of the change is the resultant enhanced manoeuvrability and strategical flexibility in an opponent's base.

## Test 1 - 500 detection range vs Black Lotus
The Strategy Center is pretty much revealed at the same time as Black Lotus is detected. No counterplay potential - especially when factoring in network latency.

https://user-images.githubusercontent.com/11547761/200460543-e689627a-59cc-4f1e-ab95-8dacb03ff022.mp4

## Test 2 - 400 detection range vs Black Lotus
There is now a reasonable amount of time to react to the presence of a Strategy Center, and improved manoeuvrability within its proximity. Allows greater potential for heroes to access other areas of the opponent's base without detection.

https://user-images.githubusercontent.com/11547761/200461751-f4e386dc-3945-404f-b9b3-d97d2088b368.mp4

## Test 3 - 350 detection range vs Black Lotus
Even more time to react to a Strategy Center's presence, and further manoeuvrability prospects around an opponent's base. Provides heroes with further access to other areas of the opponent's base without detection.

https://user-images.githubusercontent.com/11547761/200467805-67e1abbb-0fd5-47e9-9307-85384115c5b2.mp4

## Comparison

![image](https://user-images.githubusercontent.com/11547761/200462223-09d80a52-cace-420e-99d1-4f59991fb3a5.png)

Common stealth detection ranges for reference:

| | Range |
| - | - |
Scout Drone | 150 |
Tunnel | 150 |
Troop Crawler | 175 |
Gattling Cannon | 200 |
King Raptor | 200 |
Pathfinder | 200 |
Patriot Battery | 200 |
Stinger Site | 200 |
Sentry Drone | 225 |
Radar Van | 250 |
Spy Drone | 250 |
Black Lotus | 300 |
Outpost | 300 |
Strategy Center (this) | 350 |
Strategy Center (1.04) | 500 |