### PR TITLE
Change: Adjusted Battle, Hellfire and Scout Drone armour and health.

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -291,6 +291,26 @@ Armor AvengerArmor
   Armor = SUBDUAL_BUILDING     0%
 End
 
+Armor DroneArmor
+  Armor = SMALL_ARMS       120%
+  Armor = GATTLING         120%
+  Armor = EXPLOSION        200%
+  Armor = INFANTRY_MISSILE 120%
+  Armor = JET_MISSILES     200%
+  Armor = RADIATION         25%
+  Armor = POISON            25%
+  Armor = KILL_PILOT         0%
+  Armor = SUBDUAL_VEHICLE    0%
+  Armor = SUBDUAL_MISSILE    0%
+  Armor = SUBDUAL_BUILDING   0%
+  Armor = MELEE              0%
+  Armor = SURRENDER          0%
+  Armor = SNIPER             0%
+  Armor = MELEE              0%
+  Armor = LASER              0%
+  Armor = HAZARD_CLEANUP     0%
+  Armor = MICROWAVE          0%
+End
 
 Armor ToxinTruckArmor ;TruckArmor that is immune to poison
   Armor = CRUSH             50%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -292,10 +292,10 @@ Armor AvengerArmor
 End
 
 Armor DroneArmor
-  Armor = SMALL_ARMS       120%
-  Armor = GATTLING         120%
+  Armor = SMALL_ARMS       100%
+  Armor = GATTLING         100%
   Armor = EXPLOSION        200%
-  Armor = INFANTRY_MISSILE 120%
+  Armor = INFANTRY_MISSILE 100%
   Armor = JET_MISSILES     200%
   Armor = RADIATION         25%
   Armor = POISON            25%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5948,8 +5948,8 @@ Object AirF_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 160.0
+    InitialHealth   = 160.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5972,7 +5972,7 @@ Object AirF_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 40.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -6101,8 +6101,8 @@ Object AirF_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6138,7 +6138,7 @@ Object AirF_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -6354,7 +6354,7 @@ Object AirF_AmericaVehicleSpyDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   VisionRange     = 250
@@ -6379,8 +6379,8 @@ Object AirF_AmericaVehicleSpyDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6434,7 +6434,7 @@ Object AirF_AmericaVehicleSpyDrone
   End
   Behavior = MaxHealthUpgrade ModuleTag_10
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5919,7 +5919,7 @@ Object AirF_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = AirplaneArmor
+    Armor             = DroneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -6074,7 +6074,7 @@ Object AirF_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -6217,7 +6217,7 @@ Object AirF_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5919,7 +5919,7 @@ Object AirF_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirplaneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5948,8 +5948,8 @@ Object AirF_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -6074,7 +6074,7 @@ Object AirF_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -6101,8 +6101,8 @@ Object AirF_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6138,7 +6138,7 @@ Object AirF_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -6217,7 +6217,7 @@ Object AirF_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500
@@ -6247,8 +6247,8 @@ Object AirF_AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6277,7 +6277,7 @@ Object AirF_AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -872,8 +872,8 @@ Object AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 160.0
+    InitialHealth   = 160.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -896,7 +896,7 @@ Object AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 40.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -1025,8 +1025,8 @@ Object AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -1062,7 +1062,7 @@ Object AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -1277,7 +1277,7 @@ Object AmericaVehicleSpyDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   VisionRange     = 250
@@ -1302,8 +1302,8 @@ Object AmericaVehicleSpyDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -1357,7 +1357,7 @@ Object AmericaVehicleSpyDrone
   End
   Behavior = MaxHealthUpgrade ModuleTag_10
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -843,7 +843,7 @@ Object AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = AirplaneArmor
+    Armor             = DroneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -998,7 +998,7 @@ Object AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -1139,7 +1139,7 @@ Object AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -843,7 +843,7 @@ Object AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirplaneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -872,8 +872,8 @@ Object AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -998,7 +998,7 @@ Object AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -1025,8 +1025,8 @@ Object AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -1062,7 +1062,7 @@ Object AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -1139,7 +1139,7 @@ Object AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500
@@ -1169,8 +1169,8 @@ Object AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -1199,7 +1199,7 @@ Object AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5180,8 +5180,8 @@ Object Lazr_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 160.0
+    InitialHealth   = 160.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5204,7 +5204,7 @@ Object Lazr_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 40.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5333,8 +5333,8 @@ Object Lazr_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5370,7 +5370,7 @@ Object Lazr_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5587,7 +5587,7 @@ Object Lazr_AmericaVehicleSpyDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   VisionRange     = 250
@@ -5612,8 +5612,8 @@ Object Lazr_AmericaVehicleSpyDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5667,7 +5667,7 @@ Object Lazr_AmericaVehicleSpyDrone
   End
   Behavior = MaxHealthUpgrade ModuleTag_10
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5151,7 +5151,7 @@ Object Lazr_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = AirplaneArmor
+    Armor             = DroneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5306,7 +5306,7 @@ Object Lazr_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5449,7 +5449,7 @@ Object Lazr_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5151,7 +5151,7 @@ Object Lazr_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirplaneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5180,8 +5180,8 @@ Object Lazr_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5306,7 +5306,7 @@ Object Lazr_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5333,8 +5333,8 @@ Object Lazr_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5370,7 +5370,7 @@ Object Lazr_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5449,7 +5449,7 @@ Object Lazr_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 600
@@ -5479,8 +5479,8 @@ Object Lazr_AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5509,7 +5509,7 @@ Object Lazr_AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -121,7 +121,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirplaneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -147,8 +147,8 @@ Object SupW_AmericaVehiclePointDefenseDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5631,7 +5631,7 @@ Object SupW_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirplaneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5660,8 +5660,8 @@ Object SupW_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5684,7 +5684,7 @@ Object SupW_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5786,7 +5786,7 @@ Object SupW_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5813,8 +5813,8 @@ Object SupW_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5850,7 +5850,7 @@ Object SupW_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5929,7 +5929,7 @@ Object SupW_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirplaneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500
@@ -5959,8 +5959,8 @@ Object SupW_AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5989,7 +5989,7 @@ Object SupW_AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -121,7 +121,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = AirplaneArmor
+    Armor             = DroneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5631,7 +5631,7 @@ Object SupW_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = AirplaneArmor
+    Armor             = DroneArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5786,7 +5786,7 @@ Object SupW_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5929,7 +5929,7 @@ Object SupW_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -147,8 +147,8 @@ Object SupW_AmericaVehiclePointDefenseDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 160.0
+    InitialHealth   = 160.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -171,7 +171,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 40.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5660,8 +5660,8 @@ Object SupW_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 160.0
+    InitialHealth   = 160.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5684,7 +5684,7 @@ Object SupW_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 40.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5813,8 +5813,8 @@ Object SupW_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5850,7 +5850,7 @@ Object SupW_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -6067,7 +6067,7 @@ Object SupW_AmericaVehicleSpyDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = AirplaneArmor
+    Armor           = DroneArmor
     DamageFX        = SmallTankDamageFX
   End
   VisionRange     = 250
@@ -6092,8 +6092,8 @@ Object SupW_AmericaVehicleSpyDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 200.0
-    InitialHealth   = 200.0
+    MaxHealth       = 120.0
+    InitialHealth   = 120.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6147,7 +6147,7 @@ Object SupW_AmericaVehicleSpyDrone
   End
   Behavior = MaxHealthUpgrade ModuleTag_10
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 30.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 


### PR DESCRIPTION
Battle, Hellfire and Scout Drones provide USA with a huge advantage, as they distract enemy anti-air units and act as an additional decoy and damage sponge that significantly and disproportionately extends the longevity of USA vehicles. They are fairly cheap and build incredibly fast, which exacerbates the problem even further, and are easily and readily replaced. They are also incredibly frustrating to play against, as a player's anti-air units will prioritise the drones over vehicles. It is clear that drones have a far greater impact on the game than they have any right to, and are part of an incredibly flawed design that should really be addressed[.](https://user-images.githubusercontent.com/11547761/201368326-66025352-a350-412d-af98-2176196b5a64.png)

To lessen the severity of the respective issue(s), the following changes have been applied:

- Replaced drone `TankArmor` with `AirplaneArmor`
- Doubled drone hit points from 100 to 200
- Doubled Drone Armor hit points boost from 25 to 50 to match the doubled hp

With the above changes, the three drones are now standardised with the Spy Drone, which already uses `AirplaneArmor` with 200 hit points. This provides a nice reference, as players are already familiar with the Spy Drone and its attributes. As much as these changes may make sense, it's important to note that drones are used incredibly often, and so a great deal of care and consideration must be taken when altering them. In an ideal world, these drones would have minimal armour and die in half the time they take to create, but that would have greater implications and is beyond the scope of this patch.

The key differences between the two armour types are displayed in the table below.

| | TankArmor | AirplaneArmor
-- | -- | --
SMALL_ARMS | 25% | 120%
GATTLING | 10% | 120%
FLAME | 25% | 100%
INFANTRY_MISSILE | 100% | 120%
JET_MISSILES | 100% | 25%
RADIATION | 50% | 25%

The above `TankArmor` properties - particularly the low `25% SMALL_ARMS` and ` 10% GATTLING` modifiers - are the primary offenders here, and the reason drones are so hard for Quad Cannons, Gattling Tanks and Avengers to shoot down.

In 1.04, a Quad Cannon deals 5 damage per round with its anti-air weapon. `TankArmor`'s 25% modifier for `SMALL_ARMS` damage reduces this down to a pitiful 1.25 damage per round against drones. With 100 hit points, this means a Quad Cannon must fire 80 rounds to take down a single drone. At one round every 100ms (~133ms) - roughly 7.5 rounds per second - a drone takes ~10.5 seconds to destroy. This is an outrageously long time, especially when a Humvee takes 48 rounds to destroy and a King Raptor takes just 40 rounds (half of a drone). Quite ludicrous!

Gattling Tanks are a bit trickier to compare due to the barrel spin logic, so let's assume a fully spun up state. A Gattling Tank deals 12 damage per round with its anti-air weapon. Due to the odd fact that Gattling Tanks deal `SMALL_ARMS` damage with their anti-air weapons, this damage is also multiplied by `TankArmor`'s 25% modifier to 3 damage per round against drones. With 100 hit points, a drone takes 34 rounds to kill. At one round every 100ms (~133ms), a drone takes ~4.4s for a Gattling Tank to destroy. A King Raptor takes just 17 rounds to destroy, for reference.

It is also important to note that an Ambulance's healing aura can provide drones with an additional 5 hit points per second, which is equivalent to 4 Quad Cannon Rounds and ~1.67 Gattling Tank rounds. This effectively doubles the time it takes for a Quad Cannon to destroy a drone to ~21.7s. (It takes the same time to destroy a Cold Fusion Reactor.) This bonus will be effectively halved after the change, as drones will take twice as long to heal up to 200 hit points.

With these crazy numbers in mind, let's compare the results of the change. The number of shots to destroy a drone are as follows:

| | 1.04 | This | Change
-- | -- | -- | --
Quad Rounds | 80 | 34 | ×2.35
Gattling Rounds | 34 | 14 | ×2.43
Infantry Missiles | 3 | 5 | ×0.6
King Raptor Missiles | 1 | 7 | ×0.14

The Quad Cannon and Gattling Tank's prospects seem much more reasonable against the `AirplaneArmor`, and will destroy a drone (200hp) slightly faster than a King Raptor (240hp) when both use the same armour.

An unfortunate consequence of the `AirplaneArmor` change is that it (strangely) protects strongly against `JET_MISSILES`. This is an existing problem in 1.04, as a King Raptor cannot take down a simple Spy Drone in one volley (6 × 125 × 0.25 = 187.5). Whether `AirplaneArmor`'s damage multiplier for `JET_MISSILES` should be slightly increased to offset this anomaly is another question and ideally separate from this change as it would impact most aircraft.

There is also the issue of some unspecified damage types effectively doing half damage after the change (due to the ×2 hit points), though other damage types are typically powerful enough and never really a problem in the original game. Regardless, a subsequent follow-up alteration would likely be to create a dedicated armour class for drones and apply additional damage for the respective damage types to keep them consistent with 1.04 or adjust hp where it makes sense.

## 1.04:
A dedicated anti-air unit struggles to take down three pitiful $100 drones.

https://user-images.githubusercontent.com/11547761/201356064-54cfbb49-b82b-4ca1-aaba-37332e44b282.mp4

## Patch:
The three drones are dispatched in a much more reasonable time frame.

https://user-images.githubusercontent.com/11547761/201356053-ed71930f-329c-4c16-a04e-e67c7b303e00.mp4

With the proposed changes, drones no longer stall anti-air units for ridiculously long periods of time, and their reduced durability aligns much more logically with their prices, build speed and function. Ultimately, USA will effectively have to pay more to maintain their drones.