### PR TITLE
Add small movement sway to USA Chinook, Comanche

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -2141,6 +2141,12 @@ Locomotor ComancheLocomotor
   Apply2DFrictionWhenAirborne = Yes
   AirborneTargetingHeight = 30
   LocomotorWorksWhenDead = Yes          ; HelicopterSlowDeathBehavior needs this to function correctly
+
+  ; Patch104p @tweak Adds little sway movement based on HelixLocomotor (* 0.33). Does not impact movement or combat abilities.
+  RudderCorrectionDegree    = 0.056
+  RudderCorrectionRate      = 0.027
+  ElevatorCorrectionDegree  = 0.034
+  ElevatorCorrectionRate    = 0.016
 End
 
 ;------------------------------------------------------------------------------
@@ -2170,6 +2176,12 @@ Locomotor CINE_USA08_ComancheLocomotor
   Apply2DFrictionWhenAirborne = Yes
   AirborneTargetingHeight = 30
   LocomotorWorksWhenDead = Yes          ; HelicopterSlowDeathBehavior needs this to function correctly
+
+  ; Patch104p @tweak Adds little sway movement based on HelixLocomotor (* 0.33). Does not impact movement or combat abilities.
+  RudderCorrectionDegree    = 0.056
+  RudderCorrectionRate      = 0.027
+  ElevatorCorrectionDegree  = 0.034
+  ElevatorCorrectionRate    = 0.016
 End
 
 ;------------------------------------------------------------------------------
@@ -2255,6 +2267,12 @@ Locomotor ChinookLocomotor
   Apply2DFrictionWhenAirborne = Yes
   AirborneTargetingHeight = 30
   LocomotorWorksWhenDead = Yes          ; HelicopterSlowDeathBehavior needs this to function correctly
+
+  ; Patch104p @tweak Adds little sway movement based on HelixLocomotor (* 0.33). Does not impact movement or combat abilities.
+  RudderCorrectionDegree    = 0.056
+  RudderCorrectionRate      = 0.027
+  ElevatorCorrectionDegree  = 0.034
+  ElevatorCorrectionRate    = 0.016
 End
 
 ;------------------------------------------------------------------------------
@@ -3862,6 +3880,12 @@ Locomotor CINE_ComancheLocomotor
   Apply2DFrictionWhenAirborne = Yes
   AirborneTargetingHeight = 30
   LocomotorWorksWhenDead = Yes          ; HelicopterSlowDeathBehavior needs this to function correctly
+
+  ; Patch104p @tweak Adds little sway movement based on HelixLocomotor (* 0.33). Does not impact movement or combat abilities.
+  RudderCorrectionDegree    = 0.056
+  RudderCorrectionRate      = 0.027
+  ElevatorCorrectionDegree  = 0.034
+  ElevatorCorrectionRate    = 0.016
 End
 
 ;------------------------------------------------------------------------------
@@ -4150,6 +4174,12 @@ Locomotor CINE_ChinookLocomotor
   Apply2DFrictionWhenAirborne = Yes
   AirborneTargetingHeight = 30
   LocomotorWorksWhenDead = Yes          ; HelicopterSlowDeathBehavior needs this to function correctly
+
+  ; Patch104p @tweak Adds little sway movement based on HelixLocomotor (* 0.33). Does not impact movement or combat abilities.
+  RudderCorrectionDegree    = 0.056
+  RudderCorrectionRate      = 0.027
+  ElevatorCorrectionDegree  = 0.034
+  ElevatorCorrectionRate    = 0.016
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
* Closes #1465

This change adds small movement sway to USA Chinook, Comanche. The movement is just 33% of how much the Helix sways. Originally there is no sway movement.

https://user-images.githubusercontent.com/4720891/201541778-ab662feb-43c8-451e-8173-c4606153b29d.mp4
