### PR TITLE
Change: Reduce Drone Armor upgrade bonus of USA Battle Drone from 50% to 25%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5971,7 +5971,7 @@ Object AirF_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -896,7 +896,7 @@ Object AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5203,7 +5203,7 @@ Object Lazr_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -171,7 +171,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 50.0
+    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 


### PR DESCRIPTION
This change reduces the Drone Armor bonus of USA Battle Drone from 50% to 25%. This makes the armor bonus consistent with all other drones.

| Object                      | Drone Armor Upgrade bonus | Upgraded Health |
|-----------------------------|---------------------------|-----------------|
| Original Sentry Drone       | 25%                       | 375             |
| Original Spy Drone          | 25%                       | 250             |
| Original Scout Drone        | 25%                       | 125             |
| Original Hellfire Drone     | 25%                       | 125             |
| Original Battle Drone       | 50%                       | 150             |
| Patched Battle Drone (this) | 25%                       | 125             |

# Rationale

Slave Drones do tank a lot of damage from GLA Quad Cannons and China Gattling Tanks - with and without the Drone Armor upgrade. Not upgraded, a Battle Drone dies after 80 hits from a GLA Quad Cannon, while a Humvee dies after 48 hits. Acquiring the Drone Armor upgrade will increase that to 120 hits. This means an upgraded Battle Drone will withstand 2.5 times as many bullets as a Humvee does.

The decrease of the Drone Armor bonus is by no means a big nerf for the USA Battle Drone. It remains very tough with it, identical to the other drones.