### PR TITLE
Change: Increase heal time for USA slave drones by 100%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -1008,6 +1008,29 @@ Armor FireBaseArmor
   Armor = SUBDUAL_BUILDING    100%
 End
 
+Armor AirDroneArmor ; Patch104p, based on TankArmor
+  Armor = DEFAULT           200%
+  Armor = HEALING           100%
+  Armor = CRUSH             100%
+  Armor = SMALL_ARMS        50%
+  Armor = GATTLING          20%
+  Armor = COMANCHE_VULCAN   50%
+  Armor = FLAME             50%
+  Armor = RADIATION         100%
+  Armor = MICROWAVE         0%
+  Armor = POISON            50%
+  Armor = SNIPER            0%
+  Armor = MELEE             0%
+  Armor = LASER             0%
+  Armor = HAZARD_CLEANUP    0%
+  Armor = PARTICLE_BEAM     200%
+  Armor = KILL_PILOT        200%
+  Armor = SURRENDER         0%
+  Armor = SUBDUAL_MISSILE   0%
+  Armor = SUBDUAL_VEHICLE   200%
+  Armor = SUBDUAL_BUILDING  0%
+End
+
 Armor SentryDroneArmor
   Armor = JET_MISSILES        30%
   Armor = STEALTHJET_MISSILES 30%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5918,7 +5918,7 @@ Object AirF_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5947,8 +5947,8 @@ Object AirF_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5971,7 +5971,7 @@ Object AirF_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
+    AddMaxHealth  = 50.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -6073,7 +6073,7 @@ Object AirF_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -6100,8 +6100,8 @@ Object AirF_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6137,7 +6137,7 @@ Object AirF_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -6216,7 +6216,7 @@ Object AirF_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500
@@ -6246,8 +6246,8 @@ Object AirF_AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -6276,7 +6276,7 @@ Object AirF_AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -843,7 +843,7 @@ Object AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -872,8 +872,8 @@ Object AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -896,7 +896,7 @@ Object AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
+    AddMaxHealth  = 50.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -998,7 +998,7 @@ Object AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -1025,8 +1025,8 @@ Object AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -1062,7 +1062,7 @@ Object AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -1139,7 +1139,7 @@ Object AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500
@@ -1169,8 +1169,8 @@ Object AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -1199,7 +1199,7 @@ Object AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5150,7 +5150,7 @@ Object Lazr_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5179,8 +5179,8 @@ Object Lazr_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5203,7 +5203,7 @@ Object Lazr_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
+    AddMaxHealth  = 50.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5305,7 +5305,7 @@ Object Lazr_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5332,8 +5332,8 @@ Object Lazr_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5369,7 +5369,7 @@ Object Lazr_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5448,7 +5448,7 @@ Object Lazr_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 600
@@ -5478,8 +5478,8 @@ Object Lazr_AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5508,7 +5508,7 @@ Object Lazr_AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -121,7 +121,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -147,8 +147,8 @@ Object SupW_AmericaVehiclePointDefenseDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -171,7 +171,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
+    AddMaxHealth  = 50.0 ; Patch104p @tweak Reduce bonus from 50% to 25%. Matches other drones.
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5630,7 +5630,7 @@ Object SupW_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5659,8 +5659,8 @@ Object SupW_AmericaVehicleBattleDrone
   RadarPriority       = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
   Body = ActiveBody ModuleTag_03
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_04
@@ -5683,7 +5683,7 @@ Object SupW_AmericaVehicleBattleDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_06
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5785,7 +5785,7 @@ Object SupW_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5812,8 +5812,8 @@ Object SupW_AmericaVehicleScoutDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5849,7 +5849,7 @@ Object SupW_AmericaVehicleScoutDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 
@@ -5928,7 +5928,7 @@ Object SupW_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500
@@ -5958,8 +5958,8 @@ Object SupW_AmericaVehicleHellfireDrone
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SELECTABLE CAN_ATTACK DRONE NO_SELECT
 
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 200.0 ; Patch104p @tweak from 100
+    InitialHealth   = 200.0
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
@@ -5988,7 +5988,7 @@ Object SupW_AmericaVehicleHellfireDrone
 
   Behavior = MaxHealthUpgrade ModuleTag_07
     TriggeredBy   = Upgrade_AmericaDroneArmor
-    AddMaxHealth  = 25.0
+    AddMaxHealth  = 50.0
     ChangeType    = ADD_CURRENT_HEALTH_TOO   ;Choices are PRESERVE_RATIO, ADD_CURRENT_HEALTH_TOO, and SAME_CURRENTHEALTH
   End
 


### PR DESCRIPTION
This change increases USA slave drone heal time by 100%. This affects Scout Drone, Battle Drone and Hellfire Drone. Drone armor capabilities are unchanged.

Sorted by **Max Heal Time** column.

| Object                         | Health | HEALING% | Medic Healing | Max Heal Time (s) |
|--------------------------------|--------|----------|---------------|-------------------|
| Original Slave Drones          | 100    | 100%     | 5             | 20                |
| AmericaInfantryMissileDefender | 100    | 100%     | 4             | 25                |
| AmericaInfantryPathfinder      | 120    | 100%     | 4             | 30                |
| AmericaVehicleTomahawk         | 180    | 100%     | 5             | 36                |
| Patched Slave Drones (this)    | 200    | 100%     | 5             | 40                |
| AmericaInfantryRanger          | 180    | 100%     | 4             | 45                |
| AmericaVehicleHumvee           | 240    | 100%     | 5             | 48                |
| AmericaVehicleMedic            | 240    | 100%     | 5             | 48                |
| AmericaInfantryColonelBurton   | 200    | 100%     | 4             | 50                |
| AmericaVehicleSentryDrone      | 300    | 100%     | 5             | 60                |
| AmericaTankAvenger             | 300    | 100%     | 5             | 60                |
| AmericaTankCrusader            | 480    | 100%     | 5             | 96                |

## Rationale

USA Slave Drones are cheap and powerful in masses. They can tank a respectable amount damage, especially from GLA Quad Cannons and China Gattling Tanks. To give example, a Humvee takes 48 Quad Cannon hits to die and Scout Drone takes 80 hits to die. Combining this with the fact that a Slave Drone repairs in less than half the time of a Humvee, makes the Slave Drone a very effective Bullet Tank for any host vehicle. The presented increase of healing time puts the Slave Drones from Rank 1 of fastest heal times somewhere between Infantry and Light Vehicles. Overall, Slave Drones still have a competitive heal time with this change.

The USA Medic (Ambulance) has a heal range of 100.

```
Behavior = AutoHealBehavior ModuleTag_23
    HealingAmount     = 5
    HealingDelay      = 1000
    Radius            = 100.0
```

Slave Drones do wander around the host vehicle with some distance. This means a Drone may fly out of the healing range of a Medic. This can delay healing. However, in turn that also means the Drone may fly into the range of another Medic. This will continue healing. Overall we can assume a fair distribution of penalty and benefit of random slave movements in regards to healing, depending on where the Medic unit(s) are in relation to the host vehicle(s). 

```
Behavior = SlavedUpdate ModuleTag_06
  GuardMaxRange = 35      ;How far away from master I'm allowed when master is idle (doesn't wander)
  GuardWanderRange = 35   ;How far away I'm allowed to wander from master while guarding.
  AttackRange = 75        ;How far away from master I'm allowed when master is attacking a target.
  AttackWanderRange = 10  ;How far I'm allowed to wander from target.
  ScoutRange = 75         ;How far away from master I'm allowed when master is moving.
  ScoutWanderRange = 10   ;How far I'm allowed to wander from scout point.
```