### PR TITLE
Add AirDroneArmor for USA Slave Drones

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -1008,6 +1008,29 @@ Armor FireBaseArmor
   Armor = SUBDUAL_BUILDING    100%
 End
 
+Armor AirDroneArmor ; Patch104p, based on TankArmor
+  Armor = DEFAULT           100%
+  Armor = HEALING           100%
+  Armor = CRUSH              50%
+  Armor = SMALL_ARMS         25%
+  Armor = GATTLING           10%
+  Armor = COMANCHE_VULCAN    25%
+  Armor = FLAME              25%
+  Armor = RADIATION          50%
+  Armor = MICROWAVE           0%
+  Armor = POISON             25%
+  Armor = SNIPER              0%
+  Armor = MELEE               0%
+  Armor = LASER               0%
+  Armor = HAZARD_CLEANUP      0%
+  Armor = PARTICLE_BEAM     100%
+  Armor = KILL_PILOT        100%
+  Armor = SURRENDER           0%
+  Armor = SUBDUAL_MISSILE     0%
+  Armor = SUBDUAL_VEHICLE   100%
+  Armor = SUBDUAL_BUILDING    0%
+End
+
 Armor SentryDroneArmor
   Armor = JET_MISSILES        30%
   Armor = STEALTHJET_MISSILES 30%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5918,7 +5918,7 @@ Object AirF_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -6073,7 +6073,7 @@ Object AirF_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -6216,7 +6216,7 @@ Object AirF_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -843,7 +843,7 @@ Object AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -998,7 +998,7 @@ Object AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -1139,7 +1139,7 @@ Object AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5150,7 +5150,7 @@ Object Lazr_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5305,7 +5305,7 @@ Object Lazr_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5448,7 +5448,7 @@ Object Lazr_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -121,7 +121,7 @@ Object SupW_AmericaVehiclePointDefenseDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5630,7 +5630,7 @@ Object SupW_AmericaVehicleBattleDrone
   End
   ArmorSet
     Conditions        = None
-    Armor             = TankArmor
+    Armor             = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX          = SmallTankDamageFX
   End
 
@@ -5785,7 +5785,7 @@ Object SupW_AmericaVehicleScoutDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 100
@@ -5928,7 +5928,7 @@ Object SupW_AmericaVehicleHellfireDrone
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   ArmorSet
     Conditions      = None
-    Armor           = TankArmor
+    Armor           = AirDroneArmor ; Patch104p @tweak from TankArmor
     DamageFX        = SmallTankDamageFX
   End
   BuildCost       = 500


### PR DESCRIPTION
This change adds new Armor "AirDroneArmor" to all USA Slave Drones. Armor and Health are unchanged.