### PR TITLE
Change: Decrease healing speed of USA Slave Drones by 50%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -1008,9 +1008,12 @@ Armor FireBaseArmor
   Armor = SUBDUAL_BUILDING    100%
 End
 
-Armor AirDroneArmor ; Patch104p, based on TankArmor
+; Patch104p
+; AirDroneArmor originated from TankArmor.
+; Decrease healing speed by 50%
+Armor AirDroneArmor
   Armor = DEFAULT           100%
-  Armor = HEALING           100%
+  Armor = HEALING            50%
   Armor = CRUSH              50%
   Armor = SMALL_ARMS         25%
   Armor = GATTLING           10%


### PR DESCRIPTION
This change decreases healing speed of USA Slave Drones by 50%. This affects Scout Drone, Battle Drone and Hellfire Drone. Drone armor capabilities are unchanged.

Sorted by **Max Heal Time** column.

| Object                         | Health | HEALING% | Medic Healing | Max Heal Time (s) |
|--------------------------------|--------|----------|---------------|-------------------|
| Original Slave Drones          | 100    | 100%     | 5             | 20                |
| AmericaInfantryMissileDefender | 100    | 100%     | 4             | 25                |
| AmericaInfantryPathfinder      | 120    | 100%     | 4             | 30                |
| AmericaVehicleTomahawk         | 180    | 100%     | 5             | 36                |
| Patched Slave Drones (this)    | 200    | 100%     | 5             | 40                |
| AmericaInfantryRanger          | 180    | 100%     | 4             | 45                |
| AmericaVehicleHumvee           | 240    | 100%     | 5             | 48                |
| AmericaVehicleMedic            | 240    | 100%     | 5             | 48                |
| AmericaInfantryColonelBurton   | 200    | 100%     | 4             | 50                |
| AmericaVehicleSentryDrone      | 300    | 100%     | 5             | 60                |
| AmericaTankAvenger             | 300    | 100%     | 5             | 60                |
| AmericaTankCrusader            | 480    | 100%     | 5             | 96                |

## Rationale

USA Slave Drones are cheap and powerful in masses. They can tank a respectable amount damage, especially from GLA Quad Cannons and China Gattling Tanks. To give example, a Humvee takes 48 Quad Cannon hits to die and Scout Drone takes 80 hits to die. Combining this with the fact that a Slave Drone repairs in less than half the time of a Humvee, makes the Slave Drone a very effective Bullet Tank for any host vehicle. The presented increase of healing time puts the Slave Drones from Rank 1 of fastest heal times somewhere between Infantry and Light Vehicles. Overall, Slave Drones still have a competitive heal time with this change.

The USA Medic (Ambulance) has a heal range of 100.

```
Behavior = AutoHealBehavior ModuleTag_23
    HealingAmount     = 5
    HealingDelay      = 1000
    Radius            = 100.0
```

Slave Drones do wander around the host vehicle with some distance. This means a Drone may fly out of the healing range of a Medic. This can delay healing. However, in turn that also means the Drone may fly into the range of another Medic. This will continue healing. Overall we can assume a fair distribution of penalty and benefit of random slave movements in regards to healing, depending on where the Medic unit(s) are in relation to the host vehicle(s). 

```
Behavior = SlavedUpdate ModuleTag_06
  GuardMaxRange = 35      ;How far away from master I'm allowed when master is idle (doesn't wander)
  GuardWanderRange = 35   ;How far away I'm allowed to wander from master while guarding.
  AttackRange = 75        ;How far away from master I'm allowed when master is attacking a target.
  AttackWanderRange = 10  ;How far I'm allowed to wander from target.
  ScoutRange = 75         ;How far away from master I'm allowed when master is moving.
  ScoutWanderRange = 10   ;How far I'm allowed to wander from scout point.
```