### PR TITLE
Fix: Reduce delay of USA Comanche final death explosion

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -2302,7 +2302,7 @@ Object AirF_AmericaVehicleComanche
     OCLHitGround                    = OCL_HelicopterHitGround
     FXFinalBlowUp                   = FX_GroundedHelicopterBlowUp
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
-    DelayFromGroundToFinalDeath     = 1500
+    DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -1872,7 +1872,7 @@ Object AmericaVehicleComanche
     OCLHitGround                    = OCL_HelicopterHitGround
     FXFinalBlowUp                   = FX_GroundedHelicopterBlowUp
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
-    DelayFromGroundToFinalDeath     = 1500
+    DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -1197,7 +1197,7 @@ Object CINE_USA08_AmericaVehicleComanche
     OCLHitGround                    = OCL_HelicopterHitGround
     FXFinalBlowUp                   = FX_GroundedHelicopterBlowUp
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
-    DelayFromGroundToFinalDeath     = 1500
+    DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
   End
 
@@ -3314,7 +3314,7 @@ Object CINE_AmericaVehicleComanche
     OCLHitGround                    = OCL_HelicopterHitGround
     FXFinalBlowUp                   = FX_GroundedHelicopterBlowUp
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
-    DelayFromGroundToFinalDeath     = 1500
+    DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
   End
 
@@ -6390,7 +6390,7 @@ Object CINE_AmericaVehicleComanche02
     OCLHitGround                    = OCL_HelicopterHitGround
     FXFinalBlowUp                   = FX_GroundedHelicopterBlowUp
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
-    DelayFromGroundToFinalDeath     = 1500
+    DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -1630,7 +1630,7 @@ Object Lazr_AmericaVehicleComanche
     OCLHitGround                    = OCL_HelicopterHitGround
     FXFinalBlowUp                   = FX_GroundedHelicopterBlowUp
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
-    DelayFromGroundToFinalDeath     = 1500
+    DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -2107,7 +2107,7 @@ Object SupW_AmericaVehicleComanche
     OCLHitGround                    = OCL_HelicopterHitGround
     FXFinalBlowUp                   = FX_GroundedHelicopterBlowUp
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
-    DelayFromGroundToFinalDeath     = 1500
+    DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
   End
 


### PR DESCRIPTION
This change reduces delay of USA Comanche final death explosion.

This change is consistent with behavior of other helicopters, USA Chinook, China Helix.

* Fixes #1478

## Original

https://user-images.githubusercontent.com/4720891/203944822-6c9962e6-cce4-400d-94cb-6a571cde232e.mp4

## Patched

https://user-images.githubusercontent.com/4720891/203944863-96c0f3ec-bb46-4816-989e-6cb37003fa6e.mp4
