### PR TITLE
Change: Added scorch effects to nuclear explosions

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -5153,6 +5153,11 @@ FXList FX_ChinaPowerPlantDeath
     Type = SEVERE
   End
 
+  TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
+    Type = RANDOM
+    Radius = 60
+  End
+
   Sound
     Name = ExplosionMiniNuke
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -4927,6 +4927,11 @@ FXList FX_NukeGLA
     Type = SEVERE
   End
 
+  TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
+    Type = RANDOM
+    Radius = 100
+  End
+
   Sound
     Name = ExplosionMiniNuke
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8662,6 +8662,11 @@ FXList Nuke_WeaponFX_NukeCannon
     Type = SEVERE
   End
 
+  TerrainScorch ; Patch104p @tweak Stubbjax 01/12/2022 Added scorch effect.
+    Type = RANDOM
+    Radius = 40
+  End
+
   Sound
     Name = ExplosionMiniNuke
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8838,7 +8838,7 @@ FXList Nuke_WeaponFX_NapalmMissileDetonation
   End
   TerrainScorch
     Type = RANDOM
-    Radius = 15
+    Radius = 40
   End
   LightPulse
     Color = R:255 G:128 B:51

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8315,6 +8315,11 @@ FXList Nuke_WeaponFX_CarpetBomb
     Type = SEVERE
   End
 
+  TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
+    Type = RANDOM
+    Radius = 60
+  End
+
   Sound
     Name = ExplosionMiniNuke
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -5224,6 +5224,11 @@ FXList WeaponFX_NukeCannon
     Type = SEVERE
   End
 
+  TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
+    Type = RANDOM
+    Radius = 60
+  End
+
   Sound
     Name = ExplosionMiniNuke
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -1753,7 +1753,7 @@ FXList FX_ChinaVehicleNukeCannonDeathExplosion
     Type = SEVERE
   End
 
-  TerrainScorch
+  TerrainScorch ; Patch104p @tweak Stubbjax 01/12/2022 Added scorch effect.
     Type = RANDOM
     Radius = 40
   End
@@ -8838,7 +8838,7 @@ FXList Nuke_WeaponFX_NapalmMissileDetonation
   End
   TerrainScorch
     Type = RANDOM
-    Radius = 40
+    Radius = 40 ; Patch104p @tweak Stubbjax 01/12/2022 Larger scorch effect.
   End
   LightPulse
     Color = R:255 G:128 B:51

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -1753,6 +1753,11 @@ FXList FX_ChinaVehicleNukeCannonDeathExplosion
     Type = SEVERE
   End
 
+  TerrainScorch
+    Type = RANDOM
+    Radius = 40
+  End
+
   Sound
     Name = ExplosionMiniNuke
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -5358,6 +5358,11 @@ FXList FX_CarpetBomb
     Type = SEVERE
   End
 
+  TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
+    Type = RANDOM
+    Radius = 30
+  End
+
   ParticleSystem
     Name = UpgradeCarpetBombExplosion
     InitialDelay = 0 0 UNIFORM   ;In milliseconds

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -1755,7 +1755,7 @@ FXList FX_ChinaVehicleNukeCannonDeathExplosion
 
   TerrainScorch ; Patch104p @tweak Stubbjax 01/12/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 40
+    Radius = 30
   End
 
   Sound
@@ -4926,7 +4926,7 @@ FXList FX_BaikonurNuke
 End
 
 ; ----------------------------------------------
-FXList FX_NukeGLA
+FXList FX_NukeGLA ; Used for nuklear structure explosions
 
   ViewShake
     Type = SEVERE
@@ -4934,7 +4934,7 @@ FXList FX_NukeGLA
 
   TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 100
+    Radius = 85
   End
 
   Sound
@@ -5165,7 +5165,7 @@ FXList FX_ChinaPowerPlantDeath
 
   TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 55
   End
 
   Sound
@@ -5236,7 +5236,7 @@ FXList WeaponFX_NukeCannon
 
   TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 40
   End
 
   Sound
@@ -8327,7 +8327,7 @@ FXList Nuke_WeaponFX_CarpetBomb
 
   TerrainScorch ; Patch104p @tweak Stubbjax 30/11/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 30
   End
 
   Sound
@@ -8836,9 +8836,9 @@ FXList Nuke_WeaponFX_NapalmMissileDetonation
     InitialDelay = 1000 1000 UNIFORM   ;In milliseconds
     Offset = X:0.0 Y:0.0 Z:35.0
   End
-  TerrainScorch
+  TerrainScorch ; Patch104p @tweak Stubbjax 01/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 40 ; Patch104p @tweak Stubbjax 01/12/2022 Larger scorch effect.
+    Radius = 30
   End
   LightPulse
     Color = R:255 G:128 B:51


### PR DESCRIPTION
Added scorch effects to the following:

- China Power Plant explosion
- Nuke Cannon shell explosion
- Nuke Carpet Bomber explosion
- Nuclear Missile Silo explosion

https://user-images.githubusercontent.com/11547761/204748812-ddce94db-440d-4132-badc-9d8369f7e023.mp4

Before (1.04) vs after (this):

![image](https://user-images.githubusercontent.com/11547761/204750606-1bc36997-f53f-4311-a0fd-93343db1435d.png)

### TODO

- [x] Remove scorch from FX_ChinaVehicleNukeCannonDeathExplosion (Added to FX_ChinaVehicleNukeCannonDeathExplosionInitial)