### PR TITLE
Change: Improved death explosion of Nuclear Missile Silo

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -8096,7 +8096,7 @@ Object Boss_NuclearMissileLauncher
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_12
-    DeathWeapon = ChinaPowerPlantDeathWeapon
+    DeathWeapon = ChinaNuclearMissileLauncherDeathWeapon ; @tweak Stubbjax 30/11/2022 Added dedicated + improved death weapon.
     StartsActive  = Yes
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -14959,7 +14959,7 @@ Object ChinaNuclearMissileLauncher
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_12
-    DeathWeapon = ChinaPowerPlantDeathWeapon
+    DeathWeapon = ChinaNuclearMissileLauncherDeathWeapon ; @tweak Stubbjax 30/11/2022 Added dedicated + improved death weapon.
     StartsActive  = Yes
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -6863,7 +6863,7 @@ Object Infa_ChinaNuclearMissileLauncher
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_12
-    DeathWeapon = ChinaPowerPlantDeathWeapon
+    DeathWeapon = ChinaNuclearMissileLauncherDeathWeapon ; @tweak Stubbjax 30/11/2022 Added dedicated + improved death weapon.
     StartsActive  = Yes
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -8653,7 +8653,7 @@ Object Nuke_ChinaNuclearMissileLauncher
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_12
-    DeathWeapon = ChinaPowerPlantDeathWeapon
+    DeathWeapon = ChinaNuclearMissileLauncherDeathWeapon ; @tweak Stubbjax 30/11/2022 Added dedicated + improved death weapon.
     StartsActive  = Yes
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -6642,7 +6642,7 @@ Object Tank_ChinaNuclearMissileLauncher
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_12
-    DeathWeapon = ChinaPowerPlantDeathWeapon
+    DeathWeapon = ChinaNuclearMissileLauncherDeathWeapon ; @tweak Stubbjax 30/11/2022 Added dedicated + improved death weapon.
     StartsActive  = Yes
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2914,6 +2914,25 @@ Weapon ChinaPowerPlantDeathWeapon
 End
 
 ;------------------------------------------------------------------------------
+Weapon ChinaNuclearMissileLauncherDeathWeapon
+  PrimaryDamage               = 600.0
+  PrimaryDamageRadius         = 75.0
+  SecondaryDamage             = 150.0
+  SecondaryDamageRadius       = 125.0
+  AttackRange                 = 100.0
+  DamageType                  = EXPLOSION
+  DeathType                   = EXPLODED
+  WeaponSpeed                 = 99999.0
+  FireFX                      = FX_ChinaPowerPlantDeath
+  FireOCL                     = OCL_RadiationFieldMedium
+  RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots           = 0
+  ClipSize                    = 1
+  ClipReloadTime              = 0
+  AutoReloadsClip             = No
+End
+
+;------------------------------------------------------------------------------
 Weapon TomahawkMissileWeapon
   PrimaryDamage               = 150.0
   PrimaryDamageRadius         = 10.0


### PR DESCRIPTION
Improved the explosion / death of the Nuclear Missile Silo. More damage; greater area.

## 1.04:
The Nuclear Missile Silo's explosive destruction applies damage in a very confusing and counterintuitive way due to sharing its death weapon with the Nuclear Reactor while having a much larger profile. It is extremely rare that a unit will take full damage from the explosion, as demonstrated in the footage below.

https://user-images.githubusercontent.com/11547761/204782424-a03b3445-2535-4049-9652-c870027cafdc.mp4

## Patch:
The Nuclear Missile Silo now applies harsher damage over a greater area, which feels much more in line with player expectations when considering the size and intensity of the explosion effect.

https://user-images.githubusercontent.com/11547761/204783349-64b3befa-ef34-4753-b9dc-4de4ae507a83.mp4

All units can attack from a distance outside of the primary blast radius. Only Overlords and elite+ Crusaders and Paladins can survive the primary blast. Heroes, Rangers and some elite+ infantry can survive the secondary blast. Colonel Burton will run to just the right distance after deploying a bomb to escape the secondary blast unscathed.

Values are compared in the table below:

| | Nuclear Reactor | Nuclear Missile Silo | Change |
| - | - | - | - |
| Primary Damage | 400 | 600 | +50% |
| Primary Damage Radius | 50 | 75 | +50% |
| Secondary Damage | 100 | 150 | +50% |
| Secondary Damage Radius | 100 | 125 | +25% |

And here is a rough diagram of the difference:

![image](https://user-images.githubusercontent.com/11547761/204794561-37d19d53-2b30-422d-9388-1670d2425cfa.png)