### PR TITLE
Fix: The EMP Patriot now uses the correct model during construction and sale

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -15456,20 +15456,20 @@ Object SupW_AmericaPatriotBattery
     ;This block handles every possible case with construction process, selling process, awaiting construction, and sold states
     ;for this draw module
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model              = ABPatriot
+      Model              = ABPatriotSW
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT
 
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED SNOW
-      Model              = ABPatriot_S
+      Model              = ABPatriotSW_S
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
-      Model              = ABPatriot_D
+      Model              = ABPatriotSW_D
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED NIGHT
@@ -15477,7 +15477,7 @@ Object SupW_AmericaPatriotBattery
 
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED SNOW
-      Model              = ABPatriot_DS
+      Model              = ABPatriotSW_DS
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED NIGHT SNOW
@@ -15485,13 +15485,13 @@ Object SupW_AmericaPatriotBattery
 
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED
-      Model              = ABPatriot_E
+      Model              = ABPatriotSW_E
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED NIGHT
 
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED SNOW
-      Model              = ABPatriot_ES
+      Model              = ABPatriotSW_ES
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     AliasConditionState  = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED NIGHT SNOW


### PR DESCRIPTION
The EMP Patriot uses the vanilla Patriot model during construction / sale in 1.04, as demonstrated below. This is now fixed.

https://user-images.githubusercontent.com/11547761/205080494-c529f56c-4673-494f-8ea3-da17826cdd28.mp4

