### PR TITLE
Fix: Nuke Battlemaster Detonation Effect Has Offset

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5100,6 +5100,35 @@ Object NukeCannonNeutronShellDetonationDummy
   End
 End
 
+; Patch104p @bugfix xezon 01/12/2022 Dummy to spawn Nuke Battlemaster detonation.
+;------------------------------------------------------------------------------
+Object NukeBattlemasterDeathDetonationDummy
+
+  ; ***DESIGN parameters ***
+  EditorSorting   = SYSTEM
+  KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
+
+  ; *** ENGINEERING Parameters ***
+  Body                  = ActiveBody ModuleTag_01
+    MaxHealth           = 1.0
+    InitialHealth       = 1.0
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_02
+    MinLifetime = 0   ; min lifetime in msec
+    MaxLifetime = 0   ; max lifetime in msec
+  End
+
+  Behavior = DestroyDie ModuleTag_03
+    ;nothing
+  End
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_04
+    DeathWeapon   = NukeBattlemasterDeathDetonationDummyWeapon
+    StartsActive  = Yes
+  End
+End
+
 ;------------------------------------------------------------------------------
 Object InfernoTankShell
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -9466,6 +9466,15 @@ ObjectCreationList OCL_NukeCannonNeutronShellDetonation
   End
 End
 
+; Patch104p @bugfix xezon 01/12/2022 Spawns dummy to trigger detonation effect at correct position.
+; ----------------------------------------------
+ObjectCreationList OCL_NukeBattlemasterDeathDetonation
+  CreateObject
+    ObjectNames = NukeBattlemasterDeathDetonationDummy
+    Disposition = ON_GROUND_ALIGNED
+  End
+End
+
 ; Patch104p @bugfix commy2 29/08/2021 Creates dummies used to handle Demolitions upgrade with the Battle Bus.
 ; -----------------------------------------------------------------------------
 ; Demolitions General

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7992,8 +7992,7 @@ Weapon Nuke_NuclearTankDeathWeapon
   DeathType                   = EXPLODED
   WeaponSpeed                 = 99999.0
   ProjectileObject            = NONE
-  FireFX                      = Nuke_WeaponFX_NapalmMissileDetonation
-  FireOCL                     = OCL_RadiationFieldSmall
+  FireOCL                     = OCL_NukeBattlemasterDeathDetonation ; Patch104p @bugfix xezon 01/12/2022 Fix detonation position offset by spawning effect via dummy object.
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 0                   ; time between shots, msec
   ClipSize                    = 1                            ; how many shots in a Clip (0 == infinite)
@@ -8003,6 +8002,11 @@ Weapon Nuke_NuclearTankDeathWeapon
   DamageDealtAtSelfPosition   = Yes
 End
 
+; Patch104p @bugfix xezon 01/12/2022 Dummy weapon to create detonation effect.
+Weapon NukeBattlemasterDeathDetonationDummyWeapon
+  FireFX = Nuke_WeaponFX_NapalmMissileDetonation
+  FireOCL = OCL_RadiationFieldSmall
+End
 
 
 


### PR DESCRIPTION
This change fixes detonation offset of Nuke Battlemaster. The fix uses same principles as
* #1122

### Original

https://user-images.githubusercontent.com/4720891/205148273-7354f628-6c53-49f1-a694-a4e61052663a.mp4
