### PR TITLE
Change: Normalize Placement view angle

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -14455,7 +14455,7 @@ Object AirF_AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -45
+  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -16520,7 +16520,7 @@ Object AirF_AmericaPatriotBattery
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName       = OBJECT:PatriotBattery
@@ -17068,7 +17068,7 @@ Object AirF_AmericaFireBase
       Flags           = START_FRAME_LAST
     End
   End
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -11731,7 +11731,7 @@ Object AirF_AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -12189,7 +12189,7 @@ Object Boss_PatriotBattery
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName       = OBJECT:PatriotBattery
@@ -14586,7 +14586,7 @@ Object Boss_GattlingCannon
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:GattlingCannon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -6342,7 +6342,7 @@ Object Chem_GLAStingerSite
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName         = OBJECT:StingerSite

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -12488,7 +12488,7 @@ Object Chem_GLASneakAttackTunnelNetworkStart
       Model             = UBSNATK_RS
     End
   End
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork
@@ -12631,7 +12631,7 @@ Object Chem_GLASneakAttackTunnelNetwork
     End
   End
 
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -6225,7 +6225,7 @@ Object Demo_GLAStingerSite
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName         = OBJECT:StingerSite

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12432,7 +12432,7 @@ Object Demo_GLASneakAttackTunnelNetworkStart
       Model             = UBSNATK_RS
     End
   End
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork
@@ -12569,7 +12569,7 @@ Object Demo_GLASneakAttackTunnelNetwork
     End
   End
 
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7215,7 +7215,7 @@ Object AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -35039,7 +35039,7 @@ Object GLASneakAttackTunnelNetworkStart
       Model             = UBSNATK_RS
     End
   End
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork
@@ -35182,7 +35182,7 @@ Object GLASneakAttackTunnelNetwork
     End
   End
 
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -17371,7 +17371,7 @@ Object GLAStingerSite
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName         = OBJECT:StingerSite
@@ -30648,7 +30648,7 @@ Object AmericaPatriotBattery
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName       = OBJECT:PatriotBattery
@@ -33837,7 +33837,7 @@ Object ChinaGattlingCannon
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:GattlingCannon
@@ -36717,7 +36717,7 @@ Object AmericaFireBase
       Flags           = START_FRAME_LAST
     End
   End
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -22816,7 +22816,7 @@ Object AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -45
+  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -917,7 +917,7 @@ Object GC_Chem_GLAStingerSite
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName         = OBJECT:StingerSite

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -2893,7 +2893,7 @@ Object GC_Slth_GLAStingerSite
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName         = OBJECT:StingerSite

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -13020,7 +13020,7 @@ Object Infa_ChinaGattlingCannon
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:GattlingCannon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14139,7 +14139,7 @@ Object Lazr_AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -45
+  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11416,7 +11416,7 @@ Object Lazr_AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -16190,7 +16190,7 @@ Object Lazr_AmericaFireBase
       Flags           = START_FRAME_LAST
     End
   End
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
 
 
@@ -16838,7 +16838,7 @@ Object Lazr_AmericaPatriotBattery
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName       = OBJECT:Lazr_PatriotBattery

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -15677,7 +15677,7 @@ Object Nuke_ChinaGattlingCannon
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:GattlingCannon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13157,7 +13157,7 @@ Object Slth_GLASneakAttackTunnelNetworkStart
       Model             = UBSNATK_RS
     End
   End
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork
@@ -13294,7 +13294,7 @@ Object Slth_GLASneakAttackTunnelNetwork
     End
   End
 
-  PlacementViewAngle = -44
+  PlacementViewAngle = -45 ; Patch104p @tweak from -44
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:TunnelNetwork

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -6924,7 +6924,7 @@ Object Slth_GLAStingerSite
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName         = OBJECT:StingerSite

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -15751,7 +15751,7 @@ Object SupW_AmericaPatriotBattery
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName       = OBJECT:SupW_PatriotBattery
@@ -16247,7 +16247,7 @@ Object SupW_AmericaFireBase
       Flags           = START_FRAME_LAST
     End
   End
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13684,7 +13684,7 @@ Object SupW_AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -45
+  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -10961,7 +10961,7 @@ Object SupW_AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -14740,7 +14740,7 @@ Object Tank_ChinaGattlingCannon
     End
   End
 
-  PlacementViewAngle = -45
+  PlacementViewAngle = -135 ; Patch104p @tweak from -45 to match default angle of other base defenses
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:GattlingCannon


### PR DESCRIPTION
**Merge with Rebase**

This change normalizes placement view angles of all faction structures.

* All base defenses have matching placement view angle
* ~~All faction tech buildings have matching placement view angle~~ #1534
* ~~All faction barracks have matching placement view angle~~ #1534

## Original Base Defenses

![shot_20230101_114435_2](https://user-images.githubusercontent.com/4720891/210168087-f29e0e30-9574-49b4-83b3-b24caea21931.jpg)

## Patched Base Defenses

![shot_20230101_113601_4](https://user-images.githubusercontent.com/4720891/210168088-f464de65-d53a-4cb4-96ce-656b0577751e.jpg)

## Original Tech Buildings

![shot_20230101_114544_3](https://user-images.githubusercontent.com/4720891/210168093-1544a721-f15a-4dd4-9ccc-56daf799a009.jpg)

## ~~Patched Tech Buildings~~

![shot_20230101_113728_5](https://user-images.githubusercontent.com/4720891/210168095-941b2741-605e-4c52-86f8-c4b5ad0bd73e.jpg)

## Original Barracks

![shot_20230101_114337_1](https://user-images.githubusercontent.com/4720891/210168098-f03d2da1-acdb-41d9-ae56-5d5a7060cc10.jpg)

## ~~Patched Barracks~~

![shot_20230101_113404_1](https://user-images.githubusercontent.com/4720891/210168102-bca74999-6ea1-4388-a379-a85bf4fe0d69.jpg)
