### PR TITLE
Fix: Missile particle gliches

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -2455,13 +2455,13 @@ ParticleSystem HeroicMissileDefenderMissileExhaust
   AngularDamping = 1.00 1.00
   VelocityDamping = 0.99 0.99
   Gravity = 0.00
-  SlaveSystem = InfantryStingerMissileLenzflare
+  SlaveSystem = HeroicInfantryStingerMissileLenzflare ; Patch104p @tweak from InfantryStingerMissileLenzflare
   SlavePosOffset = X:0.00 Y:0.00 Z:0.00
   Lifetime = 30.00 30.00 ; Patch104p @tweak from 35.00 35.00
   SystemLifetime = 0
-  Size = 0.05 0.05
+  Size = 0.20 0.20 ; Patch104p @tweak from 0.05 0.05 to match non heroic particle size
   StartSizeRate = 0.00 0.00
-  SizeRate = 0.10 0.10
+  SizeRate = 0.00 0.30 ; Patch104p @tweak from 0.10 0.10 to match non heroic particle size
   SizeRateDamping = 0.93 0.94
   Alpha1 = 0.00 0.00 0
   Alpha2 = 0.00 0.00 0
@@ -19516,7 +19516,7 @@ ParticleSystem HeroicInfantryStingerMissileLenzflare
   IsOneShot = No
   Shader = ADDITIVE
   Type = PARTICLE
-  ParticleName = EXLnzFlar2.tga
+  ParticleName = EXLnzFlar6.tga ; Patch104p @tweak from EXLnzFlar2.tga
   AngleZ = 0.00 0.00
   AngularRateZ = 0.00 0.00
   AngularDamping = 1.00 1.00
@@ -35874,7 +35874,7 @@ ParticleSystem MissileDefenderMissileExhaust
   SlavePosOffset = X:0.00 Y:0.00 Z:0.00
   Lifetime = 30.00 30.00 ; Patch104p @tweak from 35.00 35.00
   SystemLifetime = 0
-  Size = 0.25 0.25
+  Size = 0.20 0.20 ; Patch104p @tweak from 0.25 0.25 to reduce size a bit
   StartSizeRate = 0.00 0.00
   SizeRate = 0.00 0.30
   SizeRateDamping = 0.93 0.94
@@ -37582,7 +37582,7 @@ ParticleSystem HeroicInfantryStingerMissileExhaust
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  SlaveSystem = InfantryStingerMissileLenzflare
+  SlaveSystem = HeroicInfantryStingerMissileLenzflare ; Patch104p @tweak from InfantryStingerMissileLenzflare
   SlavePosOffset = X:0.00 Y:0.00 Z:0.00
   Lifetime = 30.00 30.00
   SystemLifetime = 0

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -28657,7 +28657,7 @@ ParticleSystem HeroicMissileLenzflare
   IsOneShot = No
   Shader = ADDITIVE
   Type = PARTICLE
-  ParticleName = EXLnzFlar4.tga
+  ParticleName = EXLnzFlar6.tga ; Patch104p @tweak from EXLnzFlar4.tga to match lens flare shape of non heroic particle
   AngleZ = 0.00 0.00
   AngularRateZ = 0.00 0.00
   AngularDamping = 1.00 1.00
@@ -28686,7 +28686,7 @@ ParticleSystem HeroicMissileLenzflare
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 100.00 100.00
+  BurstDelay = 0.00 0.00 ; Patch104p @tweak from 100.00 100.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.25
@@ -42874,7 +42874,7 @@ ParticleSystem HeroicMissileExhaust
   AngularDamping = 1.00 1.00
   VelocityDamping = 0.99 0.99
   Gravity = 0.00
-  SlaveSystem = HeroicComancheMissileLenzflare
+  SlaveSystem = HeroicMissileLenzflare ; Patch104p @tweak from HeroicComancheMissileLenzflare
   SlavePosOffset = X:0.00 Y:0.00 Z:0.00
   Lifetime = 25.00 25.00
   SystemLifetime = 0

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -866,7 +866,7 @@ ParticleSystem HeroicComancheMissileExhaust
   Gravity = 0.00
   SlaveSystem = HeroicComancheMissileLenzflare
   SlavePosOffset = X:0.00 Y:0.00 Z:0.00
-  Lifetime = 35.00 35.00
+  Lifetime = 30.00 30.00 ; Patch104p @tweak from 35.00 35.00
   SystemLifetime = 0
   Size = 0.05 0.05
   StartSizeRate = 0.00 0.00
@@ -2457,7 +2457,7 @@ ParticleSystem HeroicMissileDefenderMissileExhaust
   Gravity = 0.00
   SlaveSystem = InfantryStingerMissileLenzflare
   SlavePosOffset = X:0.00 Y:0.00 Z:0.00
-  Lifetime = 35.00 35.00
+  Lifetime = 30.00 30.00 ; Patch104p @tweak from 35.00 35.00
   SystemLifetime = 0
   Size = 0.05 0.05
   StartSizeRate = 0.00 0.00
@@ -28663,8 +28663,8 @@ ParticleSystem HeroicMissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 10.00 10.00
-  SystemLifetime = 1
+  Lifetime = 3.00 3.00 ; Patch104p @tweak from 10.00 10.00 to match non heroic particle
+  SystemLifetime = 0 ; Patch104p @tweak from 1 to match non heroic particle
   Size = 180.00 240.00
   StartSizeRate = 0.00 0.00
   SizeRate = 0.20 0.20
@@ -28679,7 +28679,7 @@ ParticleSystem HeroicMissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 10
+  Color3 = R:0 G:0 B:0 3
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -35872,7 +35872,7 @@ ParticleSystem MissileDefenderMissileExhaust
   Gravity = 0.00
   SlaveSystem = InfantryStingerMissileLenzflare
   SlavePosOffset = X:0.00 Y:0.00 Z:0.00
-  Lifetime = 35.00 35.00
+  Lifetime = 30.00 30.00 ; Patch104p @tweak from 35.00 35.00
   SystemLifetime = 0
   Size = 0.25 0.25
   StartSizeRate = 0.00 0.00

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -1190,7 +1190,7 @@ ParticleSystem MOABstarburst
   WindPingPongEndAngleMax = 0.000000
 End
 
-ParticleSystem HeroicPatriotMissileTrail
+ParticleSystem HeroicPatriotMissileTrail ; Unused
   Priority = WEAPON_TRAIL
   IsOneShot = No
   Shader = ADDITIVE
@@ -24444,7 +24444,7 @@ ParticleSystem BuildUpSnowSmoke
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem A10ThunderboltMissileLenzflare
+ParticleSystem A10ThunderboltMissileLenzflare ; Unused
   Priority = WEAPON_TRAIL
   IsOneShot = No
   Shader = ADDITIVE
@@ -44351,7 +44351,7 @@ ParticleSystem DaisyExplosionGas
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem A10ThunderboltMissileExhaust
+ParticleSystem A10ThunderboltMissileExhaust ; Unused
   Priority = WEAPON_TRAIL
   IsOneShot = No
   Shader = ADDITIVE
@@ -56397,7 +56397,7 @@ ParticleSystem PuffMedium
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem RedMissileExhaust
+ParticleSystem RedMissileExhaust ; Unused
   Priority = WEAPON_TRAIL
   IsOneShot = No
   Shader = ADDITIVE

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -10888,7 +10888,7 @@ ParticleSystem MissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 3.00 3.00
+  Lifetime = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to match optimized color frames.
   SystemLifetime = 0
   Size = 180.00 240.00
   StartSizeRate = 0.00 0.00
@@ -10904,7 +10904,7 @@ ParticleSystem MissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 3
+  Color3 = R:0 G:0 B:0 2 ; Patch104p @tweak from R:0 G:0 B:0 3 to show flare just for the duration of one frame.
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -18388,7 +18388,7 @@ ParticleSystem InfantryStingerMissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 3.00 3.00
+  Lifetime = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to match optimized color frames.
   SystemLifetime = 0
   Size = 60.00 80.00
   StartSizeRate = 0.00 0.00
@@ -18404,7 +18404,7 @@ ParticleSystem InfantryStingerMissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 3
+  Color3 = R:0 G:0 B:0 2 ; Patch104p @tweak from R:0 G:0 B:0 3 to show flare just for the duration of one frame.
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -19522,7 +19522,7 @@ ParticleSystem HeroicInfantryStingerMissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 3.00 3.00
+  Lifetime = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to match optimized color frames.
   SystemLifetime = 0
   Size = 60.00 80.00
   StartSizeRate = 0.00 0.00
@@ -19538,7 +19538,7 @@ ParticleSystem HeroicInfantryStingerMissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 3
+  Color3 = R:0 G:0 B:0 2 ; Patch104p @tweak from R:0 G:0 B:0 3 to show flare just for the duration of one frame.
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -24455,7 +24455,7 @@ ParticleSystem A10ThunderboltMissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 3.00 3.00
+  Lifetime = 1.00 1.00 ; Patch104p @tweak from 3.00 3.00 to match optimized color frames.
   SystemLifetime = 0
   Size = 10.00 10.00
   StartSizeRate = 0.00 0.00
@@ -24471,7 +24471,7 @@ ParticleSystem A10ThunderboltMissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 3
+  Color3 = R:0 G:0 B:0 2 ; Patch104p @tweak from R:0 G:0 B:0 3 to show flare just for the duration of one frame.
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -28663,7 +28663,7 @@ ParticleSystem HeroicMissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 3.00 3.00 ; Patch104p @tweak from 10.00 10.00 to match non heroic particle
+  Lifetime = 2.00 2.00 ; Patch104p @tweak from 10.00 10.00 to match non heroic particle
   SystemLifetime = 0 ; Patch104p @tweak from 1 to match non heroic particle
   Size = 180.00 240.00
   StartSizeRate = 0.00 0.00
@@ -28679,7 +28679,7 @@ ParticleSystem HeroicMissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 3
+  Color3 = R:0 G:0 B:0 2 ; Patch104p @tweak from R:0 G:0 B:0 3 to show flare just for the duration of one frame.
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -40199,7 +40199,7 @@ ParticleSystem HeroicComancheMissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 3.00 3.00
+  Lifetime = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to match optimized color frames.
   SystemLifetime = 0
   Size = 120.00 160.00
   StartSizeRate = 0.00 0.00
@@ -40215,7 +40215,7 @@ ParticleSystem HeroicComancheMissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 3
+  Color3 = R:0 G:0 B:0 2 ; Patch104p @tweak from R:0 G:0 B:0 3 to show flare just for the duration of one frame.
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -63175,7 +63175,7 @@ ParticleSystem PatriotMissileLenzflare
   AngularDamping = 1.00 1.00
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
-  Lifetime = 3.00 3.00
+  Lifetime = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to match optimized color frames.
   SystemLifetime = 0
   Size = 20.00 20.00
   StartSizeRate = 0.00 0.00
@@ -63191,7 +63191,7 @@ ParticleSystem PatriotMissileLenzflare
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
   Color2 = R:255 G:255 B:255 1
-  Color3 = R:0 G:0 B:0 3
+  Color3 = R:0 G:0 B:0 2 ; Patch104p @tweak from R:0 G:0 B:0 3 to show flare just for the duration of one frame.
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -7176,7 +7176,7 @@ ParticleSystem InfantryStingerMissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
@@ -22657,7 +22657,7 @@ ParticleSystem AirF_RaptorMissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.08 Y:0.16 Z:0.01
@@ -37607,7 +37607,7 @@ ParticleSystem HeroicInfantryStingerMissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
@@ -41984,7 +41984,7 @@ ParticleSystem Chem_InfantryStingerMissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.08 Y:0.16 Z:0.01
@@ -42899,7 +42899,7 @@ ParticleSystem HeroicMissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.08 Y:0.16 Z:0.01
@@ -44385,7 +44385,7 @@ ParticleSystem A10ThunderboltMissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:-0.20
@@ -45928,7 +45928,7 @@ ParticleSystem MissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.08 Y:0.16 Z:0.01
@@ -50353,7 +50353,7 @@ ParticleSystem Chem_InfantryStingerMissileExhaustGamma
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.08 Y:0.16 Z:0.01
@@ -56431,7 +56431,7 @@ ParticleSystem RedMissileExhaust
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 1.00 1.00
+  BurstDelay = 0.00 0.00 ; Patch104p @bugfix from 1.00 1.00 to avoid skipped frame
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.20


### PR DESCRIPTION
Merge with Rebase.

This change fixes and improves missile particles:

* Fixes skipping frames on several missile flares (1)
* Fixes particle life time inconsistencies (2)
* Fixes heroic missile shape of China Tank Hunter, GLA Tunnel Defender (3)
* Fixes missile texture (3), size of USA Missile Defender (4)

## Details

(1) Skipped frames means lens flares spawned every 2nd frame only. This gives the illusion of stutter.

(2) Some missile particles had life times exceeding their max draw time (Color, Alpha). Life time can be matched with max draw time.

(3) Original heroic red lens flare shape (EXLenzflare4.dds) does not match non-heroic yellow lens flare shape (EXLenzflare2.dds). Therefore texture was changed to EXLenzflare6.dds, which is red and matches shape of yellow flare.

(4) Original Missile Defender non-heroic exhaust trail and lens flare has large size. And original heroic exhaust trail + lens flare has very tiny size. Non-heroic and heroic effects where changed to have same size, just 20% smaller than original non-heroic effects. They are still larger than effects from GLA Tunnel Defender and China Tank Hunter, as is illustrated in video below.


## Original 1

https://user-images.githubusercontent.com/4720891/211104619-d82ac124-7c3b-4e01-9fd5-a3c3adcbfdc1.mp4

## Patched 1

https://user-images.githubusercontent.com/4720891/211104651-bba92730-4dae-4a6d-b721-380401eadfee.mp4
