### PR TITLE
Change: Decrease China Neutron Mines cost to 400, time to 15

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -242,8 +242,8 @@ End
 Upgrade Upgrade_ChinaEMPMines
   DisplayName        = UPGRADE:EMPMine
   Type               = OBJECT
-  BuildTime          = 25.0
-  BuildCost          = 500
+  BuildTime          = 15.0 ; Patch104p @balance from 25.0
+  BuildCost          = 400 ; Patch104p @balance from 500
   ButtonImage        = SNEMPMine
   ResearchSound      = MineFieldPlaced
 End


### PR DESCRIPTION
* Fixes #1250

This change slightly decreases build cost and time of China Neutron Mines.

| Mines                          | Cost   | Time  |
|--------------------------------|--------|-------|
| Original Mines                 | 600    | 20    |
| Original Neutron Mines         | 500    | 25    |
| Original Mines + Neutron       | 1100   | 45    |
| Patched Neutron Mines (this)   | 400    | 15    |
| Patched Mines + Neutron (this) | 1000   | 35    |

# Rationale

China Neutron Mines are almost never used in competitive matches. Reducing the cost and time to research them can make them a bit more attractive for occasional investment.