### PR TITLE
Fix: Use Jet Engine sound for China Carpet Bomber

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
@@ -308,7 +308,7 @@ Object ChinaJetCarpetBomber
   CommandSet        = Command_ScriptedTransportDrops
 
   ; *** AUDIO Parameters ***
-  SoundAmbient = C130AmbientLoop
+  SoundAmbient = B52AmbientLoop ; Patch104p @tweak from C130AmbientLoop to replace propeller engine with jet engine
   SoundAmbientRubble    = NoSound
 
   ; *** ENGINEERING Parameters ***


### PR DESCRIPTION
* Fixes #1517

Replaces Propeller Engine sound with Jet Engine sound for China Carpet Bomber.