### PR TITLE
Fix: Remove Booby Trap physics to prevent pushing by weapons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -2480,6 +2480,7 @@ Object TNTStickyBomb ;Created by Chinese Tank Hunters
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix #1502 Removes PhysicsBehavior to avoid pushing by weapons
 Object BoobyTrap ; created by upgraded rebels
 
   ;No drawable because it's invisible
@@ -2508,10 +2509,6 @@ Object BoobyTrap ; created by upgraded rebels
   Body = HighlanderBody ModuleTag_01
     MaxHealth = 1.0
     InitialHealth = 1.0
-  End
-
-  Behavior = PhysicsBehavior ModuleTag_02
-    Mass = 5
   End
 
   Behavior = StickyBombUpdate ModuleTag_03


### PR DESCRIPTION
* Fixes #1502

This change removes Physics from BoobyTrap object to prevent pushing by weapons. Object RemoteC4Charge, TimedC4Charge also do not have physics.