### PR TITLE
Fix: Wrong exploded death animation of supply box carrying GLA Worker

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -15883,7 +15883,6 @@ Object Chem_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16717,7 +16717,6 @@ Object Demo_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1233,7 +1233,6 @@ Object GC_Chem_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
       AnimationMode = ONCE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -176,7 +176,6 @@ Object GC_Slth_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -6035,7 +6035,6 @@ Object CINE_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -8015,7 +8014,6 @@ Object CINE_CheeringWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -3692,7 +3692,6 @@ Object GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17093,7 +17093,6 @@ Object Slth_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
-    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1


### PR DESCRIPTION
**This change has been superseded by https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2120**

* Fixes #1468