### PR TITLE
Change: Increase USA Comanche Armor by up to 23%, Comanche Armor with Countermeasures by up to 9%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1530_comanche_armor.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1530_comanche_armor.yaml
@@ -1,0 +1,23 @@
+---
+date: 2023-01-07
+
+title: Increases armor of USA Comanche by up to 23%
+
+changes:
+  - tweak: The armor of the USA Comanche against Quad Cannons, Gattlings and Infantry Missiles is now set to 100% instead of 120% (smaller is better).
+  - tweak: The armor of the USA Comanche against Explosions is now set to 100% instead of 130%.
+  - tweak: The armor of the USA Comanche with Countermeasures against Explosions is now set to 100% instead of 110%.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - major
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1530
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -478,12 +478,16 @@ End
 ;*******************************************************************
 ;***IF YOU CHANGE THESE, CHANGE CountermeasuresComancheArmor TOO!***
 ;*******************************************************************
+; Patch104p @tweak Changes SMALL_ARMS armor from 120% (#1530)
+; Patch104p @tweak Changes GATTLING armor from 120%
+; Patch104p @tweak Changes EXPLOSION armor from 130%
+; Patch104p @tweak Changes INFANTRY_MISSILE armor from 120%
 Armor ComancheArmor
   Armor = DEFAULT           100%  ;this sets the level for all nonspecified damage types
-  Armor = SMALL_ARMS        120%  ;gives Quad and gattling a little more punch.
-  Armor = GATTLING          120%  ;resistant to gattling tank
-  Armor = EXPLOSION         130%  ;gives patriot some more punch
-  Armor = INFANTRY_MISSILE  120%  ;gives missile guys some more punch
+  Armor = SMALL_ARMS        100%  ;gives Quad and gattling a little more punch.
+  Armor = GATTLING          100%  ;resistant to gattling tank
+  Armor = EXPLOSION         100%  ;gives patriot some more punch
+  Armor = INFANTRY_MISSILE  100%  ;gives missile guys some more punch
   Armor = LASER             0%    ;lasers are anti-personel and anti-projectile only (for point defense laser)
   Armor = HEALING           100%
   Armor = HAZARD_CLEANUP    0%    ;Not harmed by cleaning weapons
@@ -502,11 +506,12 @@ End
 ;****************************************************
 ;***IF YOU CHANGE THESE, CHANGE ComancheArmor TOO!***
 ;****************************************************
+; Patch104p @tweak Changes EXPLOSION armor from 110% (#1530)
 Armor CountermeasuresComancheArmor
   Armor = DEFAULT           100%
-  Armor = SMALL_ARMS        75%  ; currently set to 37.5% increase (120 x 0.75 -- 25% reduction off ComancheArmor)
-  Armor = GATTLING          75%  ; currently set to 37.5% increase (120 x 0.75 -- 25% reduction off ComancheArmor)
-  Armor = EXPLOSION         110%
+  Armor = SMALL_ARMS        75%
+  Armor = GATTLING          75%
+  Armor = EXPLOSION         100%
   Armor = INFANTRY_MISSILE  100%
   Armor = LASER             0%
   Armor = HEALING           100%


### PR DESCRIPTION
This change makes Comanche Armor and Countermeasures by up to 23% stronger.

## Stats

| Type             | Original Armor | Patched Armor (this) | Change % |
|------------------|---------------:|---------------------:|---------:|
| DEFAULT          | 100%           | 100%                 | 0%       |
| SMALL_ARMS       | 120%           | 100%                 | -17%     |
| GATTLING         | 120%           | 100%                 | -17%     |
| EXPLOSION        | 130%           | 100%                 | -23%     |
| INFANTRY_MISSILE | 120%           | 100%                 | -17%     |

| Type             | Original Countermeasures | Patched Countermeasures (this) | Change % |
|------------------|-------------------------:|-------------------------------:|---------:|
| DEFAULT          | 100%                     | 100%                           | 0%       |
| SMALL_ARMS       | 75%                      | 75%                            | 0%       |
| GATTLING         | 75%                      | 75%                            | 0%       |
| EXPLOSION        | 110%                     | 100%                           | -9%      |
| INFANTRY_MISSILE | 100%                     | 100%                           | 0%       |
| HEALING          | 100%                     | 100%                           | 0%       |

# Rationale

Regular Comanches are rarely used. This changes improves the utility of regular Comanches.
