### PR TITLE
Fix Helix Commandset

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3022,11 +3022,12 @@ CommandButton Command_UpgradeChinaHelixBattleBunker
   UnitSpecificSound       = HelixVoiceModeBunker
 End
 
+; Patch104p @bugfix Adds NOT_QUEUEABLE to grey out upgrade icon while other upgrade is in production.
 CommandButton Command_UpgradeChinaHelixNapalmBomb
   Command                 = OBJECT_UPGRADE
   Upgrade                 = Upgrade_HelixNapalmBomb
   TextLabel               = CONTROLBAR:UpgradeHelixNapalmBomb
-  Options                 = OK_FOR_MULTI_SELECT
+  Options                 = OK_FOR_MULTI_SELECT NOT_QUEUEABLE
   ButtonImage             = SNHelixUp04
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ChinaUpgradeHelixNapalmBomb
@@ -6478,9 +6479,10 @@ CommandButton Nuke_Command_UpgradeChinaFusionReactors
   DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaNuclearTanks
 End
 
+; Patch104p @bugfix Adds NOT_QUEUEABLE to grey out upgrade icon while other upgrade is in production.
 CommandButton Nuke_Command_UpgradeChinaHelixNukeBomb
   Command                 = OBJECT_UPGRADE
-  Options                 = OK_FOR_MULTI_SELECT
+  Options                 = OK_FOR_MULTI_SELECT NOT_QUEUEABLE
   Upgrade                 = Nuke_Upgrade_HelixNukeBomb
   TextLabel               = CONTROLBAR:UpgradeHelixNukeBomb
   ButtonImage             = SNHelixUp05

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -645,7 +645,26 @@ CommandSet ChinaVehicleHelixCommandSet
   8 = Command_UpgradeChinaHelixPropagandaTower
  10 = Command_UpgradeChinaHelixGattlingCannon
   ;---------
-  7 = Command_UpgradeChinaHelixNapalmBomb
+  9 = Command_UpgradeChinaHelixNapalmBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
+CommandSet ChinaHelixBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
+  8 = Command_UpgradeChinaHelixPropagandaTower
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -661,7 +680,22 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  7 = Command_UpgradeChinaHelixNapalmBomb
+  9 = Command_UpgradeChinaHelixNapalmBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
+CommandSet ChinaHelixGattlingCannonAndBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -677,7 +711,22 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  7 = Command_UpgradeChinaHelixNapalmBomb
+  9 = Command_UpgradeChinaHelixNapalmBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
+CommandSet ChinaHelixPropagandaTowerAndBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -693,7 +742,22 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  7 = Command_UpgradeChinaHelixNapalmBomb
+  9 = Command_UpgradeChinaHelixNapalmBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
+CommandSet ChinaHelixBattleBunkerAndBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -3316,7 +3380,26 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   8 = Command_UpgradeChinaHelixPropagandaTower
  10 = Command_UpgradeChinaHelixGattlingCannon
   ;---------
-  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
+CommandSet Nuke_ChinaHelixBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
+  8 = Command_UpgradeChinaHelixPropagandaTower
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3332,7 +3415,22 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
+CommandSet Nuke_ChinaHelixGattlingCannonAndBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3348,7 +3446,22 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
+CommandSet Nuke_ChinaHelixPropagandaTowerAndBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3364,7 +3477,22 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
+  ;---------
+ 11 = Command_AttackMove
+ 12 = Command_Evacuate
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
+; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
+CommandSet Nuke_ChinaHelixBattleBunkerAndBombCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -4167,7 +4295,6 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   8 = Command_TransportExit
   ;---------
   9 = Command_UpgradeChinaHelixNapalmBomb
-; 10 = Command_ChinaHelixDropNapalmBomb
   10 = Infa_Command_UpgradeChinaHelixBattleBunker
   ;---------
  11 = Command_AttackMove

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15808,7 +15808,14 @@ Object Boss_VehicleHelix
 
 
 
-  ;--------------------------
+  ; Patch104p @tweak Add dedicated Command Sets for Napalm Bomb
+  ; ----- NapalmBomb
+  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
+    CommandSet = ChinaHelixBombCommandSet
+    TriggeredBy   = Upgrade_HelixNapalmBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+  End
+  ; ----- GattlingCannon
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -15817,7 +15824,13 @@ Object Boss_VehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
+    CommandSet = ChinaHelixGattlingCannonAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -15828,7 +15841,7 @@ Object Boss_VehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ;--------------------------
+  ; ----- PropagandaTower
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -15837,9 +15850,15 @@ Object Boss_VehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
   End
-  ;--------------------------
+  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
+    CommandSet = ChinaHelixPropagandaTowerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
+  End
+  ; ----- BattleBunker
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -15848,7 +15867,13 @@ Object Boss_VehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
+    CommandSet = ChinaHelixBattleBunkerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
+    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -199,7 +199,14 @@ Object ChinaVehicleHelix
 
 
 
-  ;--------------------------
+  ; Patch104p @tweak Add dedicated Command Sets for Napalm Bomb
+  ; ----- NapalmBomb
+  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
+    CommandSet = ChinaHelixBombCommandSet
+    TriggeredBy   = Upgrade_HelixNapalmBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+  End
+  ; ----- GattlingCannon
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -208,7 +215,13 @@ Object ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
+    CommandSet = ChinaHelixGattlingCannonAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -219,7 +232,7 @@ Object ChinaVehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ;--------------------------
+  ; ----- PropagandaTower
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -228,9 +241,15 @@ Object ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
   End
-  ;--------------------------
+  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
+    CommandSet = ChinaHelixPropagandaTowerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
+  End
+  ; ----- BattleBunker
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -239,7 +258,13 @@ Object ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
+    CommandSet = ChinaHelixBattleBunkerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
+    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -473,7 +473,14 @@ Object Nuke_ChinaVehicleHelix
 
 
 
-  ;--------------------------
+  ; Patch104p @tweak Add dedicated Command Sets for Nuke Bomb
+  ; ----- NukeBomb
+  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
+    CommandSet = Nuke_ChinaHelixBombCommandSet
+    TriggeredBy   = Nuke_Upgrade_HelixNukeBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+  End
+  ; ----- GattlingCannon
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -482,7 +489,13 @@ Object Nuke_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = Nuke_ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Nuke_Upgrade_HelixNukeBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
+    CommandSet = Nuke_ChinaHelixGattlingCannonAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Nuke_Upgrade_HelixNukeBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -493,7 +506,7 @@ Object Nuke_ChinaVehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ;--------------------------
+  ; ----- PropagandaTower
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -502,9 +515,15 @@ Object Nuke_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = Nuke_ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Nuke_Upgrade_HelixNukeBomb
   End
-  ;--------------------------
+  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
+    CommandSet = Nuke_ChinaHelixPropagandaTowerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Nuke_Upgrade_HelixNukeBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
+  End
+  ; ----- BattleBunker
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -513,7 +532,13 @@ Object Nuke_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = Nuke_ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Nuke_Upgrade_HelixNukeBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
+    CommandSet = Nuke_ChinaHelixBattleBunkerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Nuke_Upgrade_HelixNukeBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
+    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -201,7 +201,14 @@ Object Tank_ChinaVehicleHelix
 
 
 
-  ;--------------------------
+  ; Patch104p @tweak Add dedicated Command Sets for Napalm Bomb
+  ; ----- NapalmBomb
+  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
+    CommandSet = ChinaHelixBombCommandSet
+    TriggeredBy   = Upgrade_HelixNapalmBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+  End
+  ; ----- GattlingCannon
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -210,7 +217,13 @@ Object Tank_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
+    CommandSet = ChinaHelixGattlingCannonAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -221,7 +234,7 @@ Object Tank_ChinaVehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ;--------------------------
+  ; ----- PropagandaTower
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -230,9 +243,15 @@ Object Tank_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
   End
-  ;--------------------------
+  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
+    CommandSet = ChinaHelixPropagandaTowerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
+    RequiresAllTriggers = Yes
+  End
+  ; ----- BattleBunker
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -241,7 +260,13 @@ Object Tank_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
+  End
+  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
+    CommandSet = ChinaHelixBattleBunkerAndBombCommandSet
+    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
+    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker


### PR DESCRIPTION
This change was partially reverted with

* #1538

Merge with Rebase.

* ~~Fixes #1513~~

~~This change puts Helix Bomb Upgrade and Helix Bomb Drop buttons on same Command position for all Helix variants.~~ Additionally, Helix Bomb Upgrade is now greyed out while another upgrade is in production.

### No upgrades

![shot_20230108_143327_1](https://user-images.githubusercontent.com/4720891/211198912-d3e95cfd-1f5a-47dc-88eb-130fbb27556b.jpg)

### Bomb purchased

![shot_20230108_143418_3](https://user-images.githubusercontent.com/4720891/211198926-f1986d82-8229-40ca-9975-b51d81bc3e73.jpg)

### Bomb Upgrade greyed out

![shot_20230108_143340_2](https://user-images.githubusercontent.com/4720891/211198955-c27a325d-1c34-485c-8290-ea8d37bf384c.jpg)
