### PR TITLE
Change: Decrease China Mines build time by 2 seconds, Neutron Mines build time by 7 seconds

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -232,8 +232,7 @@ End
 Upgrade Upgrade_ChinaMines
   DisplayName        = UPGRADE:Mines
   Type               = OBJECT
-  BuildTime          = 20.0
-; BuildTime          = 1.0  ; for testing purposes
+  BuildTime          = 18.0 ; Patch104p @balance from 20.0
   BuildCost          = 600
   ButtonImage        = SSMineBunker
   ResearchSound      = MineFieldPlaced
@@ -242,7 +241,7 @@ End
 Upgrade Upgrade_ChinaEMPMines
   DisplayName        = UPGRADE:EMPMine
   Type               = OBJECT
-  BuildTime          = 15.0 ; Patch104p @balance from 25.0
+  BuildTime          = 18.0 ; Patch104p @balance from 25.0
   BuildCost          = 400 ; Patch104p @balance from 500
   ButtonImage        = SNEMPMine
   ResearchSound      = MineFieldPlaced


### PR DESCRIPTION
* Successor to #1523

This change decreases build time of China Mines. Regular Mines and Neutron Mines now have identical build time.

| Mines                              | Time  |
|------------------------------------|-------|
| Original Mines                     | 20    |
| Original Neutron Mines             | 25    |
| Original Mines + Neutron           | 45    |
| Patched Neutron Mines (1)          | 15    |
| Patched Mines + Neutron (1)        | 35    |
| **Patched Mines (this)**           | 18    |
| **Patched Neutron Mines (this)**   | 18    |
| **Patched Mines + Neutron (this)** | 36    |

# Rationale

With this change, regular Mines build 2 seconds faster than original. There needs to be a balance between too quick and too slow. Mines should not become subject of abuse by purchasing them while enemy forces are located near a China structure. On the other hand, the production of Mines should not delay production queue for too long. Even though it is just a small buff, China will be happy with each buff it can get for free.