### PR TITLE
Revert changes to Placement View Angle of USA Barracks and USA Strategy Center

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -14456,7 +14456,7 @@ Object AirF_AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
+  PlacementViewAngle     = -45
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -11731,7 +11731,7 @@ Object AirF_AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
+  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7215,7 +7215,7 @@ Object AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
+  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -22817,7 +22817,7 @@ Object AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
+  PlacementViewAngle     = -45
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -14140,7 +14140,7 @@ Object Lazr_AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
+  PlacementViewAngle     = -45
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11416,7 +11416,7 @@ Object Lazr_AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
+  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -13685,7 +13685,7 @@ Object SupW_AmericaBarracks
   ; *** ART Parameters ***
   SelectPortrait         = SABarracks_L
   ButtonImage            = SABarracks
-  PlacementViewAngle     = -135 ; Patch104p @tweak from -45 to match default angle of China Barracks, GLA Barracks
+  PlacementViewAngle     = -45
 
   ;Main barracks model
   Draw                   = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -10961,7 +10961,7 @@ Object SupW_AmericaStrategyCenter
 
   End
 
-  PlacementViewAngle = 45 ; Patch104p @tweak from -45 to look similar to default angle of China Propaganda Center, GLA Palace
+  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:StrategyCenter


### PR DESCRIPTION
Merge with Rebase.

This change reverts changes to Placement View Angle of USA Barracks and USA Strategy Center.

* See #1514
