### PR TITLE
Fix: Remove duplicate death scorch of China Listening Outpost, Dragon Tank

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -2407,6 +2407,34 @@ FXList FX_SupplyTruckExplosionOneFinal
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p, A copy of FX_SupplyTruckExplosionOneFinal
+; Another death effect spawns the scorch.
+; -----------------------------------------------------------------------------
+FXList FX_ListeningOutpostExplosionOneInitial
+  ParticleSystem
+    Name = ScudLauncherExplosionSmoke
+    OrientToObject = Yes
+  End
+  ParticleSystem
+    Name = BattleMasterTankExplosionDebris
+  End
+  ParticleSystem
+    Name = BattleMasterTankExplosionShockwave
+    Offset = X:0 Y:0 Z:2
+  End
+  ParticleSystem
+    Name = BattleMasterTankExplosionLenzflare
+    Offset = X:0 Y:0 Z:10
+  End
+  ViewShake
+    Type = STRONG
+  End
+  Sound
+    Name = TankDie
+  End
+End
+
+; -----------------------------------------------------------------------------
 FXList FX_ToxinTruckExplosionOneFinal
   ParticleSystem
     Name = BattleMasterTankExplosionSmoke

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -21116,7 +21116,7 @@ Object Boss_TankDragon
 ;    ProbabilityModifier = 33
     DestructionDelay = 500
     DestructionDelayVariance = 500
-    FX  = INITIAL  FX_BattleMasterExplosionOneFinal
+    FX  = INITIAL  FX_Suicide_BattleMasterExplosionOneFinal ; Patch104p @tweak from FX_BattleMasterExplosionOneFinal to prevent two scorch effects.
     OCL = FINAL    OCL_DragonDebris
     FX  = FINAL    FX_DragonTankDeathExplosionFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -2819,7 +2819,7 @@ Object CINE_ChinaTankDragon
 ;    ProbabilityModifier = 33
     DestructionDelay = 500
     DestructionDelayVariance = 500
-    FX  = INITIAL  FX_BattleMasterExplosionOneFinal
+    FX  = INITIAL  FX_Suicide_BattleMasterExplosionOneFinal ; Patch104p @tweak from FX_BattleMasterExplosionOneFinal to prevent two scorch effects.
     OCL = FINAL    OCL_DragonDebris
     FX  = FINAL    FX_DragonTankDeathExplosionFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2882,7 +2882,7 @@ Object ChinaVehicleListeningOutpost
 
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
-    DestructionDelay = 1789
+    DestructionDelay = 1800
     FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1058,7 +1058,7 @@ Object ChinaTankDragon
 ;    ProbabilityModifier = 33
     DestructionDelay = 500
     DestructionDelayVariance = 500
-    FX  = INITIAL  FX_BattleMasterExplosionOneFinal
+    FX  = INITIAL  FX_Suicide_BattleMasterExplosionOneFinal ; Patch104p @tweak from FX_BattleMasterExplosionOneFinal to prevent two scorch effects.
     OCL = FINAL    OCL_DragonDebris
     FX  = FINAL    FX_DragonTankDeathExplosionFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2883,7 +2883,7 @@ Object ChinaVehicleListeningOutpost
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay = 1789
-    FX  = INITIAL    FX_SupplyTruckExplosionOneFinal
+    FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal
     OCL = FINAL    OCL_FinalListeningOutpostDebris

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16219,7 +16219,7 @@ Object Infa_ChinaVehicleListeningOutpost
 
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
-    DestructionDelay = 1789
+    DestructionDelay = 1800
     FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16220,7 +16220,7 @@ Object Infa_ChinaVehicleListeningOutpost
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay = 1789
-    FX  = INITIAL    FX_SupplyTruckExplosionOneFinal
+    FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal
     OCL = FINAL    OCL_FinalListeningOutpostDebris

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1779,7 +1779,7 @@ Object Infa_ChinaTankDragon
 ;    ProbabilityModifier = 33
     DestructionDelay = 500
     DestructionDelayVariance = 500
-    FX  = INITIAL  FX_BattleMasterExplosionOneFinal
+    FX  = INITIAL  FX_Suicide_BattleMasterExplosionOneFinal ; Patch104p @tweak from FX_BattleMasterExplosionOneFinal to prevent two scorch effects.
     OCL = FINAL    OCL_DragonDebris
     FX  = FINAL    FX_DragonTankDeathExplosionFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4956,7 +4956,7 @@ Object Nuke_ChinaVehicleListeningOutpost
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay = 1789
-    FX  = INITIAL    FX_SupplyTruckExplosionOneFinal
+    FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal
     OCL = FINAL    OCL_FinalListeningOutpostDebris

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3131,7 +3131,7 @@ Object Nuke_ChinaTankDragon
 ;    ProbabilityModifier = 33
     DestructionDelay = 500
     DestructionDelayVariance = 500
-    FX  = INITIAL  FX_BattleMasterExplosionOneFinal
+    FX  = INITIAL  FX_Suicide_BattleMasterExplosionOneFinal ; Patch104p @tweak from FX_BattleMasterExplosionOneFinal to prevent two scorch effects.
     OCL = FINAL    OCL_DragonDebris
     FX  = FINAL    FX_DragonTankDeathExplosionFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4955,7 +4955,7 @@ Object Nuke_ChinaVehicleListeningOutpost
 
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
-    DestructionDelay = 1789
+    DestructionDelay = 1800
     FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3842,7 +3842,7 @@ Object Tank_ChinaTankDragon
 ;    ProbabilityModifier = 33
     DestructionDelay = 500
     DestructionDelayVariance = 500
-    FX  = INITIAL  FX_BattleMasterExplosionOneFinal
+    FX  = INITIAL  FX_Suicide_BattleMasterExplosionOneFinal ; Patch104p @tweak from FX_BattleMasterExplosionOneFinal to prevent two scorch effects.
     OCL = FINAL    OCL_DragonDebris
     FX  = FINAL    FX_DragonTankDeathExplosionFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5186,7 +5186,7 @@ Object Tank_ChinaVehicleListeningOutpost
 
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
-    DestructionDelay = 1789
+    DestructionDelay = 1800
     FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5187,7 +5187,7 @@ Object Tank_ChinaVehicleListeningOutpost
   Behavior = SlowDeathBehavior ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay = 1789
-    FX  = INITIAL    FX_SupplyTruckExplosionOneFinal
+    FX  = INITIAL    FX_ListeningOutpostExplosionOneInitial ; Patch104p @tweak from FX_SupplyTruckExplosionOneFinal to prevent two scorch effects.
     OCL = INITIAL    OCL_InitialListeningOutpostDebris
     FX  = FINAL    FX_SupplyTruckExplosionOneFinal
     OCL = FINAL    OCL_FinalListeningOutpostDebris


### PR DESCRIPTION
Merge with Rebase.

This change fixes duplicate death scorch effect of China Listening Outpost, Dragon Tank.