### PR TITLE
Change: Fine tune tank scorch sizes

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -1915,6 +1915,11 @@ FXList FX_ChinaVehicleNukeCannonDeathExplosion
     Offset = X:0.0 Y:0.0 Z:35.0
   End
 
+  TerrainScorch
+    Type = RANDOM
+    Radius = 30
+  End
+
 End
 
 ;---------------------------------------------------------------------------------------
@@ -2268,10 +2273,6 @@ FXList FX_ChinaVehicleNukeCannonDeathExplosionInitial
   End
   ViewShake
     Type = STRONG
-  End
-  TerrainScorch
-    Type = RANDOM
-    Radius = 30
   End
   Sound
     Name = TankDie

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -1656,7 +1656,7 @@ FXList FX_BombExplosion
 End
 
 ; ----------------------------------------------
-FXList FX_TankDieExplosion
+FXList FX_TankDieExplosion ; Unused
   ViewShake
     Type = NORMAL
   End
@@ -2153,7 +2153,7 @@ FXList FX_BattleMasterExplosionOneInitial
 End
 
 ; -----------------------------------------------------------------------------
-FXList FX_GattlingExplosionOneInitial
+FXList FX_GattlingExplosionOneInitial ; Unused
   ParticleSystem
     Name = HotPillarArms
     Offset = X:0 Y:0 Z:10
@@ -2163,37 +2163,6 @@ FXList FX_GattlingExplosionOneInitial
   End
   Sound
     Name = ExplosionBarrel
-  End
-End
-
-; -----------------------------------------------------------------------------
-FXList FX_GattlingExplosionOneFinal
-  ParticleSystem
-    Name = BattleMasterTankExplosionSmoke
-  End
-  ParticleSystem
-    Name = BattleMasterTankSubExplosionSmoke
-    Count = 3
-    Radius = 15 30 UNIFORM
-    Height = 0 20 UNIFORM
-    InitialDelay = 167 667 UNIFORM
-  End
-  ParticleSystem
-    Name = BattleMasterTankExplosionDebris
-  End
-  ParticleSystem
-    Name = BattleMasterTankExplosionShockwave
-    Offset = X:0 Y:0 Z:2 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
-  End
-  ViewShake
-    Type = STRONG
-  End
-  TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
-    Type = RANDOM
-    Radius = 20
-  End
-  Sound
-    Name = TankDie
   End
 End
 
@@ -3957,7 +3926,7 @@ FXList FX_RaptorMidAirCrashingExplosion
 End
 
 ; ----------------------------------------------
-FXList FX_RaptorCrashExplosion
+FXList FX_RaptorCrashExplosion ; Unused
   ParticleSystem
     Name = LargeStructureExplosionShockwave
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -1549,7 +1549,7 @@ FXList WeaponFX_NuclearTankDeathDetonation
   End
   TerrainScorch
     Type = RANDOM
-    Radius = 30
+    Radius = 25
   End
   LightPulse
     Color = R:255 G:128 B:51
@@ -1753,7 +1753,7 @@ FXList FX_GenericTankDeathExplosion
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -1818,7 +1818,7 @@ FXList FX_AmericaVehicleTomahawkDeathExplosion
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -1917,7 +1917,7 @@ FXList FX_ChinaVehicleNukeCannonDeathExplosion
 
   TerrainScorch
     Type = RANDOM
-    Radius = 30
+    Radius = 25
   End
 
 End
@@ -2187,7 +2187,7 @@ FXList FX_BattleMasterExplosionOneFinal
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -2304,7 +2304,7 @@ FXList FX_ScudLauncherExplosionOneFinal
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 25
+    Radius = 22
   End
   Sound
     Name = TankDie
@@ -2369,7 +2369,7 @@ FXList FX_SupplyTruckExplosionOneFinal
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -2425,7 +2425,7 @@ FXList FX_ToxinTruckExplosionOneFinal
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -2481,7 +2481,7 @@ FXList FX_ToxinTruckExplosionUpgraded
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -2536,7 +2536,7 @@ FXList Chem_FX_ToxinTruckExplosionGamma
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -2564,7 +2564,7 @@ FXList FX_GattlingExplosionOneFinal
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -2713,7 +2713,7 @@ FXList FX_OverlordExplosionOneFinal
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 30
+    Radius = 25
   End
   Sound
     Name = TankDie
@@ -2857,7 +2857,7 @@ FXList FX_DragonTankDeathExplosionFinal
   End
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Change scorch size from 15.
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = TankDie
@@ -4793,7 +4793,7 @@ FXList FX_BattleBusDeathExplosion
   End
   TerrainScorch
     Type = RANDOM
-    Radius = 20
+    Radius = 18
   End
   Sound
     Name = CarDie
@@ -7159,7 +7159,7 @@ FXList WeaponFX_BombTruckHighExplosiveBombDetonation
 
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 55
   End
 
   Sound
@@ -7197,7 +7197,7 @@ FXList Demo_WeaponFX_BombTruckHighExplosiveBombDetonation
 
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 55
   End
 
   Sound
@@ -7235,7 +7235,7 @@ FXList WeaponFX_BombTruckHighExplosiveBioBombDetonation
 
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 55
   End
 
   Sound
@@ -7273,7 +7273,7 @@ FXList WeaponFX_BombTruckHighExplosiveAnthraxBombDetonation
 
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 55
   End
 
   Sound
@@ -7313,7 +7313,7 @@ FXList Chem_WeaponFX_BombTruckHighExplosiveGammaBombDetonation
 
   TerrainScorch ; Patch104p @tweak xezon 03/12/2022 Added scorch effect.
     Type = RANDOM
-    Radius = 60
+    Radius = 55
   End
 
   Sound


### PR DESCRIPTION
Merge with Rebase.

* Successor to #1494

This change fine tunes tank scorch sizes. They are 10-20% smaller than before, but larger than Original.

This change also removes the duplicate FX_GattlingExplosionOneFinal definition. And spawns the Nuke Cannon death scorch on the secondary explosion instead of the first one, like other China tanks.