### PR TITLE
Fix: Keep acquired China Helix attachment upgrade in command set

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -680,6 +680,8 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
   9 = Command_UpgradeChinaHelixNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -696,6 +698,8 @@ CommandSet ChinaHelixGattlingCannonAndBombCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -710,6 +714,8 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  ;---------
+  8 = Command_UpgradeChinaHelixPropagandaTower
   ;---------
   9 = Command_UpgradeChinaHelixNapalmBomb
   ;---------
@@ -727,6 +733,8 @@ CommandSet ChinaHelixPropagandaTowerAndBombCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
+  8 = Command_UpgradeChinaHelixPropagandaTower
+  ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -741,6 +749,8 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
   ;---------
   9 = Command_UpgradeChinaHelixNapalmBomb
   ;---------
@@ -757,6 +767,8 @@ CommandSet ChinaHelixBattleBunkerAndBombCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
   ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
@@ -3415,6 +3427,8 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
   9 = Nuke_Command_UpgradeChinaHelixNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3431,6 +3445,8 @@ CommandSet Nuke_ChinaHelixGattlingCannonAndBombCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3445,6 +3461,8 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  ;---------
+  8 = Command_UpgradeChinaHelixPropagandaTower
   ;---------
   9 = Nuke_Command_UpgradeChinaHelixNukeBomb
   ;---------
@@ -3462,6 +3480,8 @@ CommandSet Nuke_ChinaHelixPropagandaTowerAndBombCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
+  8 = Command_UpgradeChinaHelixPropagandaTower
+  ;---------
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3476,6 +3496,8 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
   ;---------
   9 = Nuke_Command_UpgradeChinaHelixNukeBomb
   ;---------
@@ -3492,6 +3514,8 @@ CommandSet Nuke_ChinaHelixBattleBunkerAndBombCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
   ;---------
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------


### PR DESCRIPTION
This change keeps acquired China Helix attachment upgrade in command set. Applies to regular Helix and Nuke Helix. This way keyboard shortcut for said attachment will work when multiple Helixes are selected where some have it purchased and others do not yet. This behavior is consistent with Infantry Helix.

![shot_20230109_211447_1](https://user-images.githubusercontent.com/4720891/211401010-09350fb5-1a7c-4ced-b95c-9ac8cffa2d4b.jpg)

![shot_20230109_211450_2](https://user-images.githubusercontent.com/4720891/211401021-216095c0-b661-464c-982c-462b1f8650fb.jpg)

![shot_20230109_211454_3](https://user-images.githubusercontent.com/4720891/211401031-6cccc074-3f62-4242-bdd4-2b64d19b3105.jpg)
