### PR TITLE
Revert Change: Put Helix Bomb Upgrade and Bomb Drop buttons on same command position

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -645,26 +645,7 @@ CommandSet ChinaVehicleHelixCommandSet
   8 = Command_UpgradeChinaHelixPropagandaTower
  10 = Command_UpgradeChinaHelixGattlingCannon
   ;---------
-  9 = Command_UpgradeChinaHelixNapalmBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
-CommandSet ChinaHelixBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
-  6 = Command_UpgradeChinaHelixBattleBunker
-  8 = Command_UpgradeChinaHelixPropagandaTower
- 10 = Command_UpgradeChinaHelixGattlingCannon
-  ;---------
+  7 = Command_UpgradeChinaHelixNapalmBomb
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -680,22 +661,7 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  9 = Command_UpgradeChinaHelixNapalmBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
-CommandSet ChinaHelixGattlingCannonAndBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
+  7 = Command_UpgradeChinaHelixNapalmBomb
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -711,22 +677,7 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  9 = Command_UpgradeChinaHelixNapalmBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
-CommandSet ChinaHelixPropagandaTowerAndBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
+  7 = Command_UpgradeChinaHelixNapalmBomb
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -742,22 +693,7 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  9 = Command_UpgradeChinaHelixNapalmBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Command_UpgradeChinaHelixNapalmBomb when upgraded
-CommandSet ChinaHelixBattleBunkerAndBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
+  7 = Command_UpgradeChinaHelixNapalmBomb
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
@@ -3380,26 +3316,7 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   8 = Command_UpgradeChinaHelixPropagandaTower
  10 = Command_UpgradeChinaHelixGattlingCannon
   ;---------
-  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
-CommandSet Nuke_ChinaHelixBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
-  6 = Command_UpgradeChinaHelixBattleBunker
-  8 = Command_UpgradeChinaHelixPropagandaTower
- 10 = Command_UpgradeChinaHelixGattlingCannon
-  ;---------
+  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3415,22 +3332,7 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
-CommandSet Nuke_ChinaHelixGattlingCannonAndBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
+  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3446,22 +3348,7 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
-CommandSet Nuke_ChinaHelixPropagandaTowerAndBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
+  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -3477,22 +3364,7 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   4 = Command_TransportExit
   5 = Command_TransportExit
   ;---------
-  9 = Nuke_Command_UpgradeChinaHelixNukeBomb
-  ;---------
- 11 = Command_AttackMove
- 12 = Command_Evacuate
- 13 = Command_Guard
- 14 = Command_Stop
-End
-
-; Patch104p @tweak New command set redesign to hide Nuke_Command_UpgradeChinaHelixNukeBomb when upgraded
-CommandSet Nuke_ChinaHelixBattleBunkerAndBombCommandSet
-  1 = Command_TransportExit
-  2 = Command_TransportExit
-  3 = Command_TransportExit
-  4 = Command_TransportExit
-  5 = Command_TransportExit
-  ;---------
+  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
@@ -4295,6 +4167,7 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   8 = Command_TransportExit
   ;---------
   9 = Command_UpgradeChinaHelixNapalmBomb
+; 10 = Command_ChinaHelixDropNapalmBomb
   10 = Infa_Command_UpgradeChinaHelixBattleBunker
   ;---------
  11 = Command_AttackMove

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15808,14 +15808,7 @@ Object Boss_VehicleHelix
 
 
 
-  ; Patch104p @tweak Add dedicated Command Sets for Napalm Bomb
-  ; ----- NapalmBomb
-  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
-    CommandSet = ChinaHelixBombCommandSet
-    TriggeredBy   = Upgrade_HelixNapalmBomb
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
-  ; ----- GattlingCannon
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -15824,13 +15817,7 @@ Object Boss_VehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
-    CommandSet = ChinaHelixGattlingCannonAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -15841,7 +15828,7 @@ Object Boss_VehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ; ----- PropagandaTower
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -15850,15 +15837,9 @@ Object Boss_VehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
-    CommandSet = ChinaHelixPropagandaTowerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
-  ; ----- BattleBunker
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -15867,13 +15848,7 @@ Object Boss_VehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
-    CommandSet = ChinaHelixBattleBunkerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -199,14 +199,7 @@ Object ChinaVehicleHelix
 
 
 
-  ; Patch104p @tweak Add dedicated Command Sets for Napalm Bomb
-  ; ----- NapalmBomb
-  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
-    CommandSet = ChinaHelixBombCommandSet
-    TriggeredBy   = Upgrade_HelixNapalmBomb
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
-  ; ----- GattlingCannon
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -215,13 +208,7 @@ Object ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
-    CommandSet = ChinaHelixGattlingCannonAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -232,7 +219,7 @@ Object ChinaVehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ; ----- PropagandaTower
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -241,15 +228,9 @@ Object ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
-    CommandSet = ChinaHelixPropagandaTowerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
-  ; ----- BattleBunker
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -258,13 +239,7 @@ Object ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
-    CommandSet = ChinaHelixBattleBunkerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -473,14 +473,7 @@ Object Nuke_ChinaVehicleHelix
 
 
 
-  ; Patch104p @tweak Add dedicated Command Sets for Nuke Bomb
-  ; ----- NukeBomb
-  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
-    CommandSet = Nuke_ChinaHelixBombCommandSet
-    TriggeredBy   = Nuke_Upgrade_HelixNukeBomb
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
-  ; ----- GattlingCannon
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -489,13 +482,7 @@ Object Nuke_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = Nuke_ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Nuke_Upgrade_HelixNukeBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
-    CommandSet = Nuke_ChinaHelixGattlingCannonAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Nuke_Upgrade_HelixNukeBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -506,7 +493,7 @@ Object Nuke_ChinaVehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ; ----- PropagandaTower
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -515,15 +502,9 @@ Object Nuke_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = Nuke_ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Nuke_Upgrade_HelixNukeBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
-    CommandSet = Nuke_ChinaHelixPropagandaTowerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Nuke_Upgrade_HelixNukeBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
-  ; ----- BattleBunker
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -532,13 +513,7 @@ Object Nuke_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = Nuke_ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Nuke_Upgrade_HelixNukeBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
-    CommandSet = Nuke_ChinaHelixBattleBunkerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Nuke_Upgrade_HelixNukeBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -201,14 +201,7 @@ Object Tank_ChinaVehicleHelix
 
 
 
-  ; Patch104p @tweak Add dedicated Command Sets for Napalm Bomb
-  ; ----- NapalmBomb
-  Behavior = CommandSetUpgrade ModuleTag_BombCommandSet
-    CommandSet = ChinaHelixBombCommandSet
-    TriggeredBy   = Upgrade_HelixNapalmBomb
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
-  ; ----- GattlingCannon
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
@@ -217,13 +210,7 @@ Object Tank_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_26
     CommandSet = ChinaHelixGattlingCannonCommandSet
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_GattlingCannonAndBombCommandSet
-    CommandSet = ChinaHelixGattlingCannonAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
@@ -234,7 +221,7 @@ Object Tank_ChinaVehicleHelix
 ;    ConflictsWith  = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
 ;    HideSubObjects = MINIGUN
 ;  End
-  ; ----- PropagandaTower
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_23
     UpgradeObject = OCL_HelixPropagandaTower
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
@@ -243,15 +230,9 @@ Object Tank_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_27
     CommandSet = ChinaHelixPropagandaTowerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_PropagandaTowerAndBombCommandSet
-    CommandSet = ChinaHelixPropagandaTowerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-    RequiresAllTriggers = Yes
   End
-  ; ----- BattleBunker
+  ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
@@ -260,13 +241,7 @@ Object Tank_ChinaVehicleHelix
   Behavior = CommandSetUpgrade ModuleTag_28
     CommandSet = ChinaHelixBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower Upgrade_HelixNapalmBomb
-  End
-  Behavior = CommandSetUpgrade ModuleTag_BattleBunkerAndBombCommandSet
-    CommandSet = ChinaHelixBattleBunkerAndBombCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker Upgrade_HelixNapalmBomb
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-    RequiresAllTriggers = Yes
   End
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker


### PR DESCRIPTION
This change reverts change: Put Helix Bomb Upgrade and Bomb Drop buttons on same command position.

* #1532