### PR TITLE
Fix: Optimize USA vehicle drone spawn positions

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -3232,11 +3232,11 @@ ObjectCreationList OCL_GenericWallSegmentDebris
 End
 
 ; -----------------------------------------------------------------------------
-; American Rangers can spawn slaved scout drones
+; Certain American vehicles can spawn slaved scout drones
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_AmericanScoutDrone
   CreateObject
-    Offset = X:-8 Y:0 Z:10 ;Spawn at backpack offset
+    Offset = X:0 Y:0 Z:12 ; Patch104p @tweak from X:-8 Y:0 Z:10
     ObjectNames = AmericaVehicleScoutDrone
     IgnorePrimaryObstacle = Yes
     Disposition = LIKE_EXISTING
@@ -3250,7 +3250,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_AmericanBattleDrone
   CreateObject
-    Offset = X:0 Y:0 Z:10
+    Offset = X:0 Y:0 Z:12 ; Patch104p @tweak from X:0 Y:0 Z:10
     ObjectNames = AmericaVehicleBattleDrone
     IgnorePrimaryObstacle = Yes
     Disposition = LIKE_EXISTING
@@ -3264,7 +3264,7 @@ End
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_AmericanHellfireDrone
   CreateObject
-    Offset = X:0 Y:0 Z:10
+    Offset = X:0 Y:0 Z:12 ; Patch104p @tweak from X:0 Y:0 Z:10
     ObjectNames = AmericaVehicleHellfireDrone
     IgnorePrimaryObstacle = Yes
     Disposition = LIKE_EXISTING


### PR DESCRIPTION
This change optimizes USA vehicle drone spawn positions.

Scout drone now spawns at the vehicle center like the other drones.

And all drones spawn a bit higher to clip less with the host vehicle.

https://user-images.githubusercontent.com/4720891/211419684-3e2f29c4-396c-4ff5-8682-6996b25009d1.mp4

https://user-images.githubusercontent.com/4720891/211419711-d9fa649f-a6c1-4779-ac37-8f2a49353951.mp4

https://user-images.githubusercontent.com/4720891/211419735-100cec6e-e60d-40b3-9307-2f162c6d47c8.mp4
