### PR TITLE
Change: Increase Nuke Bomb damage from 300 to 400, decrease secondary damage from 50 to 20

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8375,9 +8375,9 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon HelixNukeBombDetonationWeaponWithAnEvenLongerName
-  PrimaryDamage               = 300.0
+  PrimaryDamage               = 400.0 ; Patch104p @balance from 300 to deal as much damage as NukeCannonGun.
   PrimaryDamageRadius         = 50.0
-  SecondaryDamage             = 50.0
+  SecondaryDamage             = 20.0 ; Patch104p @balance from 50 to deal as much damage as NukeCannonGun.
   SecondaryDamageRadius       = 60.0
   AttackRange                 = 100.0
   DamageType                  = EXPLOSION


### PR DESCRIPTION
* Related to #1014

This change increases Helix Nuke Bomb primary damage by 33% (300 to 400), decreases secondary damage by 60% (50 to 20). Damage is identical to Nuke Cannon.

| Weapon                       | Primary Damage | Secondary Damage |
|------------------------------|---------------:|-----------------:|
| Original Nuke Cannon Shell   | 400            | 20               |
| Original Nuke Bomb           | 300            | 50               |
| **Patched Nuke Bomb (this)** | 400            | 20               |

Damage values of Napalm Bomb and Nuke Bomb cannot be compared, because one is type FIRE and the other is EXPLOSION. They apply different damages to things depending on the Armor of those things.

| Weapon               | Effective Damage Radius |
|----------------------|------------------------:|
| Original Napalm Bomb | 90                      |
| Original Nuke Bomb   | 50                      |

Napalm Fire Storm can hit more things with wider radius. But it is easier to hit moving targets with Nuke Bomb, because units cannot escape this bomb as quickly as the Napalm Fire Storm.

The following table shows damage results in best case scenario, which includes full Napalm Fire Storm and Nuke Radiation to apply their damages over time.

| Weapon                       | Damage vs China War Factory | Damage vs China Overlord |
| -----------------------------|----------------------------:|-------------------------:|
| Original Napalm Bomb         | 34%                         | 35%                      |
| Original Black N. Bomb       | 47%                         | 47%                      |
| Original Nuke Bomb           | 15%                         | 49%                      |
| **Patched Nuke Bomb (this)** | 20%                         | 65%                      |

# Rationale

The increased primary damage of Helix Nuke Bomb makes it more attractive to use. Since it now applies as much damage as Nuke Cannon does, the damages are easier to anticipate.

The Nuke Bomb is typically better against vehicles than the Napalm Bomb due its instant detonation, but the Napalm Bomb is better against structures and has an almost twice as large effective damage radius.