### PR TITLE
Fix NukeCannonRing position offset in Helix Nuke Bomb explosion

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -9244,7 +9244,7 @@ FXList Nuke_WeaponFX_NukeCannon ; Mig Nuke Missile, Helix Nuke Bomb
 
   ParticleSystem
     Name = NukeCannonRing
-    Offset = X:0.0 Y:0.0 Z:5.0 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
+    Offset = X:0.0 Y:0.0 Z:0.0
   End
 
   ParticleSystem

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -41646,7 +41646,7 @@ ParticleSystem NukeCannonRing
   BurstDelay = 2.00 2.00
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
-  DriftVelocity = X:0.00 Y:0.00 Z:0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.10 ; Patch104p @bugfix from Z:0.00 to fix z clipping on flat terrain
   VelocityType = ORTHO
   VelOrthoX = 0.00 0.00
   VelOrthoY = 0.00 0.00


### PR DESCRIPTION
This change fixes NukeCannonRing position offset in Helix Nuke Bomb explosion. It appears the XY offset is caused by the effect having a Z offset.