### PR TITLE
Fix: Keep disabled Helix attachment upgrade buttons in Command Set

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -654,7 +654,7 @@ CommandSet ChinaVehicleHelixCommandSet
  14 = Command_Stop
 End
 
-CommandSet ChinaHelixGattlingCannonCommandSet
+CommandSet ChinaHelixGattlingCannonCommandSet ; Legacy
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -670,7 +670,7 @@ CommandSet ChinaHelixGattlingCannonCommandSet
  14 = Command_Stop
 End
 
-CommandSet ChinaHelixPropagandaTowerCommandSet
+CommandSet ChinaHelixPropagandaTowerCommandSet ; Legacy
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -686,7 +686,7 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
  14 = Command_Stop
 End
 
-CommandSet ChinaHelixBattleBunkerCommandSet
+CommandSet ChinaHelixBattleBunkerCommandSet ; Legacy
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -3325,7 +3325,7 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
  14 = Command_Stop
 End
 
-CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
+CommandSet Nuke_ChinaHelixGattlingCannonCommandSet ; Legacy
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -3341,7 +3341,7 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
  14 = Command_Stop
 End
 
-CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
+CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet ; Legacy
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -3357,7 +3357,7 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
  14 = Command_Stop
 End
 
-CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
+CommandSet Nuke_ChinaHelixBattleBunkerCommandSet ; Legacy
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15808,19 +15808,17 @@ Object Boss_VehicleHelix
 
 
 
+  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_26
-    CommandSet = ChinaHelixGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
 ; lorenzen commented out 8/4... the helix now keeps its minigun, even when upgraded to gattling
 ;  Behavior = SubObjectsUpgrade ModuleTag_36
@@ -15834,24 +15832,16 @@ Object Boss_VehicleHelix
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_27
-    CommandSet = ChinaHelixPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-  End
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
-  Behavior = CommandSetUpgrade ModuleTag_28
-    CommandSet = ChinaHelixBattleBunkerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
   ;--------------------------
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -199,19 +199,17 @@ Object ChinaVehicleHelix
 
 
 
+  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_26
-    CommandSet = ChinaHelixGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
 ; lorenzen commented out 8/4... the helix now keeps its minigun, even when upgraded to gattling
 ;  Behavior = SubObjectsUpgrade ModuleTag_36
@@ -225,24 +223,16 @@ Object ChinaVehicleHelix
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_27
-    CommandSet = ChinaHelixPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-  End
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
-  Behavior = CommandSetUpgrade ModuleTag_28
-    CommandSet = ChinaHelixBattleBunkerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
   ;--------------------------
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -473,19 +473,17 @@ Object Nuke_ChinaVehicleHelix
 
 
 
+  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_26
-    CommandSet = Nuke_ChinaHelixGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
 ; lorenzen commented out 8/4... the helix now keeps its minigun, even when upgraded to gattling
 ;  Behavior = SubObjectsUpgrade ModuleTag_36
@@ -499,24 +497,16 @@ Object Nuke_ChinaVehicleHelix
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_27
-    CommandSet = Nuke_ChinaHelixPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-  End
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
-  Behavior = CommandSetUpgrade ModuleTag_28
-    CommandSet = Nuke_ChinaHelixBattleBunkerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
   ;--------------------------
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -201,19 +201,17 @@ Object Tank_ChinaVehicleHelix
 
 
 
+  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
     TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
     ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_26
-    CommandSet = ChinaHelixGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixGattlingCannon
-    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = WeaponSetUpgrade ModuleTag_35
     TriggeredBy = Upgrade_ChinaHelixGattlingCannon
+    ConflictsWith = Upgrade_ChinaHelixPropagandaTower Upgrade_ChinaHelixBattleBunker
   End
 ; lorenzen commented out 8/4... the helix now keeps its minigun, even when upgraded to gattling
 ;  Behavior = SubObjectsUpgrade ModuleTag_36
@@ -227,24 +225,16 @@ Object Tank_ChinaVehicleHelix
     TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
   End
-  Behavior = CommandSetUpgrade ModuleTag_27
-    CommandSet = ChinaHelixPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixPropagandaTower
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixBattleBunker
-  End
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_24
     UpgradeObject = OCL_HelixBattleBunker
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
     ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
-  Behavior = CommandSetUpgrade ModuleTag_28
-    CommandSet = ChinaHelixBattleBunkerCommandSet
-    TriggeredBy   = Upgrade_ChinaHelixBattleBunker
-    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
-  End
+  ; Patch104p @bugfix Adds ConflictsWith entry to disable conflicting buttons once this upgrade was acquired.
   Behavior = PassengersFireUpgrade ModuleTag_34
     TriggeredBy   = Upgrade_ChinaHelixBattleBunker
+    ConflictsWith = Upgrade_ChinaHelixGattlingCannon Upgrade_ChinaHelixPropagandaTower
   End
   ;--------------------------
 


### PR DESCRIPTION
This change simplifies Helix attachment Command Set. Buttons will no longer disappear after research. This means shortcut key can be used on multi Helix selection to build an upgrade any time.

This behavior is consistent with USA vehicle drone upgrade buttons.

![shot_20230111_220238_1](https://user-images.githubusercontent.com/4720891/211918446-e00b4e67-e0e0-4a83-b8e3-2f6d34dde92c.jpg)
