### PR TITLE
Fix: China Overlord, Emperor command sets

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -605,25 +605,30 @@ CommandSet ChinaTankOverlordDefaultCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @tweak Keeps upgrade buttons in all command sets.
+; Patch104p @tweak Moves Command_Evacuate from 6 into same position as Outpost, Troopcrawler evacuate.
 CommandSet ChinaTankOverlordBattleBunkerCommandSet
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  6 = Command_Evacuate
+  6  = Command_UpgradeChinaOverlordBattleBunker
+  8  = Command_UpgradeChinaOverlordPropagandaTower
+  9  = Command_Evacuate
+  10 = Command_UpgradeChinaOverlordGattlingCannon
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
-CommandSet ChinaTankOverlordGattlingCannonCommandSet
+CommandSet ChinaTankOverlordGattlingCannonCommandSet ; Legacy
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
-CommandSet ChinaTankOverlordPropagandaTowerCommandSet
+CommandSet ChinaTankOverlordPropagandaTowerCommandSet ; Legacy
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -4731,13 +4736,13 @@ CommandSet Tank_ChinaVehicleBattleMasterCommandSet
   14 = Command_Stop
 End
 
-CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
+CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet ; Legacy
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
-CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
+CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet ; Legacy
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -594,11 +594,12 @@ CommandSet ChinaTankBattlemasterCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @tweak Moves upgrade buttons into same position as Helix upgrade buttons.
 ;--------------------------------------------
 CommandSet ChinaTankOverlordDefaultCommandSet
-  1  = Command_UpgradeChinaOverlordBattleBunker
-  3  = Command_UpgradeChinaOverlordGattlingCannon
-  5  = Command_UpgradeChinaOverlordPropagandaTower
+  6  = Command_UpgradeChinaOverlordBattleBunker
+  8  = Command_UpgradeChinaOverlordPropagandaTower
+  10 = Command_UpgradeChinaOverlordGattlingCannon
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -4749,9 +4750,10 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
   14 = Command_Stop
 End
 
-CommandSet Tank_ChinaTankEmperorDefaultCommandSet
+; Patch104p @tweak Moves upgrade buttons into same position as Helix upgrade buttons.
+CommandSet Tank_ChinaTankEmperorDefaultCommandSet ; Alias Tank_ChinaTankOverlordDefaultCommandSet
   ;1  = Command_UpgradeChinaOverlordBattleBunker   ;Does not get this upgrade.
-  3  = Tank_Command_UpgradeChinaOverlordGattlingCannon
+  10 = Tank_Command_UpgradeChinaOverlordGattlingCannon
   ;5  = Command_UpgradeChinaOverlordPropagandaTower ;Is granted this upgrade innately.
   11 = Command_AttackMove
   13 = Command_Guard

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -370,16 +370,9 @@ Object ChinaTankOverlord
   Behavior = ProductionUpdate ModuleTag_10
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
   End
-  Behavior = CommandSetUpgrade ModuleTag_11
-    CommandSet = ChinaTankOverlordGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordGattlingCannon
-    ConflictsWith = Upgrade_ChinaOverlordPropagandaTower Upgrade_ChinaOverlordBattleBunker
-  End
-  Behavior = CommandSetUpgrade ModuleTag_12
-    CommandSet = ChinaTankOverlordPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordPropagandaTower
-    ConflictsWith = Upgrade_ChinaOverlordGattlingCannon Upgrade_ChinaOverlordBattleBunker
-  End
+
+  ; Patch104p @tweak Removes Gattling And Propaganda CommandSetUpgrade behaviours to keep disabled upgrade buttons.
+
   Behavior = CommandSetUpgrade ModuleTag_13
     CommandSet = ChinaTankOverlordBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaOverlordBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -202,11 +202,13 @@ Object ChinaTankOverlord
   SelectPortrait         = SNOverlord_L
   ButtonImage            = SNOverlord
 
+  ; Patch104p @tweak Moves upgrade icons into same position as Helix, Emperor upgrade icons.
+
   UpgradeCameo1 = Upgrade_ChinaUraniumShells
   UpgradeCameo2 = Upgrade_ChinaNuclearTanks
-  UpgradeCameo3 = Upgrade_ChinaOverlordBattleBunker
-  UpgradeCameo4 = Upgrade_ChinaOverlordGattlingCannon
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo3 = Upgrade_ChinaOverlordGattlingCannon
+  UpgradeCameo4 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo5 = Upgrade_ChinaOverlordBattleBunker
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17286,16 +17286,9 @@ Object Nuke_ChinaTankOverlord
   Behavior = ProductionUpdate ModuleTag_10
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
   End
-  Behavior = CommandSetUpgrade ModuleTag_11
-    CommandSet = ChinaTankOverlordGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordGattlingCannon
-    ConflictsWith = Upgrade_ChinaOverlordPropagandaTower Upgrade_ChinaOverlordBattleBunker
-  End
-  Behavior = CommandSetUpgrade ModuleTag_12
-    CommandSet = ChinaTankOverlordPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordPropagandaTower
-    ConflictsWith = Upgrade_ChinaOverlordGattlingCannon Upgrade_ChinaOverlordBattleBunker
-  End
+
+  ; Patch104p @tweak Removes Gattling And Propaganda CommandSetUpgrade behaviours to keep disabled upgrade buttons.
+
   Behavior = CommandSetUpgrade ModuleTag_13
     CommandSet = ChinaTankOverlordBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaOverlordBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17122,11 +17122,13 @@ Object Nuke_ChinaTankOverlord
   SelectPortrait         = SNOverlord_L
   ButtonImage            = SNOverlord
 
+  ; Patch104p @tweak Moves upgrade icons into same position as Helix, Emperor upgrade icons.
+
   UpgradeCameo1 = Upgrade_ChinaWGUraniumShells
   UpgradeCameo2 = Upgrade_ChinaFusionReactors
-  UpgradeCameo3 = Upgrade_ChinaOverlordBattleBunker
-  UpgradeCameo4 = Upgrade_ChinaOverlordGattlingCannon
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo3 = Upgrade_ChinaOverlordGattlingCannon
+  UpgradeCameo4 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo5 = Upgrade_ChinaOverlordBattleBunker
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2902,7 +2902,7 @@ End
 
 
 ;------------------------------------------------------------------------------
-Object Tank_ChinaTankEmperor
+Object Tank_ChinaTankEmperor ; Alias Tank_ChinaTankOverlord
 
   ; *** ART Parameters ***
   SelectPortrait         = SNEmpTank_L
@@ -3095,11 +3095,9 @@ Object Tank_ChinaTankEmperor
     ; MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
      MaxQueueEntries = 2; Propaganda model is hacked to not show up.
   End
-  Behavior = CommandSetUpgrade ModuleTag_11
-    CommandSet = Tank_ChinaTankOverlordGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordGattlingCannon
-    ConflictsWith = Upgrade_ChinaOverlordPropagandaTower Upgrade_ChinaOverlordBattleBunker
-  End
+
+  ; Patch104p @tweak Removes Gattling CommandSetUpgrade behaviour to keep disabled upgrade button.
+
   ;Behavior = CommandSetUpgrade ModuleTag_12
    ; CommandSet = Tank_ChinaTankOverlordPropagandaTowerCommandSet
     ;TriggeredBy   = Upgrade_ChinaOverlordPropagandaTower


### PR DESCRIPTION
**Merge with Rebase.**

This change fixes and improves China Overlord, Emperor command sets.

### TODO

- [ ] Remake this change for optional use

## Overlord

* Upgrade buttons now have same position as Helix upgrade buttons
* Upgrade buttons now have same order as Helix upgrade buttons, ordered left to right from least expensive upgrade to most expensive upgrade
* Upgrade icons now have same order as Helix, Emperor upgrade icons - matching order of upgrade buttons
* Evacuate button in Bunker Command Set now has same position as Listening Outpost, Troopcrawler evacuate button
* Disabled upgrade buttons remain visible in Command Set - allowing use of shortcut key to research upgrade on multi unit selection

## Emperor

* Upgrade buttons now have same position as Helix upgrade buttons
* Disabled upgrade buttons remain visible in Command Set - allowing use of shortcut key to research upgrade on multi unit selection


## Original Overlord Command Set & Cameo

![shot_20230112_195805_1](https://user-images.githubusercontent.com/4720891/212160578-155b3120-53d8-4efb-83fe-591dfe325c40.jpg)

## Patched Overlord Command Set & Cameo

![shot_20230112_193923_1](https://user-images.githubusercontent.com/4720891/212160668-9c479f99-be4f-435f-b8a7-c51c66b14ab2.jpg)

## Original Overlord Bunker Command Set

![shot_20230112_195815_2](https://user-images.githubusercontent.com/4720891/212160765-a8fa067d-03d5-484d-babd-b94effda63b6.jpg)

## Patched Overlord Bunker Command Set

![shot_20230112_195436_1](https://user-images.githubusercontent.com/4720891/212160825-a8fa432d-b6f9-4a1b-a35b-12c43a278194.jpg)

## Original Emperor Command Set

![shot_20230112_195903_3](https://user-images.githubusercontent.com/4720891/212160950-1bc634aa-899d-4c7d-9843-e7875f597ce6.jpg)

## Patched Emperor Command Set

![shot_20230112_195655_2](https://user-images.githubusercontent.com/4720891/212161014-b801954d-41cf-4892-a15e-220ad4aa49d2.jpg)
