### PR TITLE
Fix evacuate buttons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1674,16 +1674,16 @@ CommandButton Command_FireBaseExit
   DescriptLabel           = CONTROLBAR:FireBaseExit
 End
 
-CommandButton Command_ScuttleCombatBike
+CommandButton Command_ScuttleCombatBike ; unload bike
   Command                 = EVACUATE
   Options                 = OK_FOR_MULTI_SELECT MUST_BE_STOPPED
   TextLabel               = CONTROLBAR:Evacuate
-  ButtonImage             = SSEvacButton
+  ButtonImage             = SSEmptyCrawler ; Patch104p @tweak from SSEvacButton
   ButtonBorderType        = SYSTEM ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipEvacuate
 End
 
-CommandButton Command_Evacuate
+CommandButton Command_Evacuate ; unload structure
   Command                 = EVACUATE
   Options                 = OK_FOR_MULTI_SELECT
   TextLabel               = CONTROLBAR:Evacuate
@@ -1692,7 +1692,7 @@ CommandButton Command_Evacuate
   DescriptLabel           = CONTROLBAR:ToolTipEvacuate
 End
 
-CommandButton Command_TunnelEvacuate
+CommandButton Command_TunnelEvacuate ; unload tunnel
   Command                 = EVACUATE
   TextLabel               = CONTROLBAR:Evacuate
   ButtonImage             = SSEvacButton
@@ -1700,7 +1700,7 @@ CommandButton Command_TunnelEvacuate
   DescriptLabel           = CONTROLBAR:ToolTipEvacuate
 End
 
-CommandButton Command_EmptyCrawler
+CommandButton Command_EmptyCrawler ; unload vehicle
   Command                 = EVACUATE
   Options                 = OK_FOR_MULTI_SELECT
   TextLabel               = CONTROLBAR:Evacuate
@@ -1709,7 +1709,7 @@ CommandButton Command_EmptyCrawler
   DescriptLabel           = CONTROLBAR:ToolTipEvacuate
 End
 
-CommandButton Command_ChinookUnload
+CommandButton Command_ChinookUnload ; unload helicopter
   Command                 = EVACUATE
   Options                 = OK_FOR_MULTI_SELECT
   TextLabel               = CONTROLBAR:Evacuate

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -649,7 +649,7 @@ CommandSet ChinaVehicleHelixCommandSet
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -665,7 +665,7 @@ CommandSet ChinaHelixGattlingCannonCommandSet ; Legacy
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -681,7 +681,7 @@ CommandSet ChinaHelixPropagandaTowerCommandSet ; Legacy
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -697,7 +697,7 @@ CommandSet ChinaHelixBattleBunkerCommandSet ; Legacy
   9 = Command_ChinaHelixDropNapalmBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -3320,7 +3320,7 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -3336,7 +3336,7 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet ; Legacy
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -3352,7 +3352,7 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet ; Legacy
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -3368,7 +3368,7 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet ; Legacy
   9 = Nuke_Command_ChinaHelixDropNukeBomb
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -4171,7 +4171,7 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   10 = Infa_Command_UpgradeChinaHelixBattleBunker
   ;---------
  11 = Command_AttackMove
- 12 = Command_Evacuate
+ 12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -4189,7 +4189,7 @@ CommandSet Infa_ChinaHelixBombCommandSet
   9 = Command_ChinaHelixDropNapalmBomb
   10 = Infa_Command_UpgradeChinaHelixBattleBunker
   11 = Command_AttackMove
-  12 = Command_Evacuate
+  12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   13 = Command_Guard
   14 = Command_Stop
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -105,7 +105,7 @@ CommandSet AmericaTransportCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -134,7 +134,7 @@ CommandSet CivilianTransportCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
 End
@@ -150,7 +150,7 @@ CommandSet RailedTransportCommandSet
   8 = Command_TransportExit
   9 = Command_TransportExit
  10 = Command_TransportExit
- 11 = Command_Evacuate
+ 11 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  12 = Command_ExecuteRailedTransport
 End
 
@@ -214,7 +214,7 @@ CommandSet AmericaVehicleHumveeCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -236,7 +236,7 @@ CommandSet CivilianVehicleLimoCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  6 = Command_Evacuate
+  6 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   14 = Command_Stop
 End
 
@@ -367,7 +367,7 @@ CommandSet GLAVehicleBattleBusCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -386,7 +386,7 @@ CommandSet GLAVehicleTechnicalCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -539,7 +539,7 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   5  = Command_TransportExit
   6  = Command_TransportExit
   7  = Command_TransportExit
-  9  = Command_Evacuate
+  9  = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   10 = Command_AmbulanceCleanupArea
   11 = Command_AttackMove
   13 = Command_Guard
@@ -610,7 +610,7 @@ CommandSet ChinaTankOverlordBattleBunkerCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  6 = Command_Evacuate
+  6 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -1741,7 +1741,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   10 = GC_Slth_Command_DisguiseAsVehicle
   11 = Command_AttackMove
   13 = Command_Guard
@@ -2207,7 +2207,7 @@ CommandSet Demo_GLAVehicleBattleBusCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -2263,7 +2263,7 @@ CommandSet Demo_GLAVehicleTechnicalCommandSet
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -2292,7 +2292,7 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
@@ -2526,7 +2526,7 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
@@ -2803,7 +2803,7 @@ CommandSet Slth_GLAVehicleBattleBusCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -3672,7 +3672,7 @@ CommandSet SupW_AmericaVehicleHumveeCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -3695,7 +3695,7 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   5  = Command_TransportExit
   6  = Command_TransportExit
   7  = Command_TransportExit
-  9  = Command_Evacuate
+  9  = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   10 = Command_AmbulanceCleanupArea
   11 = Command_AttackMove
   13 = Command_Guard
@@ -4486,7 +4486,7 @@ CommandSet Lazr_AmericaVehicleHumveeCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
-  9 = Command_Evacuate
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -4509,7 +4509,7 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   5  = Command_TransportExit
   6  = Command_TransportExit
   7  = Command_TransportExit
-  9  = Command_Evacuate
+  9  = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   10 = Command_AmbulanceCleanupArea
   11 = Command_AttackMove
   13 = Command_Guard


### PR DESCRIPTION
**Merge with Rebase.**

This change fixes evacuate buttons. Result:

* All vehicles now use the Evacuate button for vehicles
* ~~All helicopters use the Evacuate button for vehicles~~
* All structures use the Evacuate button for structures

The following faction unit buttons are affected:

* USA Humvee, Ambulance, ~~Chinook, Combat Chinook~~
* China Overlord, Helix
* GLA Technical, Combat Bike, Battle Bus

With this change it is now possible to evacuate China Outpost and Troopcrawler in group selection with other vehicles, such as Humvee and Battle Bus.

## Original

![shot_20230113_202435_3](https://user-images.githubusercontent.com/4720891/212409383-96f9d233-f10e-4d9b-ae60-766cb5855edf.jpg)

## Patched

![shot_20230113_203739_3](https://user-images.githubusercontent.com/4720891/212409402-1c6dd1d9-759d-49f9-a7f7-e2f2e9c66a56.jpg)
