### PR TITLE
Change: Decrease USA Superweapon Power Plant build cost from 900 to 800

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -17270,7 +17270,7 @@ Object SupW_AmericaPowerPlant
   EditorSorting    = STRUCTURE
   Prerequisites
   End
-  BuildCost        = 900
+  BuildCost        = 800 ; Patch104p @balance from 900 to cost just as much as USA, AFG.
   BuildTime        = 10.0           ; in seconds
   EnergyProduction = 5
   EnergyBonus      = 15


### PR DESCRIPTION
* Fixes #1503

This change decrease USA Superweapon Power Plant build cost from 900 to 800.

| Object                                    | Cost | Upgrade Cost | Power | Upgraded Power |
|-------------------------------------------|-----:|-------------:|------:|---------------:|
| AmericaPowerPlant                         | 800  | 500          | 5     | 10             |
| AirF_AmericaPowerPlant                    | 800  | 500          | 5     | 10             |
| Lazr_AmericaPowerPlant                    | 700  | 500          | 8     | 16             |
| SupW_AmericaPowerPlant                    | 900  | 500          | 5     | 20             |
| **Patched SupW_AmericaPowerPlant (this)** | 800  | 500          | 5     | 20             |

## Rationale

The original USA Superweapon Power Plant price model is problematic. When an Upgraded Power Plant is lost early, then it is difficult to recover, because it takes a large investment of cash and time to rebuild and upgrade the Plant.

Reducing the initial cost by $100 will help offset the initial $850 Humvee cost without impacting the feel of the game. This will reduce the total cost per unit of power from $70 to $65, which is a more meaningful gap between Laser General's $75 per unit of power.

Additionally it adds consistency with USA and Air Force Power Plants, and widens the gap with Laser.