### PR TITLE
Fix: Corrected wrong border types of GLA Bomb Truck command buttons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1442,7 +1442,7 @@ CommandButton Command_DisguiseAsVehicle
   ButtonImage       = SSBombDisguise
   CursorName        = DisguiseAsVehicle
   InvalidCursorName = GenericInvalid
-  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipDisguiseAsVehicle
   UnitSpecificSound = BombTruckVoiceModeDisguise
 End
@@ -1481,7 +1481,7 @@ CommandButton Command_UpgradeGLABombTruckBioBomb
   Options           = OK_FOR_MULTI_SELECT
   TextLabel         = CONTROLBAR:UpgradeGLABombTruckBioBomb
   ButtonImage       = SSBioBombTruck
-  ButtonBorderType  = ACTION
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipGLAUpgradeBioBomb
   UnitSpecificSound = BombTruckVoiceModeBioBomb
 End
@@ -1492,7 +1492,7 @@ CommandButton Command_UpgradeGLABombTruckHighExplosiveBomb
   Options           = OK_FOR_MULTI_SELECT
   TextLabel         = CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb
   ButtonImage       = SSExplosiveBombTruck
-  ButtonBorderType  = BUILD ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeHEBomb
   UnitSpecificSound = BombTruckVoiceModeHiEx
 End
@@ -4306,7 +4306,7 @@ CommandButton GC_Slth_Command_DisguiseAsVehicle
   ButtonImage       = SUBusDisg
   CursorName        = DisguiseAsVehicle
   InvalidCursorName = GenericInvalid
-  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipDisguiseAsVehicle
   UnitSpecificSound = BattleBusVoiceModeDisguise
 End
@@ -5479,7 +5479,7 @@ CommandButton Slth_Command_DisguiseAsVehicle
   ButtonImage       = SUBusDisg
   CursorName        = DisguiseAsVehicle
   InvalidCursorName = GenericInvalid
-  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipDisguiseAsVehicle
   UnitSpecificSound = BattleBusVoiceModeDisguise
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1442,7 +1442,7 @@ CommandButton Command_DisguiseAsVehicle
   ButtonImage       = SSBombDisguise
   CursorName        = DisguiseAsVehicle
   InvalidCursorName = GenericInvalid
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is ; Patch104p @fix from UPGRADE
   DescriptLabel     = CONTROLBAR:TooltipDisguiseAsVehicle
   UnitSpecificSound = BombTruckVoiceModeDisguise
 End
@@ -1481,7 +1481,7 @@ CommandButton Command_UpgradeGLABombTruckBioBomb
   Options           = OK_FOR_MULTI_SELECT
   TextLabel         = CONTROLBAR:UpgradeGLABombTruckBioBomb
   ButtonImage       = SSBioBombTruck
-  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is ; Patch104p @fix from ACTION
   DescriptLabel     = CONTROLBAR:TooltipGLAUpgradeBioBomb
   UnitSpecificSound = BombTruckVoiceModeBioBomb
 End
@@ -1492,7 +1492,7 @@ CommandButton Command_UpgradeGLABombTruckHighExplosiveBomb
   Options           = OK_FOR_MULTI_SELECT
   TextLabel         = CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb
   ButtonImage       = SSExplosiveBombTruck
-  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is ; Patch104p @fix from BUILD
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeHEBomb
   UnitSpecificSound = BombTruckVoiceModeHiEx
 End
@@ -4306,7 +4306,7 @@ CommandButton GC_Slth_Command_DisguiseAsVehicle
   ButtonImage       = SUBusDisg
   CursorName        = DisguiseAsVehicle
   InvalidCursorName = GenericInvalid
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is ; Patch104p @fix from UPGRADE
   DescriptLabel     = CONTROLBAR:TooltipDisguiseAsVehicle
   UnitSpecificSound = BattleBusVoiceModeDisguise
 End
@@ -5479,7 +5479,7 @@ CommandButton Slth_Command_DisguiseAsVehicle
   ButtonImage       = SUBusDisg
   CursorName        = DisguiseAsVehicle
   InvalidCursorName = GenericInvalid
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is ; Patch104p @fix from UPGRADE
   DescriptLabel     = CONTROLBAR:TooltipDisguiseAsVehicle
   UnitSpecificSound = BattleBusVoiceModeDisguise
 End


### PR DESCRIPTION
Bomb Truck command buttons now use the correct border types.

🟦 Blue = build
🟩 Green = action
🟧 Orange = upgrade
🟨 Yellow = system

Old:

![image](https://user-images.githubusercontent.com/11547761/212470300-ab61f746-8e60-4b16-877c-2214d1108251.png)


New:

![image](https://user-images.githubusercontent.com/11547761/212470304-caeea25f-e64b-4c7a-a3ee-f247a12524dd.png)
