### PR TITLE
Fix: Added missing border types to USA Strategy Center's battle plan command buttons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1003,6 +1003,7 @@ End
 
 
 ;Structure commands -----------------------------------------------------------
+; Patch104p @fix Adds ButtonBorderType to battle plan buttons.
 
 CommandButton Command_InitiateBattlePlanBombardment
   Command           = SPECIAL_POWER

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1010,6 +1010,7 @@ CommandButton Command_InitiateBattlePlanBombardment
   Options           = NEED_SPECIAL_POWER_SCIENCE CHECK_LIKE OPTION_ONE
   TextLabel         = CONTROLBAR:InitiateBattlePlanBombardment
   ButtonImage       = SSBombardment
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipBattlePlansBombardment
 End
 
@@ -1019,6 +1020,7 @@ CommandButton Command_InitiateBattlePlanHoldTheLine
   Options           = NEED_SPECIAL_POWER_SCIENCE CHECK_LIKE OPTION_TWO
   TextLabel         = CONTROLBAR:InitiateBattlePlanHoldTheLine
   ButtonImage       = SSHoldLine
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipBattlePlansHoldTheLine
 End
 
@@ -1028,6 +1030,7 @@ CommandButton Command_InitiateBattlePlanSearchAndDestroy
   Options           = NEED_SPECIAL_POWER_SCIENCE CHECK_LIKE OPTION_THREE
   TextLabel         = CONTROLBAR:InitiateBattlePlanSearchAndDestroy
   ButtonImage       = SSSeekDestroy
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipBattlePlansSearchAndDestroy
 End
 


### PR DESCRIPTION
Added missing border types to the Strategy Center's battle plan command buttons.

🟦 Blue = build
🟩 Green = action
🟧 Orange = upgrade
🟨 Yellow = system

Old:

![image](https://user-images.githubusercontent.com/11547761/212470817-51b2949a-d6b2-42e6-a211-b3d41a8ba4b5.png)

New:

![image](https://user-images.githubusercontent.com/11547761/212470821-830c9357-e90b-4ca7-8b07-4c3a9f43ce00.png)