### PR TITLE
Change: Decrease USA Airforce Comanche Armor with Countermeasures by up to 21%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1553_afg_comanche_armor.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1553_afg_comanche_armor.yaml
@@ -1,0 +1,23 @@
+---
+date: 2023-01-15
+
+title: Decrease armor of USA Airforce Comanche with Countermeasures by up to 21%
+
+changes:
+  - tweak: The armor of the USA Airforce Comanche with Countermeasures against Quad Cannons and Gattlings is now set to 75% instead of 62% (smaller is better).
+  - tweak: The armor of the USA Airforce Comanche with Countermeasures against Explosions and Infantry Missiles is now set to 100% instead of 90%.
+  - fix: The USA Airforce Comanche with Countermeasures no longer heals 11% slower than without Countermeasures.
+
+labels:
+  - controversial
+  - design
+  - major
+  - nerf
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1553
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -1104,9 +1104,9 @@ Armor DemoGenTerroristArmor ; Special Boost for Demo Generals Terrorist
 
 End
 
-;*******************************************************************
+;***********************************************************************
 ;***IF YOU CHANGE THESE, CHANGE AFG_CountermeasuresComancheArmor TOO!***
-;*******************************************************************
+;***********************************************************************
 Armor AFG_ComancheArmor
   Armor = DEFAULT           100%    ;this sets the level for all nonspecified damage types
   Armor = SMALL_ARMS        100%    ;gives Quad and gattling a little more punch.
@@ -1128,17 +1128,23 @@ Armor AFG_ComancheArmor
   Armor = MELEE               0%
 End
 
-;****************************************************
+;********************************************************
 ;***IF YOU CHANGE THESE, CHANGE AFG_ComancheArmor TOO!***
-;****************************************************
+;********************************************************
+; Patch104p @tweak Changes DEFAULT armor from 90% (#1553)
+; Patch104p @tweak Changes SMALL_ARMS armor from 62%
+; Patch104p @tweak Changes GATTLING armor from 62%
+; Patch104p @tweak Changes EXPLOSION armor from 90%
+; Patch104p @tweak Changes INFANTRY_MISSILE armor from 90%
+; Patch104p @tweak Changes HEALING armor from 90%
 Armor AFG_CountermeasuresComancheArmor
-  Armor = DEFAULT            90%
-  Armor = SMALL_ARMS         62%    ; currently set to 37.5% increase (120 x 0.75 -- 25% reduction off ComancheArmor)
-  Armor = GATTLING           62%    ; currently set to 37.5% increase (120 x 0.75 -- 25% reduction off ComancheArmor)
-  Armor = EXPLOSION          90%
-  Armor = INFANTRY_MISSILE   90%
+  Armor = DEFAULT           100%
+  Armor = SMALL_ARMS         75%
+  Armor = GATTLING           75%
+  Armor = EXPLOSION         100%
+  Armor = INFANTRY_MISSILE  100%
   Armor = LASER               0%
-  Armor = HEALING            90%
+  Armor = HEALING           100%
   Armor = HAZARD_CLEANUP      0%
   Armor = KILL_PILOT          0%
   Armor = POISON             25%


### PR DESCRIPTION
* Follow up for #1530
* Related to #1135

This change makes AFG Comanche Countermeasures by up to 21% weaker.

## Stats

| Type             | Original AFG Armor | Patched AFG Armor (this) | Change % |
|------------------|-------------------:|-------------------------:|---------:|
| DEFAULT          | 100%               | 100%                     | 0%       |
| SMALL_ARMS       | 100%               | 100%                     | 0%       |
| GATTLING         | 100%               | 100%                     | 0%       |
| EXPLOSION        | 100%               | 100%                     | 0%       |
| INFANTRY_MISSILE | 100%               | 100%                     | 0%       |

| Type             | Original AFG Countermeasures | Patched AFG Countermeasures (this) | Change % |
|------------------|-----------------------------:|-----------------------------------:|---------:|
| DEFAULT          | 90%                          | 100%                               | +11%       |
| SMALL_ARMS       | 62%                          | 75%                                | +21%     |
| GATTLING         | 62%                          | 75%                                | +21%     |
| EXPLOSION        | 90%                          | 100%                               | +11%       |
| INFANTRY_MISSILE | 90%                          | 100%                               | +11%       |
| HEALING          | 90%                          | 100%                               | +11%     |

## Rationale

This change takes a bit of the edge off of Air Force Comanches by amplifying the impact of user-error that often comes as a result of direct anti-air engagement, as well as improving the counter-play abilities of opponents.

This is achieved by reducing inconsistencies instead of adding them. The regular Comanche and Air Force Comanche now have identical armor sets. The 90% `HEALING` modifier is no longer present.
