### PR TITLE
Change: Increase USA unit armor bonus of HOLD THE LINE Battle Plan from 11.1% to 20.0%

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -11823,7 +11823,7 @@ Object AirF_AmericaStrategyCenter
     ValidMemberKindOf                   = INFANTRY CAN_ATTACK VEHICLE ;Battle plans affect any kind of these...
     InvalidMemberKindOf                 = DOZER STRUCTURE AIRCRAFT DRONE   ;...but make sure they don't have any of these
     BattlePlanChangeParalyzeTime          = 5000 ;Subjected to paralyzation whenever a battle plan is changed.
-    HoldTheLinePlanArmorDamageScalar      = 0.9 ;Armor damage bonus scalar -- LESS is better!
+    HoldTheLinePlanArmorDamageScalar      = 0.8333333 ;Armor damage bonus scalar -- LESS is better! ; Patch104p @balance from 0.9 to increase damage resistance from 11.1% to 20.0%
     SearchAndDestroyPlanSightRangeScalar  = 1.2 ;Sight range bonus -- more is better!
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7312,7 +7312,7 @@ Object AmericaStrategyCenter
     ValidMemberKindOf                   = INFANTRY CAN_ATTACK VEHICLE ;Battle plans affect any kind of these...
     InvalidMemberKindOf                 = DOZER STRUCTURE AIRCRAFT DRONE   ;...but make sure they don't have any of these
     BattlePlanChangeParalyzeTime          = 5000 ;Subjected to paralyzation whenever a battle plan is changed.
-    HoldTheLinePlanArmorDamageScalar      = 0.9 ;Armor damage bonus scalar -- LESS is better!
+    HoldTheLinePlanArmorDamageScalar      = 0.8333333 ;Armor damage bonus scalar -- LESS is better! ; Patch104p @balance from 0.9 to increase damage resistance from 11.1% to 20.0%
     SearchAndDestroyPlanSightRangeScalar  = 1.2 ;Sight range bonus -- more is better!
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -11508,7 +11508,7 @@ Object Lazr_AmericaStrategyCenter
     ValidMemberKindOf                   = INFANTRY CAN_ATTACK VEHICLE ;Battle plans affect any kind of these...
     InvalidMemberKindOf                 = DOZER STRUCTURE AIRCRAFT DRONE   ;...but make sure they don't have any of these
     BattlePlanChangeParalyzeTime          = 5000 ;Subjected to paralyzation whenever a battle plan is changed.
-    HoldTheLinePlanArmorDamageScalar      = 0.9 ;Armor damage bonus scalar -- LESS is better!
+    HoldTheLinePlanArmorDamageScalar      = 0.8333333 ;Armor damage bonus scalar -- LESS is better! ; Patch104p @balance from 0.9 to increase damage resistance from 11.1% to 20.0%
     SearchAndDestroyPlanSightRangeScalar  = 1.2 ;Sight range bonus -- more is better!
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -11053,7 +11053,7 @@ Object SupW_AmericaStrategyCenter
     ValidMemberKindOf                   = INFANTRY CAN_ATTACK VEHICLE ;Battle plans affect any kind of these...
     InvalidMemberKindOf                 = DOZER STRUCTURE AIRCRAFT DRONE   ;...but make sure they don't have any of these
     BattlePlanChangeParalyzeTime          = 5000 ;Subjected to paralyzation whenever a battle plan is changed.
-    HoldTheLinePlanArmorDamageScalar      = 0.9 ;Armor damage bonus scalar -- LESS is better!
+    HoldTheLinePlanArmorDamageScalar      = 0.8333333 ;Armor damage bonus scalar -- LESS is better! ; Patch104p @balance from 0.9 to increase damage resistance from 11.1% to 20.0%
     SearchAndDestroyPlanSightRangeScalar  = 1.2 ;Sight range bonus -- more is better!
     ;***NOTE*** WEAPON bonuses for army are specified in GameData.ini file!
 


### PR DESCRIPTION
* Fixes #1212

This change increases the USA unit armor bonus of HOLD THE LINE Battle Plan from 11.1% to 20.0%. Armor bonus is synonymous for damage resistance.

| Battle Plan                      | Damage Bonus | Range Bonus | Armor Bonus |
|----------------------------------|-------------:|------------:|------------:|
| Original BOMBARDMENT             | +20%         |             |             |
| Original SEARCH AND DESTROY      |              | +20%        |             |
| Original HOLD THE LINE           |              |             | +11.1%      |
| **Patched HOLD THE LINE (this)** |              |             | +20%        |

Infantry, vehicles ~~and planes~~ benefit from armor bonus. Combat samples:

| Battle to death              | Shots | Shots with HOLD THE LINE | Bonus |
|------------------------------|------:|-------------------------:|------:|
| Crusader vs Crusader         | 8     | 10                       | 20%   |
| Crusader vs Missile Defender | 17    | 21                       | 19%   |
| Quad vs Missile Defender     | 9     | 12                       | 25%   |
| Gatling vs Raptor            | 12    | 12                       | 0%    |

HOLD THE LINE ~~applies armor bonus to all units, whereas~~ BOMBARDMENT and SEARCH AND DESTROY apply damage and range bonus to infantry and vehicles only.

| Battle Plan        | Infantry Bonus | Vehicle Bonus | Planes Bonus | Structure Bonus | Strategy Center Perks |
|--------------------|----------------|---------------|--------------|-----------------|-----------------------|
| BOMBARDMENT        | Yes            | Yes           | No           | No              | Yes                   |
| SEARCH AND DESTROY | Yes            | Yes           | No           | No              | Yes                   |
| HOLD THE LINE      | Yes            | Yes           | No           | No              | Yes                   |

All Battle Plan perks in a nutshell:

### BOMBARDMENT
* gives ground units +20% damage.
* gives Strategy Center a gun.

### SEARCH AND DESTROY
* gives ground units an attack range bonus of 20%
* gives ground units a sight range bonus of 20%
* gives Strategy Center a sight range bonus
* gives Strategy Center stealth detection

### HOLD THE LINE
* gives ground units an armor bonus of 20%
* doubles the health of the USA Strategy Center

# Rationale

This change makes the use of the HOLD THE LINE Battle Plan more attractive for all USA factions. ~~It is especially attractive for USA strategies that involve planes, such as spamming Comanche, Aurora and Raptor.~~ Traditionally USA favors the SEARCH AND DESTROY Battle Plan above the others by a large margin.