### PR TITLE
Change: Remove second Point Defense Laser from USA King Raptor and halve reload time of single Point Defense Laser

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1555_king_raptor_point_defense_laser.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1555_king_raptor_point_defense_laser.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-01-15
+
+title: Removes second Point Defense Laser from USA King Raptor and halves reload time of single Point Defense Laser
+
+changes:
+  - fix: The USA King Raptor no longer has 2 Point Defense Laser modules with reload times of 266 ms each. Instead it now has just one with a reload time of 133 ms.
+
+labels:
+  - controversial
+  - design
+  - major
+  - nerf
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1555
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -18136,6 +18136,7 @@ Object AirF_AmericaJetRaptor
     AflameDamageAmount = 3       ; taking this much damage...
     AflameDamageDelay = 500       ; this often.
   End
+
   Behavior = PointDefenseLaserUpdate ModuleTag_22 ; Alias ModuleTag_Laser_One
     WeaponTemplate        = AirF_RaptorPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
@@ -18143,6 +18144,7 @@ Object AirF_AmericaJetRaptor
     ScanRange             = 200.0
     PredictTargetVelocityFactor = 2.0
   End
+
   Behavior = StealthDetectorUpdate ModuleTag_24
     DetectionRate   = 500   ; how often to rescan for stealthed things in my sight (msec)
     ;DetectionRange = 250 ;Dustin, enable this for independant balancing!
@@ -18150,13 +18152,14 @@ Object AirF_AmericaJetRaptor
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
 
-  Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One ; Alias ModuleTag_Laser_Two
-    WeaponTemplate        = AirF_PointDefenseLaser
-    PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
-    ScanRate              = 0
-    ScanRange             = 200.0
-    PredictTargetVelocityFactor = 1.0
-  End
+  ; Patch104p @tweak xezon 15/01/2023 Removes second point defense laser from King Raptor. (#1555)
+  ;Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One ; Alias ModuleTag_Laser_Two
+  ;  WeaponTemplate        = AirF_PointDefenseLaser
+  ;  PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
+  ;  ScanRate              = 0
+  ;  ScanRange             = 200.0
+  ;  PredictTargetVelocityFactor = 1.0
+  ;End
 
   Behavior                = ArmorUpgrade ModuleTag_Armor25
     TriggeredBy           = Upgrade_AmericaCountermeasures

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8103,7 +8103,7 @@ Weapon AirF_AuroraBombWeapon ; unused
 End
 
 
-
+; Patch104p @tweak xezon 15/01/2023 Changes delay between shots from 250 to accomodate single Point Defense Laser module. (#1555)
 ;------------------------------------------------------------------------------
 Weapon AirF_RaptorPointDefenseLaser
   PrimaryDamage       = 100.0
@@ -8112,8 +8112,7 @@ Weapon AirF_RaptorPointDefenseLaser
   DamageType          = LASER
   DeathType           = LASERED
   WeaponSpeed         = 999999.0     ; dist/sec
-  DelayBetweenShots   = 250         ; time between shots, msec
-  ;DelayBetweenShots   = 1000         ; time between shots, msec
+  DelayBetweenShots   = 125         ; time between shots, msec
   ClipSize            = 0            ; how many shots in a Clip (0 == infinite)
   ClipReloadTime      = 0            ; how long to reload a Clip, msec
   AcceptableAimDelta  = 180          ; Don't need to turn at all.


### PR DESCRIPTION
* Relates to #638
* Closes #1107

This change removes one PDL (Point Defense Laser) module with a reload time of 266 ms from the USA Airforce King Raptor and halves the reload time of the remaining single PDL module to 133 ms. The overall reload time is the same, but the reduced PDL module count allows for a volley of two rockets instead of three rockets to break through the PDL onto the King Raptor. This is a nerf for Airforce General.

Likewise, the Boss King Raptor now also has the same PDL module with a reload time of 133 ms instead of just one PDL module with a reload time of 266 ms. This is a buff for Boss General.

# Rationale

USA Airforce is the best General in the game. Originally, the Airforce King Raptor is very effective in defending against enemy missiles. USA opponents typically struggle to take out King Raptors even with respectable amounts of missiles. With this change it will be a bit easier to combat King Raptors with missiles and take a bit off the edge of Airforce General, without reducing the effectiveness of the King Raptor to engage in typical attacks.

The King Raptor was likely never meant to have 2 PDL modules, which is evident by the small mistake in one of the two PDL modules of the Airforce King Raptor and the Boss King Raptor only owning one PDL module.
