### PR TITLE
Fix: Enable toxins to shoot on USA Fire Base

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -985,6 +985,7 @@ Armor BattleBusStructureArmorToughPlusTwo
   Armor = SUBDUAL_BUILDING    80%
 End
 
+; Patch104p @fix Set POISON value from 0% like other structures. This allows toxin weapons to target this structure.
 Armor FireBaseArmor
   Armor = DEFAULT             100%      ; this sets the level for all nonspecified damage types
   Armor = SMALL_ARMS           50%
@@ -993,7 +994,7 @@ Armor FireBaseArmor
   Armor = RADIATION             0%      ; all these 1%s are so the base will receive the damage then transfer it to occupants
   Armor = MICROWAVE             0%
   Armor = SNIPER              100%
-  Armor = POISON                0%
+  Armor = POISON                1%    ; Poison does a tiny amount to allow firing on empty buildings
   Armor = SURRENDER             0%
   Armor = MELEE                 0%
   Armor = LASER                 0%


### PR DESCRIPTION
* Related to #1203
* Related to #1557

This change enables toxin weapons to shoot on USA Fire Base. This way it behaves like all other faction structures.