### PR TITLE
Fix: China Inferno Tank shell object does not always emit sound and fire storm on hit

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5158,6 +5158,9 @@ Object Nuke_NuclearTankDeathDetonationDummy
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix Removes the HeightDieUpdate module to fix issue where
+;   random hits trigger no sound effect (#1561) and no fire storm (#963).
+;------------------------------------------------------------------------------
 Object InfernoTankShell
 
   ; *** ART Parameters ***
@@ -5204,13 +5207,6 @@ Object InfernoTankShell
     Mass = 10
   End
 
-  Behavior = HeightDieUpdate ModuleTag_06
-    TargetHeight = 1.0
-    TargetHeightIncludesStructures = Yes
-    OnlyWhenMovingDown = Yes
-    InitialDelay                    = 1000 ; Can't explode in the first second so we don't explode on the pad
-  End
-
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_07
     DeathWeapon   = SmallFireFieldCreationWeapon
     StartsActive  = Yes
@@ -5223,6 +5219,9 @@ Object InfernoTankShell
 End
 
 
+;------------------------------------------------------------------------------
+; Patch104p @bugfix Removes the HeightDieUpdate module to fix issue where
+;   random hits trigger no sound effect (#1561) and no fire storm (#963).
 ;------------------------------------------------------------------------------
 Object InfernoTankShellUpgraded
 
@@ -5268,13 +5267,6 @@ Object InfernoTankShellUpgraded
 
   Behavior = PhysicsBehavior ModuleTag_05
     Mass = 10
-  End
-
-  Behavior = HeightDieUpdate ModuleTag_06
-    TargetHeight = 1.0
-    TargetHeightIncludesStructures = Yes
-    OnlyWhenMovingDown = Yes
-    InitialDelay                    = 1000 ; Can't explode in the first second so we don't explode on the pad
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_08


### PR DESCRIPTION
* Fixes #1561
* Fixes #963

This change fixes China Inferno Tank shell object by removing its `HeightDieUpdate` module.

This way it triggers sound and fire storm reliably.