### PR TITLE
Change: Use vehicle evacuation button for USA Chinook evacuation

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1565_chinook_evacuation_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1565_chinook_evacuation_button.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-01-19
+
+title: Replaces USA Chinook specific evacuation button with generic vehicle evacuation button
+
+changes:
+  - tweak: Replaces the USA Chinook specific evacuation button with the generic vehicle evacuation button. The Chinook can now be evacuated with other types of vehicles in a group selection.
+
+labels:
+  - gui
+  - minor
+  - optional
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1565
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -121,7 +121,12 @@ CommandSet AmericaVehicleChinookCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
+;patch104p-core-begin
   9 = Command_ChinookUnload
+;patch104p-core-end
+;patch104p-optional-begin
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+;patch104p-optional-end
  10 = Command_CombatDrop
 ; 13 = Command_Guard
  14 = Command_Stop
@@ -1934,7 +1939,12 @@ CommandSet AirF_AmericaVehicleChinookCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
+;patch104p-core-begin
   9 = Command_ChinookUnload
+;patch104p-core-end
+;patch104p-optional-begin
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+;patch104p-optional-end
  10 = Command_CombatDrop
  11 = Command_AttackMove
 ;12 = Command_GuardFlyingUnitsOnly ; Helix does not have air guard either.
@@ -3795,7 +3805,12 @@ CommandSet SupW_AmericaVehicleChinookCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
+;patch104p-core-begin
   9 = Command_ChinookUnload
+;patch104p-core-end
+;patch104p-optional-begin
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+;patch104p-optional-end
  10 = Command_CombatDrop
 ; 13 = Command_Guard
  14 = Command_Stop
@@ -4525,7 +4540,12 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
   6 = Command_TransportExit
   7 = Command_TransportExit
   8 = Command_TransportExit
+;patch104p-core-begin
   9 = Command_ChinookUnload
+;patch104p-core-end
+;patch104p-optional-begin
+  9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+;patch104p-optional-end
  10 = Command_CombatDrop
 ; 13 = Command_Guard
  14 = Command_Stop


### PR DESCRIPTION
* Successor to #1545

This change streamlines evacuate buttons. Result:

* All helicopters use the Evacuate button for vehicles

The following faction unit buttons are affected:

* USA Chinook, Combat Chinook

With this change it will be possible to make Chinooks and Helixes evacuate in a group selection. Otherwise impossible.

## Patched

![shot_20230114_141155_5](https://user-images.githubusercontent.com/4720891/212474162-f3bf19fd-345e-4c6c-b3ec-9f07612d3216.jpg)