### PR TITLE
Change: Increase spin up time of China Gattling Tank Ground Gun by 6 frames

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1120,6 +1120,9 @@ Weapon RedguardBayonet
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak from ContinuousFireCoast=1000 to prolong barrel spin timeout (same as GattlingTankGun of Generals 1.08, GattlingTankGunAir)
+; Patch104p @tweak from ContinuousFireOne=2 to prolong spin up time (same as GattlingTankGun of Generals 1.08, GattlingTankGunAir)
+;------------------------------------------------------------------------------
 Weapon GattlingTankGun
   PrimaryDamage         = 15.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -1135,10 +1138,9 @@ Weapon GattlingTankGun
   DelayBetweenShots     = 400               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
-  ContinuousFireOne     = 2 ; How many shots at the same target constitute "Continuous Fire"
+  ContinuousFireOne     = 3 ; How many shots at the same target constitute "Continuous Fire"
   ContinuousFireTwo     = 6 ; How many shots at the same target constitute "Continuous Fire Two"
   ContinuousFireCoast   = 2000 ; msec we can coast without firing before we lose Continuous Fire
-                               ; Patch104p @tweak from 1000 to prolong max damage time
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire
   WeaponBonus           = CONTINUOUS_FIRE_FAST RATE_OF_FIRE 300% ; This is not cumulative, so with Delay of 40, and values of 2 and 4 for these bonuses, you shoot at (40, 20, 10)
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125%     ; ChainGun upgrade


### PR DESCRIPTION
* Successor to #1199
* Closes #1691

This change increases barrel spin up time of China Gattling Tank Ground Gun by 6 frames. An alternative to #1691.

| Weapon                          | ContinuousFireOne | ContinuousFireTwo | ContinuousFireCoast |
|---------------------------------|-------------------|-------------------|---------------------|
| Original CCG GattlingTankGun    | 3                 | 6                 | 2000                |
| Original CCG GattlingTankGunAir | 3                 | 6                 | 2000                |
| Original ZH GattlingTankGun     | 2                 | 6                 | 1000                |
| Original ZH GattlingTankGunAir  | 3                 | 6                 | 2000                |
| Patched GattlingTankGun (1)     | 2                 | 6                 | 2000                |
| **Patched GattlingTankGun (this)** | 3              | 6                 | 2000                |

### Gattling Tank Ground Gun firing sequence in frames

Exclamation mark (!) represents a shot fired in timeline.

```
Original 12          6     6     6     3  3  3  3  3  3
         !...........!.....!.....!.....!..!..!..!..!..!

Patched  12          12          6     6     3  3  3  3  3  3
         !...........!...........!.....!.....!..!..!..!..!..!
```

## Rationale

Original `GattlingTankGun` and `GattlingTankGunAir` have inconsistent spin up times. With this change they are consistent.