### PR TITLE
Change: Worker Fake Structure command button border color from Orange to Green

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1461,21 +1461,23 @@ CommandButton Command_BombTruckDetonateNow
   DescriptLabel     = CONTROLBAR:TooltipDetonateBombTruck
 End
 
+; Patch104p @tweak ButtonBorderType from UPGRADE.
 CommandButton Command_UpgradeGLAWorkerFakeCommandSet
   Command       = OBJECT_UPGRADE
   Upgrade       = Upgrade_GLAWorkerFakeCommandSet
   TextLabel     = CONTROLBAR:UpgradeGLAWorkerFakeCommandSet
   ButtonImage   = SUFakeToggle
-  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUpgradeGLAWorkerFakeCommandSet
 End
 
+; Patch104p @tweak ButtonBorderType from UPGRADE.
 CommandButton Command_UpgradeGLAWorkerRealCommandSet
   Command       = OBJECT_UPGRADE
   Upgrade       = Upgrade_GLAWorkerRealCommandSet
   TextLabel     = CONTROLBAR:UpgradeGLAWorkerRealCommandSet
   ButtonImage   = SUFakeToggle
-  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUpgradeGLAWorkerRealCommandSet
 End
 


### PR DESCRIPTION
This changes Worker Fake Structure command button border color from Orange to Green.

🟦 Blue = BUILD
🟩 Green = ACTION
🟧 Orange = UPGRADE
🟨 Yellow = SYSTEM

Technically it is an UPGRADE button, but it does not act like an UPGRADE user facing, it acts more like an action button, such as the Machine Gun, Flash Bang Weapon toggle of USA Ranger.

Therefore Green border fits better logically.

## Patched

![shot_20230120_232205_1](https://user-images.githubusercontent.com/4720891/213815866-7442e2e8-f75d-400c-b009-6dbbaf900f99.jpg)
