### PR TITLE
Change: Cancel Construction command button border color from Blue to Yellow

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -2238,11 +2238,13 @@ CommandButton Command_AmbulanceCleanupArea
 End
 
 ; Dozer construction commands ---------------------------------------------------------------------
+
+; Patch104p @tweak ButtonBorderType from BUILD.
 CommandButton Command_CancelConstruction
   Command       = DOZER_CONSTRUCT_CANCEL
   TextLabel     = CONTROLBAR:CancelBuild
   ButtonImage   = SSStop
-  ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
+  ButtonBorderType        = SYSTEM ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipCancelConstruction
 End
 


### PR DESCRIPTION
This changes Cancel Construction command button border color from Blue to Yellow.

🟦 Blue = BUILD
🟩 Green = ACTION
🟧 Orange = UPGRADE
🟨 Yellow = SYSTEM

The Yellow border color matches better the color scheme of similar buttons, such as Yellow STOP button for units, and Yellow SELL button for structures.

## Patched

![shot_20230120_232357_2](https://user-images.githubusercontent.com/4720891/213816248-c40cc1e5-7f65-49b3-8a2d-5d6abc47d07f.jpg)
