### PR TITLE
Fix: Remove all Special Power Shortcut command button border colors

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -124,13 +124,14 @@ CommandButton Command_FireParticleUplinkCannon
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_FireParticleUplinkCannonFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SuperweaponParticleUplinkCannon
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannonShortcut
   ButtonImage       = SSParticleFire
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
   InvalidCursorName = GenericInvalid
@@ -298,6 +299,7 @@ CommandButton Command_SpectreGunship
   InvalidCursorName     = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_SpectreGunshipFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SuperweaponSpectreGunship
@@ -305,7 +307,7 @@ CommandButton Command_SpectreGunshipFromShortcut
   Science           = SCIENCE_SpectreGunshipSolo ;These will cause the buttons to change icons, nothing more
   TextLabel         = CONTROLBAR:SpectreGunshipFromShortcut
   ButtonImage       = SASpGunship2; until Samm makes a new cameo for this...
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipSpectreGunship
   RadiusCursorType  = SPECTREGUNSHIP
   InvalidCursorName     = GenericInvalid
@@ -460,13 +462,14 @@ CommandButton Command_NeutronMissile
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_NeutronMissileFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SuperweaponNeutronMissile
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   TextLabel         = CONTROLBAR:NeutronMissileShortcut
   ButtonImage       = SNNukeLaunch
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireNukeMissile
   RadiusCursorType  = NUCLEARMISSILE
   InvalidCursorName = GenericInvalid
@@ -484,13 +487,14 @@ CommandButton Command_ScudStorm
   InvalidCursorName       = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_ScudStormFromShortcut
   Command                 = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower            = SuperweaponScudStorm
   Options                 = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   TextLabel               = CONTROLBAR:ScudStormShortcut
   ButtonImage             = SSScudStorm
-  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipFireSCUDStorm
   RadiusCursorType        = SCUDSTORM
   InvalidCursorName       = GenericInvalid
@@ -642,13 +646,14 @@ CommandButton Command_CommunicationsDownload
   DescriptLabel     = CONTROLBAR:TooltipCommunicationsDownload
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_CommunicationsDownloadFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SpecialPowerCommunicationsDownload
   Options           = NEED_SPECIAL_POWER_SCIENCE
   TextLabel         = CONTROLBAR:CommunicationsDownloadShortcut
   ButtonImage       = SSCIA
-  ButtonBorderType  = ACTION
+  ;ButtonBorderType  = ACTION
   DescriptLabel     = CONTROLBAR:TooltipCommunicationsDownload
 End
 
@@ -690,6 +695,7 @@ CommandButton Command_RadarVanScan
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_RadarVanScanFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SpecialPowerRadarVanScan
@@ -697,7 +703,7 @@ CommandButton Command_RadarVanScanFromShortcut
   Upgrade           = Upgrade_GLARadarVanScan
   TextLabel         = CONTROLBAR:RadarVanScanShortcut
   ButtonImage       = SSRadarVanScan
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireRadarVanScan
   RadiusCursorType  = RADAR
   InvalidCursorName = GenericInvalid
@@ -813,6 +819,7 @@ CommandButton Early_Command_EmergencyRepair
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Early_Command_EmergencyRepairFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = Early_SuperweaponEmergencyRepair
@@ -820,7 +827,7 @@ CommandButton Early_Command_EmergencyRepairFromShortcut
   Science           = Early_SCIENCE_EmergencyRepair1 Early_SCIENCE_EmergencyRepair2 Early_SCIENCE_EmergencyRepair3 ;These will cause the buttons to change icons, nothing more
   TextLabel         = GUI:SuperweaponEmergencyRepair
   ButtonImage       = SSRepair
-  ButtonBorderType  = ACTION
+  ;ButtonBorderType  = ACTION
   DescriptLabel     = CONTROLBAR:TooltipFireEmergencyRepair
   RadiusCursorType  = EMERGENCY_REPAIR
   InvalidCursorName = GenericInvalid
@@ -915,13 +922,14 @@ CommandButton Command_CIAIntelligence
   DescriptLabel     = CONTROLBAR:TooltipCIAIntelligence
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_CIAIntelligenceFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SuperweaponCIAIntelligence
   Options           = NEED_SPECIAL_POWER_SCIENCE
   TextLabel         = CONTROLBAR:CIAIntelligenceShortcut
   ButtonImage       = SSCIA
-  ButtonBorderType  = ACTION
+  ;ButtonBorderType  = ACTION
   DescriptLabel     = CONTROLBAR:TooltipCIAIntelligence
 End
 
@@ -1311,13 +1319,14 @@ CommandButton Command_SatelliteHackTwo
   DescriptLabel     = CONTROLBAR:TooltipSatelliteHackTwo
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_SatelliteHackTwoFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SuperweaponSatelliteHackTwo
   Options           = NEED_SPECIAL_POWER_SCIENCE
   TextLabel         = CONTROLBAR:SatelliteHackTwoShortcut
   ButtonImage       = SNIntCntup02
-  ButtonBorderType  = ACTION
+  ;ButtonBorderType  = ACTION
   DescriptLabel     = CONTROLBAR:TooltipSatelliteHackTwo
 End
 
@@ -3723,12 +3732,13 @@ End
 ; Mission specific buttons - Kris Morness 06/03
 ;------------------------------------------------------------------------------
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_SelectAircraftCarriersFromShortcut
   Command           = SELECT_ALL_UNITS_OF_TYPE
   Object            = AmericaAircraftCarrier
   TextLabel         = CONTROLBAR:SelectAircraftCarriersFromShortcut
   ButtonImage       = SAcarrier
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:ToolTipSelectAircraftCarriers
 End
 
@@ -3741,6 +3751,7 @@ End
 ;  DescriptLabel     = CONTROLBAR:ToolTipSelectBattleships
 ;End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_SelectBattleshipsFromShortcut ;****Command_BattleshipFireViaSpecialPowerFromShortcut
   Command                 = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower            = SpecialPowerBattleshipBombardment
@@ -3748,7 +3759,7 @@ CommandButton Command_SelectBattleshipsFromShortcut ;****Command_BattleshipFireV
   TextLabel               = CONTROLBAR:BattleshipFire
   ButtonImage             = SABattleship
   InvalidCursorName       = GenericInvalid
-  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipFireBattleship
   RadiusCursorType        = ARTILLERYBARRAGE
 End
@@ -3767,6 +3778,7 @@ CommandButton Command_SneakAttack
   DescriptLabel     = CONTROLBAR:ToolTipGLASneakAttack
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_SneakAttackFromShortcut
   Command           = SPECIAL_POWER_CONSTRUCT_FROM_SHORTCUT
   SpecialPower      = SuperweaponSneakAttack
@@ -3774,7 +3786,7 @@ CommandButton Command_SneakAttackFromShortcut
   Object            = GLASneakAttackTunnelNetwork
   TextLabel         = CONTROLBAR:SneakAttackShort
   ButtonImage       = SUSneakAttack
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:ToolTipGLASneakAttack
 End
 
@@ -4650,6 +4662,7 @@ CommandButton AirF_Command_SpectreGunship
   InvalidCursorName     = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton AirF_Command_SpectreGunshipFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = AirF_SuperweaponSpectreGunship
@@ -4657,7 +4670,7 @@ CommandButton AirF_Command_SpectreGunshipFromShortcut
   Science           = SCIENCE_SpectreGunship1 SCIENCE_SpectreGunship2 SCIENCE_SpectreGunship3 ;These will cause the buttons to change icons, nothing more
   TextLabel         = CONTROLBAR:SpectreGunshipFromShortcut
   ButtonImage       = SASpGunship; until Samm makes a new cameo for this...
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:AirF_TooltipSpectreGunship
   RadiusCursorType  = SPECTREGUNSHIP
   InvalidCursorName     = GenericInvalid
@@ -6561,13 +6574,14 @@ CommandButton Nuke_Command_UpgradeChinaIsotopeStability
   DescriptLabel = CONTROLBAR:TooltipUpgradeChinaIsotopeStability
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Nuke_Command_NeutronMissileFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = Nuke_SuperweaponNeutronMissile
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   TextLabel         = CONTROLBAR:NeutronMissileShortcut
   ButtonImage       = SNNukeLaunch
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireNukeMissile
   RadiusCursorType  = NUCLEARMISSILE
   InvalidCursorName = GenericInvalid
@@ -6947,13 +6961,14 @@ CommandButton SupW_Command_NeutronMissile
 End
 
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton SupW_Command_NeutronMissileFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SupW_SuperweaponNeutronMissile
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   TextLabel         = CONTROLBAR:ICBMShortcut
   ButtonImage       = SNNukeLaunch
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireNukeMissile
   RadiusCursorType  = NUCLEARMISSILE
   InvalidCursorName = GenericInvalid
@@ -6971,13 +6986,14 @@ CommandButton SupW_Command_CruiseMissile
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton SupW_Command_CruiseMissileFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SupW_CruiseMissile
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   TextLabel         = CONTROLBAR:ICBMShortcut
   ButtonImage       = SNNukeLaunch
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireNukeMissile
   RadiusCursorType  = NUCLEARMISSILE
   InvalidCursorName = GenericInvalid
@@ -7005,13 +7021,14 @@ CommandButton SupW_Command_FireParticleUplinkCannon
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton SupW_Command_FireParticleUplinkCannonFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SuperweaponParticleUplinkCannon
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireParticleUplinkCannonShortcut
   ButtonImage       = SSParticleFire
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
   CursorName        = ParticleUplinkCannon
   InvalidCursorName = GenericInvalid
@@ -7472,13 +7489,14 @@ CommandButton Lazr_Command_FireLaserCannon
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Lazr_Command_FireLaserCannonFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = Lazr_LaserCannon
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
   TextLabel         = CONTROLBAR:FireLaserCannonShortcut
   ButtonImage       = SSParticleFire
-  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  ;ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireLaserCannon
   CursorName        = ParticleUplinkCannon
   InvalidCursorName = GenericInvalid


### PR DESCRIPTION
This change removes all Special Power Shortcut command button border colors consistently.

## Original

![shot_20230120_230240_5](https://user-images.githubusercontent.com/4720891/213816614-f046a8b8-ce10-4044-b7bb-d62d03dd931b.jpg)

![shot_20230120_230416_6](https://user-images.githubusercontent.com/4720891/213816640-36caeea9-d091-4415-8f64-ca1a5d6bf51c.jpg)
