### PR TITLE
Fix: Preserve Clear Mines button in GLA Worker Fake Buildings command set

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -70,6 +70,7 @@ CommandSet GLAWorkerCommandSet
  14  = Command_DisarmMinesAtPosition
 End
 
+; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
 CommandSet GLAWorkerFakeBuildingsCommandSet
   1 = Command_ConstructFakeGLACommandCenter
   2 = Command_ConstructFakeGLABarracks
@@ -77,6 +78,7 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   4 = Command_ConstructFakeGLAArmsDealer
   5 = Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
+ 14 = Command_DisarmMinesAtPosition
 End
 
 CommandSet ChinaDozerCommandSet
@@ -2020,6 +2022,7 @@ CommandSet Demo_GLAWorkerCommandSet
  14  = Command_DisarmMinesAtPosition
 End
 
+; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   1 = Demo_Command_ConstructFakeGLACommandCenter
   2 = Demo_Command_ConstructFakeGLABarracks
@@ -2027,6 +2030,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   4 = Demo_Command_ConstructFakeGLAArmsDealer
   5 = Demo_Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
+ 14 = Command_DisarmMinesAtPosition
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -2338,7 +2342,7 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
 End
 
 ; Patch104p @bugfix commy2 03/09/2021 Used for fake buildings after Demolitions upgrade is researched.
-
+; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   1 = Demo_Command_ConstructFakeGLACommandCenter
   2 = Demo_Command_ConstructFakeGLABarracks
@@ -2347,6 +2351,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   5 = Demo_Command_ConstructFakeGLABlackMarket
  12 = Demo_Command_TertiarySuicide
  13 = Command_UpgradeGLAWorkerRealCommandSet
+ 14 = Command_DisarmMinesAtPosition
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -2615,6 +2620,7 @@ CommandSet Slth_GLAWorkerCommandSet
  14  = Command_DisarmMinesAtPosition
 End
 
+; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   1 = Slth_Command_ConstructFakeGLACommandCenter
   2 = Slth_Command_ConstructFakeGLABarracks
@@ -2622,6 +2628,7 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   4 = Slth_Command_ConstructFakeGLAArmsDealer
   5 = Slth_Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
+ 14 = Command_DisarmMinesAtPosition
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -2898,6 +2905,7 @@ CommandSet Chem_GLAWorkerCommandSet
  14  = Command_DisarmMinesAtPosition
 End
 
+; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   1 = Chem_Command_ConstructFakeGLACommandCenter
   2 = Chem_Command_ConstructFakeGLABarracks
@@ -2905,6 +2913,7 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   4 = Chem_Command_ConstructFakeGLAArmsDealer
   5 = Chem_Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
+ 14 = Command_DisarmMinesAtPosition
 End
 
 CommandSet Chem_GLABarracksCommandSet


### PR DESCRIPTION
This change preserves Clear Mines button in GLA Worker Fake Buildings command set.

## Patched

![shot_20230121_122751_1](https://user-images.githubusercontent.com/4720891/213864996-72243196-031f-4952-bed9-52f22db166af.jpg)
