### PR TITLE
Fix: Add Stop command button to all worker units

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -42,17 +42,18 @@ End
 ; Dozer Command Sets ----------------------------------------------------------
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
+; Patch104p @tweak Move Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10.
 CommandSet AmericaDozerCommandSet
   1  = Command_ConstructAmericaPowerPlant
-  2  = Command_ConstructAmericaStrategyCenter
+  2  = Command_ConstructAmericaAirfield
   3  = Command_ConstructAmericaBarracks
-  4  = Command_ConstructAmericaSupplyDropZone
+  4  = Command_ConstructAmericaStrategyCenter
   5  = Command_ConstructAmericaSupplyCenter
-  6  = Command_ConstructAmericaParticleCannonUplink
+  6  = Command_ConstructAmericaSupplyDropZone
   7  = Command_ConstructAmericaPatriotBattery
-  8  = Command_ConstructAmericaCommandCenter
+  8  = Command_ConstructAmericaParticleCannonUplink
   9  = Command_ConstructAmericaFireBase
-  10 = Command_ConstructAmericaAirfield
+  10 = Command_ConstructAmericaCommandCenter
   11 = Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop
@@ -1808,17 +1809,18 @@ CommandSet AirF_SpecialPowerShortcutUSA
 END
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
+; Patch104p @tweak Move Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10.
 CommandSet AirF_AmericaDozerCommandSet
   1  = AirF_Command_ConstructAmericaPowerPlant
-  2  = AirF_Command_ConstructAmericaStrategyCenter
+  2  = AirF_Command_ConstructAmericaAirfield
   3  = AirF_Command_ConstructAmericaBarracks
-  4  = AirF_Command_ConstructAmericaSupplyDropZone
+  4  = AirF_Command_ConstructAmericaStrategyCenter
   5  = AirF_Command_ConstructAmericaSupplyCenter
-  6  = AirF_Command_ConstructAmericaParticleCannonUplink
+  6  = AirF_Command_ConstructAmericaSupplyDropZone
   7  = AirF_Command_ConstructAmericaPatriotBattery
-  8  = AirF_Command_ConstructAmericaCommandCenter
+  8  = AirF_Command_ConstructAmericaParticleCannonUplink
   9  = AirF_Command_ConstructAmericaFireBase
-  10 = AirF_Command_ConstructAmericaAirfield
+  10 = AirF_Command_ConstructAmericaCommandCenter
   11 = AirF_Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop
@@ -3515,17 +3517,18 @@ CommandSet SupW_SpecialPowerShortcutUSA
 END
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
+; Patch104p @tweak Move Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10.
 CommandSet SupW_AmericaDozerCommandSet
   1  = SupW_Command_ConstructAmericaPowerPlant
-  2  = SupW_Command_ConstructAmericaStrategyCenter
+  2  = SupW_Command_ConstructAmericaAirfield
   3  = SupW_Command_ConstructAmericaBarracks
-  4  = SupW_Command_ConstructAmericaSupplyDropZone
+  4  = SupW_Command_ConstructAmericaStrategyCenter
   5  = SupW_Command_ConstructAmericaSupplyCenter
-  6  = SupW_Command_ConstructAmericaParticleCannonUplink
+  6  = SupW_Command_ConstructAmericaSupplyDropZone
   7  = SupW_Command_ConstructAmericaPatriotBattery
-  8  = SupW_Command_ConstructAmericaCommandCenter
+  8  = SupW_Command_ConstructAmericaParticleCannonUplink
   9  = SupW_Command_ConstructAmericaFireBase
-  10 = SupW_Command_ConstructAmericaAirfield
+  10 = SupW_Command_ConstructAmericaCommandCenter
   11 = SupW_Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop
@@ -4331,18 +4334,18 @@ CommandSet Lazr_SpecialPowerShortcutUSA
 END
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
+; Patch104p @tweak Move Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10.
 CommandSet Lazr_AmericaDozerCommandSet
   1  = Lazr_Command_ConstructAmericaPowerPlant
-  2  = Lazr_Command_ConstructAmericaStrategyCenter
+  2  = Lazr_Command_ConstructAmericaAirfield
   3  = Lazr_Command_ConstructAmericaBarracks
-  4  = Lazr_Command_ConstructAmericaSupplyDropZone
+  4  = Lazr_Command_ConstructAmericaStrategyCenter
   5  = Lazr_Command_ConstructAmericaSupplyCenter
-; 6  = Lazr_Command_ConstructLaserCannon
-  6  = Lazr_Command_ConstructAmericaParticleCannonUplink
+  6  = Lazr_Command_ConstructAmericaSupplyDropZone
   7  = Lazr_Command_ConstructAmericaPatriotBattery
-  8  = Lazr_Command_ConstructAmericaCommandCenter
+  8  = Lazr_Command_ConstructAmericaParticleCannonUplink
   9  = Lazr_Command_ConstructAmericaFireBase
-  10 = Lazr_Command_ConstructAmericaAirfield
+  10 = Lazr_Command_ConstructAmericaCommandCenter
   11 = Lazr_Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5024,12 +5024,13 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
 End
 
 
+; Patch104p @fix Move Barracks from 5 to 3, SupplyCenter from 3 to 5.
 CommandSet Boss_AmericaDozerCommandSet
   1  = Boss_Command_ConstructAmericaPowerPlant
   2  = Boss_Command_ConstructChinaBunker
-  3  = Boss_Command_ConstructChinaSupplyCenter
+  3  = Boss_Command_ConstructChinaBarracks
   4  = Boss_Command_ConstructChinaGattlingCannon
-  5  = Boss_Command_ConstructChinaBarracks
+  5  = Boss_Command_ConstructChinaSupplyCenter
   6  = Boss_Command_ConstructAmericaPatriotBattery
   7  = Boss_Command_ConstructChinaWarFactory
   8  = Boss_Command_ConstructGLATunnelNetwork

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -40,6 +40,8 @@ CommandSet EmptyCommandSet
 End
 
 ; Dozer Command Sets ----------------------------------------------------------
+
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
 CommandSet AmericaDozerCommandSet
   1  = Command_ConstructAmericaPowerPlant
   2  = Command_ConstructAmericaStrategyCenter
@@ -50,11 +52,13 @@ CommandSet AmericaDozerCommandSet
   7  = Command_ConstructAmericaPatriotBattery
   8  = Command_ConstructAmericaCommandCenter
   9  = Command_ConstructAmericaFireBase
+  10 = Command_ConstructAmericaAirfield
   11 = Command_ConstructAmericaWarFactory
-  13 = Command_ConstructAmericaAirfield
-  14 = Command_DisarmMinesAtPosition
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
 End
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it.
 CommandSet GLAWorkerCommandSet
   1  = Command_ConstructGLASupplyStash
   2  = Command_ConstructGLADemoTrap
@@ -66,21 +70,25 @@ CommandSet GLAWorkerCommandSet
   8  = Command_ConstructGLAScudStorm
   9  = Command_ConstructGLAArmsDealer
  10  = Command_ConstructGLACommandCenter
- 13  = Command_UpgradeGLAWorkerFakeCommandSet
- 14  = Command_DisarmMinesAtPosition
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it.
 CommandSet GLAWorkerFakeBuildingsCommandSet
   1 = Command_ConstructFakeGLACommandCenter
   2 = Command_ConstructFakeGLABarracks
   3 = Command_ConstructFakeGLASupplyStash
   4 = Command_ConstructFakeGLAArmsDealer
   5 = Command_ConstructFakeGLABlackMarket
- 13 = Command_UpgradeGLAWorkerRealCommandSet
- 14 = Command_DisarmMinesAtPosition
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
 End
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
 CommandSet ChinaDozerCommandSet
   1  = Command_ConstructChinaPowerPlant
   2  = Command_ConstructChinaInternetCenter
@@ -94,7 +102,8 @@ CommandSet ChinaDozerCommandSet
  10  = Command_ConstructChinaNuclearMissileLauncher
  11  = Command_ConstructChinaWarFactory
  12  = Command_ConstructChinaCommandCenter
- 14  = Command_DisarmMinesAtPosition
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 ; Unit Command Sets -----------------------------------------------------------
@@ -1490,6 +1499,7 @@ CommandSet GC_Chem_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
 CommandSet GC_Chem_GLAWorkerCommandSet
   1  = GC_Chem_Command_ConstructGLASupplyStash
   2  = GC_Chem_Command_ConstructGLADemoTrap
@@ -1501,7 +1511,8 @@ CommandSet GC_Chem_GLAWorkerCommandSet
   8  = GC_Chem_Command_ConstructGLAScudStorm
   9  = GC_Chem_Command_ConstructGLAArmsDealer
  10  = GC_Chem_Command_ConstructGLACommandCenter
- 14  = Command_DisarmMinesAtPosition
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 CommandSet GC_Chem_GLABarracksCommandSet
@@ -1613,6 +1624,7 @@ CommandSet GC_Slth_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
 CommandSet GC_Slth_GLAWorkerCommandSet
   1  = GC_Slth_Command_ConstructGLASupplyStash
   2  = GC_Slth_Command_ConstructGLADemoTrap
@@ -1624,7 +1636,8 @@ CommandSet GC_Slth_GLAWorkerCommandSet
   8  = GC_Slth_Command_ConstructGLAScudStorm
   9  = GC_Slth_Command_ConstructGLAArmsDealer
  10  = GC_Slth_Command_ConstructGLACommandCenter
- 14  = Command_DisarmMinesAtPosition
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 CommandSet GC_Slth_GLACommandCenterCommandSet
@@ -1794,6 +1807,7 @@ CommandSet AirF_SpecialPowerShortcutUSA
   11 = AirF_Command_CarpetBombFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
 CommandSet AirF_AmericaDozerCommandSet
   1  = AirF_Command_ConstructAmericaPowerPlant
   2  = AirF_Command_ConstructAmericaStrategyCenter
@@ -1804,9 +1818,10 @@ CommandSet AirF_AmericaDozerCommandSet
   7  = AirF_Command_ConstructAmericaPatriotBattery
   8  = AirF_Command_ConstructAmericaCommandCenter
   9  = AirF_Command_ConstructAmericaFireBase
+  10 = AirF_Command_ConstructAmericaAirfield
   11 = AirF_Command_ConstructAmericaWarFactory
-  13 = AirF_Command_ConstructAmericaAirfield
-  14 = Command_DisarmMinesAtPosition
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
 End
 
 CommandSet AirF_AmericaCommandCenterCommandSet
@@ -2007,6 +2022,7 @@ CommandSet Demo_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it.
 CommandSet Demo_GLAWorkerCommandSet
   1  = Demo_Command_ConstructGLASupplyStash
   2  = Demo_Command_ConstructGLADemoTrap
@@ -2018,19 +2034,22 @@ CommandSet Demo_GLAWorkerCommandSet
   8  = Demo_Command_ConstructGLAScudStorm
   9  = Demo_Command_ConstructGLAArmsDealer
  10  = Demo_Command_ConstructGLACommandCenter
- 13  = Command_UpgradeGLAWorkerFakeCommandSet
- 14  = Command_DisarmMinesAtPosition
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it.
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   1 = Demo_Command_ConstructFakeGLACommandCenter
   2 = Demo_Command_ConstructFakeGLABarracks
   3 = Demo_Command_ConstructFakeGLASupplyStash
   4 = Demo_Command_ConstructFakeGLAArmsDealer
   5 = Demo_Command_ConstructFakeGLABlackMarket
- 13 = Command_UpgradeGLAWorkerRealCommandSet
- 14 = Command_DisarmMinesAtPosition
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -2325,6 +2344,7 @@ CommandSet Demo_GLATankScorpionCommandSetUpgrade
   14 = Command_Stop
 End
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it.
 CommandSet Demo_GLAWorkerCommandSetUpgrade
   1  = Demo_Command_ConstructGLASupplyStash
   2  = Demo_Command_ConstructGLADemoTrap
@@ -2336,13 +2356,15 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   8  = Demo_Command_ConstructGLAScudStorm
   9  = Demo_Command_ConstructGLAArmsDealer
  10  = Demo_Command_ConstructGLACommandCenter
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
  12  = Demo_Command_TertiarySuicide
- 13  = Command_UpgradeGLAWorkerFakeCommandSet
- 14  = Command_DisarmMinesAtPosition
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 ; Patch104p @bugfix commy2 03/09/2021 Used for fake buildings after Demolitions upgrade is researched.
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it.
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   1 = Demo_Command_ConstructFakeGLACommandCenter
   2 = Demo_Command_ConstructFakeGLABarracks
@@ -2350,8 +2372,9 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   4 = Demo_Command_ConstructFakeGLAArmsDealer
   5 = Demo_Command_ConstructFakeGLABlackMarket
  12 = Demo_Command_TertiarySuicide
- 13 = Command_UpgradeGLAWorkerRealCommandSet
- 14 = Command_DisarmMinesAtPosition
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -2605,6 +2628,7 @@ CommandSet Slth_SpecialPowerShortcutGLA
   7 = Slth_Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it.
 CommandSet Slth_GLAWorkerCommandSet
   1  = Slth_Command_ConstructGLASupplyStash
   2  = Slth_Command_ConstructGLADemoTrap
@@ -2616,19 +2640,22 @@ CommandSet Slth_GLAWorkerCommandSet
   8  = Slth_Command_ConstructGLAScudStorm
   9  = Slth_Command_ConstructGLAArmsDealer
  10  = Slth_Command_ConstructGLACommandCenter
- 13  = Command_UpgradeGLAWorkerFakeCommandSet
- 14  = Command_DisarmMinesAtPosition
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it.
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   1 = Slth_Command_ConstructFakeGLACommandCenter
   2 = Slth_Command_ConstructFakeGLABarracks
   3 = Slth_Command_ConstructFakeGLASupplyStash
   4 = Slth_Command_ConstructFakeGLAArmsDealer
   5 = Slth_Command_ConstructFakeGLABlackMarket
- 13 = Command_UpgradeGLAWorkerRealCommandSet
- 14 = Command_DisarmMinesAtPosition
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -2890,6 +2917,7 @@ CommandSet Chem_SpecialPowerShortcutGLA
   ;7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it.
 CommandSet Chem_GLAWorkerCommandSet
   1  = Chem_Command_ConstructGLASupplyStash
   2  = Chem_Command_ConstructGLADemoTrap
@@ -2901,19 +2929,22 @@ CommandSet Chem_GLAWorkerCommandSet
   8  = Chem_Command_ConstructGLAScudStorm
   9  = Chem_Command_ConstructGLAArmsDealer
  10  = Chem_Command_ConstructGLACommandCenter
- 13  = Command_UpgradeGLAWorkerFakeCommandSet
- 14  = Command_DisarmMinesAtPosition
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it.
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   1 = Chem_Command_ConstructFakeGLACommandCenter
   2 = Chem_Command_ConstructFakeGLABarracks
   3 = Chem_Command_ConstructFakeGLASupplyStash
   4 = Chem_Command_ConstructFakeGLAArmsDealer
   5 = Chem_Command_ConstructFakeGLABlackMarket
- 13 = Command_UpgradeGLAWorkerRealCommandSet
- 14 = Command_DisarmMinesAtPosition
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
 End
 
 CommandSet Chem_GLABarracksCommandSet
@@ -3091,6 +3122,7 @@ CommandSet Nuke_SpecialPowerShortcutChina
   10 = Command_FrenzyFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
 CommandSet Nuke_ChinaDozerCommandSet
   1  = Nuke_Command_ConstructChinaPowerPlant
   2  = Nuke_Command_ConstructChinaInternetCenter
@@ -3104,7 +3136,8 @@ CommandSet Nuke_ChinaDozerCommandSet
  10  = Nuke_Command_ConstructChinaNuclearMissileLauncher
  11  = Nuke_Command_ConstructChinaWarFactory
  12  = Nuke_Command_ConstructChinaCommandCenter
- 14  = Command_DisarmMinesAtPosition
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 
@@ -3481,6 +3514,7 @@ CommandSet SupW_SpecialPowerShortcutUSA
   10 = Command_CIAIntelligenceFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
 CommandSet SupW_AmericaDozerCommandSet
   1  = SupW_Command_ConstructAmericaPowerPlant
   2  = SupW_Command_ConstructAmericaStrategyCenter
@@ -3491,9 +3525,10 @@ CommandSet SupW_AmericaDozerCommandSet
   7  = SupW_Command_ConstructAmericaPatriotBattery
   8  = SupW_Command_ConstructAmericaCommandCenter
   9  = SupW_Command_ConstructAmericaFireBase
+  10 = SupW_Command_ConstructAmericaAirfield
   11 = SupW_Command_ConstructAmericaWarFactory
-  13 = SupW_Command_ConstructAmericaAirfield
-  14 = Command_DisarmMinesAtPosition
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
 End
 
 CommandSet SupW_AmericaBarracksCommandSet
@@ -3828,6 +3863,7 @@ CommandSet Infa_SpecialPowerShortcutChina
 END
 
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
 CommandSet Infa_ChinaDozerCommandSet
   1  = Infa_Command_ConstructChinaPowerPlant
   2  = Infa_Command_ConstructChinaInternetCenter
@@ -3841,7 +3877,8 @@ CommandSet Infa_ChinaDozerCommandSet
  10  = Infa_Command_ConstructChinaNuclearMissileLauncher
  11  = Infa_Command_ConstructChinaWarFactory
  12  = Infa_Command_ConstructChinaCommandCenter
- 14  = Command_DisarmMinesAtPosition
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 CommandSet Infa_ChinaPowerPlantCommandSet
@@ -4293,6 +4330,7 @@ CommandSet Lazr_SpecialPowerShortcutUSA
   11 = Lazr_Command_FireLaserCannonFromShortcut
 END
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it.
 CommandSet Lazr_AmericaDozerCommandSet
   1  = Lazr_Command_ConstructAmericaPowerPlant
   2  = Lazr_Command_ConstructAmericaStrategyCenter
@@ -4304,9 +4342,10 @@ CommandSet Lazr_AmericaDozerCommandSet
   7  = Lazr_Command_ConstructAmericaPatriotBattery
   8  = Lazr_Command_ConstructAmericaCommandCenter
   9  = Lazr_Command_ConstructAmericaFireBase
+  10 = Lazr_Command_ConstructAmericaAirfield
   11 = Lazr_Command_ConstructAmericaWarFactory
-  13 = Lazr_Command_ConstructAmericaAirfield
-  14 = Command_DisarmMinesAtPosition
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -4625,6 +4664,7 @@ CommandSet Tank_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut
 End
 
+; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
 CommandSet Tank_ChinaDozerCommandSet
   1  = Tank_Command_ConstructChinaPowerPlant
   2  = Tank_Command_ConstructChinaInternetCenter
@@ -4638,7 +4678,8 @@ CommandSet Tank_ChinaDozerCommandSet
  10  = Tank_Command_ConstructChinaNuclearMissileLauncher
  11  = Tank_Command_ConstructChinaWarFactory
  12  = Tank_Command_ConstructChinaCommandCenter
- 14  = Command_DisarmMinesAtPosition
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -90,13 +90,14 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
 End
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
+; Patch104p @tweak Move Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6.
 CommandSet ChinaDozerCommandSet
   1  = Command_ConstructChinaPowerPlant
-  2  = Command_ConstructChinaInternetCenter
+  2  = Command_ConstructChinaAirfield
   3  = Command_ConstructChinaBarracks
-  4  = Command_ConstructChinaAirfield
+  4  = Command_ConstructChinaPropagandaCenter
   5  = Command_ConstructChinaSupplyCenter
-  6  = Command_ConstructChinaPropagandaCenter
+  6  = Command_ConstructChinaInternetCenter
   7  = Command_ConstructChinaBunker
   8  = Command_ConstructChinaSpeakerTower
   9  = Command_ConstructChinaGattlingCannon
@@ -3125,13 +3126,14 @@ CommandSet Nuke_SpecialPowerShortcutChina
 END
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
+; Patch104p @tweak Move Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6.
 CommandSet Nuke_ChinaDozerCommandSet
   1  = Nuke_Command_ConstructChinaPowerPlant
-  2  = Nuke_Command_ConstructChinaInternetCenter
+  2  = Nuke_Command_ConstructChinaAirfield
   3  = Nuke_Command_ConstructChinaBarracks
-  4  = Nuke_Command_ConstructChinaAirfield
+  4  = Nuke_Command_ConstructChinaPropagandaCenter
   5  = Nuke_Command_ConstructChinaSupplyCenter
-  6  = Nuke_Command_ConstructChinaPropagandaCenter
+  6  = Nuke_Command_ConstructChinaInternetCenter
   7  = Nuke_Command_ConstructChinaBunker
   8  = Nuke_Command_ConstructChinaSpeakerTower
   9  = Nuke_Command_ConstructChinaGattlingCannon
@@ -3867,13 +3869,14 @@ END
 
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
+; Patch104p @tweak Move Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6.
 CommandSet Infa_ChinaDozerCommandSet
   1  = Infa_Command_ConstructChinaPowerPlant
-  2  = Infa_Command_ConstructChinaInternetCenter
+  2  = Infa_Command_ConstructChinaAirfield
   3  = Infa_Command_ConstructChinaBarracks
-  4  = Infa_Command_ConstructChinaAirfield
+  4  = Infa_Command_ConstructChinaPropagandaCenter
   5  = Infa_Command_ConstructChinaSupplyCenter
-  6  = Infa_Command_ConstructChinaPropagandaCenter
+  6  = Infa_Command_ConstructChinaInternetCenter
   7  = Infa_Command_ConstructChinaBunker
   8  = Infa_Command_ConstructChinaSpeakerTower
   9  = Infa_Command_ConstructChinaGattlingCannon
@@ -4668,13 +4671,14 @@ CommandSet Tank_SpecialPowerShortcutChina
 End
 
 ; Patch104p @fix Add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it.
+; Patch104p @tweak Move Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6.
 CommandSet Tank_ChinaDozerCommandSet
   1  = Tank_Command_ConstructChinaPowerPlant
-  2  = Tank_Command_ConstructChinaInternetCenter
+  2  = Tank_Command_ConstructChinaAirfield
   3  = Tank_Command_ConstructChinaBarracks
-  4  = Tank_Command_ConstructChinaAirfield
+  4  = Tank_Command_ConstructChinaPropagandaCenter
   5  = Tank_Command_ConstructChinaSupplyCenter
-  6  = Tank_Command_ConstructChinaPropagandaCenter
+  6  = Tank_Command_ConstructChinaInternetCenter
   7  = Tank_Command_ConstructChinaBunker
   8  = Tank_Command_ConstructChinaSpeakerTower
   9  = Tank_Command_ConstructChinaGattlingCannon


### PR DESCRIPTION
**Merge with Rebase**

This change adds Stop command button to all worker units (except Boss). This way button can be pressed to stop worker units, including in group selection with other units.

To put the Stop button at its expected position, the Clear Mines, GLA Fake Structures and USA Airfield buttons had to be moved.

### Advantages

* Stop button added
* Clear Mines button now at same Position as Guard Mode button
* USA Airfield button is closer to other structures, and in same row as China Airfield

### Disadvantages

* Clear Mines, GLA Fake Structures, USA Airfield buttons moved
* GLA Fake Structures button is closer to Arms Dealer button

### TODO

- [ ] Replicate these changes in optional CommandSet.ini file

## Current

![shot_20230121_131853_1](https://user-images.githubusercontent.com/4720891/213867013-6a1f373d-0a7f-47f7-997d-7dcd34b197ab.jpg)

![shot_20230121_131859_3](https://user-images.githubusercontent.com/4720891/213867014-577b515a-abc0-4513-b32f-c63ec95e3803.jpg)

![shot_20230121_131902_4](https://user-images.githubusercontent.com/4720891/213867015-59a71fff-40ac-4189-b6ad-e37fef355c92.jpg)

## Patched

![shot_20230121_133026_2](https://user-images.githubusercontent.com/4720891/213867031-711fdab9-2da3-45e1-8640-d314ff892aa1.jpg)

![shot_20230121_133030_3](https://user-images.githubusercontent.com/4720891/213867038-551e8b2a-313f-4833-bce2-e388ff0fe097.jpg)

![shot_20230121_133037_4](https://user-images.githubusercontent.com/4720891/213867042-9a628bd6-0c26-49fe-a8da-38e4bea75c8b.jpg)

All worker units selected.

![shot_20230121_132855_1](https://user-images.githubusercontent.com/4720891/213867086-5cbf44fc-ae83-4d3c-b0fd-bfcb2889ec1b.jpg)
