### PR TITLE
Fix: Increase reload time of USA Patriot missile assist weapons from 1000 to 2000

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1580_patriot_assist_reload_time.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1580_patriot_assist_reload_time.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-01-21
+
+title: Increases reload time of USA Patriot missile assist weapons from 1000 to 2000
+
+changes:
+  - fix: Increases the reload time of USA Patriot missile assist weapons from 1000 to 2000. This way reload time is consistent for all weapons of the Patriot Battery and there can be no scenarios where the turret can shoot on new targets after just 1 instead of 2 seconds.
+
+labels:
+  - bug
+  - controversial
+  - minor
+  - nerf
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1580
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2053,6 +2053,7 @@ End
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 ; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
+; Patch104p @fix xezon 21/01/2023 Changes clip reload time from 1000 to match non-assist Patriot weapons.
 Weapon PatriotMissileAssistWeapon
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
@@ -2068,7 +2069,7 @@ Weapon PatriotMissileAssistWeapon
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 1000               ; how long to reload a Clip, msec
+  ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
   AutoReloadWhenIdle          = 2100
   AntiAirborneVehicle         = Yes
@@ -6727,6 +6728,7 @@ End
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 ; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
+; Patch104p @fix xezon 21/01/2023 Changes clip reload time from 1000 to match non-assist Patriot weapons.
 Weapon Lazr_PatriotMissileAssistWeapon
   PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 3.0
@@ -6741,7 +6743,7 @@ Weapon Lazr_PatriotMissileAssistWeapon
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 1000               ; how long to reload a Clip, msec
+  ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
   AutoReloadWhenIdle          = 2100
   AntiAirborneVehicle         = Yes
@@ -7784,6 +7786,7 @@ End
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 ; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
+; Patch104p @fix xezon 21/01/2023 Changes clip reload time from 1000 to match non-assist Patriot weapons.
 Weapon SupW_PatriotMissileAssistWeapon
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
@@ -7799,7 +7802,7 @@ Weapon SupW_PatriotMissileAssistWeapon
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 250                   ; time between shots, msec
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 1000               ; how long to reload a Clip, msec
+  ClipReloadTime              = 2000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
   AutoReloadWhenIdle          = 2100
   AntiAirborneVehicle         = Yes


### PR DESCRIPTION
**This change has been reverted with #2422**

* Related to #1755

~~This change increases the reload time of USA Patriot missile assist weapons from 1000 to 2000.~~

## Original

See the below footage for reference. In 1.04, the assisting Patriot Battery reloads its second (assist) volley faster than the left Patriot. (Note: The assist weapon's `DelayBetweenShots` is set to 100 here for consistency.)

https://user-images.githubusercontent.com/11547761/221337051-f083f66a-0d9f-4140-87f5-23a95a2522a2.mp4

---

First assist volley times:

00:11.25 [355]
00:11.29 [359]
00:12.03 [363]
00:12.07 [367]

Second assist volley times:

00:13.15 [405]
00:13.19 [409]
00:13.23 [413]
00:13.27 [417]

Conclusion:

The time between the first and second assist volleys in the above demonstration is only 38 frames. Normally there are exactly 60 frames (2000ms) between continuous non-assist volleys. This change removes this discrepancy and nerfs the assist weapon of the EMP Patriot by increasing its reload from 1000ms to 2000ms.

# Rationale

Patriot missile assist weapons no longer reload twice as fast as non-assisted Patriot missile weapons. This in turn prevents the Patriot to attack a new target after just 1000 ms after an assisted attack, which makes it consistent with non-assisted Patriot missile attacks. This likely is what player would naturally expect always.