### PR TITLE
Fix: USA Tomahawk missile angle jump before target hit

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3220,6 +3220,8 @@ Object TomahawkMissile
   Behavior = PhysicsBehavior ModuleTag_06
     Mass = 1
   End
+
+  ; Patch104p @bugfix Remove DistanceToTargetForLock = 10 setting to fix missile angle jump before target hit (#1574).
   Behavior = MissileAIUpdate ModuleTag_07
     TryToFollowTarget = Yes
     FuelLifetime = 4000
@@ -3230,8 +3232,6 @@ Object TomahawkMissile
     DistanceToTargetBeforeDiving = 100 ; When I hit this close to target, I ignore PreferredHeight.
     ; Note, if this is too small, the missile will turn too late to hit.  And, since we have a 2D
     ; heart, being over the target counts as "there", so we'll give up and just go straight.
-
-    DistanceToTargetForLock = 10 ; Short lock on, as it looks better flying.  jba.
   End
   Locomotor = SET_NORMAL TomahawkMissileLocomotor
 


### PR DESCRIPTION
* Fixes #1574

This change fixes USA Tomahawk missile angle jump before target hit.

## Patched

https://user-images.githubusercontent.com/4720891/213878482-d3029365-6e47-4a1a-8ba2-77f88d17f56f.mp4

