### PR TITLE
Fix: USA Avenger Laser Turret object icons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6917,14 +6917,9 @@ End
 Object AirF_AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
-  SelectPortrait         = SNPropSpeaker_L
-  ButtonImage            = SNPropSpeaker
-
-  UpgradeCameo1 = Upgrade_Nationalism
-  UpgradeCameo2 = Upgrade_ChinaUraniumShells
-  UpgradeCameo3 = Upgrade_ChinaNuclearTanks
-  ;UpgradeCameo4 = NONE
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  ; Patch104p @fix Put appropriate SelectPortrait and ButtonImage, remove all UpgradeCameo.
+  SelectPortrait         = SAAvnger_L
+  ButtonImage            = SAAvnger
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2312,14 +2312,9 @@ End
 Object AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
-  SelectPortrait         = SNPropSpeaker_L
-  ButtonImage            = SNPropSpeaker
-
-  UpgradeCameo1 = Upgrade_Nationalism
-  UpgradeCameo2 = Upgrade_ChinaUraniumShells
-  UpgradeCameo3 = Upgrade_ChinaNuclearTanks
-  ;UpgradeCameo4 = NONE
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  ; Patch104p @fix Put appropriate SelectPortrait and ButtonImage, remove all UpgradeCameo.
+  SelectPortrait         = SAAvnger_L
+  ButtonImage            = SAAvnger
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6619,14 +6619,9 @@ End
 Object Lazr_AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
-  SelectPortrait         = SNPropSpeaker_L
-  ButtonImage            = SNPropSpeaker
-
-  UpgradeCameo1 = Upgrade_Nationalism
-  UpgradeCameo2 = Upgrade_ChinaUraniumShells
-  UpgradeCameo3 = Upgrade_ChinaNuclearTanks
-  ;UpgradeCameo4 = NONE
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  ; Patch104p @fix Put appropriate SelectPortrait and ButtonImage, remove all UpgradeCameo.
+  SelectPortrait         = SAAvnger_L
+  ButtonImage            = SAAvnger
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7089,14 +7089,9 @@ End
 Object SupW_AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
-  SelectPortrait         = SNPropSpeaker_L
-  ButtonImage            = SNPropSpeaker
-
-  UpgradeCameo1 = Upgrade_Nationalism
-  UpgradeCameo2 = Upgrade_ChinaUraniumShells
-  UpgradeCameo3 = Upgrade_ChinaNuclearTanks
-  ;UpgradeCameo4 = NONE
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  ; Patch104p @fix Put appropriate SelectPortrait and ButtonImage, remove all UpgradeCameo.
+  SelectPortrait         = SAAvnger_L
+  ButtonImage            = SAAvnger
 
   Draw                    = W3DDependencyModelDraw ModuleTag_01
     OkToChangeModelColor  = Yes


### PR DESCRIPTION
This change fixes USA Avenger Laser Turret object icons. This fix is not user facing. It may manifest only when placing Avenger Turret Object in World Builder as single entity.