### PR TITLE
Fix: Wrong positional offset of GLA Battle Bus wreck

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -7699,7 +7699,7 @@ End
 ObjectCreationList OCL_BattleBusDeath
   CreateObject
     ObjectNames = DeadBattleBusHulk
-    Offset      = X:-7.962 Y:0.0 Z:0.0
+    Offset      = X:0.0 Y:0.0 Z:0.0 ; Patch104p @bugfix Fix offset.
     Count       = 1
     Disposition = LIKE_EXISTING
   End
@@ -7735,7 +7735,7 @@ End
 ObjectCreationList Demo_OCL_BattleBusDeath
   CreateObject
     ObjectNames = DeadBattleBusHulk
-    Offset      = X:-7.962 Y:0.0 Z:0.0
+    Offset      = X:0.0 Y:0.0 Z:0.0
     Count       = 1
     Disposition = LIKE_EXISTING
   End


### PR DESCRIPTION
* Fixes #1584

This change fixes the wrong positional offset of GLA Battle Bus wreck aka hull aka debris.