### PR TITLE
Fix: Change damage type of Gattling Air weapons from SMALL_ARMS to GATTLING

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -1012,12 +1012,14 @@ Armor FireBaseArmor
   Armor = SUBDUAL_BUILDING    100%
 End
 
-Armor AirDroneArmor ; Patch104p, based on TankArmor
+; Patch104p, New armor for airborne slave drones, based on TankArmor.
+; Patch104p @tweak xezon 02/02/2023 Changes GATTLING armor from 10% to be identical to SMALL_ARMS armor - while original Gattling Air weapons use the SMALL_ARMS damage type.
+Armor AirDroneArmor
   Armor = DEFAULT           100%
   Armor = HEALING           100%
   Armor = CRUSH              50%
   Armor = SMALL_ARMS         25%
-  Armor = GATTLING           10%
+  Armor = GATTLING           25%
   Armor = COMANCHE_VULCAN    25%
   Armor = FLAME              25%
   Armor = RADIATION          50%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1124,7 +1124,7 @@ Weapon GattlingTankGun
   PrimaryDamage         = 15.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 150.0
-  DamageType            = Gattling
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = NONE
@@ -1148,11 +1148,13 @@ Weapon GattlingTankGun
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
+;------------------------------------------------------------------------------
 Weapon GattlingTankGunAir
   PrimaryDamage         = 12.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 350.0
-  DamageType            = SMALL_ARMS
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = NONE
@@ -1179,7 +1181,7 @@ Weapon GattlingBuildingGun
   PrimaryDamage         = 10.0 ;5.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 225.0
-  DamageType            = Gattling
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = NONE
@@ -1211,7 +1213,7 @@ Weapon SpectreGattlingGun
   PrimaryDamage         = 90.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 2222.0 ; huge range
-  DamageType            = Gattling
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = NONE
@@ -1268,11 +1270,13 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
+;------------------------------------------------------------------------------
 Weapon GattlingBuildingGunAir
   PrimaryDamage         = 5.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 400.0
-  DamageType            = SMALL_ARMS
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = NONE
@@ -1300,14 +1304,16 @@ Weapon GattlingBuildingGunAir
   AntiGround            = No
 End
 
-;Given to the overlord tank so it's AI can target air manually from out of range. Must match
-;GattlingBuildingGunAir's range
+;------------------------------------------------------------------------------
+; Given to the overlord tank so it's AI can target air manually from out of range.
+; Must match GattlingBuildingGunAir's range.
+; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
 ;------------------------------------------------------------------------------
 Weapon GattlingBuildingGunAirDummy
   PrimaryDamage         = 0.0001
   PrimaryDamageRadius   = 0.0            ; 0 primary radius means "hits only intended victim"
   AttackRange           = 400.0
-  DamageType            = SMALL_ARMS
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0       ; dist/sec (huge value == effectively instant)
   ProjectileObject      = DummyWeaponProjectile
@@ -2680,7 +2686,7 @@ Weapon TechnicalMachineGunWeapon
   PrimaryDamage           = 10.0
   PrimaryDamageRadius     = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange             = 150.0
-  DamageType              = Gattling
+  DamageType              = GATTLING
   DeathType               = NORMAL
   WeaponSpeed             = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject        = NONE
@@ -6486,7 +6492,7 @@ Weapon Infa_MiniGunnerGun
   PrimaryDamage         = 10.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 125.0
-  DamageType            = Gattling
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = NONE
@@ -6509,11 +6515,13 @@ Weapon Infa_MiniGunnerGun
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
+;------------------------------------------------------------------------------
 Weapon Infa_MiniGunnerGunAir
   PrimaryDamage         = 10.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 350.0
-  DamageType            = SMALL_ARMS
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = NONE
@@ -6869,11 +6877,13 @@ Weapon BattleBusPassengerDummyWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
+;------------------------------------------------------------------------------
 Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
   PrimaryDamage         = 0.001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 60.0 ; Small enough that the minigunners at their bones can shoot their gun.
-  DamageType            = SMALL_ARMS
+  DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
   ProjectileObject      = DummyWeaponProjectile


### PR DESCRIPTION
This change fixes damage types of Gattling Air guns to match their Gattling Ground guns counterparts. Instead of `SMALL_ARMS` they now use `GATTLING`.

All Armor Sets for air units, except `AirDroneArmor`, use identical armor modifiers for `SMALL_ARMS` and `GATTLING`. `AirDroneArmor`'s `GATTLING` was adjusted accordingly. Therefore this change does not modify unit damages.