### PR TITLE
Fix: Standardize the China Dragon Tank's upgraded primary weapon's minimum range with its non-upgraded weapon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3091,7 +3091,7 @@ Weapon DragonTankFlameWeaponUpgraded
   SecondaryDamageRadius       = 10.0
   ScatterRadiusVsInfantry     = 0.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 75.0
-  MinimumAttackRange          = 10.0
+  MinimumAttackRange          = 0.0 ; Patch104p @bugfix Stubbjax 03/11/2022 Standardised the min range with the non-upgraded weapon.
   DamageType                  = FLAME
   DeathType                   = BURNED
   WeaponSpeed                 = 600                     ;  dist/sec


### PR DESCRIPTION
This change standardizes the China Dragon Tank's upgraded primary weapon's minimum range with its non-upgraded weapon.

~~Gameplay wise this is inconsequential, because the Dragon Tank cannot hit targets at those small distances with its primary weapon anyway.~~

![shot_20230122_180543_1](https://user-images.githubusercontent.com/4720891/213929448-11171928-9726-4724-bcd8-2e6b009e27ae.jpg)
