### PR TITLE
Fix: China Dragon Tank can now hit targets at different elevations with the primary weapon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -3328,7 +3328,7 @@ Locomotor DragonTankFlameLocomotor
   Acceleration = 2160       ; in dist/(sec^2)
   Braking = 0               ; in dist/(sec^2)
   TurnRate = 5            ; in degrees/sec
-  MaxThrustAngle = 1       ; in degrees (NOT degrees/sec)
+  MaxThrustAngle = 30       ; in degrees (NOT degrees/sec) ; Patch104p @bugfix Stubbjax 03/11/2022 Fixed flame projectiles not hitting targets on different terrain heights / angles.
   AllowAirborneMotiveForce = Yes
   Appearance = THRUST
 End


### PR DESCRIPTION
* Fixes TheSuperHackers/GeneralsGameCode#20
* Related to TheSuperHackers/GeneralsGamePatch#1417

## Original

A `MaxThrustAngle` of `1` prevents the projectile from hitting targets that are on a different height / angle to the Dragon Tank.

https://user-images.githubusercontent.com/11547761/199674100-9406518a-81ec-4807-a07d-791a79e7d52f.mp4

## Patched

A `MaxThrustAngle` of `30` allows the projectile to hit targets at a different height / angle to the Dragon Tank. Values of `20` and `25` would not hit all the Red Guard effectively.

https://user-images.githubusercontent.com/11547761/199674127-275a265a-3d46-414e-8753-720f01d37867.mp4
