### PR TITLE
Fix: Double scorch on death of China Battlemasters and Overlords before Isotope Stability and after Nuclear Tanks upgrades

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -2726,6 +2726,38 @@ FXList FX_OverlordExplosionOneFinal
   End
 End
 
+; -----------------------------------------------------------------------------------
+; Patch104p, A copy of FX_OverlordExplosionOneFinal, scorchless variant.
+; A death weapon is supposed to spawn the terrain scorch.
+; -----------------------------------------------------------------------------------
+FXList ScorchlessFX_OverlordExplosionOneFinal
+  ParticleSystem
+    Name = OverlordExplosionSmoke
+  End
+  ParticleSystem
+    Name = OverlordSubExplosionSmoke
+    Radius = 15 30 UNIFORM
+    Height = 0 20 UNIFORM
+    InitialDelay = 167 667 UNIFORM
+  End
+  ParticleSystem
+    Name = OverlordExplosionDebris
+  End
+  ParticleSystem
+    Name = OverlordExplosionLenzflare
+    Offset = X:0.0 Y:0.0 Z:10.0
+  End
+  ParticleSystem
+    Name = OverlordExplosionShockwave
+  End
+  ViewShake
+    Type = STRONG
+  End
+  Sound
+    Name = TankDie
+  End
+End
+
 ; -----------------------------------------------------------------------------
 FXList FX_OverlordDamageTransition
   ParticleSystem

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20825,13 +20825,30 @@ Object Boss_TankOverlord
 ;  End
 
   ; Just explode death
+  ; Patch104p @tweak xezon 11/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaNuclearTanks
+    StatusToSet = STATUS_RIDER1
+  End
+
   Behavior = SlowDeathBehavior ModuleTag_16
     ProbabilityModifier = 25
     DestructionDelay = 200
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankOverlordDebris
     FX  = FINAL    FX_OverlordExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
   End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankOverlordDebris
+    FX  = FINAL    ScorchlessFX_OverlordExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
+  End
+
   Behavior = CreateCrateDie ModuleTag_17
     CrateData = SalvageCrateData
     ;CrateData = EliteTankCrateData

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1433,13 +1433,30 @@ Object CINE_ChinaTankOverlord
 ;  End
 
   ; Just explode death
+  ; Patch104p @tweak xezon 11/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaNuclearTanks
+    StatusToSet = STATUS_RIDER1
+  End
+
   Behavior = SlowDeathBehavior ModuleTag_16
     ProbabilityModifier = 25
     DestructionDelay = 200
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankOverlordDebris
     FX  = FINAL    FX_OverlordExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
   End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankOverlordDebris
+    FX  = FINAL    ScorchlessFX_OverlordExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
+  End
+
   Behavior = CreateCrateDie ModuleTag_17
     CrateData = SalvageCrateData
     ;CrateData = EliteTankCrateData

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1186,6 +1186,11 @@ Object CINE_ChinaTankBattleMaster
     ;CrateData = HeroicTankCrateData
   ;End
 
+  ; Patch104p @tweak xezon 11/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaNuclearTanks
+    StatusToSet = STATUS_RIDER1
+  End
 
   Behavior = SlowDeathBehavior ModuleTag_12
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -1194,6 +1199,17 @@ Object CINE_ChinaTankBattleMaster
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankBattleMasterDebris
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankBattleMasterDebris
+    FX  = FINAL    ScorchlessFX_BattleMasterExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
   End
 
   Behavior = TransitionDamageFX ModuleTag_13

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -159,6 +159,11 @@ Object ChinaTankBattleMaster
     ;CrateData = HeroicTankCrateData
   End
 
+  ; Patch104p @tweak xezon 11/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaNuclearTanks
+    StatusToSet = STATUS_RIDER1
+  End
 
   Behavior = SlowDeathBehavior ModuleTag_12
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -167,6 +172,17 @@ Object ChinaTankBattleMaster
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankBattleMasterDebris
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankBattleMasterDebris
+    FX  = FINAL    ScorchlessFX_BattleMasterExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
   End
 
   Behavior = TransitionDamageFX ModuleTag_13

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -427,13 +427,30 @@ Object ChinaTankOverlord
 ;  End
 
   ; Just explode death
+  ; Patch104p @tweak xezon 11/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaNuclearTanks
+    StatusToSet = STATUS_RIDER1
+  End
+
   Behavior = SlowDeathBehavior ModuleTag_16
     ProbabilityModifier = 25
     DestructionDelay = 200
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankOverlordDebris
     FX  = FINAL    FX_OverlordExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
   End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankOverlordDebris
+    FX  = FINAL    ScorchlessFX_OverlordExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
+  End
+
   Behavior = CreateCrateDie ModuleTag_17
     CrateData = SalvageCrateData
     ;CrateData = EliteTankCrateData

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17305,13 +17305,30 @@ Object Nuke_ChinaTankOverlord
   End
 
   ; Just explode death
+  ; Patch104p @tweak xezon 02/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaIsotopeStability
+    StatusToSet = STATUS_RIDER1
+  End
+
   Behavior = SlowDeathBehavior ModuleTag_16
     ProbabilityModifier = 25
     DestructionDelay = 200
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankOverlordDebris
-    FX  = FINAL    FX_OverlordExplosionOneFinal
+    FX  = FINAL    ScorchlessFX_OverlordExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
   End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankOverlordDebris
+    FX  = FINAL    FX_OverlordExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
+  End
+
   Behavior = CreateCrateDie ModuleTag_17
     CrateData = SalvageCrateData
     ;CrateData = EliteTankCrateData

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17063,6 +17063,11 @@ Object Nuke_ChinaTankBattleMaster
     ;CrateData = HeroicTankCrateData
   End
 
+  ; Patch104p @tweak xezon 02/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaIsotopeStability
+    StatusToSet = STATUS_RIDER1
+  End
 
   Behavior = SlowDeathBehavior ModuleTag_12
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -17070,7 +17075,18 @@ Object Nuke_ChinaTankBattleMaster
     DestructionDelay = 200
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankBattleMasterDebris
+    FX  = FINAL    ScorchlessFX_BattleMasterExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankBattleMasterDebris
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
   End
 
   Behavior = TransitionDamageFX ModuleTag_13

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2856,6 +2856,11 @@ Object Tank_ChinaTankBattleMaster
     ;CrateData = HeroicTankCrateData
   End
 
+  ; Patch104p @tweak xezon 11/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaNuclearTanks
+    StatusToSet = STATUS_RIDER1
+  End
 
   Behavior = SlowDeathBehavior ModuleTag_12
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -2864,6 +2869,17 @@ Object Tank_ChinaTankBattleMaster
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankBattleMasterDebris
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankBattleMasterDebris
+    FX  = FINAL    ScorchlessFX_BattleMasterExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
   End
 
   Behavior = TransitionDamageFX ModuleTag_13

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3156,13 +3156,30 @@ Object Tank_ChinaTankEmperor
 ;  End
 
   ; Just explode death
+  ; Patch104p @tweak xezon 11/02/2023 Use different death behaviour with different effect(s) when upgrade is acquired.
+  Behavior = StatusBitsUpgrade ModuleTag_StatusBitsUpgrade
+    TriggeredBy = Upgrade_ChinaNuclearTanks
+    StatusToSet = STATUS_RIDER1
+  End
+
   Behavior = SlowDeathBehavior ModuleTag_16
     ProbabilityModifier = 25
     DestructionDelay = 200
     DestructionDelayVariance = 100
     OCL = FINAL    OCL_ChinaTankOverlordDebris
     FX  = FINAL    FX_OverlordExplosionOneFinal
+    ExemptStatus = STATUS_RIDER1
   End
+
+  Behavior = SlowDeathBehavior ModuleTag_SlowDeathBehavior_02
+    ProbabilityModifier = 25
+    DestructionDelay = 200
+    DestructionDelayVariance = 100
+    OCL = FINAL    OCL_ChinaTankOverlordDebris
+    FX  = FINAL    ScorchlessFX_OverlordExplosionOneFinal
+    RequiredStatus = STATUS_RIDER1
+  End
+
   Behavior = CreateCrateDie ModuleTag_17
     CrateData = SalvageCrateData
     ;CrateData = EliteTankCrateData


### PR DESCRIPTION
**Merge with Rebase**

This change fixes double scorch on death of
* Nuke Battlemaster before Isotope Stability upgrade
* Nuke Overlord before Isotope Stability upgrade
* China/Tank/Boss/CINE Battlemaster after Nuclear Tanks upgrade
* China/Tank/Boss/CINE Overlord after Nuclear Tanks upgrade

- [x] Rename FX_Suicide_BattleMasterExplosionOneFinal