### PR TITLE
Remove custom PlacementViewAngle of vehicles

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6914,6 +6914,8 @@ Object AirF_AmericaVehicleSentryDrone
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object AirF_AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
@@ -6943,8 +6945,6 @@ Object AirF_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
       TurretPitch         = TURRETEL01
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = AmericaAirForceGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2309,6 +2309,8 @@ Object AmericaVehicleSentryDrone
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
@@ -2338,8 +2340,6 @@ Object AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack i
       TurretPitch         = TURRETEL01
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = America

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -20496,6 +20496,8 @@ Object Chem_GLAVehicleRadarVan
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of 180.
+;------------------------------------------------------------------------------
 Object Chem_GLAVehicleBattleBus
 
   ; *** ART Parameters ***
@@ -20661,7 +20663,7 @@ Object Chem_GLAVehicleBattleBus
     PowerslideSpray = RocketBuggyDirtPowerSlide
 
   End
-  PlacementViewAngle = 180
+
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:BattleBus
   Side = GLAToxinGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -477,6 +477,8 @@ Object ChinaHelixGattlingCannon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object ChinaHelixPropagandaTower
 
   ; *** ART Parameters ***
@@ -508,8 +510,6 @@ Object ChinaHelixPropagandaTower
       AnimationMode = LOOP
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = China
@@ -571,6 +571,8 @@ Object ChinaHelixPropagandaTower
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object ChinaHelixBattleBunker
 
   ; *** ART Parameters ***
@@ -606,8 +608,6 @@ Object ChinaHelixBattleBunker
       ParticleSysBone = Spark01 LiveWireSparks
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = China

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -682,6 +682,8 @@ Object ChinaTankOverlordGattlingCannon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object ChinaTankOverlordPropagandaTower
 
   ; *** ART Parameters ***
@@ -718,8 +720,6 @@ Object ChinaTankOverlordPropagandaTower
       AnimationMode = LOOP
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = China
@@ -782,6 +782,8 @@ Object ChinaTankOverlordPropagandaTower
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object ChinaTankOverlordBattleBunker
 
   ; *** ART Parameters ***
@@ -822,8 +824,6 @@ Object ChinaTankOverlordBattleBunker
       ParticleSysBone = Spark01 LiveWireSparks
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = China

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -22080,6 +22080,8 @@ Object Demo_GLAVehicleRadarVan
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of 180.
+;------------------------------------------------------------------------------
 Object Demo_GLAVehicleBattleBus
 
   ; *** ART Parameters ***
@@ -22245,7 +22247,7 @@ Object Demo_GLAVehicleBattleBus
     PowerslideSpray = RocketBuggyDirtPowerSlide
 
   End
-  PlacementViewAngle = 180
+
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:BattleBus
   Side = GLADemolitionGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -3818,8 +3818,9 @@ ObjectReskin GC_Slth_GLAVehicleTechnicalChassisThree GC_Slth_GLAVehicleTechnical
 End
 
 
-; ----------------------------------------------------------------------------------------------------------------
-
+;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of 180.
+;------------------------------------------------------------------------------
 Object GC_Slth_GLAVehicleBattleBus
 
   ; *** ART Parameters ***
@@ -3981,7 +3982,7 @@ Object GC_Slth_GLAVehicleBattleBus
     PowerslideSpray = RocketBuggyDirtPowerSlide
 
   End
-  PlacementViewAngle = 180
+
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:BattleBus
   Side = GLAStealthGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -8672,7 +8672,9 @@ Object CINE_akStature
 End
 
 
-;----------------------------------------------------------------------------
+;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of 180.
+;------------------------------------------------------------------------------
 Object GLAVehicleBattleBusHighDef
 
   ; *** ART Parameters ***
@@ -8834,7 +8836,7 @@ Object GLAVehicleBattleBusHighDef
     PowerslideSpray = RocketBuggyDirtPowerSlide
 
   End
-  PlacementViewAngle = 180
+
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:BattleBus
   Side = GLA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6489,6 +6489,8 @@ Object GLAVehicleRadarVan
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of 180.
+;------------------------------------------------------------------------------
 Object GLAVehicleBattleBus
 
   ; *** ART Parameters ***
@@ -6653,7 +6655,7 @@ Object GLAVehicleBattleBus
     PowerslideSpray = RocketBuggyDirtPowerSlide
 
   End
-  PlacementViewAngle = 180
+
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:BattleBus
   Side = GLA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6616,6 +6616,8 @@ Object Lazr_AmericaVehicleSentryDrone
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Lazr_AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
@@ -6645,8 +6647,6 @@ Object Lazr_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
       TurretPitch         = TURRETEL01
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = AmericaLaserGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -758,6 +758,8 @@ Object Nuke_ChinaHelixGattlingCannon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Nuke_ChinaHelixPropagandaTower
 
   ; *** ART Parameters ***
@@ -794,8 +796,6 @@ Object Nuke_ChinaHelixPropagandaTower
       AnimationMode = LOOP
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaNukeGeneral
@@ -857,6 +857,8 @@ Object Nuke_ChinaHelixPropagandaTower
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Nuke_ChinaHelixBattleBunker
 
   ; *** ART Parameters ***
@@ -897,8 +899,6 @@ Object Nuke_ChinaHelixBattleBunker
       ParticleSysBone = Spark01 LiveWireSparks
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaNukeGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17566,6 +17566,8 @@ Object Nuke_ChinaTankOverlordGattlingCannon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Nuke_ChinaTankOverlordPropagandaTower
 
   ; *** ART Parameters ***
@@ -17602,8 +17604,6 @@ Object Nuke_ChinaTankOverlordPropagandaTower
       AnimationMode = LOOP
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaNukeGeneral
@@ -17666,6 +17666,8 @@ Object Nuke_ChinaTankOverlordPropagandaTower
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Nuke_ChinaTankOverlordBattleBunker
 
   ; *** ART Parameters ***
@@ -17706,8 +17708,6 @@ Object Nuke_ChinaTankOverlordBattleBunker
       ParticleSysBone = Spark01 LiveWireSparks
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaNukeGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -22037,6 +22037,8 @@ Object Slth_GLAVehicleRadarVan
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of 180.
+;------------------------------------------------------------------------------
 Object Slth_GLAVehicleBattleBus
 
   ; *** ART Parameters ***
@@ -22201,7 +22203,7 @@ Object Slth_GLAVehicleBattleBus
     PowerslideSpray = RocketBuggyDirtPowerSlide
 
   End
-  PlacementViewAngle = 180
+
   ; ***DESIGN parameters ***
   DisplayName      = OBJECT:BattleBus
   Side = GLAStealthGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7086,6 +7086,8 @@ Object SupW_AmericaVehicleSentryDrone
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object SupW_AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack independantly
 
   ; *** ART Parameters ***
@@ -7115,8 +7117,6 @@ Object SupW_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
       TurretPitch         = TURRETEL01
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = AmericaSuperWeaponGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3416,6 +3416,8 @@ Object Tank_ChinaTankOverlordGattlingCannon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Tank_ChinaTankOverlordPropagandaTower
 
   ; *** ART Parameters ***
@@ -3452,8 +3454,6 @@ Object Tank_ChinaTankOverlordPropagandaTower
       AnimationMode = LOOP
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaTankGeneral
@@ -3521,6 +3521,8 @@ Object Tank_ChinaTankOverlordPropagandaTower
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Tank_ChinaTankOverlordBattleBunker
 
   ; *** ART Parameters ***
@@ -3561,8 +3563,6 @@ Object Tank_ChinaTankOverlordBattleBunker
       ParticleSysBone = Spark01 LiveWireSparks
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaTankGeneral

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -484,6 +484,8 @@ Object Tank_ChinaHelixGattlingCannon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Tank_ChinaHelixPropagandaTower
 
   ; *** ART Parameters ***
@@ -520,8 +522,6 @@ Object Tank_ChinaHelixPropagandaTower
       AnimationMode = LOOP
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaTankGeneral
@@ -584,6 +584,8 @@ Object Tank_ChinaHelixPropagandaTower
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix Removes PlacementViewAngle of -45.
+;------------------------------------------------------------------------------
 Object Tank_ChinaHelixBattleBunker
 
   ; *** ART Parameters ***
@@ -624,8 +626,6 @@ Object Tank_ChinaHelixBattleBunker
       ParticleSysBone = Spark01 LiveWireSparks
     End
   End
-
-  PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
   Side             = ChinaTankGeneral


### PR DESCRIPTION
**Merge with Rebase**

This change removes custom PlacementViewAngle of vehicles. This way, placement view angle is consistent when placing vehicles in World Builder.

Affects
* All GLA Battle Bus objects
* All USA Avenger Laser Turret objects
* All China Helix Propaganda, Bunker attachment objects
* All China Overlord Propaganda, Bunker attachment objects