### PR TITLE
Streamline KindOf flags of hulk objects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -134,7 +134,8 @@ Object AmericaVehicleTomahawkHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              = NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 10.0
@@ -168,7 +169,8 @@ Object ChinaVehicleNukeCannonHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              = NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 10.0
@@ -206,7 +208,8 @@ Object AmericaJetRaptorHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 2.0
@@ -246,7 +249,8 @@ Object AmericaJetA10Hulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 2.0
@@ -288,7 +292,8 @@ Object SpectreHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 2.0
@@ -327,7 +332,8 @@ Object AmericaJetStealthHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 2.0
@@ -364,7 +370,8 @@ Object AmericaJetAuroraHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 2.0
@@ -404,7 +411,8 @@ Object ComancheRubbleHull
   Side = America
 
   ; *** ENGINEERING Parameters ***
-  KindOf = IMMOBILE NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_02
     Mass           = 25.0
@@ -446,7 +454,8 @@ Object ChinookRubbleHull
   Side = America
 
   ; *** ENGINEERING Parameters ***
-  KindOf = IMMOBILE NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_02
     Mass           = 25.0
@@ -479,7 +488,8 @@ Object HelixRubbleHull
   Side = China  ; Patch104p @bugfix commy2 12/09/2021 Fix World Builder faction.
 
   ; *** ENGINEERING Parameters ***
-  KindOf = IMMOBILE NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_02
     Mass           = 45.0
@@ -518,7 +528,8 @@ Object ChinaJetMIGHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 2.0
@@ -841,7 +852,8 @@ Object DeadTankHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -875,7 +887,8 @@ Object InfernoCannonHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -909,7 +922,8 @@ Object DeadChinaSupplyTruckHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -943,7 +957,8 @@ Object DeadChinaGattlingTankHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -979,7 +994,8 @@ Object DeadChinaECMTankHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1015,7 +1031,8 @@ Object AmericaVehicleAmbulanceDeadHull
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1066,7 +1083,8 @@ Object DeadSCUDLauncherHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1100,7 +1118,8 @@ Object DeadToxinTractorHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1134,7 +1153,8 @@ Object DeadQuadCannonHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1168,7 +1188,8 @@ Object DeadBombTruckHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1202,7 +1223,8 @@ Object DeadTechnicalVanHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1236,7 +1258,8 @@ Object DeadTechnicalJeepHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1270,7 +1293,8 @@ Object DeadTechnicalTruckHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1304,7 +1328,8 @@ Object DeadRocketBuggyHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1338,7 +1363,8 @@ Object DeadCombatBikeHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1372,7 +1398,8 @@ Object DeadCrusaderHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1405,7 +1432,8 @@ Object DeadLaserTankHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1438,7 +1466,8 @@ Object DeadPaladinHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1471,7 +1500,8 @@ Object DeadAvengerHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1504,7 +1534,8 @@ Object DeadMarauderHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1537,7 +1568,8 @@ Object DeadBattleBusHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1570,7 +1602,8 @@ Object DeadScorpionHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1603,7 +1636,8 @@ Object DestroyedMilitiaTank
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf = NONE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1636,7 +1670,8 @@ Object DeadRadarVanHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0
@@ -1670,7 +1705,8 @@ Object ChinaDeadDozerHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 100.0
@@ -1704,7 +1740,8 @@ Object AmericaDeadDozerHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 100.0
@@ -1737,7 +1774,8 @@ Object AmericaScoutDroneHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 10.0
@@ -1769,7 +1807,8 @@ Object AmericaBattleDroneHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 10.0
@@ -1804,7 +1843,8 @@ Object AmericaJetCargoHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 1.0
@@ -1840,7 +1880,8 @@ Object AmericaVehicleSentryDroneHulk
   EditorSorting       = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf              = NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior                  = PhysicsBehavior ModuleTag_03
     Mass                    = 10.0
@@ -1937,7 +1978,8 @@ Object DeadGLAToxicSupplyTruckHulk
   EditorSorting   = DEBRIS
 
   ; *** ENGINEERING Parameters ***
-  KindOf =  NO_COLLIDE HULK
+  ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -19,7 +19,9 @@ Object DeadMicrowaveHulk
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
+
+  ; Patch104p @tweak xezon 28/01/2023 Remove obsolete immobile flag.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -76,7 +78,9 @@ Object AmericaVehicleHumveeDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
+
+  ; Patch104p @tweak xezon 28/01/2023 Remove obsolete immobile flag.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -735,7 +739,9 @@ Object ChinaVehicleTroopCrawlerDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
+
+  ; Patch104p @tweak xezon 28/01/2023 Remove obsolete immobile flag.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -787,7 +793,9 @@ Object ChinaVehicleAssaultTroopCrawlerDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
+
+  ; Patch104p @tweak xezon 28/01/2023 Remove obsolete immobile flag.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0
@@ -1873,7 +1881,9 @@ Object ChinaVehicleListeningOutpostDeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK UNATTACKABLE
+
+  ; Patch104p @tweak xezon 28/01/2023 Remove obsolete immobile flag.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0


### PR DESCRIPTION
**Merge with Rebase**

This change attempts to fix some hulk flags misconfigurations.

* Hulks of USA Microwave, Humvee, China Troop Crawler(s), Listening Outpost have obsolete IMMOBILE flag removed
* All hulks can now cast reflections
