### PR TITLE
Revert: Replace Microwave Haze effect from Microwave and GPS Scrambler to avoid rendering issues on some hardware configurations

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8595,7 +8595,7 @@ End
 ; ----------------------------------------------
 FXList FX_MicrowaveTankEmitter
   ParticleSystem
-    Name = MicrowaveFlare ; Patch104p: Replace MicrowaveEmitter to remove the use of the haze particle effect. This can avoid issues on some GPUs and drivers that would cause the world to render black when haze is in viewport.
+    Name = MicrowaveEmitter
     UseCallersRadius = Yes ; Radius of emission set by radius of damage.
     Offset = X:0.0 Y:0.0 Z:1.0
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -395,7 +395,7 @@ Object GPSScrambler_InvisibleMarker
 
     DefaultConditionState
       Model = None
-      ParticleSysBone = None MicrowaveFlare ; Patch104p: Replace GPSMicrowaveScrambler to remove the use of the haze particle effect. This can avoid issues on some GPUs and drivers that would cause the world to render black when haze is in viewport.
+      ParticleSysBone = None GPSMicrowaveScrambler
       ParticleSysBone = None GPSRotisserie
       ParticleSysBone = None gpsScrambleCloud
     End


### PR DESCRIPTION
* Fixes #1519
* Related to #109

Issue introduced by 39f063905bdefcadece7f0249f87901913f03682