### PR TITLE
Fix faction vehicle/aircraft hulk physics and sink delays

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
@@ -148,10 +148,12 @@ Object GLACombatBikeToppledHulk
     MaxLifetime = 0   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Remove obsolete Sink Delay of 1.
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 3000 to 8000 (+5000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_06
-    SinkDelay = 1
+    SinkDelay = 0
     SinkRate = 1.0
-    DestructionDelay = 3000
+    DestructionDelay = 8000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -184,10 +184,11 @@ Object ChinaVehicleNukeCannonHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 10000
   End
 End
 
@@ -510,10 +511,11 @@ Object HelixRubbleHull
   End
 
   ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 13500 (+7000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 15000
   End
 
 End
@@ -660,11 +662,11 @@ Object ChinaTankOverlordDeadHull
     MaxLifetime = 0   ; max lifetime in msec
   End
 
-
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6000 to 9000 (+3000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay = 14000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 23000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -913,10 +915,11 @@ Object InfernoCannonHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 10000
   End
 
 End
@@ -948,10 +951,11 @@ Object DeadChinaSupplyTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -1106,10 +1110,11 @@ Object DeadSCUDLauncherHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -1360,7 +1365,7 @@ Object DeadRocketBuggyHulk
 End
 
 ;------------------------------------------------------------------------------
-Object DeadCombatBikeHulk
+Object DeadCombatBikeHulk ; Unused, see GLACombatBikeToppledHulk
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -1523,10 +1528,11 @@ Object DeadAvengerHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9000
   End
 End
 
@@ -1660,10 +1666,11 @@ Object DestroyedMilitiaTank
     MaxLifetime = 15000   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 8000 to 10500 (+2500) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay = 4000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 10500
   End
 End
 
@@ -1729,10 +1736,11 @@ Object ChinaDeadDozerHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9000
   End
 
 End
@@ -1764,10 +1772,11 @@ Object AmericaDeadDozerHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9000
   End
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -28,10 +28,11 @@ Object DeadMicrowaveHulk
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @fix xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -87,10 +88,11 @@ Object AmericaVehicleHumveeDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @fix xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -415,9 +417,11 @@ Object ComancheRubbleHull
   KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
 
   ; Patch104p @fix xezon 28/01/2023 Disable bouncing.
+  ; Patch104p @fix xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_02
     Mass           = 25.0
     AllowBouncing  = No
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_03
@@ -585,10 +589,11 @@ Object ChinaVehicleBattleMasterDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @fix xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -643,10 +648,11 @@ Object ChinaTankOverlordDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @fix xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -703,10 +709,11 @@ Object ChinaTankDragonDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @fix xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -988,10 +988,11 @@ Object DeadChinaGattlingTankHulk
   End
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 10000 (-2000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
+    DestructionDelay          = 10000
   End
 
 End
@@ -1024,10 +1025,11 @@ Object DeadChinaECMTankHulk
   End
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
+    DestructionDelay          = 8000
   End
 
 End
@@ -1060,10 +1062,11 @@ Object AmericaVehicleAmbulanceDeadHull
   End
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 7500 (-4500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
+    DestructionDelay          = 7500
   End
 
 
@@ -1146,10 +1149,11 @@ Object DeadToxinTractorHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10000 (-6000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 10000
   End
 
 End
@@ -1181,10 +1185,11 @@ Object DeadQuadCannonHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 8000 (-8000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 8000
   End
 
 End
@@ -1216,10 +1221,11 @@ Object DeadBombTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10000 (-6000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 10000
   End
 
 End
@@ -1251,10 +1257,11 @@ Object DeadTechnicalVanHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1286,10 +1293,11 @@ Object DeadTechnicalJeepHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1321,10 +1329,11 @@ Object DeadTechnicalTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1356,10 +1365,11 @@ Object DeadRocketBuggyHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1631,10 +1641,11 @@ Object DeadScorpionHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 8000
   End
 End
 
@@ -1701,10 +1712,11 @@ Object DeadRadarVanHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 12000 (-4000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 12000
   End
 
 End
@@ -1782,6 +1794,8 @@ Object AmericaDeadDozerHulk
 End
 
 ;------------------------------------------------------------------------------
+; Note: AmericaScoutDroneHulk is used for Hellfire Drone too.
+;------------------------------------------------------------------------------
 Object AmericaScoutDroneHulk
   ; *** ART Parameters ***
   Draw                = W3DModelDraw ModuleTag_01
@@ -1807,10 +1821,11 @@ Object AmericaScoutDroneHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 8000 to 6000 (-2000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 6000
   End
 End
 
@@ -1840,10 +1855,11 @@ Object AmericaBattleDroneHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 8000 to 6000 (-2000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 6000
   End
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -40,10 +40,11 @@ Object DeadMicrowaveHulk
     MaxLifetime = 0   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle/aircraft from 14000 to 3000 (-11000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 9000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -100,10 +101,11 @@ Object AmericaVehicleHumveeDeadHull
     MaxLifetime = 0   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle from 14000 to 3000 (-11000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 9000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -149,10 +151,11 @@ Object AmericaVehicleTomahawkHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 End
 
@@ -185,10 +188,11 @@ Object ChinaVehicleNukeCannonHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of large vehicle/aircraft from 1500 to 6000 (+4500) to sink later than small vehicles/aircraft.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 6000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 10000
+    DestructionDelay = 14500
   End
 End
 
@@ -225,10 +229,11 @@ Object AmericaJetRaptorHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -267,11 +272,11 @@ Object AmericaJetA10Hulk
   End
 
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -310,11 +315,11 @@ Object SpectreHulk
   End
 
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -349,10 +354,11 @@ Object AmericaJetStealthHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -387,10 +393,11 @@ Object AmericaJetAuroraHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -475,10 +482,11 @@ Object ChinookRubbleHull
   End
 
   ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -512,10 +520,11 @@ Object HelixRubbleHull
 
   ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 13500 (+7000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of large vehicle/aircraft from 1500 to 6000 (+4500) to sink later than small vehicles/aircraft.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 6000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 15000
+    DestructionDelay = 19500
   End
 
 End
@@ -554,10 +563,11 @@ Object ChinaJetMIGHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -603,11 +613,11 @@ Object ChinaVehicleBattleMasterDeadHull
     MaxLifetime = 0   ; max lifetime in msec
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle/aircraft from 14000 to 3000 (-11000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 9000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -663,10 +673,11 @@ Object ChinaTankOverlordDeadHull
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6000 to 9000 (+3000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of large vehicle/aircraft from 14000 to 6000 (-8000) to sink later than small vehicles/aircraft.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 6000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 23000
+    DestructionDelay = 15000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -784,10 +795,11 @@ Object ChinaVehicleTroopCrawlerDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -838,10 +850,11 @@ Object ChinaVehicleAssaultTroopCrawlerDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -880,10 +893,11 @@ Object DeadTankHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -916,10 +930,11 @@ Object InfernoCannonHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 10000
+    DestructionDelay  = 11500
   End
 
 End
@@ -952,10 +967,11 @@ Object DeadChinaSupplyTruckHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 9500
+    DestructionDelay  = 11000
   End
 
 End
@@ -989,10 +1005,11 @@ Object DeadChinaGattlingTankHulk
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 10000 (-2000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 10000
+    DestructionDelay          = 11500
   End
 
 End
@@ -1026,10 +1043,11 @@ Object DeadChinaECMTankHulk
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 8000
+    DestructionDelay          = 9500
   End
 
 End
@@ -1063,10 +1081,11 @@ Object AmericaVehicleAmbulanceDeadHull
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 7500 (-4500) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 7500
+    DestructionDelay          = 9000
   End
 
 
@@ -1114,10 +1133,11 @@ Object DeadSCUDLauncherHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 9500
+    DestructionDelay  = 11000
   End
 
 End
@@ -1150,10 +1170,11 @@ Object DeadToxinTractorHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10000 (-6000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 10000
+    DestructionDelay  = 11500
   End
 
 End
@@ -1186,10 +1207,11 @@ Object DeadQuadCannonHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 8000 (-8000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -1222,10 +1244,11 @@ Object DeadBombTruckHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10000 (-6000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 10000
+    DestructionDelay  = 11500
   End
 
 End
@@ -1436,10 +1459,11 @@ Object DeadCrusaderHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1470,10 +1494,11 @@ Object DeadLaserTankHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1504,10 +1529,11 @@ Object DeadPaladinHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1539,10 +1565,11 @@ Object DeadAvengerHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 9000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1573,10 +1600,11 @@ Object DeadMarauderHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 13500
   End
 End
 
@@ -1607,10 +1635,11 @@ Object DeadBattleBusHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 13500
   End
 End
 
@@ -1642,10 +1671,11 @@ Object DeadScorpionHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1678,10 +1708,11 @@ Object DestroyedMilitiaTank
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 8000 to 10500 (+2500) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle/aircraft from 4000 to 3000 (-1000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 4000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 10500
+    DestructionDelay = 9500
   End
 End
 
@@ -1713,10 +1744,11 @@ Object DeadRadarVanHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 12000 (-4000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 13500
   End
 
 End
@@ -1749,10 +1781,11 @@ Object ChinaDeadDozerHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 9000
+    DestructionDelay = 10500
   End
 
 End
@@ -1785,10 +1818,11 @@ Object AmericaDeadDozerHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 9000
+    DestructionDelay = 10500
   End
 
 End
@@ -1977,10 +2011,11 @@ Object ChinaVehicleListeningOutpostDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -2027,10 +2062,11 @@ Object DeadGLAToxicSupplyTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -723,11 +723,11 @@ Object ChinaTankDragonDeadHull
     MaxLifetime = 0   ; max lifetime in msec
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay from 14000 to 12000 (-2000) to start sink right after the fire particle vanished.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 12000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 18000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06


### PR DESCRIPTION
**Merge with Rebase.**

* Fixes #1183

~~This change fixes faction vehicle/aircraft hulk physics, sink delays, destruction delays.~~

* ~~ComancheRubbleHull can no longer bounce~~
* ~~Decreases the quick sink rate of USA Comanche hulk~~
* ~~Increases the slow sink rate of USA Chinook, China Helix hulks~~
* ~~Removes random sink delays from hulks of USA Ambulance, China Gattling, ECM~~
* ~~Enables kill on resting for hulks of USA Microwave, Humvee, Comache, China Battlemaster, Overlord, Dragon~~
* ~~Increases destruction delays for hulks of USA Dozer, Avenger, China Dozer, Supply Truck, Inferno Cannon, Overlord, Nuke Cannon, Helix, GLA Combat Bike, Scud Launcher to avoid deletion before object is sunk into terrain~~
* ~~Decrease destruction delays for hulks of USA Dozer, Humvee, Ambulance, Scout Drone, Battle Drone, China Gattling, ECM, GLA Technical(s), Quad Cannon, Scorpion, Toxin Truck, Radar Van, Rocket Buggy~~
* ~~Decrease sink delay for hulks of China Dragon Tank to start sink right after the fire particle vanished~~
* ~~Set sink delays for hulks of most vehicles and aircraft to at least 3000 milliseconds~~

## ~~Result~~

Dragon Tank sinks after 12000 milliseconds. It has a special death particle that lasts very long, so dead hull should stay with it.

Most small vehicles sink after 3000 ms. This way dead hulls can be seen properly after explosion particles for a bit of time, otherwise hulls can barely be seen on various vehicle kills. The new sink delay of 3000 ms is also consistent with all Infantry, which is 3000 ms as well.

Large vehicles sink after 6000 ms, which are Overlord, Nuke Cannon and Helix.

All faction vehicles and aircraft, except GLA Combat Bike, will sink with uniform speed.

No hulk disappears before it sunk into terrain.

Every hulk will disappear shortly after it sunk into terrain.

No hulk sinks with random intervals.

All changes have been tested on generously sloped terrain of around 40 degrees.

## Next Steps

In next pulls, Debris objects need fixing. They also disappear too quickly. On top of that, some vehicles could do with a small flame on the wreck. Some vehicles already have that. And there are bugs with some vehicles, such as no hulks for USA Repair Drone, Prisoner Transporter.