### PR TITLE
Fix premature hulk spawn

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7390,7 +7390,7 @@ Object AirF_AmericaTankMicrowave
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_MicrowaveTankDeath
+    OCL = FINAL    OCL_MicrowaveTankDeath ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6863,7 +6863,7 @@ Object AirF_AmericaVehicleSentryDrone
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleSentryDroneDie
+    OCL = FINAL OCL_AmericaVehicleSentryDroneDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleSentryDroneDeathExplosion ; Patch104p @tweak from FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5489,7 +5489,7 @@ Object AirF_AmericaVehicleTomahawk
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleTomahawkDie
+    OCL = FINAL OCL_AmericaVehicleTomahawkDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1754,7 +1754,7 @@ Object MISSION_AmericaVehicleSentryDrone
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleSentryDroneDie
+    OCL = FINAL OCL_AmericaVehicleSentryDroneDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2264,7 +2264,7 @@ Object AmericaVehicleSentryDrone
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleSentryDroneDie
+    OCL = FINAL OCL_AmericaVehicleSentryDroneDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleSentryDroneDeathExplosion ; Patch104p @tweak from FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2781,7 +2781,7 @@ Object AmericaTankMicrowave
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_MicrowaveTankDeath
+    OCL = FINAL    OCL_MicrowaveTankDeath ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -408,7 +408,7 @@ Object AmericaVehicleTomahawk
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleTomahawkDie
+    OCL = FINAL OCL_AmericaVehicleTomahawkDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20258,7 +20258,7 @@ Object Boss_VehicleSentryDrone
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleSentryDroneDie
+    OCL = FINAL OCL_AmericaVehicleSentryDroneDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleSentryDroneDeathExplosion ; Patch104p @tweak from FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19721,7 +19721,7 @@ Object Boss_VehicleTomahawk
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleTomahawkDie
+    OCL = FINAL OCL_AmericaVehicleTomahawkDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1838,8 +1838,7 @@ Object CINE_ChinaVehicleNukeLauncher
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
     OCL = INITIAL  OCL_RadiationFieldSmall
-    OCL = MIDPOINT OCL_ChinaVehicleNukeCannonDie
-    OCL = FINAL    OCL_RadiationFieldSmall
+    OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1633,6 +1633,7 @@ Object CINE_ChinaVehicleNukeLauncher
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -1648,17 +1649,6 @@ Object CINE_ChinaVehicleNukeLauncher
       WeaponLaunchBone                = PRIMARY Muzzle
       WeaponMuzzleFlash               = PRIMARY MuzzleFX
       WeaponFireFXBone                = PRIMARY Muzzle
-      WeaponRecoilBone                = PRIMARY Barrel
-      HideSubObject                   = TURRET01      ;Hide controlled turret
-      ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
-      Turret                          = Turret01
-      TurretPitch                     = TurretEL
-    End
-
-    ConditionState                    = RUBBLE
-      Model                           = NVNukeCn_D
-      WeaponLaunchBone                = PRIMARY Muzzle
-      WeaponMuzzleFlash               = PRIMARY MuzzleFX
       WeaponRecoilBone                = PRIMARY Barrel
       HideSubObject                   = TURRET01      ;Hide controlled turret
       ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
@@ -1682,7 +1672,8 @@ Object CINE_ChinaVehicleNukeLauncher
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
-
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
@@ -1697,12 +1688,15 @@ Object CINE_ChinaVehicleNukeLauncher
       AnimationMode   = MANUAL
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE UNPACKING
+    AliasConditionState = RUBBLE UNPACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = MANUAL
     End
+
     AliasConditionState = PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     ;***
     ConditionState    = REALLYDAMAGED PACKING
@@ -1711,6 +1705,8 @@ Object CINE_ChinaVehicleNukeLauncher
       AnimationMode   = MANUAL
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE PACKING
+    AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
     ConditionState  = DEPLOYED
@@ -1739,6 +1735,10 @@ Object CINE_ChinaVehicleNukeLauncher
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED RUBBLE FIRING_A
+    AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = DEPLOYED RUBBLE RELOADING_A
+    AliasConditionState = DEPLOYED RUBBLE MOVING
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1532,6 +1532,7 @@ Object ChinaVehicleNukeLauncher
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -1558,20 +1559,6 @@ Object ChinaVehicleNukeLauncher
       TurretPitch                     = TurretEL
     End
 
-    ConditionState                    = RUBBLE
-      Model                           = NVNukeCn_D1
-      WeaponLaunchBone                = PRIMARY Muzzle
-      WeaponMuzzleFlash               = PRIMARY MuzzleFX
-      WeaponRecoilBone                = PRIMARY Barrel
-      WeaponLaunchBone                = SECONDARY Muzzle
-      WeaponMuzzleFlash               = SECONDARY MuzzleFX
-      WeaponRecoilBone                = SECONDARY Barrel
-      HideSubObject                   = TURRET01      ;Hide controlled turret
-      ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
-      Turret                          = Turret01
-      TurretPitch                     = TurretEL
-    End
-
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
@@ -1588,7 +1575,8 @@ Object ChinaVehicleNukeLauncher
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
-
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
@@ -1603,6 +1591,8 @@ Object ChinaVehicleNukeLauncher
       AnimationMode   = MANUAL
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE UNPACKING
+    AliasConditionState = RUBBLE UNPACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
@@ -1618,6 +1608,8 @@ Object ChinaVehicleNukeLauncher
       AnimationMode   = MANUAL
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE PACKING
+    AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
     ConditionState  = DEPLOYED
@@ -1646,6 +1638,10 @@ Object ChinaVehicleNukeLauncher
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED RUBBLE FIRING_A
+    AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = DEPLOYED RUBBLE RELOADING_A
+    AliasConditionState = DEPLOYED RUBBLE MOVING
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1763,8 +1763,7 @@ Object ChinaVehicleNukeLauncher
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
     OCL = INITIAL  OCL_RadiationFieldSmall
-    OCL = MIDPOINT OCL_ChinaVehicleNukeCannonDie
-    OCL = FINAL    OCL_RadiationFieldSmall
+    OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -112,7 +112,7 @@ Object MilitiaTank
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_MilitiaTankDeathEffect
+    OCL = FINAL    OCL_MilitiaTankDeathEffect ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -153,8 +153,10 @@ End
 Object ChinaVehicleNukeCannonHulk
   ; *** ART Parameters ***
   Draw                = W3DModelDraw ModuleTag_01
+    ; Patch104p @bugfix xezon 08/02/2023 Hide TURRET01 because parts of it spawn as additional debris.
     ConditionState    = NONE
       Model           = NVNukeCn_D1
+      HideSubObject   = TURRET01
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2045,6 +2045,7 @@ Object Infa_ChinaVehicleNukeLauncher
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -2071,20 +2072,6 @@ Object Infa_ChinaVehicleNukeLauncher
       TurretPitch                     = TurretEL
     End
 
-    ConditionState                    = RUBBLE
-      Model                           = NVNukeCn_D1
-      WeaponLaunchBone                = PRIMARY Muzzle
-      WeaponMuzzleFlash               = PRIMARY MuzzleFX
-      WeaponRecoilBone                = PRIMARY Barrel
-      WeaponLaunchBone                = SECONDARY Muzzle
-      WeaponMuzzleFlash               = SECONDARY MuzzleFX
-      WeaponRecoilBone                = SECONDARY Barrel
-      HideSubObject                   = TURRET01      ;Hide controlled turret
-      ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
-      Turret                          = Turret01
-      TurretPitch                     = TurretEL
-    End
-
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
@@ -2101,7 +2088,8 @@ Object Infa_ChinaVehicleNukeLauncher
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
-
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
@@ -2116,12 +2104,15 @@ Object Infa_ChinaVehicleNukeLauncher
       AnimationMode   = MANUAL
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE UNPACKING
+    AliasConditionState = RUBBLE UNPACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = MANUAL
     End
+
     AliasConditionState = PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     ;***
     ConditionState    = REALLYDAMAGED PACKING
@@ -2130,6 +2121,8 @@ Object Infa_ChinaVehicleNukeLauncher
       AnimationMode   = MANUAL
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE PACKING
+    AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
     ConditionState  = DEPLOYED
@@ -2158,6 +2151,10 @@ Object Infa_ChinaVehicleNukeLauncher
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED RUBBLE FIRING_A
+    AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = DEPLOYED RUBBLE RELOADING_A
+    AliasConditionState = DEPLOYED RUBBLE MOVING
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2275,8 +2275,7 @@ Object Infa_ChinaVehicleNukeLauncher
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
     OCL = INITIAL  OCL_RadiationFieldSmall
-    OCL = MIDPOINT OCL_ChinaVehicleNukeCannonDie
-    OCL = FINAL    OCL_RadiationFieldSmall
+    OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4721,7 +4721,7 @@ Object Lazr_AmericaVehicleTomahawk
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleTomahawkDie
+    OCL = FINAL OCL_AmericaVehicleTomahawkDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5846,7 +5846,7 @@ Object Lazr_AmericaTankCrusader
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_LaserTankDeathEffect
+    OCL = FINAL    OCL_LaserTankDeathEffect ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6571,7 +6571,7 @@ Object Lazr_AmericaVehicleSentryDrone
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleSentryDroneDie
+    OCL = FINAL OCL_AmericaVehicleSentryDroneDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleSentryDroneDeathExplosion ; Patch104p @tweak from FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -7090,7 +7090,7 @@ Object Lazr_AmericaTankMicrowave
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_MicrowaveTankDeath
+    OCL = FINAL    OCL_MicrowaveTankDeath ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3799,8 +3799,7 @@ Object Nuke_ChinaVehicleNukeLauncher
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
     OCL = INITIAL  OCL_RadiationFieldSmall
-    OCL = MIDPOINT OCL_ChinaVehicleNukeCannonDie
-    OCL = FINAL    OCL_RadiationFieldSmall
+    OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3567,6 +3567,7 @@ Object Nuke_ChinaVehicleNukeLauncher
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -3593,20 +3594,6 @@ Object Nuke_ChinaVehicleNukeLauncher
       TurretPitch                     = TurretEL
     End
 
-    ConditionState                    = RUBBLE
-      Model                           = NVNukeCn_D1
-      WeaponLaunchBone                = PRIMARY Muzzle
-      WeaponMuzzleFlash               = PRIMARY MuzzleFX
-      WeaponRecoilBone                = PRIMARY Barrel
-      WeaponLaunchBone                = SECONDARY Muzzle
-      WeaponMuzzleFlash               = SECONDARY MuzzleFX
-      WeaponRecoilBone                = SECONDARY Barrel
-      HideSubObject                   = TURRET01      ;Hide controlled turret
-      ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
-      Turret                          = Turret01
-      TurretPitch                     = TurretEL
-    End
-
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
@@ -3623,7 +3610,8 @@ Object Nuke_ChinaVehicleNukeLauncher
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
-
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
@@ -3638,6 +3626,8 @@ Object Nuke_ChinaVehicleNukeLauncher
       AnimationMode   = ONCE
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE UNPACKING
+    AliasConditionState = RUBBLE UNPACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
@@ -3655,6 +3645,8 @@ Object Nuke_ChinaVehicleNukeLauncher
       Flags           = START_FRAME_LAST
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE PACKING
+    AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
     ConditionState  = DEPLOYED
@@ -3683,6 +3675,10 @@ Object Nuke_ChinaVehicleNukeLauncher
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED RUBBLE FIRING_A
+    AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = DEPLOYED RUBBLE RELOADING_A
+    AliasConditionState = DEPLOYED RUBBLE MOVING
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7561,7 +7561,7 @@ Object SupW_AmericaTankMicrowave
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_MicrowaveTankDeath
+    OCL = FINAL    OCL_MicrowaveTankDeath ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7041,7 +7041,7 @@ Object SupW_AmericaVehicleSentryDrone
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleSentryDroneDie
+    OCL = FINAL OCL_AmericaVehicleSentryDroneDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleSentryDroneDeathExplosion ; Patch104p @tweak from FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5203,7 +5203,7 @@ Object SupW_AmericaVehicleTomahawk
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_GenericTankDeathEffect
-    OCL = MIDPOINT OCL_AmericaVehicleTomahawkDie
+    OCL = FINAL OCL_AmericaVehicleTomahawkDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX =  FINAL FX_AmericaVehicleTomahawkDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17382,8 +17382,7 @@ Object Tank_ChinaVehicleNukeLauncher
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
     OCL = INITIAL  OCL_RadiationFieldSmall
-    OCL = MIDPOINT OCL_ChinaVehicleNukeCannonDie
-    OCL = FINAL    OCL_RadiationFieldSmall
+    OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17152,6 +17152,7 @@ Object Tank_ChinaVehicleNukeLauncher
   ;UpgradeCameo4 = NONE
   ;UpgradeCameo5 = NONE
 
+  ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -17178,20 +17179,6 @@ Object Tank_ChinaVehicleNukeLauncher
       TurretPitch                     = TurretEL
     End
 
-    ConditionState                    = RUBBLE
-      Model                           = NVNukeCn_D1
-      WeaponLaunchBone                = PRIMARY Muzzle
-      WeaponMuzzleFlash               = PRIMARY MuzzleFX
-      WeaponRecoilBone                = PRIMARY Barrel
-      WeaponLaunchBone                = SECONDARY Muzzle
-      WeaponMuzzleFlash               = SECONDARY MuzzleFX
-      WeaponRecoilBone                = SECONDARY Barrel
-      HideSubObject                   = TURRET01      ;Hide controlled turret
-      ShowSubObject                   = TURRETFRONT TURRETBACK  ;Show pack/unpack animated turret
-      Turret                          = Turret01
-      TurretPitch                     = TurretEL
-    End
-
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
@@ -17208,7 +17195,8 @@ Object Tank_ChinaVehicleNukeLauncher
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
-
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
@@ -17223,6 +17211,8 @@ Object Tank_ChinaVehicleNukeLauncher
       AnimationMode   = ONCE
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE UNPACKING
+    AliasConditionState = RUBBLE UNPACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
@@ -17240,6 +17230,8 @@ Object Tank_ChinaVehicleNukeLauncher
       Flags           = START_FRAME_LAST
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
+    AliasConditionState = RUBBLE PACKING
+    AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
     ConditionState  = DEPLOYED
@@ -17268,6 +17260,10 @@ Object Tank_ChinaVehicleNukeLauncher
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED RUBBLE FIRING_A
+    AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = DEPLOYED RUBBLE RELOADING_A
+    AliasConditionState = DEPLOYED RUBBLE MOVING
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -2171,6 +2171,11 @@ End
 
 ; ----------------------------------------------
 ObjectCreationList OCL_ChinaVehicleNukeCannonDie
+  ; Patch104p @tweak xezon 04/02/2023 Moved radiation creation of Nuke Cannon's SlowDeathBehavior to this OCL.
+  CreateObject
+    ObjectNames = RadiationFieldSmall
+    Disposition = ON_GROUND_ALIGNED
+  End
   CreateObject
     ObjectNames = ChinaVehicleNukeCannonHulk
     Offset      = X:0.0 Y:0.0 Z:0.0


### PR DESCRIPTION
**Merge with Rebase.**

* Related to #1163

This change fixes death wreck and debris spawn before model disappears.

Affects

* USA Microwave
* USA Laser Tank
* USA Tomahawk
* USA Sentry Drone
* China Nuke Cannon
* Militia Tank

Crusader Tank wreck was already fixed with #1163.

## Original

https://user-images.githubusercontent.com/4720891/216763444-5ec018bc-6862-45dd-a9ea-93a9713ce2da.mp4
