### PR TITLE
Fix: Remove duplicate radiation field on China Nuke Cannon death

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1832,12 +1832,12 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     Mass = 50.0
   End
 
+  ; Patch104p @fix xezon 04/02/2023 Remove duplicate initial small radiation field.
   Behavior = SlowDeathBehavior ModuleTag_06
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
-    OCL = INITIAL  OCL_RadiationFieldSmall
     OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1752,12 +1752,12 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     Mass = 50.0
   End
 
+  ; Patch104p @fix xezon 04/02/2023 Remove duplicate initial small radiation field.
   Behavior = SlowDeathBehavior ModuleTag_06
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
-    OCL = INITIAL  OCL_RadiationFieldSmall
     OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2265,12 +2265,12 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     Mass = 50.0
   End
 
+  ; Patch104p @fix xezon 04/02/2023 Remove duplicate initial small radiation field.
   Behavior = SlowDeathBehavior ModuleTag_06
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
-    OCL = INITIAL  OCL_RadiationFieldSmall
     OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3788,12 +3788,12 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     Mass = 50.0
   End
 
+  ; Patch104p @fix xezon 04/02/2023 Remove duplicate initial small radiation field.
   Behavior = SlowDeathBehavior ModuleTag_06
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
-    OCL = INITIAL  OCL_RadiationFieldSmall
     OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17371,12 +17371,12 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     Mass = 50.0
   End
 
+  ; Patch104p @fix xezon 04/02/2023 Remove duplicate initial small radiation field.
   Behavior = SlowDeathBehavior ModuleTag_06
     DeathTypes = ALL -CRUSHED -SPLATTED
     DestructionDelay  = 500
     DestructionDelayVariance  = 100
     FX  = INITIAL  FX_ChinaVehicleNukeCannonDeathExplosionInitial
-    OCL = INITIAL  OCL_RadiationFieldSmall
     OCL = FINAL    OCL_ChinaVehicleNukeCannonDie ; Patch104p @bugfix from MIDPOINT to spawn death hulk, debris and effects at the same time.
     FX  = FINAL    FX_ChinaVehicleNukeCannonDeathExplosion
   End


### PR DESCRIPTION
This change removes the duplicate `RadiationFieldSmall` before the Nuke Cannon explodes. This means the small radiation field no longer spawns before the Nuclear Explosion.

## Patched

https://user-images.githubusercontent.com/4720891/216764144-0d3fb69d-dd7e-4fbb-a1dd-cdf86e5c5bce.mp4
