### PR TITLE
Fix Civilian vehicle crush levels

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1212,6 +1212,10 @@ Object AmericaVehicleRepairDrone
   ExperienceRequired = 0 150 450 900 ;Experience points needed to gain each level
   IsTrainable     = Yes  ;Can gain experience
 
+  ; Patch104p @bugfix xezon 04/02/2023 Add same CrusherLevel, CrushableLevel as Sentry Drone.
+  CrusherLevel           = 0  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
   ; *** AUDIO Parameters ***
   VoiceSelect = NoSound
   VoiceMove = NoSound

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -12578,8 +12578,10 @@ Object TruckFarmer
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 1  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 1, CrushableLevel from 1.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -12437,8 +12437,10 @@ Object ForkliftSmall
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
-  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 2, CrushableLevel from 2.
+  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 1  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10551,8 +10551,10 @@ Object FarmerChickenTruck
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 1  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 1, CrushableLevel from 1.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -16291,8 +16291,10 @@ Object Tractor
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrushableLevel from 2.
   CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CrushableLevel         = 1  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -13332,8 +13332,10 @@ Object TruckWork2
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 1  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 1, CrushableLevel from 1.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -11636,7 +11636,9 @@ Object TruckChicken
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 1.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -11249,8 +11249,10 @@ Object ForkliftLarge
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrushableLevel from 3.
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 3  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10688,8 +10688,10 @@ Object SupplyTruck
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 1  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 1, CrushableLevel from 1.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -13206,8 +13206,10 @@ Object TruckWork
     Armor           = TruckArmor
     DamageFX        = CrushableCarDamageFX
   End
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 1  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 1, CrushableLevel from 1.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = CivilianCarBombCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -5211,7 +5211,9 @@ Object Humvee1
   ExperienceValue = 50 100 150 400    ;Experience point value at each level
   ExperienceRequired = 0 150 450 900  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 2.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -64,7 +64,9 @@ Object MilitiaTank
   ExperienceValue        = 70 70 140 280 ; Patch104p @balance commy2 xezon 02/08/2022 From 100 100 200 400
   ExperienceRequired     = 0 200 300 600 ;Experience points needed to gain each level
   IsTrainable            = Yes  ;Can gain experience
-  CrusherLevel           = 1  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+
+  ; Patch104p @bugfix xezon 04/02/2023 Change CrusherLevel from 1.
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet             = GenericCommandSet
 


### PR DESCRIPTION
**Merge with Rebase**

* Fixes #1599

This change fixes crush levels of Civilian, Unused vehicles.

* Civilian Humvee1 can now crush trees
* Civilian MilitiaTank can now crush trees
* Civilian Tractor (small) can now be crushed by vehicles
* Civilian ForkliftSmall can now be crushed by vehicles, can no longer crush trees
* Civilian TruckChicken can now crush trees
* Civilian FarmerChickenTruck can no longer be crushed by vehicles, can now crush trees
* Civilian SupplyTruck can no longer be crushed by vehicles, can now crush trees
* Civilian FarmerTruck can no longer be crushed by vehicles, can now crush trees
* Civilian TruckWork can no longer be crushed by vehicles, can now crush trees
* Civilian TruckWork2 can no longer be crushed by vehicles, can now crush trees
* Civilian TruckFarmer can no longer be crushed by vehicles, can now crush trees
* Civilian ForkliftLarge can now be crushed by Overlord and similar
* USA AmericaVehicleRepairDrone can now be crushed by Overlord and similar

## Controversial

TruckWork is used in popular Defcon 6 map. If cars in Defcon 6 are meant to be crushable, then cars in Defcon 6 need to be replaced with similar car that is crushable by general vehicles.

## Affected vehicles

![shot_20230204_190536_2](https://user-images.githubusercontent.com/4720891/216782716-630bf73f-cef7-4400-a068-181d3a9d20fe.jpg)
