### PR TITLE
Fix: Add proper text to Civilian Tractor

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -16188,7 +16188,7 @@ Object Tractor
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Backhoe
+  DisplayName      = OBJECT:Tractor
   EditorSorting   = VEHICLE
 
   TransportSlotCount  = 3                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
This change adds proper text to Civilian Tractor. It is no longer called "Backhoe".