### PR TITLE
Fix: Civilian FarmerTruck now has correct model

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10615,16 +10615,19 @@ Object FarmerTruck
   ButtonImage            = SUTerrorist
 
   Draw = W3DModelDraw ModuleTag_01
+    ; Patch104p @fix xezon 05/02/2023 Change Model from CVFRMRTK.
     ConditionState = NONE
-      Model = CVFrmrtk
+      Model = CVFRMRTRK
     End
 
+    ; Patch104p @fix xezon 05/02/2023 Change Model from CVFRMRTK_D.
     ConditionState = REALLYDAMAGED
-      Model = CVFrmrtk_D
+      Model = CVFRMRTRK_D
     End
 
+    ; Patch104p @fix xezon 05/02/2023 Change Model from CVFRMRTK_D.
     ConditionState = RUBBLE
-      Model = CVFrmrtk_D
+      Model = CVFRMRTRK_D
     End
   End
 


### PR DESCRIPTION
* Closes #1634

Civilian FarmerTruck now has correct model. CVFrmrtk.w3d & Co do not exist.