### PR TITLE
Fix: Civilian FarmerChickenTruck now has correct display name

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10508,7 +10508,8 @@ Object FarmerChickenTruck
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:AsianCar
+  ; Patch104p @fix xezon 05/02/2023 Change DisplayName from OBJECT:AsianCar.
+  DisplayName      = OBJECT:ChickenTruck
   EditorSorting   = VEHICLE
 
   TransportSlotCount  = 3                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
Civilian FarmerChickenTruck now has correct display name.