### PR TITLE
Remove obsolete BattleMasterTransitionDebrisSmall effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -2603,10 +2603,6 @@ FXList FX_BattleMasterDamageTransitionSmall
     Name = BattleMasterTransitionLenzflareSmall
     Offset = X:0 Y:0 Z:1
   End
-  ParticleSystem
-    Name = BattleMasterTransitionDebrisSmall
-    Offset = X:0 Y:0 Z:10
-  End
   ViewShake
     Type = SUBTLE
   End
@@ -2624,10 +2620,6 @@ FXList FX_BattleDroneDamageTransitionSmall
   ParticleSystem
     Name = BattleMasterTransitionLenzflareSmall
     Offset = X:0 Y:0 Z:1
-  End
-  ParticleSystem
-    Name = BattleMasterTransitionDebrisSmall
-    Offset = X:0 Y:0 Z:10
   End
   ViewShake
     Type = SUBTLE


### PR DESCRIPTION
This change remove obsolete BattleMasterTransitionDebrisSmall effects. The referenced effect does not exist.