### PR TITLE
Change: Civilian Humvee1 now uses the same transition damage effects as regular Humvees

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -5294,10 +5294,10 @@ Object Humvee1
   ;  CreationList = OCL_EjectPilotOnGround
   ;End
 
+  ; Patch104p @tweak xezon 05/02/2023 Use same damage transition effects as regular America Humvee.
   Behavior = TransitionDamageFX ModuleTag_12
     ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
-    ReallyDamagedParticleSystem2 = Bone:Smoke RandomBone:Yes PSys:ArmExplosionSmall01
-    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_HumveeDamageTransition
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
   End
 
   Behavior = FlammableUpdate ModuleTag_21


### PR DESCRIPTION
Humvee1 uses legacy transition damage effects. They are over the top. The arm pillar is not even shown in the video below, because pillar explosions are broken in Original. All Humvees now use the same transition damage effects.

## Original

https://user-images.githubusercontent.com/4720891/216846336-5976c6b8-9a7c-402c-a7a6-f8fc51cde6af.mp4
