### PR TITLE
Fix boat damage models and effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -12882,6 +12882,14 @@ Object BoatFishingTrowler
     ConditionState = NONE
       Model = CVTROWLER
     End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVTROWLER_D
+    End
+    ConditionState = RUBBLE
+      Model = CVTROWLER_D
+    End
   End
 
   ; ***DESIGN parameters ***
@@ -13230,6 +13238,14 @@ Object BoatTugboat
   Draw = W3DModelDraw ModuleTag_01
     ConditionState = NONE
       Model = CVTUGBOAT
+    End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVTUGBOAT_D
+    End
+    ConditionState = RUBBLE
+      Model = CVTUGBOAT_D
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -12924,7 +12924,11 @@ Object BoatFishingTrowler
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -13283,7 +13287,11 @@ Object BoatTugboat
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -12555,7 +12555,11 @@ Object BoatAsianFishing
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add standard transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_10
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED


### PR DESCRIPTION
**Merge with Rebase**

This change fixes boat damage models and effects.

Adds models for damaged states of
* BoatFishingTrowler
* BoatTugboat

Adds transition damage effects for
* BoatFishingTrowler
* BoatTugboat
* BoatAsianFishing

The other boats do not have models for damaged states.

## Patched

https://user-images.githubusercontent.com/4720891/216848957-8722986e-5f88-43a8-9c83-6b015a4ab274.mp4
