### PR TITLE
Fix plane damage models and effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -11340,6 +11340,12 @@ Object AircraftCropDuster
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes Psys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:5 FXList:FX_MIGDamageTransition
+  End
+
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
   End
@@ -11465,7 +11471,11 @@ Object AircraftCessna
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes Psys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:5 FXList:FX_MIGDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -11299,8 +11299,9 @@ Object AircraftCropDuster
       Model = CVCDTPLN_D
     End
 
+    ; Patch104p @fix xezon 05/02/2023 Change Model from CVCDTPLN.
     ConditionState = RUBBLE
-      Model = CVCDTPLN
+      Model = CVCDTPLN_D
     End
   End
 


### PR DESCRIPTION
**Merge with Rebase**

This change fixes plane damage models and effects.

Fixes models for damaged states of

* AircraftCropDuster (non-consequential)

Adds transition damage effects for

* AircraftCropDuster
* AircraftCessna

The transition damage effect is the one that all faction Jets use too.

## Patched

https://user-images.githubusercontent.com/4720891/217061169-9d4459fb-281a-41eb-a66d-4f57ce95d93d.mp4
