### PR TITLE
Fix car damage models and effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -2612,6 +2612,20 @@ FXList FX_BattleMasterDamageTransitionSmall
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @feature xezon 12/02/2023 Damage transition effect for cars.
+; -----------------------------------------------------------------------------
+FXList FX_CarDamageTransition
+  ParticleSystem
+    Name = CarTransitionSmoke
+    Offset = X:0 Y:0 Z:5
+    OrientToObject = Yes
+  End
+  Sound
+    Name = CarDamagedState
+  End
+End
+
+; -----------------------------------------------------------------------------
 FXList FX_BattleDroneDamageTransitionSmall
   ParticleSystem
     Name = BattleMasterTransitionExplosionSmall

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10558,6 +10558,11 @@ Object FarmerChickenTruck
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
@@ -10688,7 +10693,11 @@ Object SupplyTruck
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -11107,6 +11116,12 @@ Object TractorBackhoe
   Body            = ActiveBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
+  End
+
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
   End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
@@ -12291,6 +12306,12 @@ Object Firetruck
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
+
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
   End
@@ -12554,7 +12575,11 @@ Object TruckFarmer
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -12798,7 +12823,11 @@ Object TourBus
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -12917,6 +12946,11 @@ Object DoubleDeckerTourBus
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
@@ -13169,7 +13203,11 @@ Object TruckWork
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -13289,7 +13327,11 @@ Object TruckWork2
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10256,6 +10256,14 @@ Object CarAmbulance
     ConditionState = NONE
       Model = CVAMBLNCE
     End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVAMBLNCE_D
+    End
+    ConditionState = RUBBLE
+      Model = CVAMBLNCE_D
+    End
   End
 
   ; ***DESIGN parameters ***
@@ -11174,6 +11182,14 @@ Object ForkliftLarge
     ConditionState = NONE
       Model = CVCARGOBM
     End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVCARGOBM_D
+    End
+    ConditionState = RUBBLE
+      Model = CVCARGOBM_D
+    End
   End
 
   ; ***DESIGN parameters ***
@@ -11549,6 +11565,14 @@ Object TruckChicken
     ConditionState = NONE
       Model = CVCHKNTRK
     End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVCHKNTRK_D
+    End
+    ConditionState = RUBBLE
+      Model = CVCHKNTRK_D
+    End
   End
 
   ; ***DESIGN parameters ***
@@ -11670,6 +11694,14 @@ Object TractorCombine
     ConditionState = NONE
       Model = CVCOMBINE
     End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVCOMBINE_D
+    End
+    ConditionState = RUBBLE
+      Model = CVCOMBINE_D
+    End
   End
 
   ; ***DESIGN parameters ***
@@ -11789,6 +11821,14 @@ Object CarEuroVan1
     ConditionState = NONE
       Model = CVEUROVAN1
     End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVEUROVAN1_D
+    End
+    ConditionState = RUBBLE
+      Model = CVEUROVAN1_D
+    End
   End
 
   ; ***DESIGN parameters ***
@@ -11907,6 +11947,14 @@ Object CarEuroVan2
   Draw = W3DModelDraw ModuleTag_01
     ConditionState = NONE
       Model = CVEUROVAN2
+    End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVEUROVAN2_D
+    End
+    ConditionState = RUBBLE
+      Model = CVEUROVAN2_D
     End
   End
 
@@ -12029,6 +12077,14 @@ Object CarEuroPoliceVan
       Model = CVEUROVAN3
       Animation = CVEUROVAN3.CVEUROVAN3
       AnimationMode = LOOP
+    End
+
+    ; Patch104p @fix xezon 05/02/2023 Add models for damaged states.
+    ConditionState = REALLYDAMAGED
+      Model = CVEUROVAN3_D
+    End
+    ConditionState = RUBBLE
+      Model = CVEUROVAN2_D
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10434,7 +10434,10 @@ Object CarAsian1
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -10975,7 +10978,10 @@ Object CarAsian2
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED
@@ -12413,6 +12419,11 @@ Object ForkliftSmall
   Body            = ActiveBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
+  End
+
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
   End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
@@ -16243,7 +16254,10 @@ Object Tractor
     InitialHealth   = 100.0
   End
 
-
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_03
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -10301,6 +10301,10 @@ Object CarAmbulance
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
@@ -11227,6 +11231,12 @@ Object ForkliftLarge
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
+
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
   End
@@ -11610,6 +11620,11 @@ Object TruckChicken
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
@@ -11739,6 +11754,12 @@ Object TractorCombine
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
+
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
   End
@@ -11864,6 +11885,11 @@ Object CarEuroVan1
   Body            = ActiveBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
+  End
+
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
   End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
@@ -11993,6 +12019,10 @@ Object CarEuroVan2
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
+  End
 
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
@@ -12121,6 +12151,11 @@ Object CarEuroPoliceVan
   Body            = ActiveBody ModuleTag_02
     MaxHealth       = 100.0
     InitialHealth   = 100.0
+  End
+
+  ; Patch104p @fix xezon 05/02/2023 Add transition damage effects.
+  Behavior = TransitionDamageFX ModuleTag_TransitionDamage
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_CarDamageTransition
   End
 
   Behavior = DestroyDie ModuleTag_DeathTag03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -12278,13 +12278,14 @@ Object ForkliftSmall
       Model = CVFKLT
     End
 
+    ; Patch104p @fix xezon 04/02/2023 Change Model from CVFKLT.
     ConditionState = REALLYDAMAGED
-      Model = CVFKLT
-
+      Model = CVFKLT_D
     End
 
+    ; Patch104p @fix xezon 04/02/2023 Change Model from CVFKLT.
     ConditionState = RUBBLE
-      Model = CVFKLT
+      Model = CVFKLT_D
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -42979,6 +42979,65 @@ ParticleSystem MIGTransitionSmoke
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p, A copy of MIGTransitionSmoke, but smaller
+ParticleSystem CarTransitionSmoke
+  Priority = UNIT_DAMAGE_FX
+  IsOneShot = No
+  Shader = ALPHA
+  Type = PARTICLE
+  ParticleName = EXCloud01.tga
+  AngleZ = 0.00 0.25
+  AngularRateZ = -0.01 0.01
+  AngularDamping = 0.50 0.50
+  VelocityDamping = 0.90 0.98
+  Gravity = 0.00
+  Lifetime = 40.00 40.00
+  SystemLifetime = 2
+  Size = 2.00 3.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 5.00 10.00
+  SizeRateDamping = 0.70 0.70
+  Alpha1 = 0.00 0.00 0
+  Alpha2 = 1.00 1.00 5
+  Alpha3 = 0.00 0.00 30
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:128 G:128 B:128 0
+  Color2 = R:0 G:0 B:0 0
+  Color3 = R:0 G:0 B:0 0
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 1.00 1.00
+  BurstCount = 10.00 10.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.00
+  VelocityType = ORTHO
+  VelOrthoX = -0.50 0.50
+  VelOrthoY = -0.50 0.50
+  VelOrthoZ = -0.00 0.00
+  VolumeType = CYLINDER
+  VolCylinderRadius = 20.00
+  VolCylinderLength = 5.00
+  IsHollow = No
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
 ParticleSystem airCarrierShockWave
   Priority = DEATH_EXPLOSION
   IsOneShot = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -4156,6 +4156,18 @@ AudioEvent VehicleDamagedState
   Type        = world shrouded everyone
 End
 
+; Patch104p, A copy of VehicleDamagedState, but quieter.
+AudioEvent CarDamagedState
+  Sounds      = gbuidama gbuidamb gbuidamc gbuidamd gbuidame gbuidamf gbuidamg
+  Control     = random interrupt
+  VolumeShift = -20
+  PitchShift  = -10 10
+  Limit       = 2
+  Volume      = 60
+  Priority    = normal
+  Type        = world shrouded everyone
+End
+
 AudioEvent NukeCannonWeapon
   Sounds =  vnukweaa
   Control = interrupt


### PR DESCRIPTION
**Merge with Rebase**

This change fixes car damage models and effects.

Sets correct damaged models for

* ForkliftSmall

Adds models for damaged states of

* CarAmbulance
* ForkliftLarge
* TruckChicken
* TractorCombine
* CarEuroVan1
* CarEuroVan2
* CarEuroPoliceVan

Adds transition damage effects for

* CarAmbulance (SMALL)
* ForkliftLarge (LARGE)
* TruckChicken (LARGE)
* TractorCombine (LARGE)
* CarEuroVan1 (SMALL)
* CarEuroVan2 (SMALL)
* CarEuroPoliceVan (SMALL)

## The following cars already have models for damaged states

Adds SMALL transition damage effects for

* CarAsian1
* CarAsian2
* ForkliftSmall
* Tractor

Adds LARGE transition damage effects for

* FarmerChickenTruck
* SupplyTruck
* TractorBackhoe
* Firetruck
* TruckFarmer
* TourBus
* DoubleDeckerTourBus
* TruckWork
* TruckWork2

## About some other cars

There are other cars with damage models, however, they are not suitable for damage states, because their damaged models are flat cars for crushes. And the trains look odd when damaged.

* CarCamaro
* CarSport01
* CarLuxury01
* CarLuxury02
* CarLuxury03
* CarLuxury04
* CarSedan01
* CarSUV01Suicide
* CarSUV01
* CarCompact
* CarTaxiCab01
* TrainRocketTransport
* TrainCarFlat
* TrainCarRocket
* TrainRocketTransportWithRocket
* CarSUV01Nuke

Note that there are 2 relevant art issues, which are not introduced and not fixed with this change:
* #1633
* #1641

## Patched

https://user-images.githubusercontent.com/4720891/217076457-ebeb8a22-323f-4688-b6d2-3626db1720fe.mp4

https://user-images.githubusercontent.com/4720891/217076503-3dac1659-c345-4c49-a23b-e091bb104ca8.mp4
