### PR TITLE
Revert: Replace Microwave Haze effect from Microwave and GPS Scrambler to avoid rendering issues on some hardware configurations 2 (#1612)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -395,7 +395,7 @@ Object GPSScrambler_InvisibleMarker
 
     DefaultConditionState
       Model = None
-      ParticleSysBone = None GPSMicrowaveScrambler
+      ParticleSysBone = None GPSMicrowaveScambler
       ParticleSysBone = None GPSRotisserie
       ParticleSysBone = None gpsScrambleCloud
     End


### PR DESCRIPTION
Fix #1612 had mistake.