### PR TITLE
Fix: Set proper animation modes and flags for China Nuke Cannon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1667,6 +1667,15 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
+  ; Patch104p @tweak xezon 10/02/2023 Sets proper animation modes and flags on condition states for robustness:
+  ;   MOVING:    AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_FIRST
+  ;   UNPACKING: AnimationMode = ONCE
+  ;              Flags         = START_FRAME_FIRST
+  ;   PACKING:   AnimationMode = ONCE_BACKWARDS
+  ;              Flags         = START_FRAME_LAST
+  ;   DEPLOYED:  AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_LAST
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -1692,7 +1701,7 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -1701,7 +1710,7 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED MOVING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -1711,14 +1720,16 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     ;***
     ConditionState    = REALLYDAMAGED UNPACKING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE UNPACKING
@@ -1727,7 +1738,8 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
     End
 
     AliasConditionState = PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
@@ -1735,7 +1747,8 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED PACKING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE PACKING
@@ -1745,7 +1758,7 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK   ;Hide pack/unpack animated turret
@@ -1760,7 +1773,7 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK  ;Hide pack/unpack animated turret

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1565,6 +1565,15 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
+  ; Patch104p @tweak xezon 10/02/2023 Sets proper animation modes and flags on condition states for robustness:
+  ;   MOVING:    AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_FIRST
+  ;   UNPACKING: AnimationMode = ONCE
+  ;              Flags         = START_FRAME_FIRST
+  ;   PACKING:   AnimationMode = ONCE_BACKWARDS
+  ;              Flags         = START_FRAME_LAST
+  ;   DEPLOYED:  AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_LAST
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -1594,7 +1603,7 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -1603,7 +1612,7 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED MOVING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -1613,14 +1622,16 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     ;***
     ConditionState    = REALLYDAMAGED UNPACKING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE UNPACKING
@@ -1629,7 +1640,8 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
     End
 
     AliasConditionState = PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
@@ -1637,7 +1649,8 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED PACKING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE PACKING
@@ -1647,7 +1660,7 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK   ;Hide pack/unpack animated turret
@@ -1662,7 +1675,7 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK  ;Hide pack/unpack animated turret

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2045,6 +2045,15 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
+  ; Patch104p @tweak xezon 10/02/2023 Sets proper animation modes and flags on condition states for robustness:
+  ;   MOVING:    AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_FIRST
+  ;   UNPACKING: AnimationMode = ONCE
+  ;              Flags         = START_FRAME_FIRST
+  ;   PACKING:   AnimationMode = ONCE_BACKWARDS
+  ;              Flags         = START_FRAME_LAST
+  ;   DEPLOYED:  AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_LAST
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -2074,7 +2083,7 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -2083,7 +2092,7 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED MOVING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -2093,14 +2102,16 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     ;*** UNPACKING STATE  -- preparing to fire ***
     ConditionState    = UNPACKING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     ;***
     ConditionState    = REALLYDAMAGED UNPACKING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE UNPACKING
@@ -2109,7 +2120,8 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     ;*** PACKING STATE -- preparing to move ***
     ConditionState    = PACKING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
     End
 
     AliasConditionState = PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
@@ -2117,7 +2129,8 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED PACKING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = MANUAL
+      AnimationMode   = ONCE_BACKWARDS
+      Flags           = START_FRAME_LAST
     End
     AliasConditionState = REALLYDAMAGED PACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE PACKING
@@ -2127,7 +2140,7 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK   ;Hide pack/unpack animated turret
@@ -2142,7 +2155,7 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK  ;Hide pack/unpack animated turret

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3567,6 +3567,15 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
+  ; Patch104p @tweak xezon 10/02/2023 Sets proper animation modes and flags on condition states for robustness:
+  ;   MOVING:    AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_FIRST
+  ;   UNPACKING: AnimationMode = ONCE
+  ;              Flags         = START_FRAME_FIRST
+  ;   PACKING:   AnimationMode = ONCE_BACKWARDS
+  ;              Flags         = START_FRAME_LAST
+  ;   DEPLOYED:  AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_LAST
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -3596,7 +3605,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -3605,7 +3614,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED MOVING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -3616,6 +3625,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     ConditionState    = UNPACKING
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     ;***
@@ -3623,6 +3633,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
       AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE UNPACKING
@@ -3651,7 +3662,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK   ;Hide pack/unpack animated turret
@@ -3666,7 +3677,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK  ;Hide pack/unpack animated turret

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17185,6 +17185,15 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix xezon 08/02/2023 Shows NVNukeCn_D model on RUBBLE as well.
+  ; Patch104p @tweak xezon 10/02/2023 Sets proper animation modes and flags on condition states for robustness:
+  ;   MOVING:    AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_FIRST
+  ;   UNPACKING: AnimationMode = ONCE
+  ;              Flags         = START_FRAME_FIRST
+  ;   PACKING:   AnimationMode = ONCE_BACKWARDS
+  ;              Flags         = START_FRAME_LAST
+  ;   DEPLOYED:  AnimationMode = MANUAL
+  ;              Flags         = START_FRAME_LAST
   Draw = W3DTankDraw ModuleTag_01
 
     InitialRecoilSpeed   = 120
@@ -17214,7 +17223,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     ;*** PACKED STATE -- ready to move ***
     ConditionState    = MOVING
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -17223,7 +17232,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     ConditionState    = REALLYDAMAGED MOVING
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE_BACKWARDS
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A ;Very long shot delay -- possibly moving
@@ -17234,6 +17243,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     ConditionState    = UNPACKING
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     ;***
@@ -17241,6 +17251,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
       AnimationMode   = ONCE
+      Flags           = START_FRAME_FIRST
     End
     AliasConditionState = REALLYDAMAGED UNPACKING BETWEEN_FIRING_SHOTS_A ;Very long shot delay
     AliasConditionState = RUBBLE UNPACKING
@@ -17269,7 +17280,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK   ;Hide pack/unpack animated turret
@@ -17284,7 +17295,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
       Animation       = NVNukeCn_D.NVNukeCn_D
-      AnimationMode   = ONCE
+      AnimationMode   = MANUAL
       Flags           = START_FRAME_LAST
       TransitionKey   = TRANS_FIRING_A
       HideSubObject   = TURRETFRONT TURRETBACK  ;Hide pack/unpack animated turret


### PR DESCRIPTION
This change sets proper animation modes and flags for China Nuke Cannon.

The original setup does work, but logically makes no sense. The original setups of Nuke Cannon differ between Regular China and Nuke General.

With this change the model condition states get proper setup:
```
MOVING:    AnimationMode = MANUAL
           Flags         = START_FRAME_FIRST
UNPACKING: AnimationMode = ONCE
           Flags         = START_FRAME_FIRST
PACKING:   AnimationMode = ONCE_BACKWARDS
           Flags         = START_FRAME_LAST
DEPLOYED:  AnimationMode = MANUAL
           Flags         = START_FRAME_LAST
```

I looked up animation code in Thyme, and MANUAL flag is synonymous for paused state. in MOVING and DEPLOYED states it now pauses animation at first and last frames respectively, and in the UNPACKING and PACKING states it will play animation ONCE from first frame or last frame respectively.

Thyme code does not yet have Deployment logic implement, but I suspect animations work with slightly inaccurate setups because it is setup in a way where it can borrow Animation mode and flags for UNPACKING and PACKING states from MOVING AND DEPLOYED states, if UNPACKING and PACKING are set to MANUAL, aka pause. So in a way code defends itself from configuration errors.

With new configuration, animation setup is explicit.

## Patched

https://user-images.githubusercontent.com/4720891/218091512-c93798fb-7cb8-42f8-bd7b-3f6acc7edf4d.mp4

