### PR TITLE
Fix vehicle hulk flags of Civilian Militia Tank, CarLimo03, Humvee1

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -2257,7 +2257,10 @@ Object CarLimo03DeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE
+
+  ; Patch104p @tweak xezon 07/02/2023 Removes obsolete immobile flag.
+  ; Patch104p @fix xezon 07/02/2023 Adds missing no_collide, hulk, unattackable flags.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -5595,7 +5595,10 @@ Object Humvee1DeadHull
   ; *** AUDIO Parameters ***
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = CAN_CAST_REFLECTIONS IMMOBILE
+
+  ; Patch104p @tweak xezon 07/02/2023 Removes obsolete immobile flag.
+  ; Patch104p @fix xezon 07/02/2023 Adds missing no_collide, hulk, unattackable flags.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 1.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -1637,7 +1637,8 @@ Object DestroyedMilitiaTank
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
-  KindOf = CAN_CAST_REFLECTIONS HULK
+  ; Patch104p @fix xezon 28/01/2023 Adds missing no_collide flag.
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK
 
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 100.0


### PR DESCRIPTION
**Merge with Rebase**

This change fixes vehicle hulk flags of Civilian Militia Tank, CarLimo03, Humvee1. Hulks can no longer be attacked and collided with.

Collision issue can not be observed in original Game, because the hulks are not spawned correctly. This will change with fixed setups.