### PR TITLE
Change: Add suicide car bomb ability to Civilian AircraftCropDuster

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -2146,6 +2146,12 @@ Object ShiekLimo
     Weapon = PRIMARY None
   End
 
+  ; Note: This vehicle cannot be a suicide bomber because it has voices.
+  ;WeaponSet
+  ;  Conditions = CARBOMB
+  ;  Weapon = PRIMARY SuicideCarBomb
+  ;End
+
   ;Behavior = TransportContain ModuleTag_02 ; Commented out, ML. Design wants no transport caps for limo
   ;  Slots = 5
   ;End
@@ -11361,10 +11367,12 @@ Object AircraftCropDuster
     Conditions = None
     Weapon = PRIMARY None
   End
-;  WeaponSet
-;    Conditions = CARBOMB
-;    Weapon = PRIMARY  SuicideCarBomb
-;  End
+
+  ; Patch104p @feature xezon 07/02/2023 Enable suicide car bomb.
+  WeaponSet
+    Conditions = CARBOMB
+    Weapon = PRIMARY SuicideCarBomb
+  End
 
   ArmorSet
     Armor           = TruckArmor


### PR DESCRIPTION
This change adds suicide car bomb ability to Civilian AircraftCropDuster, ~~Scooter~~.

Note that other carts and planes can also be used by bombers already.

https://user-images.githubusercontent.com/4720891/217649930-f6ae893e-02c0-46f2-8e46-c576927308da.mp4

