### PR TITLE
Fix: GLA Toxin Tractor wreck spawned before model disappears

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18373,7 +18373,7 @@ Object Chem_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect ; Patch104p @bugfix from INITIAL to spawn death hulk, debris and effects at the same time.
     FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 
@@ -18386,7 +18386,7 @@ Object Chem_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect
     FX                        = FINAL Chem_FX_ToxinTruckExplosionGamma
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19756,7 +19756,7 @@ Object Demo_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL Demo_OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL Demo_OCL_ToxinTractorDeathEffect ; Patch104p @bugfix from INITIAL to spawn death hulk, debris and effects at the same time.
     ;FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1612,7 +1612,7 @@ Object GC_Chem_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect ; Patch104p @bugfix from INITIAL to spawn death hulk, debris and effects at the same time.
     FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 
@@ -1625,7 +1625,7 @@ Object GC_Chem_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect
     FX                        = FINAL Chem_FX_ToxinTruckExplosionGamma
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -5870,7 +5870,7 @@ Object CINE_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = INITIAL OCL_ToxinTractorDeathEffect ; Patch104p @note This OCL spawns too early.
     FX                        = FINAL FX_ToxinTruckExplosionOneFinal
     OCL                       = FINAL OCL_PoisonFieldSmall
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4051,7 +4051,7 @@ Object GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect ; Patch104p @bugfix from INITIAL to spawn death hulk, debris and effects at the same time.
     FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
@@ -4064,7 +4064,7 @@ Object GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect
     FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19807,7 +19807,7 @@ Object Slth_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect ; Patch104p @bugfix from INITIAL to spawn death hulk, debris and effects at the same time.
     FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
@@ -19820,7 +19820,7 @@ Object Slth_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL OCL_ToxinTractorDeathEffect
+    OCL                       = FINAL OCL_ToxinTractorDeathEffect
     FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 


### PR DESCRIPTION
* Related to #1618

This change fixes GLA Toxin Tractor wreck spawning before model disappears.

## Original

https://user-images.githubusercontent.com/4720891/217664741-c8a23a28-7196-4da0-9f58-d2d68d0746db.mp4
