### PR TITLE
Fix: China Nuke Cannon animation jumps while it creeps forward after firing

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1742,6 +1742,7 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
+    ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = ONCE
@@ -1754,6 +1755,7 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RELOADING_A
     AliasConditionState = DEPLOYED MOVING
+    AliasConditionState = DEPLOYED MOVING BETWEEN_FIRING_SHOTS_A
 
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
@@ -1768,10 +1770,12 @@ Object CINE_ChinaVehicleNukeLauncher ; Alias CINE_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE FIRING_A
     AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE RELOADING_A
     AliasConditionState = DEPLOYED RUBBLE MOVING
+    AliasConditionState = DEPLOYED RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1644,6 +1644,7 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
+    ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = ONCE
@@ -1656,6 +1657,7 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RELOADING_A
     AliasConditionState = DEPLOYED MOVING
+    AliasConditionState = DEPLOYED MOVING BETWEEN_FIRING_SHOTS_A
 
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
@@ -1670,10 +1672,12 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE FIRING_A
     AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE RELOADING_A
     AliasConditionState = DEPLOYED RUBBLE MOVING
+    AliasConditionState = DEPLOYED RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2124,6 +2124,7 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
+    ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = ONCE
@@ -2136,6 +2137,7 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RELOADING_A
     AliasConditionState = DEPLOYED MOVING
+    AliasConditionState = DEPLOYED MOVING BETWEEN_FIRING_SHOTS_A
 
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
@@ -2150,10 +2152,12 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE FIRING_A
     AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE RELOADING_A
     AliasConditionState = DEPLOYED RUBBLE MOVING
+    AliasConditionState = DEPLOYED RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3648,6 +3648,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
+    ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = ONCE
@@ -3660,6 +3661,7 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RELOADING_A
     AliasConditionState = DEPLOYED MOVING
+    AliasConditionState = DEPLOYED MOVING BETWEEN_FIRING_SHOTS_A
 
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
@@ -3674,10 +3676,12 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE FIRING_A
     AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE RELOADING_A
     AliasConditionState = DEPLOYED RUBBLE MOVING
+    AliasConditionState = DEPLOYED RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17266,6 +17266,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     AliasConditionState = RUBBLE PACKING BETWEEN_FIRING_SHOTS_A
 
     ;*** DEPLOYED STATE -- ready to fire ***
+    ; Patch104p @bugfix xezon 09/02/2023 Adds MOVING BETWEEN_FIRING_SHOTS_A states to fix animation jump while vehicle creeps forward after firing.
     ConditionState  = DEPLOYED
       Animation       = NVNukeCn.NVNukeCn
       AnimationMode   = ONCE
@@ -17278,6 +17279,7 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RELOADING_A
     AliasConditionState = DEPLOYED MOVING
+    AliasConditionState = DEPLOYED MOVING BETWEEN_FIRING_SHOTS_A
 
     ConditionState  = DEPLOYED REALLYDAMAGED
       Model           = NVNukeCn_D
@@ -17292,10 +17294,12 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
     AliasConditionState = DEPLOYED REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED REALLYDAMAGED RELOADING_A
     AliasConditionState = DEPLOYED REALLYDAMAGED MOVING
+    AliasConditionState = DEPLOYED REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE FIRING_A
     AliasConditionState = DEPLOYED RUBBLE BETWEEN_FIRING_SHOTS_A
     AliasConditionState = DEPLOYED RUBBLE RELOADING_A
     AliasConditionState = DEPLOYED RUBBLE MOVING
+    AliasConditionState = DEPLOYED RUBBLE MOVING BETWEEN_FIRING_SHOTS_A
 
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second


### PR DESCRIPTION
* Fixes #1651

This change fixes China Nuke Cannon animation jump while vehicle creeps forward after firing.

https://user-images.githubusercontent.com/4720891/218319935-7506c461-6ad3-40b8-8535-562e1d449e33.mp4
