### PR TITLE
Fix China Battlemaster and Overlord death effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20625,11 +20625,13 @@ Object Boss_TankOverlord
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01
-    ConditionState        = NONE
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -20646,13 +20648,14 @@ Object Boss_TankOverlord
       WeaponLaunchBone = PRIMARY Muzzle
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState        = RUBBLE
       Model               = NVOvrlrd_d
       Turret              = Turret01
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponRecoilBone    = PRIMARY Barrel
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponLaunchBone = PRIMARY Muzzle
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks           = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1061,9 +1061,12 @@ Object CINE_ChinaTankBattleMaster
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
+
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model               = CINE_BttlMstr
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -1077,9 +1080,15 @@ Object CINE_ChinaTankBattleMaster
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       WeaponLaunchBone    = PRIMARY Muzzle
     End
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model               = NVBtMstr_D
       Turret              = Turret01
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone    = PRIMARY None
     End
 
     TrackMarks              = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1261,11 +1261,13 @@ Object CINE_ChinaTankOverlord
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01
-    ConditionState        = NONE
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -1282,13 +1284,14 @@ Object CINE_ChinaTankOverlord
       WeaponLaunchBone = PRIMARY Muzzle
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState        = RUBBLE
       Model               = NVOvrlrd_d
       Turret              = Turret01
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponRecoilBone    = PRIMARY Barrel
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponLaunchBone = PRIMARY Muzzle
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks           = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -235,11 +235,13 @@ Object ChinaTankOverlord
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01
-    ConditionState        = NONE
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -256,13 +258,14 @@ Object ChinaTankOverlord
       WeaponLaunchBone = PRIMARY Muzzle
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState        = RUBBLE
       Model               = NVOvrlrd_d
       Turret              = Turret01
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponRecoilBone    = PRIMARY Barrel
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponLaunchBone = PRIMARY Muzzle
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks           = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -14,9 +14,12 @@ Object ChinaTankBattleMaster
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
+
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model               = NVBtMstr
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -30,9 +33,15 @@ Object ChinaTankBattleMaster
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       WeaponLaunchBone    = PRIMARY Muzzle
     End
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model               = NVBtMstr_D
       Turret              = Turret01
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone    = PRIMARY None
     End
 
     TrackMarks              = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16937,9 +16937,12 @@ Object Nuke_ChinaTankBattleMaster
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
+
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model               = NVBtMstrNG
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -16953,9 +16956,15 @@ Object Nuke_ChinaTankBattleMaster
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       WeaponLaunchBone    = PRIMARY Muzzle
     End
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model               = NVBtMstrNG_D
       Turret              = Turret01
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone    = PRIMARY None
     End
 
     TrackMarks              = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17154,11 +17154,13 @@ Object Nuke_ChinaTankOverlord
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01
-    ConditionState        = NONE
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -17175,13 +17177,14 @@ Object Nuke_ChinaTankOverlord
       WeaponLaunchBone = PRIMARY Muzzle
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState        = RUBBLE
       Model               = NVOvrlrd_d
       Turret              = Turret01
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponRecoilBone    = PRIMARY Barrel
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponLaunchBone = PRIMARY Muzzle
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks           = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2917,7 +2917,7 @@ End
 
 
 ;------------------------------------------------------------------------------
-Object Tank_ChinaTankEmperor
+Object Tank_ChinaTankEmperor ; Alias Tank_ChinaTankOverlord
 
   ; *** ART Parameters ***
   SelectPortrait         = SNEmpTank_L
@@ -2932,11 +2932,13 @@ Object Tank_ChinaTankEmperor
   UpgradeCameo5 = Upgrade_ChinaSubliminalMessaging
 
   Draw = W3DOverlordTankDraw ModuleTag_01
-    ConditionState        = NONE
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    DefaultConditionState
       Model               = NVOvrlrdT
       Animation           = NVOvrlrdT.NVOvrlrdT
       AnimationMode       = LOOP
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -2954,13 +2956,14 @@ Object Tank_ChinaTankEmperor
       HideSubObject       = Smoke06 Smoke07 Smoke08 ; Patch104p @bugfix commy2 08/10/2022 Hide visible bones.
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState        = RUBBLE
       Model               = NVOvrlrdT_D1
       Turret              = Turret01
-      WeaponFireFXBone    = PRIMARY Muzzle
-      WeaponRecoilBone    = PRIMARY Barrel
-      WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      WeaponLaunchBone = PRIMARY Muzzle
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks           = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2699,9 +2699,12 @@ Object Tank_ChinaTankBattleMaster
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
+
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model               = NVBtMstr
       Turret              = Turret01
+      HideSubObject       = MuzzleFX01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
@@ -2715,9 +2718,15 @@ Object Tank_ChinaTankBattleMaster
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
       WeaponLaunchBone    = PRIMARY Muzzle
     End
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model               = NVBtMstr_D
       Turret              = Turret01
+      WeaponFireFXBone    = PRIMARY None
+      WeaponRecoilBone    = PRIMARY None
+      WeaponMuzzleFlash   = PRIMARY None
+      WeaponLaunchBone    = PRIMARY None
     End
 
     TrackMarks              = EXTnkTrack.tga


### PR DESCRIPTION
* Fixes #1605

This change fixes China Battlemaster and Overlord death effects. Muzzle flashes no longer show on death. And turret barrel no longer recoils on death.

## Patched

https://user-images.githubusercontent.com/4720891/217946777-b4551ae6-d576-4fe5-9711-2423cd504961.mp4
