### PR TITLE
Fix: Comanche hulk can no longer bounce

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -414,9 +414,10 @@ Object ComancheRubbleHull
   ; Patch104p @fix xezon 28/01/2023 Add flag for casting reflections.
   KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
 
+  ; Patch104p @fix xezon 28/01/2023 Disable bouncing.
   Behavior = PhysicsBehavior ModuleTag_02
     Mass           = 25.0
-    AllowBouncing  = Yes
+    AllowBouncing  = No
   End
 
   Behavior = LifetimeUpdate ModuleTag_03


### PR DESCRIPTION
ComancheRubbleHull can no longer bounce. Other Helicopter hulks cannot bounce either.

Practically mostly inconsequential, because requires a physics event to push hulk, such as Nuke Mig Missile hit.