### PR TITLE
Fix: Decrease quick sink rate of USA Comanche hulk, increase slow sink rate of USA Chinook, China Helix hulks

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -468,10 +468,12 @@ Object ChinookRubbleHull
     MinLifetime    = 20000   ; min lifetime in msec
     MaxLifetime    = 20000   ; max lifetime in msec
   End
+
+  ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
-    SinkRate            = 1     ; in Dist/Sec
-    DestructionDelay = 16000
+    SinkRate         = 2     ; in Dist/Sec
+    DestructionDelay = 8000
   End
 
 End
@@ -502,10 +504,12 @@ Object HelixRubbleHull
     MinLifetime    = 20000   ; min lifetime in msec
     MaxLifetime    = 20000   ; max lifetime in msec
   End
+
+  ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
-    SinkRate            = 1     ; in Dist/Sec
-    DestructionDelay = 16000
+    SinkRate         = 2     ; in Dist/Sec
+    DestructionDelay = 8000
   End
 
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -425,10 +425,11 @@ Object ComancheRubbleHull
     MaxLifetime    = 3000   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 4 to 2, Destruction Delay from 10000 to 9500, to be consistent with other hulks.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 3000
-    SinkRate         = 4     ; in Dist/Sec
-    DestructionDelay = 10000
+    SinkRate         = 2     ; in Dist/Sec
+    DestructionDelay = 9500
   End
 
 


### PR DESCRIPTION
**Merge with Rebase**

This change decreases the quick sink rate of USA Comanche hulk, increases the slow sink rate of USA Chinook, China Helix hulks. All vehicles, helicopters, planes, except GLA Combat Bike, sink with same speed.

| Object               | Original Sink Rate | Patched Sink Rate |
|----------------------|--------------------|-------------------|
| USA Comanche Hulk    | 4                  | 2                 |
| USA Chinook Hulk     | 1                  | 2                 |
| China Helix Hulk     | 1                  | 2                 |
| Other vehicles hulks | 2                  | -                 |

## Rationale

Consistent sink speeds for most hulks. No unexplainable discrepancies. Helix hulk is big, and given its size it already takes longer to sink into terrain than all other vehicles. Half the sink speed made this even longer. Comanche no longer sinks 4 times slower than Chinook.