### PR TITLE
Change: Remove random sink delays from hulks of USA Ambulance, China Gattling, ECM

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -976,12 +976,11 @@ Object DeadChinaGattlingTankHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
-    SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
     DestructionDelay          = 12000
-    DestructionDelayVariance  = 4000
   End
 
 End
@@ -1013,12 +1012,11 @@ Object DeadChinaECMTankHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
-    SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
     DestructionDelay          = 12000
-    DestructionDelayVariance  = 4000
   End
 
 End
@@ -1050,12 +1048,11 @@ Object AmericaVehicleAmbulanceDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
-    SinkDelayVariance         = 1500
     SinkRate                  = 2     ; in Dist/Sec
     DestructionDelay          = 12000
-    DestructionDelayVariance  = 4000
   End
 
 


### PR DESCRIPTION
This change removes random sink delays from hulks of USA Ambulance, China Gattling, ECM.

## About Sink Delays

`SinkDelayVariance` and `DestructionDelayVariance` are designed a bit unfortunate.

What it does:
```
RealSinkDelay = SinkDelay + SinkDelayVariance
RealDestructionDelay = DestructionDelay + DestructionDelayVariance
```

What it should do:
```
RealSinkDelay = SinkDelay + SinkDelayVariance (*)
RealDestructionDelay = DestructionDelay + SinkDelayVariance (*)
```

(*) Apply same random generated value of variance.

## Rationale

Removal of variance makes setup much easier to maintain. If we want sink variances on hulks, it should be added as last step. Only 3 original hulks have sink delay variance. Removal makes no tangible difference to visuals.