### PR TITLE
Fix: (Demo) GLA Marauder death explosion no longer triggers effects on turret barrels

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -20056,15 +20056,16 @@ Object Chem_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelMS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model = UVMarauder_d
       Turret = Turret
       ShowSubObject = Turret
       HideSubObject = TurretUp01 TurretUp02 BarrelFX01
-      WeaponFireFXBone = PRIMARY BarrelMS
-      WeaponRecoilBone = PRIMARY Barrel
-      WeaponMuzzleFlash = PRIMARY BarrelFX
-      WeaponLaunchBone = PRIMARY BarrelMS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 1
@@ -20090,15 +20091,16 @@ Object Chem_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp01MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_ONE
       Model = UVMarauder_d
       Turret = TurretUp01
       ShowSubObject = TurretUp01
       HideSubObject = Turret TurretUp02 BarrelUp01FX01
-      WeaponFireFXBone = PRIMARY BarrelUp01MS
-      WeaponRecoilBone = PRIMARY BarrelUp01
-      WeaponMuzzleFlash = PRIMARY BarrelUp01FX
-      WeaponLaunchBone = PRIMARY BarrelUp01MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 2
@@ -20124,15 +20126,16 @@ Object Chem_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp02MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_TWO
       Model = UVMarauder_d
       Turret = TurretUp02
       ShowSubObject = TurretUp02
       HideSubObject = Turret TurretUp01 BarrelUp02FX01 BarrelUp02FX02
-      WeaponFireFXBone = PRIMARY BarrelUp02MS
-      WeaponRecoilBone = PRIMARY BarrelUp02
-      WeaponMuzzleFlash = PRIMARY BarrelUp02FX
-      WeaponLaunchBone = PRIMARY BarrelUp02MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -21566,15 +21566,16 @@ Object Demo_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelMS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model = UVMarauder_d
       Turret = Turret
       ShowSubObject = Turret
       HideSubObject = TurretUp01 TurretUp02 BarrelFX01
-      WeaponFireFXBone = PRIMARY BarrelMS
-      WeaponRecoilBone = PRIMARY Barrel
-      WeaponMuzzleFlash = PRIMARY BarrelFX
-      WeaponLaunchBone = PRIMARY BarrelMS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 1
@@ -21600,15 +21601,16 @@ Object Demo_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp01MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_ONE
       Model = UVMarauder_d
       Turret = TurretUp01
       ShowSubObject = TurretUp01
       HideSubObject = Turret TurretUp02 BarrelUp01FX01
-      WeaponFireFXBone = PRIMARY BarrelUp01MS
-      WeaponRecoilBone = PRIMARY BarrelUp01
-      WeaponMuzzleFlash = PRIMARY BarrelUp01FX
-      WeaponLaunchBone = PRIMARY BarrelUp01MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 2
@@ -21634,15 +21636,16 @@ Object Demo_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp02MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_TWO
       Model = UVMarauder_d
       Turret = TurretUp02
       ShowSubObject = TurretUp02
       HideSubObject = Turret TurretUp01 BarrelUp02FX01 BarrelUp02FX02
-      WeaponFireFXBone = PRIMARY BarrelUp02MS
-      WeaponRecoilBone = PRIMARY BarrelUp02
-      WeaponMuzzleFlash = PRIMARY BarrelUp02FX
-      WeaponLaunchBone = PRIMARY BarrelUp02MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6058,15 +6058,16 @@ Object GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelMS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model = UVMarauder_d
       Turret = Turret
       ShowSubObject = Turret
       HideSubObject = TurretUp01 TurretUp02 BarrelFX01
-      WeaponFireFXBone = PRIMARY BarrelMS
-      WeaponRecoilBone = PRIMARY Barrel
-      WeaponMuzzleFlash = PRIMARY BarrelFX
-      WeaponLaunchBone = PRIMARY BarrelMS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 1
@@ -6092,15 +6093,16 @@ Object GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp01MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_ONE
       Model = UVMarauder_d
       Turret = TurretUp01
       ShowSubObject = TurretUp01
       HideSubObject = Turret TurretUp02 BarrelUp01FX01
-      WeaponFireFXBone = PRIMARY BarrelUp01MS
-      WeaponRecoilBone = PRIMARY BarrelUp01
-      WeaponMuzzleFlash = PRIMARY BarrelUp01FX
-      WeaponLaunchBone = PRIMARY BarrelUp01MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 2
@@ -6126,15 +6128,16 @@ Object GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp02MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_TWO
       Model = UVMarauder_d
       Turret = TurretUp02
       ShowSubObject = TurretUp02
       HideSubObject = Turret TurretUp01 BarrelUp02FX01 BarrelUp02FX02
-      WeaponFireFXBone = PRIMARY BarrelUp02MS
-      WeaponRecoilBone = PRIMARY BarrelUp02
-      WeaponMuzzleFlash = PRIMARY BarrelUp02FX
-      WeaponLaunchBone = PRIMARY BarrelUp02MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -21606,15 +21606,16 @@ Object Slth_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelMS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE
       Model = UVMarauder_d
       Turret = Turret
       ShowSubObject = Turret
       HideSubObject = TurretUp01 TurretUp02 BarrelFX01
-      WeaponFireFXBone = PRIMARY BarrelMS
-      WeaponRecoilBone = PRIMARY Barrel
-      WeaponMuzzleFlash = PRIMARY BarrelFX
-      WeaponLaunchBone = PRIMARY BarrelMS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 1
@@ -21640,15 +21641,16 @@ Object Slth_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp01MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_ONE
       Model = UVMarauder_d
       Turret = TurretUp01
       ShowSubObject = TurretUp01
       HideSubObject = Turret TurretUp02 BarrelUp01FX01
-      WeaponFireFXBone = PRIMARY BarrelUp01MS
-      WeaponRecoilBone = PRIMARY BarrelUp01
-      WeaponMuzzleFlash = PRIMARY BarrelUp01FX
-      WeaponLaunchBone = PRIMARY BarrelUp01MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; crate upgrade 2
@@ -21674,15 +21676,16 @@ Object Slth_GLATankMarauder
       WeaponLaunchBone = PRIMARY BarrelUp02MS
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = RUBBLE WEAPONSET_CRATEUPGRADE_TWO
       Model = UVMarauder_d
       Turret = TurretUp02
       ShowSubObject = TurretUp02
       HideSubObject = Turret TurretUp01 BarrelUp02FX01 BarrelUp02FX02
-      WeaponFireFXBone = PRIMARY BarrelUp02MS
-      WeaponRecoilBone = PRIMARY BarrelUp02
-      WeaponMuzzleFlash = PRIMARY BarrelUp02FX
-      WeaponLaunchBone = PRIMARY BarrelUp02MS
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga


### PR DESCRIPTION
* Related to #1605 
* Related to #1657
* Related to #1663

With this change the (Demo) GLA Marauder death explosion no longer triggers effects on turret barrels.

Tested with Demo GLA Marauder, with and without Demo Upgrade, with and without Scraps.

Setup is replicated on all faction Marauders, for the case that Mod Maps & Co want to add death weapons to any Marauder.

https://user-images.githubusercontent.com/4720891/218164722-a25f5df9-8192-4e54-ad23-9358b6c4ece1.mp4
