### PR TITLE
Fix GLA Scorpion death states and effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16174,12 +16174,13 @@ Object Chem_GLATankScorpion
     ProjectileBoneFeedbackEnabledSlots = SECONDARY ; WeaponLaunchBone will be shown/hidden, not just used for firing offset
 
 ; ------------ Normal
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model = UVLiteTank
       Turret = Turret ; Logic twist bone is always this, both turrets are subobjects of it, as are both missile racks
       ; note, order-dependent: we must hide/show Missile AFTER we hide/show MissileRack!
       ShowSubObject = Turret01
-      HideSubObject = MissleRack01 MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      HideSubObject = MissleRack01 MissleRack02 TurretUP01 MuzzleFX01 MuzzleFX02; MissileRack misspelled in the Art
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponRecoilBone = PRIMARY Barrel
       WeaponMuzzleFlash = PRIMARY MuzzleFX
@@ -16189,7 +16190,15 @@ Object Chem_GLATankScorpion
     ConditionState = REALLYDAMAGED
       Model = UVLiteTank_d
     End
-    AliasConditionState = RUBBLE
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
+    ConditionState = RUBBLE
+      Model = UVLiteTank_d
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
+    End
 
 ; ------------ With big turret
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE ; one or two crates is a turret switch
@@ -16206,10 +16215,15 @@ Object Chem_GLATankScorpion
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = TurretUP01
       HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
@@ -16230,12 +16244,17 @@ Object Chem_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With missile and big turret
@@ -16255,12 +16274,17 @@ Object Chem_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 TurretUP01
       HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With two missiles and big turret
@@ -16280,12 +16304,17 @@ Object Chem_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16205,6 +16205,14 @@ Object Chem_GLATankScorpion
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = TurretUP01
+      HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+    End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
+
 ; ---------- With missile
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       ShowSubObject = MissleRack01 Turret01
@@ -16214,6 +16222,15 @@ Object Chem_GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 Turret01
+      HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
@@ -16237,6 +16254,15 @@ Object Chem_GLATankScorpion
       WeaponLaunchBone = SECONDARY WeaponA
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 TurretUP01
+      HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
 ; ---------- With two missiles and big turret
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
@@ -16246,6 +16272,15 @@ Object Chem_GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 MissleRack02 TurretUP01
+      HideSubObject = Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17347,12 +17347,13 @@ Object Demo_GLATankScorpion
     ProjectileBoneFeedbackEnabledSlots = SECONDARY ; WeaponLaunchBone will be shown/hidden, not just used for firing offset
 
 ; ------------ Normal
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model = UVLiteTank
       Turret = Turret ; Logic twist bone is always this, both turrets are subobjects of it, as are both missile racks
       ; note, order-dependent: we must hide/show Missile AFTER we hide/show MissileRack!
       ShowSubObject = Turret01
-      HideSubObject = MissleRack01 MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      HideSubObject = MissleRack01 MissleRack02 TurretUP01 MuzzleFX01 MuzzleFX02; MissileRack misspelled in the Art
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponRecoilBone = PRIMARY Barrel
       WeaponMuzzleFlash = PRIMARY MuzzleFX
@@ -17362,7 +17363,15 @@ Object Demo_GLATankScorpion
     ConditionState = REALLYDAMAGED
       Model = UVLiteTank_d
     End
-    AliasConditionState = RUBBLE
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
+    ConditionState = RUBBLE
+      Model = UVLiteTank_d
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
+    End
 
 ; ------------ With big turret
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE ; one or two crates is a turret switch
@@ -17379,10 +17388,15 @@ Object Demo_GLATankScorpion
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = TurretUP01
       HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
@@ -17403,12 +17417,17 @@ Object Demo_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With missile and big turret
@@ -17428,12 +17447,17 @@ Object Demo_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 TurretUP01
       HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With two missiles and big turret
@@ -17453,12 +17477,17 @@ Object Demo_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17378,6 +17378,14 @@ Object Demo_GLATankScorpion
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = TurretUP01
+      HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+    End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
+
 ; ---------- With missile
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       ShowSubObject = MissleRack01 Turret01
@@ -17387,6 +17395,15 @@ Object Demo_GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 Turret01
+      HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
@@ -17410,6 +17427,15 @@ Object Demo_GLATankScorpion
       WeaponLaunchBone = SECONDARY WeaponA
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 TurretUP01
+      HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
 ; ---------- With two missiles and big turret
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
@@ -17419,6 +17445,15 @@ Object Demo_GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 MissleRack02 TurretUP01
+      HideSubObject = Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1726,12 +1726,13 @@ Object GC_Chem_GLATankScorpion
 
     ProjectileBoneFeedbackEnabledSlots = SECONDARY ; WeaponLaunchBone will be shown/hidden, not just used for firing offset
 
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model = UVLiteTank
       Turret = Turret ; Logic twist bone is always this, both turrets are subobjects of it, as are both missile racks
       ; note, order-dependent: we must hide/show Missile AFTER we hide/show MissileRack!
       ShowSubObject = TurretUP01
-      HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+      HideSubObject = MissleRack01 MissleRack02 Turret01 MuzzleFX01 MuzzleFX02; MissileRack misspelled in the Art
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponRecoilBone = PRIMARY Barrel
       WeaponMuzzleFlash = PRIMARY MuzzleFX
@@ -1741,7 +1742,15 @@ Object GC_Chem_GLATankScorpion
     ConditionState = REALLYDAMAGED
       Model = UVLiteTank_d
     End
-    AliasConditionState = RUBBLE
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
+    ConditionState = RUBBLE
+      Model = UVLiteTank_d
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
+    End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
@@ -1757,7 +1766,19 @@ Object GC_Chem_GLATankScorpion
       WeaponFireFXBone = SECONDARY WeaponA
       WeaponLaunchBone = SECONDARY WeaponA
     End
-    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 MissleRack02 TurretUP01
+      HideSubObject = Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
+    End
 
     TrackMarks = EXTnkTrack.tga
     TreadAnimationRate      = 2.0  ; amount of tread texture to move per second

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -3170,6 +3170,15 @@ Object CINE_GLATankScorpion
       WeaponHideShowBone = SECONDARY Missile
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponHideShowBone = SECONDARY Missile
+    End
+
     TrackMarks = EXTnkTrack.tga
     TreadAnimationRate      = 2.0  ; amount of tread texture to move per second
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -20,12 +20,13 @@ Object GLATankScorpion
     ProjectileBoneFeedbackEnabledSlots = SECONDARY ; WeaponLaunchBone will be shown/hidden, not just used for firing offset
 
 ; ------------ Normal
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model = UVLiteTank
       Turret = Turret ; Logic twist bone is always this, both turrets are subobjects of it, as are both missile racks
       ; note, order-dependent: we must hide/show Missile AFTER we hide/show MissileRack!
       ShowSubObject = Turret01
-      HideSubObject = MissleRack01 MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      HideSubObject = MissleRack01 MissleRack02 TurretUP01 MuzzleFX01 MuzzleFX02; MissileRack misspelled in the Art
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponRecoilBone = PRIMARY Barrel
       WeaponMuzzleFlash = PRIMARY MuzzleFX
@@ -35,7 +36,15 @@ Object GLATankScorpion
     ConditionState = REALLYDAMAGED
       Model = UVLiteTank_d
     End
-    AliasConditionState = RUBBLE
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
+    ConditionState = RUBBLE
+      Model = UVLiteTank_d
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
+    End
 
 ; ------------ With big turret
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE ; one or two crates is a turret switch
@@ -52,10 +61,15 @@ Object GLATankScorpion
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = TurretUP01
       HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
@@ -76,12 +90,17 @@ Object GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With missile and big turret
@@ -101,12 +120,17 @@ Object GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 TurretUP01
       HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With two missiles and big turret
@@ -126,12 +150,17 @@ Object GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -51,6 +51,14 @@ Object GLATankScorpion
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = TurretUP01
+      HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+    End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
+
 ; ---------- With missile
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       ShowSubObject = MissleRack01 Turret01
@@ -60,6 +68,15 @@ Object GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 Turret01
+      HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
@@ -83,6 +100,15 @@ Object GLATankScorpion
       WeaponLaunchBone = SECONDARY WeaponA
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 TurretUP01
+      HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
 ; ---------- With two missiles and big turret
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
@@ -92,6 +118,15 @@ Object GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 MissleRack02 TurretUP01
+      HideSubObject = Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17711,6 +17711,14 @@ Object Slth_GLATankScorpion
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = TurretUP01
+      HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+    End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
+
 ; ---------- With missile
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       ShowSubObject = MissleRack01 Turret01
@@ -17720,6 +17728,15 @@ Object Slth_GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 Turret01
+      HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
@@ -17743,6 +17760,15 @@ Object Slth_GLATankScorpion
       WeaponLaunchBone = SECONDARY WeaponA
     End
 
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 TurretUP01
+      HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
 ; ---------- With two missiles and big turret
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
@@ -17752,6 +17778,15 @@ Object Slth_GLATankScorpion
     End
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
+      Model = UVLiteTank_d
+      ShowSubObject = MissleRack01 MissleRack02 TurretUP01
+      HideSubObject = Turret01; MissileRack misspelled in the Art
+      WeaponFireFXBone = SECONDARY WeaponA
+      WeaponLaunchBone = SECONDARY WeaponA
+    End
+
+    ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17680,12 +17680,13 @@ Object Slth_GLATankScorpion
     ProjectileBoneFeedbackEnabledSlots = SECONDARY ; WeaponLaunchBone will be shown/hidden, not just used for firing offset
 
 ; ------------ Normal
+    ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
     DefaultConditionState
       Model = UVLiteTank
       Turret = Turret ; Logic twist bone is always this, both turrets are subobjects of it, as are both missile racks
       ; note, order-dependent: we must hide/show Missile AFTER we hide/show MissileRack!
       ShowSubObject = Turret01
-      HideSubObject = MissleRack01 MissleRack02 TurretUP01; MissileRack misspelled in the Art
+      HideSubObject = MissleRack01 MissleRack02 TurretUP01 MuzzleFX01 MuzzleFX02; MissileRack misspelled in the Art
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponRecoilBone = PRIMARY Barrel
       WeaponMuzzleFlash = PRIMARY MuzzleFX
@@ -17695,7 +17696,15 @@ Object Slth_GLATankScorpion
     ConditionState = REALLYDAMAGED
       Model = UVLiteTank_d
     End
-    AliasConditionState = RUBBLE
+
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
+    ConditionState = RUBBLE
+      Model = UVLiteTank_d
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
+    End
 
 ; ------------ With big turret
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE ; one or two crates is a turret switch
@@ -17712,10 +17721,15 @@ Object Slth_GLATankScorpion
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO REALLYDAMAGED
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = TurretUP01
       HideSubObject = MissleRack01 MissleRack02 Turret01   ; MissileRack misspelled in the Art
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
@@ -17736,12 +17750,17 @@ Object Slth_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 Turret01
       HideSubObject = MissleRack02 TurretUP01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With missile and big turret
@@ -17761,12 +17780,17 @@ Object Slth_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_ONE RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 TurretUP01
       HideSubObject = MissleRack02 Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
 ; ---------- With two missiles and big turret
@@ -17786,12 +17810,17 @@ Object Slth_GLATankScorpion
     End
 
     ; Patch104p @bugfix xezon 09/02/2023 No longer lose upgrades on death.
+    ; Patch104p @bugfix xezon 09/02/2023 Reset weapon on death because this unit does fire or could fire a turret unrelated death weapon.
     ConditionState = WEAPONSET_PLAYER_UPGRADE WEAPONSET_CRATEUPGRADE_TWO RUBBLE
       Model = UVLiteTank_d
       ShowSubObject = MissleRack01 MissleRack02 TurretUP01
       HideSubObject = Turret01; MissileRack misspelled in the Art
-      WeaponFireFXBone = SECONDARY WeaponA
-      WeaponLaunchBone = SECONDARY WeaponA
+      WeaponFireFXBone = SECONDARY None
+      WeaponLaunchBone = SECONDARY None
+      WeaponFireFXBone = PRIMARY None
+      WeaponRecoilBone = PRIMARY None
+      WeaponMuzzleFlash = PRIMARY None
+      WeaponLaunchBone = PRIMARY None
     End
 
     TrackMarks = EXTnkTrack.tga


### PR DESCRIPTION
**Merge with Rebase**

* Related to #1605
* Related to #1657
* Related to #1662
* Fixes #1655
* Fixes #1656

With this change the (Demo) GLA Scorpion death explosion no longer triggers effects on turret barrels. On top of that all GLA Scorpions no longer lose upgrades on death.

Tested with Demo GLA Scorpion, with and without Demo Upgrade, with and without Scraps.

Setup is replicated on all faction Scorpions, for the case that Mod Maps & Co want to add death weapons to any Scorpion.

https://user-images.githubusercontent.com/4720891/218188806-b27f8bd6-3865-4900-9599-43c7b97ea4e5.mp4
