### PR TITLE
Change: Eject Pilot on death of USA Comanche immediately without delay of 1500 ms

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -2302,7 +2302,7 @@ Object AirF_AmericaVehicleComanche
     ; Most things that eject pilots do so immediately upon death,
     ; via use of EjectPilotDie, but Helicopters are a special case...
     ; they need to do so after their blades are ejected.
-    OCLEjectPilot                   = OCL_EjectPilotViaParachute
+    ;OCLEjectPilot                   = OCL_EjectPilotViaParachute
     FXBlade                         = FX_HelicopterBladeExplosion
     OCLBlade                        = OCL_HelicopterBladeExplosion
     FXHitGround                     = FX_HelicopterHitGround
@@ -2311,6 +2311,14 @@ Object AirF_AmericaVehicleComanche
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
     DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
+  End
+
+  ; Patch104p @tweak xezon 11/02/2023 Eject pilot without delay of 1500 ms to guarantee creation.
+  Behavior = EjectPilotDie ModuleTag_EjectPilot
+    GroundCreationList = OCL_EjectPilotOnGround
+    AirCreationList = OCL_EjectPilotViaParachute
+    ExemptStatus = HIJACKED
+    VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
   Behavior = TransitionDamageFX ModuleTag_09

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -1866,7 +1866,7 @@ Object AmericaVehicleComanche
     ; Most things that eject pilots do so immediately upon death,
     ; via use of EjectPilotDie, but Helicopters are a special case...
     ; they need to do so after their blades are ejected.
-    OCLEjectPilot                   = OCL_EjectPilotViaParachute
+    ;OCLEjectPilot                   = OCL_EjectPilotViaParachute
     FXBlade                         = FX_HelicopterBladeExplosion
     OCLBlade                        = OCL_HelicopterBladeExplosion
     FXHitGround                     = FX_HelicopterHitGround
@@ -1875,6 +1875,14 @@ Object AmericaVehicleComanche
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
     DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
+  End
+
+  ; Patch104p @tweak xezon 11/02/2023 Eject pilot without delay of 1500 ms to guarantee creation.
+  Behavior = EjectPilotDie ModuleTag_EjectPilot
+    GroundCreationList = OCL_EjectPilotOnGround
+    AirCreationList = OCL_EjectPilotViaParachute
+    ExemptStatus = HIJACKED
+    VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
   Behavior = TransitionDamageFX ModuleTag_09

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -1624,7 +1624,7 @@ Object Lazr_AmericaVehicleComanche
     ; Most things that eject pilots do so immediately upon death,
     ; via use of EjectPilotDie, but Helicopters are a special case...
     ; they need to do so after their blades are ejected.
-    OCLEjectPilot                   = OCL_EjectPilotViaParachute
+    ;OCLEjectPilot                   = OCL_EjectPilotViaParachute
     FXBlade                         = FX_HelicopterBladeExplosion
     OCLBlade                        = OCL_HelicopterBladeExplosion
     FXHitGround                     = FX_HelicopterHitGround
@@ -1633,6 +1633,14 @@ Object Lazr_AmericaVehicleComanche
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
     DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
+  End
+
+  ; Patch104p @tweak xezon 11/02/2023 Eject pilot without delay of 1500 ms to guarantee creation.
+  Behavior = EjectPilotDie ModuleTag_EjectPilot
+    GroundCreationList = OCL_EjectPilotOnGround
+    AirCreationList = OCL_EjectPilotViaParachute
+    ExemptStatus = HIJACKED
+    VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
   Behavior = TransitionDamageFX ModuleTag_09

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -2103,7 +2103,7 @@ Object SupW_AmericaVehicleComanche
     ; Most things that eject pilots do so immediately upon death,
     ; via use of EjectPilotDie, but Helicopters are a special case...
     ; they need to do so after their blades are ejected.
-    OCLEjectPilot                   = OCL_EjectPilotViaParachute
+    ;OCLEjectPilot                   = OCL_EjectPilotViaParachute
     FXBlade                         = FX_HelicopterBladeExplosion
     OCLBlade                        = OCL_HelicopterBladeExplosion
     FXHitGround                     = FX_HelicopterHitGround
@@ -2112,6 +2112,14 @@ Object SupW_AmericaVehicleComanche
     OCLFinalBlowUp                  = OCL_GroundedHelicopterBlowUp
     DelayFromGroundToFinalDeath     = 30 ; Patch104p @tweak from 1500 to explode on impact like other Helicopters
     FinalRubbleObject               = ComancheRubbleHull
+  End
+
+  ; Patch104p @tweak xezon 11/02/2023 Eject pilot without delay of 1500 ms to guarantee creation.
+  Behavior = EjectPilotDie ModuleTag_EjectPilot
+    GroundCreationList = OCL_EjectPilotOnGround
+    AirCreationList = OCL_EjectPilotViaParachute
+    ExemptStatus = HIJACKED
+    VeterancyLevels =  ALL -REGULAR ;only vet+ gives pilot
   End
 
   Behavior = TransitionDamageFX ModuleTag_09


### PR DESCRIPTION
* Fixes TheSuperHackers/GeneralsGameCode#175

This change ejects Pilot on death of USA Comanche immediately without delay of 1500 ms.

## Patched

First 3 pilots eject without delay. Last pilot ejects with 1500 ms delay.

https://user-images.githubusercontent.com/4720891/218223494-619e5c15-abe6-482d-b99b-81db97127df0.mp4

## Patched Advantage

Pilot can spawn when Comanche is killed on repair pad. It spawns like all other USA vehicle pilots without delay.

https://user-images.githubusercontent.com/4720891/218223460-f567e039-3c61-448d-91a5-7c9d6957a3d4.mp4
