### PR TITLE
Change: China Overlord will always reload when idle

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -236,6 +236,7 @@ Weapon ScorpionTankGunFXWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon OverlordTankGun
   PrimaryDamage = 80 ;100.0
   PrimaryDamageRadius = 5.0
@@ -259,6 +260,8 @@ Weapon OverlordTankGun
   ShotsPerBarrel = 1                   ; By default, shoot one shot per barrel
   ClipSize = 2                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 2000              ; how long to reload a Clip, msec
+  AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 2100
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; UraniumShells
 
   ; note, these only apply to units that aren't the explicit target
@@ -6461,6 +6464,7 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon Tank_OverlordTankGun
   PrimaryDamage = 80 ;100.0
   PrimaryDamageRadius = 5.0
@@ -6484,6 +6488,8 @@ Weapon Tank_OverlordTankGun
   ShotsPerBarrel = 1                   ; By default, shoot one shot per barrel
   ClipSize = 2                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 1500              ; how long to reload a Clip, msec
+  AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 1600
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; UraniumShells
 
   ; note, these only apply to units that aren't the explicit target
@@ -8139,6 +8145,7 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon Nuke_OverlordTankGun
   PrimaryDamage = 80 ;100.0
   PrimaryDamageRadius = 5.0
@@ -8162,6 +8169,8 @@ Weapon Nuke_OverlordTankGun
   ShotsPerBarrel = 1                   ; By default, shoot one shot per barrel
   ClipSize = 2                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 2000              ; how long to reload a Clip, msec
+  AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 2100
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; UraniumShells
   ProjectileCollidesWith = STRUCTURES WALLS
 End


### PR DESCRIPTION
* Resolves #1669

With this change the China Overlord will always reload when idle.

This makes the unit a bit better in scenarios where it managed to only fire with one of its barrel on its target and some time passes until the next target is attacked.

This situation is perhaps not as rare as one may assume. There is a `ClipReloadTime` of 2000 ms vs a `DelayBetweenShots` of 333 (300) ms. This means there is a 14% chance that Overlord gets into state with one clip in barrels when attacking and moving Overlord around.

# Rationale

Eliminates situations where Overlord would only fire once on a fresh engagement. This likely is what player would expect always.

## Patched

First attack fires 2 clips normally, second attack fires only 1 clip because of interruption (Stop), and third attack fires 2 clips again because of new auto reload when idle.

https://user-images.githubusercontent.com/4720891/218267994-e0c773cf-7fef-4c08-a572-05c6ddf1ed3c.mp4