### PR TITLE
Fix: Set correct firing sequence on GLA Marauder with double barrel

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -71,6 +71,8 @@ Weapon MarauderTankGunUpgradeOne
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 11/02/2023 Set DelayBetweenShots from 750 to 100
+;   and ClipReloadTime from 100 to 750 to correct the firing sequence.
 Weapon MarauderTankGunUpgradeTwo
   PrimaryDamage = 60.0
   PrimaryDamageRadius = 5.0
@@ -88,9 +90,9 @@ Weapon MarauderTankGunUpgradeTwo
   ProjectileDetonationFX = WeaponFX_GenericTankShellDetonation
   FireSound = MarauderTankWeapon
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 750           ; time between shots, msec
+  DelayBetweenShots = 100           ; time between shots, msec
   ClipSize = 2                      ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime = 100              ; how long to reload a Clip, msec
+  ClipReloadTime = 750              ; how long to reload a Clip, msec
 
   ; note, these only apply to units that aren't the explicit target
   ; (ie, units that just happen to "get in the way"... projectiles
@@ -8502,7 +8504,7 @@ Weapon BuggyRocketREDWeaponUpgraded
 End
 
 ;------------------------------------------------------------------------------
-Weapon REDMarauderTankGun
+Weapon REDMarauderTankGun ; Alias Demo_MarauderTankGun
   PrimaryDamage = 60.0
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
@@ -8531,7 +8533,7 @@ Weapon REDMarauderTankGun
 End
 
 ;------------------------------------------------------------------------------
-Weapon REDMarauderTankGunUpgradeOne
+Weapon REDMarauderTankGunUpgradeOne ; Alias Demo_MarauderTankGunUpgradeOne
   PrimaryDamage = 60.0
   PrimaryDamageRadius = 5.0
   AttackRange = 170.0
@@ -8559,7 +8561,9 @@ Weapon REDMarauderTankGunUpgradeOne
 End
 
 ;------------------------------------------------------------------------------
-Weapon REDMarauderTankGunUpgradeTwo
+; Patch104p @bugfix xezon 11/02/2023 Set DelayBetweenShots from 750 to 100
+;   and ClipReloadTime from 100 to 750 to correct the firing sequence.
+Weapon REDMarauderTankGunUpgradeTwo ; Alias Demo_MarauderTankGunUpgradeTwo
   PrimaryDamage = 60.0
   PrimaryDamageRadius = 5.0
   ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
@@ -8576,9 +8580,9 @@ Weapon REDMarauderTankGunUpgradeTwo
   ProjectileDetonationFX = WeaponFX_DEMOGenericTankShellDetonation
   FireSound = MarauderTankWeapon
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 750           ; time between shots, msec
+  DelayBetweenShots = 100           ; time between shots, msec
   ClipSize = 2                      ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime = 100              ; how long to reload a Clip, msec
+  ClipReloadTime = 750              ; how long to reload a Clip, msec
 
   ; note, these only apply to units that aren't the explicit target
   ; (ie, units that just happen to "get in the way"... projectiles


### PR DESCRIPTION
* Fixes #1671

This change sets correct firing sequence on GLA Marauder with double barrel.

It will now always start by firing 2 clips instead of just 1 clip.

This gives the unit an inconsequential buff.