### PR TITLE
Change: GLA Marauder with double barrel will always reload when idle

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -73,6 +73,7 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix xezon 11/02/2023 Set DelayBetweenShots from 750 to 100
 ;   and ClipReloadTime from 100 to 750 to correct the firing sequence.
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon MarauderTankGunUpgradeTwo
   PrimaryDamage = 60.0
   PrimaryDamageRadius = 5.0
@@ -93,6 +94,8 @@ Weapon MarauderTankGunUpgradeTwo
   DelayBetweenShots = 100           ; time between shots, msec
   ClipSize = 2                      ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 750              ; how long to reload a Clip, msec
+  AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 850
 
   ; note, these only apply to units that aren't the explicit target
   ; (ie, units that just happen to "get in the way"... projectiles
@@ -8563,6 +8566,7 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix xezon 11/02/2023 Set DelayBetweenShots from 750 to 100
 ;   and ClipReloadTime from 100 to 750 to correct the firing sequence.
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon REDMarauderTankGunUpgradeTwo ; Alias Demo_MarauderTankGunUpgradeTwo
   PrimaryDamage = 60.0
   PrimaryDamageRadius = 5.0
@@ -8583,6 +8587,8 @@ Weapon REDMarauderTankGunUpgradeTwo ; Alias Demo_MarauderTankGunUpgradeTwo
   DelayBetweenShots = 100           ; time between shots, msec
   ClipSize = 2                      ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 750              ; how long to reload a Clip, msec
+  AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 850
 
   ; note, these only apply to units that aren't the explicit target
   ; (ie, units that just happen to "get in the way"... projectiles


### PR DESCRIPTION
* Merge after #1672
* Resolves #1673

With this change the GLA Marauder will always reload when idle.

This makes the unit a bit better in scenarios where it managed to only fire with one of its barrel on its target and some time passes until the next target is attacked.

This situation is perhaps not as rare as one may assume. There is a `ClipReloadTime` of 800 (750) ms vs a `DelayBetweenShots` of 133 (100) ms. This means there is a 14% chance that Marauder gets into state with one clip in barrels when attacking and moving Marauder around.

# Rationale

Eliminates situations where Marauder would only fire once on a fresh engagement. This likely is what player would expect always.

## Patched

First attack fires only 1 clip because of interruption (Stop), and second attack fires 2 clips again because of new auto reload when idle.

https://user-images.githubusercontent.com/4720891/218272291-7894e528-f8a1-4d54-92b7-104b094231cc.mp4
