### PR TITLE
Fix: Add CRATE flag to SalvageCrate

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1675_salvage_crate_crate_flag.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1675_salvage_crate_crate_flag.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-02-11
+
+title: Adds missing CRATE flag to SalvageCrate
+
+changes:
+  - fix: Adds missing CRATE flag to SalvageCrate.
+
+labels:
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1675
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -192,7 +192,8 @@ Object SalvageCrate
   EditorSorting   = MISC_MAN_MADE
 
   ; *** ENGINEERING Parameters ***
-  KindOf = PARACHUTABLE SELECTABLE ;Only Salvage crates are marked Selectable so the Mouse can interact with them and give Salvage voices.  Being dead makes them not actually selectable
+  ; Patch104p @fix xezon 11/02/2023 Adds missing crate flag.
+  KindOf = PARACHUTABLE CRATE SELECTABLE ;Only Salvage crates are marked Selectable so the Mouse can interact with them and give Salvage voices.  Being dead makes them not actually selectable
 
   Behavior = SalvageCrateCollide ModuleTag_02
     ForbiddenKindOf = PROJECTILE


### PR DESCRIPTION
This change adds the CRATE flag to SalvageCrate object. All other Crates have this flag too. Appears to make no difference in player facing behavior.