### PR TITLE
Fix: GLA Salvage Crate can no longer be removed by scaffolds

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1676_salvage_crate_exploit.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1676_salvage_crate_exploit.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-02-11
+
+title: Fixes GLA Salvage Crate being removable by scaffolds
+
+changes:
+  - fix: The GLA Salvage Crate is no longer deleted when a scaffold is placed on top of it. It remains intact under the scaffold until it is picked up or times out.
+
+labels:
+  - bug
+  - controversial
+  - gla
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1676
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -194,7 +194,8 @@ Object SalvageCrate
   ; *** ENGINEERING Parameters ***
   ; Patch104p @fix xezon 11/02/2023 Adds missing crate flag.
   ; Patch104p @fix xezon 11/02/2023 Removes selectable flag to avoid crate eventually being selectable over terrain with non GLA faction.
-  KindOf = PARACHUTABLE CRATE
+  ; Patch104p @bugfix xezon 11/02/2023 Adds inert flag to avoid removal by scaffolds.
+  KindOf = PARACHUTABLE CRATE INERT
 
   Behavior = SalvageCrateCollide ModuleTag_02
     ForbiddenKindOf = PROJECTILE


### PR DESCRIPTION
* Merge after #1675
* Related to #648

With this change the GLA Salvage Crate can no longer be removed by scaffolds. Crates simply stay intact under the scaffold until they are picked up or time out.

## Patched

![shot_20230212_000305_1](https://user-images.githubusercontent.com/4720891/218285270-f7e12c14-4c6d-4f51-8f3f-1f0cf59c3e03.jpg)

# Rationale

It took until around year 2017 for top players to figure out the obscure exploit of removing visible and invisible Salvage Crate objects by placing Scaffolds over them. In top level matches this is now exploited accordingly. The reason this is accepted by top players is the weakness of China against (scrapped) GLA. A fully scrapped GLA Technical for example can present a major problem in the early stages of a China build.

Since this Project aims to strengthen China and make all faction match-ups more playable, this exploit ideally will no longer be required to achieve fair chances for China vs GLA in the future.

The big advantage is clean game mechanics, and no exploits sold as features to achieve some sort of balancing. The big disadvantage is that this fundamentally changes how top level GLA matches are played, which almost always revolve around Scrap scaffold exploits.

For many Noob, Semi and Pro players this change is inconsequential, because they do not use this obscure exploit to gain the advantage.

This change also makes the mechanics consistent with the inability to delete money crates and any other pickable crate, which was implemented with #443.
