### PR TITLE
Change: Super Technical balance

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1680_supply_truck_xp_reward.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1680_supply_truck_xp_reward.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-02-12
+
+title: Decreases XP reward of China Supply Truck from 50 to 25
+
+changes:
+  - tweak: The China Supply Truck now gives 25 XP instead of 50 XP on kill. This takes a bit of pressure off of China when losing Supply Trucks to the opposition by not promoting enemy units as much.
+
+labels:
+  - buff
+  - china
+  - controversial
+  - design
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1680
+
+authors:
+  - Stubbjax

--- a/Patch104pZH/Design/Changes/v1.0/1680_technical_xp_requirement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1680_technical_xp_requirement.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-02-12
+
+title: Increases XP requirement of GLA Technical from 50 75 150 to 50 100 150
+
+changes:
+  - tweak: The GLA Technical now requires 100 XP instead of just 75 XP to reach elite rank. This makes it a bit more challenging for GLA to acquire strong Technicals.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - major
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1680
+
+authors:
+  - Stubbjax

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15082,7 +15082,8 @@ Object Boss_VehicleSupplyTruck
     Mass = 5.0
   End
 
-  ExperienceValue    = 50 50 50 50 ;Experience point value at each level
+  ; Patch104p @balance Stubbjax 12/02/2023 Decreases XP reward from 50. (#1680)
+  ExperienceValue    = 25 25 25 25 ;Experience point value at each level
 
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -19557,8 +19557,9 @@ Object Chem_GLAVehicleTechnicalChassisOne
     Object = Chem_GLAArmsDealer
   End
 
+  ; Patch104p @balance Stubbjax 12/02/2023 Increases required XP from 0 50 75 150. (#1680)
   ExperienceValue         = 25 25 50 100    ;Experience point value at each level
-  ExperienceRequired      = 0 50 75 150  ;Experience points needed to gain each level
+  ExperienceRequired      = 0 50 100 150  ;Experience points needed to gain each level
   IsTrainable             = Yes             ;Can gain experience
   CrusherLevel            = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel          = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2357,7 +2357,8 @@ Object ChinaVehicleSupplyTruck
     Mass = 50.0
   End
 
-  ExperienceValue    = 50 50 50 50 ;Experience point value at each level
+  ; Patch104p @balance Stubbjax 12/02/2023 Decreases XP reward from 50. (#1680)
+  ExperienceValue    = 25 25 25 25 ;Experience point value at each level
 
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -21073,8 +21073,9 @@ Object Demo_GLAVehicleTechnicalChassisOne
     Object = Demo_GLAArmsDealer
   End
 
+  ; Patch104p @balance Stubbjax 12/02/2023 Increases required XP from 0 50 75 150. (#1680)
   ExperienceValue         = 25 25 50 100    ;Experience point value at each level
-  ExperienceRequired      = 0 50 75 150  ;Experience points needed to gain each level
+  ExperienceRequired      = 0 50 100 150  ;Experience points needed to gain each level
   IsTrainable             = Yes             ;Can gain experience
   CrusherLevel            = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel          = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -3359,8 +3359,9 @@ Object GC_Slth_GLAVehicleTechnicalChassisOne
     Object = Slth_GLAArmsDealer
   End
 
+  ; Patch104p @balance Stubbjax 12/02/2023 Increases required XP from 0 50 75 150. (#1680)
   ExperienceValue         = 25 25 50 100    ;Experience point value at each level
-  ExperienceRequired      = 0 50 75 150  ;Experience points needed to gain each level
+  ExperienceRequired      = 0 50 100 150  ;Experience points needed to gain each level
   IsTrainable             = Yes             ;Can gain experience
   CrusherLevel            = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel          = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -5119,8 +5119,9 @@ Object GLAVehicleTechnicalChassisOne
     Object = GLAArmsDealer
   End
 
+  ; Patch104p @balance Stubbjax 12/02/2023 Increases required XP from 0 50 75 150. (#1680)
   ExperienceValue         = 25 25 50 100    ;Experience point value at each level
-  ExperienceRequired      = 0 50 75 150  ;Experience points needed to gain each level
+  ExperienceRequired      = 0 50 100 150  ;Experience points needed to gain each level
   IsTrainable             = Yes             ;Can gain experience
   CrusherLevel            = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel          = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2908,7 +2908,8 @@ Object Infa_ChinaVehicleSupplyTruck
     Mass = 50.0
   End
 
-  ExperienceValue    = 50 50 50 50 ;Experience point value at each level
+  ; Patch104p @balance Stubbjax 12/02/2023 Decreases XP reward from 50. (#1680)
+  ExperienceValue    = 25 25 25 25 ;Experience point value at each level
 
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4466,7 +4466,8 @@ Object Nuke_ChinaVehicleSupplyTruck
     Mass = 50.0
   End
 
-  ExperienceValue    = 50 50 50 50 ;Experience point value at each level
+  ; Patch104p @balance Stubbjax 12/02/2023 Decreases XP reward from 50. (#1680)
+  ExperienceValue    = 25 25 25 25 ;Experience point value at each level
 
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -21166,8 +21166,9 @@ Object Slth_GLAVehicleTechnicalChassisOne
     Object = Slth_GLAArmsDealer
   End
 
+  ; Patch104p @balance Stubbjax 12/02/2023 Increases required XP from 0 50 75 150. (#1680)
   ExperienceValue         = 25 25 50 100    ;Experience point value at each level
-  ExperienceRequired      = 0 50 75 150  ;Experience points needed to gain each level
+  ExperienceRequired      = 0 50 100 150  ;Experience points needed to gain each level
   IsTrainable             = Yes             ;Can gain experience
   CrusherLevel            = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
   CrushableLevel          = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4664,7 +4664,8 @@ Object Tank_ChinaVehicleSupplyTruck
     Mass = 50.0
   End
 
-  ExperienceValue    = 50 50 50 50 ;Experience point value at each level
+  ; Patch104p @balance Stubbjax 12/02/2023 Decreases XP reward from 50. (#1680)
+  ExperienceValue    = 25 25 25 25 ;Experience point value at each level
 
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED


### PR DESCRIPTION
This PR is a response to #1145 and #592 (and somewhat #648) and aims to strike a balance between reducing the strength of GLA's Super Technical[^1] and preserving the original feeling and traditional gameplay of 1.04.

### Changes include:

1. Increased GLA Technical xp requirements from [0 50 75 150] to [0 50 100 150]
2. Reduced China Supply Truck xp yield from 50 to 25

# Rationale

### 1. Technical xp requirements

In 1.04, the Technical's 25 xp requirement to go from Veteran to Elite rank is extremely small, and somewhat skewed in terms of progression (50 → 25 → 125). At the bare minimum, this allows a Technical to achieve Elite rank from killing a couple of infantry, but otherwise doesn't make any difference when it comes to vehicular combat, as most vehicles are worth at least 50 xp. Adding a further 25 xp to the Elite rank requirement is a small price to pay for a substantial reduction in Super Tech potential.

Before and after the change, a Technical still ranks up from Veteran to Elite by killing its prey of choice, the Humvee (which is worth 50 xp).

https://user-images.githubusercontent.com/11547761/218027015-98ddb214-5efe-470a-a570-616d72c7de54.mp4

In 1.04, a Technical only needs to kill two rocket infantry / rangers (worth 20 xp each) in order to progress from Veteran to Elite rank (50 + 20 + 20 = 90). This can be seen in the below footage, where a Technical reaches Elite rank by merely driving to an opponent's oils on Defcon 6, which is a very common occurrence. However, after the change, an additional infantry needs to be killed to reach Elite rank (50 + 20 + 20 + 20 = 110).

https://user-images.githubusercontent.com/11547761/218043401-53eb322b-aa6f-4992-b0d7-7388741b1068.mp4

Another way of looking at it is that a Technical now only needs an additional 10 xp to reach Elite rank. A Technical typically reaches Elite rank via infantry kills in 1.04 by going from 70 xp to 90 xp to cross the 75 xp requirement. The practical difference can thus be considered as an extra 10 xp (90 xp vs 100 xp).

### 2. Supply Truck xp yield

For the Technical xp adjustment to make a difference, the xp yield of Supply Trucks must also be reduced. Reducing the xp yield of Supply Trucks primarily targets the Super Tech issue while not drastically impacting too many other areas of the game. It is reasonable that Supply Trucks yield half the xp of Chinooks, as they cost half as much and are far easier to destroy. Other tanks / vehicles are typically worth 50+ xp for comparison. Combined with the Technical xp requirement increase, a Technical now only reaches Elite rank from killing two Supply Trucks, instead of Heroic as in 1.04. The Technical must destroy an extra tank / vehicle or hunt down another two Supply Trucks to achieve Heroic status - a feat that is far more worthy of the rank.

Not only do Elite Technicals have less firepower than Heroic Technicals, but they also have less health. This affords the opponent more time to deal with the Technical, and is less punishing over the same time frame. Note that the Technical does not acquire the fire rate boost that it typically would after killing the first truck (Veteran to Elite), making the destruction of the next truck a slightly more timely endeavour.

## 1.04:
A Technical can kill two Supply Trucks to reach Heroic rank. This assumes Technical Training is applied, which gives the Technical 50 xp by default. The two Supply Truck kills add +50 xp each to a total of 150 xp. The (high) reward does not align with the (relatively low) effort required.

https://user-images.githubusercontent.com/11547761/218010778-f8e4dda9-24df-41c7-a859-537d823492bb.mp4

## Patch:
A Technical will only reach Elite rank after killing two Supply Trucks. This assumes Technical Training is applied, which gives the Technical 50 xp by default. The two Supply Truck kills add +25 xp each for a total of 100 xp. The (medium-high) reward is closer to the (relatively low) effort required.

https://user-images.githubusercontent.com/11547761/218010868-51cf7060-3f0e-4305-b9a2-3ef1f82ca324.mp4

## Further considerations

If the halved xp yield is deemed too low, it can be increased to 30 or 40 while maintaining the altered Technical xp requirements to achieve the same outcome with reduced external impact. A Technical would still need to destroy two 40 xp Supply Trucks to reach Elite rank (50 + 40 + 40 = 130), though they would be much closer to reaching Heroic rank. Requiring three Supply Trucks to reach Heroic rank may be a reasonable compromise if this change is deemed too controversial or test results are negative.

If Technical xp requirements are more of a concern than Supply Truck xp yields, then another approach would be to change the Technical's Elite xp requirement to 80 xp (only +5 xp from 1.04), and leave Supply Trucks yielding 25 xp. This would result in the Technical still needing to destroy two 25 xp Supply Trucks to reach Elite rank (50 + 25 + 25 = 100), while effectively maintaining the same quick ranking progression via infantry kills.

Other ideas may involve subtly reducing the damage of the Technical's RPG weapon, e.g. from 50 damage to 45 damage to match the cannon weapon's damage (it may allow a Gattling Tank to take an extra hit). A damage increase counterbalanced with a fire rate reduction could also amplify the Technical's role as a hit-and-run type of unit, and make it more susceptible to prolonged engagements.

## Summary

The xp alterations serve as a reasonable balance approach because they are relatively subtle, intuitive, preserve the original feeling of 1.04, and make Super Techs harder to acquire instead of reducing their performance, which many players enjoy. Once acquired, a Super Tech can wreak the same havoc as it does in 1.04. The heightened requirement provides the opponent with a bit more counterplay potential, and heightens the skill required to acquire a Super Tech. The higher requirement ties in better with the devastating capabilities of a Super Tech, and adds more weight to their acquisition.

At the end of the day, an Elite Technical is a bit easier for China to deal with than a Heroic Technical. A Veteran Gattling Tank can effectively go head to head with an Elite Technical. An unranked Gattling Tank can even destroy the Technical if micromanaged correctly (#1199). This, of course, assumes limited micro on the Technical's part.

https://user-images.githubusercontent.com/11547761/218047806-5c4ebd12-ef16-4e25-b89f-304238e1cc55.mp4

https://user-images.githubusercontent.com/11547761/218047828-741b0bcc-33f9-40e8-9c56-127950bc9503.mp4

https://user-images.githubusercontent.com/11547761/218295923-c7e833ea-48e8-4a97-a047-a72c1efa701e.mp4

Also note that altering the xp yield for Supply Trucks will affect other units, and effectively double their requirements in terms of killing Supply Trucks. Humvees, for example, will need to kill four Supply Trucks to acquire Veteran rank, instead of two as in 1.04. However, this could also result in a positive outcome, and help reduce the severity of other issues, such as #640.

At the very least, this branch can serve as a testing ground to observe the impact Super Techs have on China's prospects. I believe this proposal will directly address the issue while incurring minimal costs elsewhere.

[^1]: A Super Technical is a Technical that has achieved god-like status by ranking up to Heroic (third) rank and collecting two salvage crates to acquire the RPG weapon. The RPG weapon deals 50 `EXPLOSION` damage, which is a damage type that is not resisted by many units in the game.