### PR TITLE
Air Force Chinook balance

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17497,10 +17497,10 @@ Object AFG_AmericaVehicleChinook
   End
 
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
-    WeaponTemplate        = AirF_PointDefenseLaser
+    WeaponTemplate        = AirF_ChinookPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
-    ScanRate              = 33
-    ScanRange             = 500.0
+    ScanRate              = 0
+    ScanRange             = 200.0
     PredictTargetVelocityFactor = 1.0
   End
 
@@ -17754,10 +17754,10 @@ Object AirF_AmericaVehicleChinook
   End
 
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
-    WeaponTemplate        = AirF_PointDefenseLaser
+    WeaponTemplate        = AirF_ChinookPointDefenseLaser
     PrimaryTargetTypes    = BALLISTIC_MISSILE SMALL_MISSILE
-    ScanRate              = 33
-    ScanRange             = 250.0
+    ScanRate              = 0
+    ScanRange             = 200.0
     PredictTargetVelocityFactor = 1.0
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17612,8 +17612,8 @@ Object AirF_AmericaVehicleChinook
   TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)
   VisionRange         = 300.0
   ShroudClearingRange = 600
-  BuildCost           = 1200
-  BuildTime           = 25.0          ;in seconds
+  BuildCost           = 1400
+  BuildTime           = 30.0          ;in seconds
   Prerequisites
     Object = AirF_AmericaWarFactory
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7063,7 +7063,24 @@ Weapon AirF_PointDefenseLaser
   FireFX              = WeaponFX_PaladinPointDefenseLaser
 End
 
-
+;------------------------------------------------------------------------------
+Weapon AirF_ChinookPointDefenseLaser
+  PrimaryDamage       = 100.0
+  PrimaryDamageRadius = 0.0
+  AttackRange         = 65.0
+  DamageType          = LASER
+  DeathType           = LASERED
+  WeaponSpeed         = 999999.0     ; dist/sec 
+  DelayBetweenShots   = 500          ; time between shots, msec
+  ClipSize            = 0            ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime      = 0            ; how long to reload a Clip, msec
+  AcceptableAimDelta  = 180          ; Don't need to turn at all.
+  AntiSmallMissile    = Yes
+  AntiProjectile      = No
+  LaserName           = AirF_PointDefenseLaserBeam
+  LaserBoneName       = WeaponA01
+  FireFX              = WeaponFX_PaladinPointDefenseLaser
+End
 
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
This PR is a response to #1254 and aims to strike a balance between reducing the strength of Air Force General's Chinooks and preserving the original feeling and traditional gameplay of 1.04.

### Changes include:

1. Increased Combat Chinook price from $1200 to $1400
2. Increased Combat Chinook build time from 25s to 30s
3. Increased the delay between shots of both Chinook point defense lasers from 0.25s (266.67ms) to 0.5s (533.33ms)

## Rationale

### 1. Price

As explained [here](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1254#issuecomment-1256043796), a $200 increase from $1200 to $1400 is fairly subtle, aligns well with several other units priced at $1400, and may delay any subsequent or additional strategies that the user may employ, making an early Combat Chinook strategy a riskier endeavour. It would also increase the user's susceptibility to counter-rush strategies, and would mostly impact the start of the game when the Combat Chinook is the most difficult to counter.

Let's factor the increased price into some typical early Combat Chinook build orders:

![image](https://user-images.githubusercontent.com/11547761/214866292-ab4ffb22-da14-4762-9677-2154351f2777.png) ![image](https://user-images.githubusercontent.com/11547761/214866333-7d3bf34b-c9a4-4c74-945a-831e7bda7c87.png)

As can be seen at the end of the two build orders shown above, a $1200 Combat Chinook leaves the user with enough funds for a Humvee or 8th Missile Defender, whereas a $1400 Combat Chinook may not. This could prevent or delay the user from countering a drop (which would also be more effective due to the slower PDLs). While a price increase doesn't make the Combat Chinook much easier for opponents to deal with, it does increase the prospects of counterattacks for the opponent. It also amplifies any momentum the opponent may acquire after surviving or countering the initial attack.

### 2. Build time

One of the most difficult aspects of facing a Combat Chinook is the lack of preparation time, which is primarily due to its high mobility. A build time increase from 25s to 30s (+20%) would give the opponent an extra (and likely crucial) five seconds to prepare for the attack. An increase of five seconds is reasonable as it maintains a nice balance between impact and invisibility. It is also a nice round number, which is always nice. Increasing the time any further would likely incur too much of a visibility cost.

### 3. PDL

The third and final change and the main culprit behind the Combat Chinook's dominance (and ultimately Air Force's dominance) is the infamous PDL. It is quite imbalanced that Air Force's supply collection is so much hardier than those of other factions, especially considering how much of a flow-on effect this has to other areas of the game. Not only are Air Force's Chinooks cheaper - which already reduces the impact of economy harassment - but their rapid-fire 250ms PDLs make them almost immune to infantry missiles, which makes life very difficult for opposing rocket-reliant USAs. It is worth noting that Chinooks often gather in pairs, allowing their PDLs to help cover one another and exacerbating the problem further.

In an ideal world, the Chinook's 250ms PDL should probably be slowed to match the Paladin's 1000ms PDL, which would allow it to block just a single rocket infantry, and give USA an edge with its 500ms Laser Lock. But that would be too drastic of a change from 1.04, so a compromise of 500ms makes sense, and directly matches the Laser Lock ability's fire rate of 500ms. This type of change has the most impact against USA, which heavily relies on rocket-based firepower.

As Chinooks are so mobile, they are easily able to outrun missiles if appropriately controlled. Even with a slower PDL, a Combat Chinook has little trouble outmanoeuvring and avoiding rockets by simply flying away. This puts more emphasis on player reaction and unit micro rather than allowing the Chinooks to passively block rockets without any effort required from the user.

Below is a demonstration of 500ms PDLs against 3 Missile Defenders (a very common rush strategy). This hopefully shows that it is fairly difficult to identify the slower PDLs. (The silly Easy Army always makes three Chinooks, but the outcome is still easily distinguishable.)

https://user-images.githubusercontent.com/11547761/218296448-d1b05831-4c04-4913-89e3-8a2309033561.mp4

## Further considerations

### Air Force Chinook vs King Raptor

There was some concern expressed in #1254 around Air Force vs Air Force gameplay regarding Chinook sniping with King Raptors, as this is a gameplay element that many players seem to enjoy, and may be affected by such a change. However, due to the nature of PDL zaps detonating missiles, the damage a Chinook sustains from a King Raptor remains similar before and after the change. Even with the faster zap rate in 1.04, several of a Raptor's missiles get close enough for their radius damage to apply to the target when zapped. This can be seen in the footage below.

Before the change, when the King Raptor fires at the Chinook, a total of five zaps can be heard, suggesting that only one of the six missiles hit. However this is not the case, and the Chinook ends up taking four missiles for 250 damage.

https://user-images.githubusercontent.com/11547761/214832719-b129480f-0da1-4eff-abfb-dddce56c6bcb.mp4

After the change, when the King Raptor fires at the Chinook, three zaps can be heard, suggesting that only three of the six missiles hit. However this is not the case, and the Chinook still ends up taking four missiles for 250 damage. This is marginally nicer as the number of zaps more accurately represents the outcome in this scenario.

https://user-images.githubusercontent.com/11547761/214832765-6bcf5c59-c7e6-42e5-a8be-4ecb34417c7b.mp4

### Combat Chinook health

Combat Chinooks have 350 health, whereas standard Chinooks have 300 health. It may be an idea to scale the 350 back to 300 (a ~14% reduction) to align with the other Chinooks and provide opponents a bit more opportunity to take them down. This would also be a reasonably subtle change, though it would allow a King Raptor to snipe them in one strike, which could upset players and is the reason I have not included it in this proposal. Below is a rough comparison of Chinook vs Combat Chinook health:

https://user-images.githubusercontent.com/11547761/218296136-80fc8f7f-a3a6-4447-a26a-03ccfed0e164.mp4

### Chinook price

Increasing the price of Air Force's Chinook from $950 to $1200 to align with the other factions could also be an idea to further amplify the impact of the Combat Chinook's price increase. It would likely result in one less Missile Defender aboard the Combat Chinook, or some additional delay while awaiting income. It would certainly help bring Air Force's economy in line with other factions.

## Summary

A slight price and build time increase, combined with a slower PDL would take some of the edge off of early Combat Chinook strategies and afford opponents greater opportunities to counter them. The PDL alteration would also help bring Air Force's economy in line with other factions, and expand strategic diversity as an added bonus. The visibility of the changes is kept reasonably low, and strategies would mostly play out the same way, preserving the feeling of 1.04.