### PR TITLE
Pathfinder balance

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4590,7 +4590,7 @@ Object AirF_AmericaInfantryPathfinder
     AlwaysHeal = 0.25 ; if we get below 25%, find healing right away.
   End
 
-  Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25
 
   Behavior = ExperienceScalarUpgrade ModuleTag_05
     TriggeredBy = Upgrade_AmericaAdvancedTraining

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4607,7 +4607,7 @@ Object AirF_AmericaInfantryPathfinder
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
   Behavior = StealthUpdate ModuleTag_09
-    StealthDelay                = 0           ; msec
+    StealthDelay                = 1000        ; msec
     StealthForbiddenConditions  = MOVING ; stays stealthy while attacking
     FriendlyOpacityMin          = 30.0%
     FriendlyOpacityMax          = 80.0%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4541,8 +4541,8 @@ Object AirF_AmericaInfantryPathfinder
   BuildCost = 800
   BuildTime = 12.0          ;in seconds
 
-  ExperienceValue = 40 40 60 80    ;Experience point value at each level
-  ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level
+  ExperienceValue = 60 60 80 100    ;Experience point value at each level
+  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet      = AmericaInfantryPathfinderCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4538,8 +4538,8 @@ Object AirF_AmericaInfantryPathfinder
     Object = AirF_AmericaBarracks
     Science = SCIENCE_Pathfinder
   End
-  BuildCost = 600
-  BuildTime = 10.0          ;in seconds
+  BuildCost = 800
+  BuildTime = 12.0          ;in seconds
 
   ExperienceValue = 40 40 60 80    ;Experience point value at each level
   ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1788,8 +1788,8 @@ Object AmericaInfantryPathfinder
     Object = AmericaBarracks
     Science = SCIENCE_Pathfinder
   End
-  BuildCost = 600
-  BuildTime = 10.0          ;in seconds
+  BuildCost = 800
+  BuildTime = 12.0          ;in seconds
 
   ExperienceValue = 40 40 60 80    ;Experience point value at each level
   ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1791,8 +1791,8 @@ Object AmericaInfantryPathfinder
   BuildCost = 800
   BuildTime = 12.0          ;in seconds
 
-  ExperienceValue = 40 40 60 80    ;Experience point value at each level
-  ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level
+  ExperienceValue = 60 60 80 100    ;Experience point value at each level
+  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet      = AmericaInfantryPathfinderCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1856,7 +1856,7 @@ Object AmericaInfantryPathfinder
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
   Behavior = StealthUpdate ModuleTag_09
-    StealthDelay                = 0           ; msec
+    StealthDelay                = 1000        ; msec
     StealthForbiddenConditions  = MOVING ; stays stealthy while attacking
     FriendlyOpacityMin          = 30.0%
     FriendlyOpacityMax          = 80.0%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1839,7 +1839,7 @@ Object AmericaInfantryPathfinder
     AlwaysHeal = 0.25 ; if we get below 25%, find healing right away.
   End
 
-  Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25
 
   Behavior = ExperienceScalarUpgrade ModuleTag_05
     TriggeredBy = Upgrade_AmericaAdvancedTraining

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17888,7 +17888,7 @@ Object Boss_InfantryPathfinder
     AlwaysHeal = 0.25 ; if we get below 25%, find healing right away.
   End
 
-  Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25
 
   Behavior = ExperienceScalarUpgrade ModuleTag_05
     TriggeredBy = Upgrade_AmericaAdvancedTraining

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17905,7 +17905,7 @@ Object Boss_InfantryPathfinder
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
   Behavior = StealthUpdate ModuleTag_09
-    StealthDelay                = 0           ; msec
+    StealthDelay                = 1000        ; msec
     StealthForbiddenConditions  = MOVING ; stays stealthy while attacking
     FriendlyOpacityMin          = 30.0%
     FriendlyOpacityMax          = 80.0%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17836,8 +17836,8 @@ Object Boss_InfantryPathfinder
     Object = Boss_Barracks
     Science = SCIENCE_Pathfinder
   End
-  BuildCost = 600
-  BuildTime = 10.0          ;in seconds
+  BuildCost = 800
+  BuildTime = 12.0          ;in seconds
 
   ExperienceValue = 40 40 60 80    ;Experience point value at each level
   ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17839,8 +17839,8 @@ Object Boss_InfantryPathfinder
   BuildCost = 800
   BuildTime = 12.0          ;in seconds
 
-  ExperienceValue = 40 40 60 80    ;Experience point value at each level
-  ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level
+  ExperienceValue = 60 60 80 100    ;Experience point value at each level
+  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet      = AmericaInfantryPathfinderCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4078,8 +4078,8 @@ Object Lazr_AmericaInfantryPathfinder
     Object = Lazr_AmericaBarracks
     Science = SCIENCE_Pathfinder
   End
-  BuildCost = 600
-  BuildTime = 10.0          ;in seconds
+  BuildCost = 800
+  BuildTime = 12.0          ;in seconds
 
   ExperienceValue = 40 40 60 80    ;Experience point value at each level
   ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4081,8 +4081,8 @@ Object Lazr_AmericaInfantryPathfinder
   BuildCost = 800
   BuildTime = 12.0          ;in seconds
 
-  ExperienceValue = 40 40 60 80    ;Experience point value at each level
-  ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level
+  ExperienceValue = 60 60 80 100    ;Experience point value at each level
+  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet      = AmericaInfantryPathfinderCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4130,7 +4130,7 @@ Object Lazr_AmericaInfantryPathfinder
     AlwaysHeal = 0.25 ; if we get below 25%, find healing right away.
   End
 
-  Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25
 
   Behavior = ExperienceScalarUpgrade ModuleTag_05
     TriggeredBy = Upgrade_AmericaAdvancedTraining

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4147,7 +4147,7 @@ Object Lazr_AmericaInfantryPathfinder
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
   Behavior = StealthUpdate ModuleTag_09
-    StealthDelay                = 0           ; msec
+    StealthDelay                = 1000        ; msec
     StealthForbiddenConditions  = MOVING ; stays stealthy while attacking
     FriendlyOpacityMin          = 30.0%
     FriendlyOpacityMax          = 80.0%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4631,7 +4631,7 @@ Object SupW_AmericaInfantryPathfinder
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
   End
   Behavior = StealthUpdate ModuleTag_09
-    StealthDelay                = 0           ; msec
+    StealthDelay                = 1000        ; msec
     StealthForbiddenConditions  = MOVING ; stays stealthy while attacking
     FriendlyOpacityMin          = 30.0%
     FriendlyOpacityMax          = 80.0%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4614,7 +4614,7 @@ Object SupW_AmericaInfantryPathfinder
     AlwaysHeal = 0.25 ; if we get below 25%, find healing right away.
   End
 
-  Locomotor = SET_NORMAL ColonelBurtonGroundLocomotor
+  Locomotor = SET_NORMAL BasicHumanLocomotorPlus25
 
   Behavior = ExperienceScalarUpgrade ModuleTag_05
     TriggeredBy = Upgrade_AmericaAdvancedTraining

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4562,8 +4562,8 @@ Object SupW_AmericaInfantryPathfinder
     Object = SupW_AmericaBarracks
     Science = SCIENCE_Pathfinder
   End
-  BuildCost = 600
-  BuildTime = 10.0          ;in seconds
+  BuildCost = 800
+  BuildTime = 12.0          ;in seconds
 
   ExperienceValue = 40 40 60 80    ;Experience point value at each level
   ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4565,8 +4565,8 @@ Object SupW_AmericaInfantryPathfinder
   BuildCost = 800
   BuildTime = 12.0          ;in seconds
 
-  ExperienceValue = 40 40 60 80    ;Experience point value at each level
-  ExperienceRequired = 0 50 100 200  ;Experience points needed to gain each level
+  ExperienceValue = 60 60 80 100    ;Experience point value at each level
+  ExperienceRequired = 0 100 200 400  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet      = AmericaInfantryPathfinderCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -911,7 +911,7 @@ End
 Weapon USAPathfinderSniperRifle
   PrimaryDamage = 100.0
   PrimaryDamageRadius = 0.0
-  AttackRange = 300.0
+  AttackRange = 275.0
   DamageType = SNIPER
   DeathType = NORMAL
   WeaponSpeed = 999999.0          ; dist/sec (huge value == effectively instant)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -920,7 +920,7 @@ Weapon USAPathfinderSniperRifle
   VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
   FireSound = PathfinderWeapon
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 2000               ; time between shots, msec
+  DelayBetweenShots = 4000               ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP weapon upgrade


### PR DESCRIPTION
Welcome to the Pathfinder balance branch! This PR is a response to TheSuperHackers/GeneralsGamePatch#690 and can hopefully serve as a testing ground for various balance adjustments involving the fearsome Pathfinder.

The Pathfinder is one of the most overpowered units in the game due to its ability to immediately eliminate infantry at a great distance with very little recourse for opponents. This is a unit that severely tips the balance once it becomes available, and effectively renders all infantry-based gameplay obsolete from that point forward.

The primary objective in addressing this issue is to reduce the Pathfinder's effectiveness in the most impactful _and_ subtle way possible while maintaining traditional mechanics and gameplay. Unfortunately, it is practically impossible to completely balance the Pathfinder without significantly altering the feel of the game and upsetting a lot of players, so a compromise is naturally required. Changes that result in infantry taking multiple shots to take down for example, while perhaps an effective balance option, would be incredibly visible and thus highly susceptible to controversy. These types of changes are thus generally best avoided.

Keep in mind that not all of the following changes have to be agreed upon, and even a single nerf is still better than 1.04's massively overpowered state. Pathfinders will likely always remain overpowered to some degree, but the extent to which they are overpowered can certainly be reduced in an elegant manner.

The suggested changes below intend to spread the impact across a broad range of attributes - most of which I'd confidently expect to go unnoticed by the majority of players. They are roughly listed in order of impact over visibility.

### Changes include:

1. Double the delay between shots from 2s to 4s
2. Double experience requirements from [0 50 100 200] to [0 100 200 400]
3. Increase build time from 10s to 12s
4. Reduce attack range from 300 to 275
5. Increase unit cost from $600 to $800
6. Reduce move speed from 30 to 25 (ColonelBurtonGroundLocomotor → BasicHumanLocomotorPlus25)
7. Increase stealth delay from 0s to 1s
8. Increase experience yields from [40 40 60 80] to [60 60 80 100]

## Rationale

### 1. Shot delay
Increasing the delay between shots from 2s to 4s may seem like a big change, but it is an incredibly effective way of reducing DPS without the accompanying visibility cost of an equivalent damage reduction. A 2s increase is really as high as it can go before it starts to become conspicuous, and I'd argue most players would not notice any difference. The realism card can also be played here, as it makes sense that snipers (especially of the meticulous and conscientious USA) take time and care to aim and perfectly execute their shots. The higher delay between shots also contrasts nicely with the much faster Jarmen Kell, who wastes no time mercilessly firing off no-scoped shots like a cold-blooded killer at the cost of shorter range and revealing himself when doing so.

The greater delay between shots also affords opponents a larger window to react after witnessing the first shot, providing a greater degree of counterplay and allowing them to rescue or retreat ~more~ some of their soldiers.

A fire rate reduction is preferable to an equivalent damage reduction due to the fact that players are accustomed to interpreting a single shot as a kill. If damage were to be altered instead, Pathfinders would potentially fire multiple shots per target, which would significantly reduce feedback clarity and certainly change the feeling of the game in comparison to 1.04.

Pathfinder fire rate in 1.04:
```
60 frames at rank 0
50 frames at rank 1 (120% fire rate = 60 / 1.2 = 50)
43 frames at rank 2 (140% fire rate = 60 / 1.4 = 42.6)
38 frames at rank 3 (160% fire rate = 60 / 1.6 = 37.5)
```
Pathfinder fire rate in patch:
```
120 frames at rank 0
100 frames at rank 1 (120% fire rate = 120 / 1.2 = 100)
 86 frames at rank 2 (140% fire rate = 120 / 1.4 = 85.7)
 75 frames at rank 3 (160% fire rate = 120 / 1.6 = 75)
```
Increasing the delay between shots by a factor of two is a very reasonable adjustment for a long-range unit that typically kills all of its targets in one shot. With such a long range, Pathfinders can be likened to or considered artillery units, where a slower fire rate is a very common and reasonable tradeoff. A reduced fire rate would more closely align with the design principles of other long-range units.

| Unit | Fire Rate |
| - | - |
| Pathfinder (1.04) | 2s |
| Pathfinder (this) | 4s |
| Inferno Cannon | 4s |
| Rocket Buggy | 6s |
| Tomahawk | 7s |
| Nuke Cannon | 10s |
| SCUD Launcher | 10s |

Below is some footage demonstrating how effortlessly three Pathfinders can take out an entire squad of Tunnel Defenders.

https://user-images.githubusercontent.com/11547761/197380205-09aacc4e-1f78-45f2-8537-c75918a6a8a9.mp4

After such violent and graphic footage, you must be thinking - wow, Pathfinders are really strong! But guess what? The above footage was not taken on 1.04, but on this branch with the respective changes applied! The Tunnel Defenders would be eliminated in less than half the time in 1.04, and each Pathfinder would be Elite rank and 1 - 2 kills from Heroic. The increased shot delay appears to strike a perfect balance between reducing the unit's effectiveness and maintaining the same feeling as 1.04.

### 2. Experience requirements
On average, Pathfinders rank up faster than every other single-target unit in the game, and can reach Veteran rank after 4 seconds, Elite after 7 seconds, and Heroic after 15 seconds - assuming the targets are unranked missile infantry (the most common encounter). It takes as little as 7 seconds to reach Heroic rank with Advanced Training.

Doubling the experience requirements, in combination with the reduced fire rate, results in a 4x longer rank up duration in comparison to 1.04. With the respective change, a Pathfinder has to take out 20 / 10 (~62s / ~31s) missile infantry to reach Heroic rank, rather than 10 / 5 (~15s / ~7s) as in 1.04. This slower rate of progression feels more natural and a lot closer to the time investment required of other units to achieve similar ranks - especially considering the lack of risk Pathfinders typically face against their targets. As Pathfinders become more valuable over time, their loss also becomes much more impactful. This leads to a higher potential for / degree of rubberbanding. The requirements are compared in the table below. Time is displayed in {minutes:seconds.frames}. Each row is a single shot.

![image](https://user-images.githubusercontent.com/11547761/200435550-b4356a16-6898-4064-8296-91e46e7c4584.png)

This change technically serves as an additional fire rate reduction, without actually reducing the fire rate directly, by delaying access to faster fire rates via ranking. This reduces visibility and allows the game to feel the same while still reducing DPS further. The slower fire rate and ranking speed result in a much greater time investment from the user, and affords opponents more time to react and adapt to the situation before incurring heavy losses.

### 3. Build time
A slight build time increase from 10s to 12s will make the unit a bit harder to spam, and gives opponents slightly more time to prepare. An increase of two seconds is reasonable as it is an even number and relatively close to the original value. Increasing the time any further would likely incur too much of a visibility cost. Note that the build times do add up, and more Pathfinders are already required than previously to achieve the same effect.

### 4. Attack range
A slight attack range reduction gives opponents a bit more flexibility, and requires Pathfinders to get a bit closer to danger. Pathfinders are often combined with the Search & Destroy battle plan, and it feels reasonable to select a value that would put the maximum range at a nice midpoint between the two original ranges (275 → 330 vs 300 → 360). A value of 275 also ties in with the ranges of some base defences, such as the Firebase and EMP Patriot, which allows opponents to more accurately protect their infantry within or behind their defences. It is hard to reduce the range much further without affecting the realism aspect of the unit and potentially becoming too noticeable.

The below image illustrates the 25 range difference (300 vs 275), which is about the length of a Humvee.

![image](https://user-images.githubusercontent.com/11547761/197380186-be7db472-c0fa-41fc-b6de-f2d21b2f1cbc.png)

### 5. Price
A $200 increase from $600 to $800 will make the unit a bit harder to spam, and will potentially require players to make compromises elsewhere. A player might not be able to afford a few extra Missile Defenders or another Humvee, which could be the distinguishing factor in an important encounter. A price of $800 is reasonable as it is not too different from 1.04 and has a degree of consistency due to being shared with other infantry units like the Angry Mob and Saboteur. It also helps that 8 is visually similar to 6. A $200 / 33% increase is probably as big of a change as you'd want to make when considering the unit's prevalence and specialisation while minimising visibility / controversy.

### 6. Movement
It does not seem fair that infantry are more or less screwed if they attempt to outrun Pathfinders. Applying a slower movement speed affords opponents a greater opportunity to retreat and slightly increases the time it takes to load up Humvees. The only infantry that can 'outrun' (match) Pathfinders in 1.04 are Saboteurs, Hijackers, Workers (with shoes) and heroes. After the change; Rangers, Red Guard, Rebels, Workers (without shoes), Terrorists and Hackers* join the club. Also note that the `BasicHumanLocomotorPlus25` locomotor has a slower turn rate of 360, compared with the original 500. (Not only is the slower rotation or 'aiming' more realistic, but a value of 360 fits right in with internet culture.)

### 7. Stealth delay
A one second stealth delay allows Pathfinders to be briefly seen after they stop moving, which provides opponents with enhanced readability and a greater opportunity to recall their position. This heightens the risk of movement, and ties in more effectively with the other conditional stealth behaviours in the game, which all feature some form of delay. It also allows opponents to more effectively see when a Pathfinder is evacuated from a vehicle, and more care will have to be taken when evacuating.

### 8. Experience yields
Increasing the experience yields is a subtle way to reward opponents for killing such a powerful and specialised unit. Though Pathfinders are often contained in some form of transport (where xp is not distributed if the occupant dies with the transport; see TheSuperHackers/GeneralsGameCode#55), it could add some much-needed risk to leaving Pathfinders out in the open, or make players think twice about evacuating a critically damaged Humvee.

## Further considerations

### Strategy Center prerequisite
Another idea would be to introduce the Strategy Center as a prerequisite. This would provide opponents with some additional counterplay options / strategies, where they can destroy an opponent's Strategy Center to halt Pathfinder production. It also makes sense that such a powerful, late-game unit is locked behind the tech building. It would also increase the risk of selling one's Command Center and protecting one's dozers, as it might prevent the user from being able to acquire a Strategy Center and Pathfinders by extension. The only caveat with such a change - and the reason I have not included it in the initial list of changes - would be its high visibility and susceptibility to controversy, as it would likely be noticed by the majority of players. Regardless, it could certainly be considered reasonable enough for most players to accept.

### Hero resistance
It might also be an idea to introduce alternate 'hero' armour types for Colonel Burton, Black Lotus and Jarmen Kell, with the only difference being a reduced SNIPER damage multiplier. This would allow the respective heroes to take a few extra shots from Pathfinders, which could be an acceptable change as heroes can already sustain a hit from a lesser ranked Pathfinder in 1.04.

### Fire vulnerability
As Pathfinders wear gillie suits, it would add a bit of humour and realism if they made good kindling. Sometimes a Dragon's firewall ability or a MiG force-firing on the ground is all China has at its disposal to deal with an immediate Pathfinder threat in their base.

## Summary

I firmly believe the above combination of changes strikes a very reasonable balance between reducing the Pathfinder's effectiveness and maintaining the original feeling of 1.04, with no major discernible behavioural or mechanical differences. The doubled weapon reload time and experience requirements may seem fairly substantial, but when considering the fact that a _single_ Pathfinder typically ends up killing dozens of infantry in 1.04, the adjustments are more than reasonable. In an ideal world, Pathfinders would likely be nerfed even further / differently.

Anyway, feel free to test the proposed changes and see how the game feels!