### PR TITLE
Comanche experience requirements

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -2205,7 +2205,7 @@ Object AirF_AmericaVehicleComanche
   BuildCost           = 1200
   BuildTime           = 20              ; in seconds
   ExperienceValue     = 50 50 100 200   ; Experience point value at each level
-  ExperienceRequired  = 0 100 200 400   ; Experience points needed to gain each level
+  ExperienceRequired  = 0 150 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CommandSet          = AirF_AmericaVehicleComancheCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -1775,7 +1775,7 @@ Object AmericaVehicleComanche
   BuildCost           = 1500
   BuildTime           = 20              ; in seconds
   ExperienceValue     = 50 50 100 200   ; Experience point value at each level
-  ExperienceRequired  = 0 100 200 400   ; Experience points needed to gain each level
+  ExperienceRequired  = 0 150 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CommandSet          = AmericaVehicleComancheCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -1102,7 +1102,7 @@ Object CINE_USA08_AmericaVehicleComanche
   BuildCost           = 1500
   BuildTime           = 20              ; in seconds
   ExperienceValue     = 50 50 100 200   ; Experience point value at each level
-  ExperienceRequired  = 0 100 200 400   ; Experience points needed to gain each level
+  ExperienceRequired  = 0 150 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CommandSet          = AmericaVehicleComancheCommandSet
 
@@ -3220,7 +3220,7 @@ Object CINE_AmericaVehicleComanche
   BuildCost           = 1500
   BuildTime           = 20              ; in seconds
   ExperienceValue     = 50 50 100 200   ; Experience point value at each level
-  ExperienceRequired  = 0 100 200 400   ; Experience points needed to gain each level
+  ExperienceRequired  = 0 150 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CommandSet          = AmericaVehicleComancheCommandSet
 
@@ -6296,7 +6296,7 @@ Object CINE_AmericaVehicleComanche02
   BuildCost           = 1500
   BuildTime           = 20              ; in seconds
   ExperienceValue     = 50 50 100 200   ; Experience point value at each level
-  ExperienceRequired  = 0 100 200 400   ; Experience points needed to gain each level
+  ExperienceRequired  = 0 150 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CommandSet          = AmericaVehicleComancheCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -1533,7 +1533,7 @@ Object Lazr_AmericaVehicleComanche
   BuildCost           = 1500
   BuildTime           = 20              ; in seconds
   ExperienceValue     = 50 50 100 200   ; Experience point value at each level
-  ExperienceRequired  = 0 100 200 400   ; Experience points needed to gain each level
+  ExperienceRequired  = 0 150 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CommandSet          = Lazr_AmericaVehicleComancheCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -2011,7 +2011,7 @@ Object SupW_AmericaVehicleComanche
   BuildCost           = 1800
   BuildTime           = 20              ; in seconds
   ExperienceValue     = 50 50 100 200   ; Experience point value at each level
-  ExperienceRequired  = 0 100 200 400   ; Experience points needed to gain each level
+  ExperienceRequired  = 0 150 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CommandSet          = SupW_AmericaVehicleComancheCommandSet
 


### PR DESCRIPTION
This PR is a response to #1016 and aims to address the relatively low experience requirements of Comanches, which have significant potential when it comes to destroying units and buildings, as noted by @ImTimK [here](https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1553#issuecomment-1416730416). (This change was originally going to be part of a broader Comanche balance PR, but as several changes have been split across #1553 and #1530, this is now a standalone change as well.)

### Changes include:

1. Increased Comanche experience requirements from [0 100 200 400] to [0 150 300 600]

## Rationale

The main issue in 1.04 is that Air Force's Comanches are incredibly adept at taking down buildings and ranking up as a result. This makes them even harder to kill than they already are, as the ranking provides them with automatic healing and increased hit points.

A subtle way to curb this kind of snowballing is to align their experience requirements with those of the updated Rocket Buggy (#727), which is a similar type of glass cannon / hit-and-run-type unit featuring high mobility, low armour, and a similar initial burst of firepower. The experience values tie in nicely together.

It's worth noting that Advanced Training still provides Comanches with a significant advantage over Rocket Buggies in the ranking department.

## Further considerations

The armour changes from #1553 / #1530 need to also be considered, as they will effectively stack with this change.

## Summary

This change may be one of the most subtle ways of balancing Air Force Comanches. The change mainly impacts Air Force Comanches, which are used in an extremely aggressive manner, whereas standard Comanches are typically used more defensively, and so are not affected as much.