### PR TITLE
Change: Increase USA Comanche stealth delay from 1500 to 2000 ms

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -2337,7 +2337,7 @@ Object AirF_AmericaVehicleComanche
   End
 
   Behavior = StealthUpdate ModuleTag_22
-    StealthDelay                          = 1500 ; msec
+    StealthDelay                          = 2000 ; msec
     StealthForbiddenConditions            = FIRING_PRIMARY ATTACKING USING_ABILITY
     FriendlyOpacityMin                    = 50.0%
     FriendlyOpacityMax                    = 100.0%


### PR DESCRIPTION
This PR aims to reduce the incredible prowess of Air Force Comanches and is intended to address at least one of the problems I previously noted [here](https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1135#issuecomment-1252022265). (This change was originally going to be part of a broader Comanche balance PR, but as several changes have been split across #1553 and #1530, this is now a standalone change as well.)

### Changes include:

1. Increased Air Force Comanche stealth delay from 1500ms to 2000ms.

## Rationale

Air Force's Comanches are incredibly hard to take down in 1.04 due to their high mobility, armour, quick ranking and stealth ability. Combine these factors with their massive initial burst of firepower and you have a deadly force that is extremely difficult to respond to - especially in team-based games. The short stealth delay allows Comanches to easily fire off a volley of rockets and take out a variety of targets without facing much risk due to the extremely limited window of opportunity for opponents to react.

To mitigate this, it makes sense to increase the `StealthDelay` from 1500ms to 2000ms (+33%) to add weight to attack commands, provide opponents with more counterplay opportunities, further amplify the impact of mistakes and increase the overall skill ceiling. 

## Further considerations

The armour changes from #1553 / #1530 need to also be considered, as they will effectively stack with this change.

## Summary

This change is a subtle way of balancing Air Force Comanches without altering traditional gameplay or incurring too much of a visibility cost (though the Comanches may be visible for longer!). Opponents will be afforded more counterplay potential, with the only cost being the increased level of skill required to avoid danger and time one's strikes.