### PR TITLE
Helix experience requirements

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15685,7 +15685,7 @@ Object Boss_VehicleHelix
     Object = Boss_Airfield
   End
   ExperienceValue     = 50 100 150 200 ;Experience point value at each level
-  ExperienceRequired  = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired  = 0 75 150 300  ;Experience points needed to gain each level
   IsTrainable         = Yes
   CommandSet          = ChinaVehicleHelixCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -78,7 +78,7 @@ Object ChinaVehicleHelix
     Object = ChinaAirfield
   End
   ExperienceValue     = 50 100 150 200 ;Experience point value at each level
-  ExperienceRequired  = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired  = 0 75 150 300  ;Experience points needed to gain each level
   IsTrainable         = Yes
   CommandSet          = ChinaVehicleHelixCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16357,7 +16357,7 @@ Object Infa_ChinaVehicleHelix
     Object = Infa_ChinaAirfield
   End
   ExperienceValue     = 50 100 150 200 ;Experience point value at each level
-  ExperienceRequired  = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired  = 0 75 150 300  ;Experience points needed to gain each level
   IsTrainable         = Yes
   CommandSet          = Infa_ChinaVehicleHelixCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -349,7 +349,7 @@ Object Nuke_ChinaVehicleHelix
     Object = Nuke_ChinaAirfield
   End
   ExperienceValue     = 50 100 150 200 ;Experience point value at each level
-  ExperienceRequired  = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired  = 0 75 150 300  ;Experience points needed to gain each level
   IsTrainable         = Yes
   CommandSet          = Nuke_ChinaVehicleHelixCommandSet
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -78,7 +78,7 @@ Object Tank_ChinaVehicleHelix
     Object = Tank_ChinaAirfield
   End
   ExperienceValue     = 50 100 150 200 ;Experience point value at each level
-  ExperienceRequired  = 0 100 200 400  ;Experience points needed to gain each level
+  ExperienceRequired  = 0 75 150 300  ;Experience points needed to gain each level
   IsTrainable         = Yes
   CommandSet          = ChinaVehicleHelixCommandSet
 


### PR DESCRIPTION
This change aims to slightly reduce the Helix's ranking requirements so it is a bit easier to rank up.

### Changes include:

1. Reduced Helix experience requirements from [0 100 200 400] to [0 75 150 300]

## Rationale

It is extremely rare that a Helix happens to destroy anything, as its passengers often do the job. This significantly limits its ranking prospects (also exacerbated by TheSuperHackers/GeneralsGameCode#87) and makes even a Veteran Helix a rare sight. Taking out many targets or a big target with such a weak gun is certainly a rank-worthy achievement, and it seems reasonable to lower the bar by 25% to facilitate this notion.

## Further considerations

It should be noted that the Gattling Cannon attachment or Napalm bomb may provide experience to their creators as a result of future modifications.

## Summary

Traditional gameplay is preserved and the change is unlikely to be noticed by even the most skilled players. I suspect this change will have very little impact, and the majority of Helixes will remain unranked. But the increased prospects are still enticing and certainly better than in 1.04.