### PR TITLE
Change: Despawn Salvage Crates deterministically after 32500 ms

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1688_salvage_crate_despawn_time.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1688_salvage_crate_despawn_time.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-02-12
+
+title: Sets despawn time of Salvage Crate to 32500 ms
+
+changes:
+  - tweak: The despawn time of the Salvage Crate is now set deterministically to 32500 ms from previously somewhere random between 30000 ms and 35000 ms.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1688
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -207,8 +207,8 @@ Object SalvageCrate
   End
 
   Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
-    MinLifetime = 30000
-    MaxLifetime = 35000
+    MinLifetime = 32500 ; Patch104p @tweak xezon 12/02/2023 From 30000 to achieve deterministic despawn timing.
+    MaxLifetime = 32500 ; Patch104p @tweak xezon 12/02/2023 From 35000 to achieve deterministic despawn timing.
   End
 
   Geometry = BOX


### PR DESCRIPTION
This change despawns Salvage Crates deterministically after 32500 ms instead of sometime between 30000 ms and 35000 ms.

32500 ms because that sits between the former min and mix deletion time of Salvage Crate.

## Original

https://user-images.githubusercontent.com/4720891/218302482-4cecb49a-083f-44c3-a3f3-be6593952ffc.mp4

## Patched

https://user-images.githubusercontent.com/4720891/218302490-52a592fe-c770-4988-a827-f7e37046665b.mp4

# Rationale

Deterministic timings make game events predictable. Randomness typically leads to random outcomes which are generally not desired for core game mechanics that affect the game state.