### PR TITLE
Change: Salvage Crates now sink for about 5 seconds into terrain before deletion

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -206,9 +206,19 @@ Object SalvageCrate
     MaxMoney = 75
   End
 
-  Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
-    MinLifetime = 30000
-    MaxLifetime = 35000
+  ; Patch104p @tweak xezon 12/02/2023 Change module from DeletionUpdate.
+  ; Patch104p @tweak xezon 12/02/2023 Decrease min lifetime from 30000 by 5150, max lifetime from 35000 by 5150 to accomodate slow death destruction delay.
+  Behavior = LifetimeUpdate ModuleTag_03
+    MinLifetime = 24850
+    MaxLifetime = 29850
+  End
+
+  ; Patch104p @tweak xezon 12/02/2023 Adds slow death to sink crate into ground. It can still be picked up while it sinks.
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL
+    SinkDelay           = 0
+    SinkRate            = 2.0     ; in Dist/Sec
+    DestructionDelay    = 5150
   End
 
   Geometry = BOX


### PR DESCRIPTION
This change makes Salvage Crates sink for about 5 seconds into terrain before deletion.

### TODO

- [ ] Fix decal ring update with Thyme

## Rationale

Original Salvage Crate gives no clue on about when it will disappear. Racing for a crate can become a matter of luck in certain situations. The randomized deletion of Salvage Crate at some time between 30000 ms and 35000 ms exacerbates this problem.

With Sink mechanic added to Salvage Create, the deletion can now be anticipated for at least 5 seconds before the crate is deleted.

## Video

https://user-images.githubusercontent.com/4720891/218304962-2bdb22f9-857c-438f-848d-5e243b4fcefb.mp4
