### PR TITLE
Change: Decrease USA Super Weapon Humvee cost from 850 to 800

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4894,7 +4894,7 @@ Object SupW_AmericaVehicleHumvee
     Armor           = HumveeArmor
     DamageFX        = TruckDamageFX
   End
-  BuildCost       = 850
+  BuildCost       = 800
   BuildTime       = 10.0          ;in seconds
   VisionRange     = 150
   ShroudClearingRange = 320


### PR DESCRIPTION
This change slightly reduces the price of Super Weapon Humvees.

### Changes include:

1. Reduced Humvee price from $850 to $800

## Rationale

Super Weapon General has a particularly hard time in competitive 1v1 matches due to its incredibly expensive Humvees. The advantages that the faction possesses do not make up for this disadvantage early on in a match, which often makes life incredibly difficult for the SWG player, who has to either bunker down in a bid to acquire their second-tier bonuses or play at an unfavourable disadvantage. A slight $50 reduction to equalise their Humvee prices with the traditionally superior Air Force will at least allow the faction to go toe to toe with Air Force if both parties opt for vehicular combat. Perhaps more importantly, it could be the difference between being able to afford an Ambulance or having to wait for the next income drop.

## Further considerations

It has been discussed and suggested several times in the past that the prices of Super Weapon Humvees be _swapped_ with Air Force Humvees to help even the playing field. Increasing Air Force Humvee prices from $800 to $850 may be a future consideration.

## Summary

This is quite a visible change that most players would likely notice, but also a reasonable change that I expect to be widely accepted due to how relatively weak SWG's early-game prospects are. It should allow SWG to be a bit more aggressive, which should in turn make the faction a bit less predictable and a bit more dangerous by extension. Such a change is certainly likely to make a positive difference.