### PR TITLE
Change: Decrease spin up time of China Gattling Tank Air Gun by 6 frames

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1149,6 +1149,7 @@ End
 
 ;------------------------------------------------------------------------------
 ; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
+; Patch104p @tweak xezon 12/02/2023 Change ContinuousFireOne from 3.
 ;------------------------------------------------------------------------------
 Weapon GattlingTankGunAir
   PrimaryDamage         = 12.0
@@ -1165,7 +1166,7 @@ Weapon GattlingTankGunAir
   DelayBetweenShots     = 400               ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
-  ContinuousFireOne     = 3 ; How many shots at the same target constitute "Continuous Fire"
+  ContinuousFireOne     = 2 ; How many shots at the same target constitute "Continuous Fire"
   ContinuousFireTwo     = 6 ; How many shots at the same target constitute "Continuous Fire Two"
   ContinuousFireCoast   = 2000 ; msec we can coast without firing before we lose Continuous Fire
   WeaponBonus           = CONTINUOUS_FIRE_MEAN RATE_OF_FIRE 200% ; When the object achieves this state, this weapon gets double the rate of fire


### PR DESCRIPTION
* Successor to #1199
* Closes #1567

This change decreases barrel spin up time of China Gattling Tank Air Gun by 6 frames. An alternative to #1567.

| Weapon                           | ContinuousFireOne | ContinuousFireTwo | ContinuousFireCoast |
|----------------------------------|-------------------|-------------------|---------------------|
| Original CCG GattlingTankGun     | 3                 | 6                 | 2000                |
| Original CCG GattlingTankGunAir  | 3                 | 6                 | 2000                |
| Original ZH GattlingTankGun      | 2                 | 6                 | 1000                |
| Original ZH GattlingTankGunAir   | 3                 | 6                 | 2000                |
| Patched GattlingTankGun (1)      | 2                 | 6                 | 2000                |
| **Patched GattlingTankGunAir (this)** | 2            | 6                 | 2000                |

### Gattling Tank Air Gun firing sequence in frames

Exclamation mark (!) represents a shot fired in timeline.

```
Original 12          12          6     6     3  3  3  3  3  3
         !...........!...........!.....!.....!..!..!..!..!..!

Patched  12          6     6     6     3  3  3  3  3  3
         !...........!.....!.....!.....!..!..!..!..!..!
```

## Rationale

Original `GattlingTankGun` and `GattlingTankGunAir` have inconsistent spin up times. With this change they are consistent.

This gives Gattling Tanks a minuscule better chance at damaging and killing air units, such as USA Raptor, Aurora and Comanche. This in turn makes China intangibly better against USA Airforce General and air force centrist strategies. Has no impact against GLA.