### PR TITLE
Fix: Increase USA Comanche missile lifetime by 200 ms

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -2846,7 +2846,7 @@ Object ComancheAntiTankMissile
   End
   Behavior = MissileAIUpdate ModuleTag_07
     TryToFollowTarget = Yes
-    FuelLifetime = 1000
+    FuelLifetime = 1200
     InitialVelocity = 150                ; in dist/sec
     IgnitionDelay = 0
     DistanceToTravelBeforeTurning = 10
@@ -2923,7 +2923,7 @@ Object ComancheRocketPodRocket
   End
   Behavior = MissileAIUpdate ModuleTag_07
     TryToFollowTarget = No
-    FuelLifetime = 1000
+    FuelLifetime = 1200
     InitialVelocity = 150                ; in dist/sec
     IgnitionDelay = 0
     DistanceToTravelBeforeTurning = 10


### PR DESCRIPTION
This change gives an additional 200ms (+20%, 6 frames) of fuel to Comanche missiles so that they can hit targets on slightly lower terrain. This is a frequent occurrence on maps like Defcon 6, which contains valleys and hills across the terrain where Comanches are often on a different elevation to their targets. It feels bad when the missiles just magically disappear into thin air because the Comanches are hovering over slightly elevated terrain.

This occurs with both the regular anti-tank missiles and rocket pods, which both have a lifetime of 1000ms in 1.04.

### TODO

- [ ] Address #1700 first, then revisit this setup

## 1.04:
The missiles fail to reach their target and disappear if the Comanche is on a marginally higher elevation than the target.

https://user-images.githubusercontent.com/11547761/218321120-b599a813-8ccf-40c9-91b6-d3732ab96855.mp4

## Patch:
The missiles have just enough fuel to hit the target if the Comanche is on a marginally higher elevation than their target. The missiles will still disappear if the height is large enough, but that height is quite a bit more reasonable. It's a minor buff for a relatively substantial usability improvement.

https://user-images.githubusercontent.com/11547761/218321125-28bb200d-9384-4ce7-968e-e4a3007b33e3.mp4