### PR TITLE
Change: Increase fire rate of GLA RPG Trooper on Combat Bike by 88%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1694_biker_rocket_weapon.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1694_biker_rocket_weapon.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-02-12
+
+title: Increases fire rate of GLA RPG Trooper on Combat Bike by 88%
+
+changes:
+  - tweak: The GLA RPG Trooper on the Combat Bike now shoots a rocket every 533 ms instead of 1000 ms.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1694
+
+authors:
+  - Stubbjax

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2151,7 +2151,7 @@ Weapon TunnelDefenderBikerRocketWeapon
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   ScatterRadius               = 0      ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly
-  DelayBetweenShots           = 1000  ; time between shots, msec
+  DelayBetweenShots           = 500  ; time between shots, msec
   ClipSize                    = 0             ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 0    ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7802,7 +7802,7 @@ Weapon Chem_TunnelDefenderBikerRocketWeapon
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   ScatterRadius               = 0      ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly
-  DelayBetweenShots           = 1000  ; time between shots, msec
+  DelayBetweenShots           = 500  ; time between shots, msec
   ClipSize                    = 0             ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 0    ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
@@ -7832,7 +7832,7 @@ Weapon Chem_TunnelDefenderBikerRocketWeaponGamma
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   ScatterRadius               = 0      ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly
-  DelayBetweenShots           = 1000  ; time between shots, msec
+  DelayBetweenShots           = 500  ; time between shots, msec
   ClipSize                    = 0             ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 0    ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
@@ -9020,7 +9020,7 @@ Weapon DEMO_TunnelDefenderBikerRocketWeapon
   VeterancyProjectileExhaust  = HEROIC HeroicMissileExhaust
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   ScatterRadius               = 0      ; This weapon will scatter somewhere within a circle of this radius, instead of hitting someone directly
-  DelayBetweenShots           = 1000  ; time between shots, msec
+  DelayBetweenShots           = 500  ; time between shots, msec
   ClipSize                    = 0             ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 0    ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2136,6 +2136,7 @@ Weapon TunnelDefenderRocketWeapon
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP rocket upgrade
 End
 
+; Patch104p @tweak Stubbjax 12/02/2023 Changes delay between shots from 1000. (#1694)
 ;------------------------------------------------------------------------------
 Weapon TunnelDefenderBikerRocketWeapon
   PrimaryDamage               = 40.0
@@ -7786,7 +7787,7 @@ Weapon Chem_ScorpionMissileWeaponPlusTwo
 End
 
 ; Patch104p @bugfix commy2 10/09/2021 Make Tox Biker RPG fire the same weapon as regular Tox RPG.
-
+; Patch104p @tweak Stubbjax 12/02/2023 Changes delay between shots from 1000. (#1694)
 ;------------------------------------------------------------------------------
 Weapon Chem_TunnelDefenderBikerRocketWeapon
   PrimaryDamage               = 40.0
@@ -7817,6 +7818,7 @@ Weapon Chem_TunnelDefenderBikerRocketWeapon
   AcceptableAimDelta    = 20.0
 End
 
+; Patch104p @tweak Stubbjax 12/02/2023 Changes delay between shots from 1000. (#1694)
 ;------------------------------------------------------------------------------
 Weapon Chem_TunnelDefenderBikerRocketWeaponGamma
   PrimaryDamage               = 52.0
@@ -9003,9 +9005,8 @@ Weapon DEMO_SCUDLauncherGunExplosivePlusTwo
 End
 
 ; Patch104p @bugfix commy2 10/09/2021 Make Demo Biker RPG fire the same weapon as regular Demo RPG.
-
+; Patch104p @tweak Stubbjax 12/02/2023 Changes delay between shots from 1000. (#1694)
 ;-----------------------------------------------------------------------------------
-
 Weapon DEMO_TunnelDefenderBikerRocketWeapon
   PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 5.0


### PR DESCRIPTION
This change halves the delay between shots for the Combat Cycle's RPG weapon from 1000ms to 500ms. This is to provide some tangible benefit to going to the trouble of replacing a Combat Cycle's rider with a Tunnel Defender, which is a pointless endeavour in pretty much every scenario in 1.04.

There will likely never be a worthwhile use for this unit due to its vulnerability to its preferred targets, vehicles and tanks, in combination with the effort involved in its acquisition and the relatively poor output for the price / time investment. A Technical + Tunnel Defender is cheaper and far more flexible. The goal of this change isn't to make the unit viable, but to make it slightly less of a joke. The fire rate reduction was chosen for its simplicity. See #1147 for other proposals.

Below is a comparison between one Tunnel Defender, two Tunnel Defenders, and the RPG Combat Cycle after the change.

https://user-images.githubusercontent.com/11547761/218325613-b0be6255-25e1-4df9-aa9d-906e31ebc817.mp4