### PR TITLE
Change: GLA Scorpion Rocket will always reload when idle

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -197,6 +197,7 @@ Weapon ScorpionTankGunPlusOne
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon ScorpionMissileWeaponPlusTwo
   PrimaryDamage = 100.0
   PrimaryDamageRadius = 5.0
@@ -218,6 +219,7 @@ Weapon ScorpionMissileWeaponPlusTwo
   ClipSize = 2            ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 15000  ; how long to reload a Clip, msec
   AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 15100
   ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
 
   ; note, these only apply to units that aren't the explicit target
@@ -7526,6 +7528,7 @@ End
 ; Patch104p @bugfix commy2 19/09/2021 Fix double/scrap +2 Scorpion Rocket spawns blue poison after Anthrax Gamma upgrade.
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon Chem_ScorpionMissileWeaponPlusTwo
   PrimaryDamage = 100.0
   PrimaryDamageRadius = 5.0
@@ -7547,6 +7550,7 @@ Weapon Chem_ScorpionMissileWeaponPlusTwo
   ClipSize = 2            ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 15000  ; how long to reload a Clip, msec
   AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 15100
   ProjectileDetonationFX = WeaponFX_RocketBuggyMissileDetonation
 
   ; note, these only apply to units that aren't the explicit target
@@ -8636,7 +8640,8 @@ Weapon REDScorpionMissileWeapon
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; AP weapon upgrade
 End
 ;------------------------------------------------------------------------------
-Weapon REDScorpionMissileWeaponPlusTwo
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
+Weapon REDScorpionMissileWeaponPlusTwo ; Alias Demo_ScorpionMissileWeaponPlusTwo
   PrimaryDamage = 100.0
   PrimaryDamageRadius = 5.0
   SecondaryDamage = 80.0
@@ -8657,6 +8662,7 @@ Weapon REDScorpionMissileWeaponPlusTwo
   ClipSize = 2            ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 15000  ; how long to reload a Clip, msec
   AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 15100
   ProjectileDetonationFX = WeaponFX_DEMOGENRocketBuggyMissileDetonation
 
   ; note, these only apply to units that aren't the explicit target


### PR DESCRIPTION
* Resolves #1698

With this change the GLA Scorpion Rocket will always reload when idle.

This makes the unit a bit better in scenarios where it managed to only fire with one of its rockets on its target and some time passes until the next target is attacked.

This situation is rare. There is a `ClipReloadTime` of 15000 ms vs a `DelayBetweenShots` of 200 ms. This means there is a measly 1.3% chance that Scorpion Tank gets into state with one rocket in racks when attacking and moving Scorpion Tank around.

# Rationale

Eliminates situations where Scorpion Tank would only fire one rocket on a fresh engagement. This likely is what player would expect always.
