### PR TITLE
Fix: GLA Scud Storm will always fully reload

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1612,6 +1612,7 @@ Weapon NeutronMissileWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 11/02/2023 Enables automatic reload when idle.
 Weapon ScudStormWeapon
   PrimaryDamage = 0               ; not used for this weapon (it's "special")
   PrimaryDamageRadius = 0         ; not used for this weapon (it's "special")
@@ -1629,6 +1630,7 @@ Weapon ScudStormWeapon
   ClipSize = 9
   ClipReloadTime = 10000 ; give it time to sink into the ground
   AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 10100
   ScatterRadius   = 0;changed to zero, unless you want to soften the results of the table below
 
   ; Instead of a purely random scatter distance, this will divide a clip evenly and randomly at these spots
@@ -6789,6 +6791,7 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 11/02/2023 Enables automatic reload when idle.
 Weapon GC_Chem_ScudStormWeapon
   PrimaryDamage = 0               ; not used for this weapon (it's "special")
   PrimaryDamageRadius = 0         ; not used for this weapon (it's "special")
@@ -6806,6 +6809,7 @@ Weapon GC_Chem_ScudStormWeapon
   ClipSize = 9
   ClipReloadTime = 10000 ; give it time to sink into the ground
   AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 10100
   ScatterRadius   = 0;changed to zero, unless you want to soften the results of the table below
 
   ; Instead of a purely random scatter distance, this will divide a clip evenly and randomly at these spots
@@ -7975,6 +7979,7 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 11/02/2023 Enables automatic reload when idle.
 Weapon Demo_ScudStormWeapon
   PrimaryDamage = 0               ; not used for this weapon (it's "special")
   PrimaryDamageRadius = 0         ; not used for this weapon (it's "special")
@@ -7992,6 +7997,7 @@ Weapon Demo_ScudStormWeapon
   ClipSize = 9
   ClipReloadTime = 10000 ; give it time to sink into the ground
   AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 10100
   ScatterRadius   = 0;changed to zero, unless you want to soften the results of the table below
 
   ; Instead of a purely random scatter distance, this will divide a clip evenly and randomly at these spots
@@ -8244,6 +8250,7 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 11/02/2023 Enables automatic reload when idle.
 Weapon Chem_ScudStormWeapon
   PrimaryDamage = 0               ; not used for this weapon (it's "special")
   PrimaryDamageRadius = 0         ; not used for this weapon (it's "special")
@@ -8261,6 +8268,7 @@ Weapon Chem_ScudStormWeapon
   ClipSize = 9
   ClipReloadTime = 10000 ; give it time to sink into the ground
   AutoReloadsClip = Yes
+  AutoReloadWhenIdle = 10100
   ScatterRadius   = 0;changed to zero, unless you want to soften the results of the table below
 
   ; Instead of a purely random scatter distance, this will divide a clip evenly and randomly at these spots


### PR DESCRIPTION
* Fixes #1701

With this change the GLA Scud Storm will always fully reload.

## Original

https://user-images.githubusercontent.com/4720891/218556461-4d9ffeec-2818-4654-82f3-9f57b62b0602.mp4

## Patched

https://user-images.githubusercontent.com/4720891/218559695-dc57570c-0ad9-4e73-b7ee-c04dd6ddba7e.mp4
