### PR TITLE
Change: China Tank Battlemaster with Autoloader will always reload when idle

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1704_battlemaster_autoloader_idle_reload.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1704_battlemaster_autoloader_idle_reload.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-02-11
+
+title: Adds idle auto reload after 2100 ms to China Tank Battlemaster with Autoloader upgrade
+
+changes:
+  - tweak: The China Tank Battlemaster with Autoloader upgrade will now always reload when idle. This makes the unit much better in scenarios where it managed to only fire 1 or 2 of its shells and at least 2 seconds pass until the next attack.
+
+labels:
+  - buff
+  - china
+  - controversial
+  - design
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1704
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6641,6 +6641,7 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle. (#1704)
 Weapon Tank_BattleMasterTankGun
   PrimaryDamage           = 40.0
   PrimaryDamageRadius     = 5.0
@@ -6661,6 +6662,8 @@ Weapon Tank_BattleMasterTankGun
   DelayBetweenShots       = 500               ; time between shots, msec
   ClipSize                = 3                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime          = 2000              ; how long to reload a Clip, msec
+  AutoReloadsClip         = Yes
+  AutoReloadWhenIdle      = 2100
   WeaponBonus             = PLAYER_UPGRADE DAMAGE 125% ; UraniumShells
 
   ; note, these only apply to units that aren't the explicit target


### PR DESCRIPTION
* Resolves TheSuperHackers/GeneralsGamePatch#1702

With this change the China Tank Battlemaster with Autoloader will always reload when idle.

This makes the unit significantly better in scenarios where it managed to only fire 1 or 2 times and some time passes until the next target is attacked.

This situation is common. There is a `ClipReloadTime` of 2000 ms vs a `DelayBetweenShots` of 533 (500) ms with 3 clips. This means there is a 44% chance that Tank Battlemaster with Autoloader gets into state with just 1 or 2 loaded clips in regular battle engagements.

# Rationale

Eliminates situations where Tank Battlemaster with Autoloader would only fire 1 or 2 shells on a fresh engagement. This likely is what player would expect always.

## Original

https://user-images.githubusercontent.com/4720891/218558233-5fcee6c8-cefe-4a95-8049-7e2a80d6cd25.mp4

## Patched

https://user-images.githubusercontent.com/4720891/218562135-13c0d00c-cead-47f3-8faf-c7164ba996a1.mp4
