### PR TITLE
Change: USA Comanche Rocket Pod will always reload when idle

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1425,6 +1425,7 @@ Weapon ComancheAntiTankMissileWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 11/02/2023 Enables automatic reload when idle.
 Weapon ComancheRocketPodWeapon
   PrimaryDamage           = 30.0
   PrimaryDamageRadius     = 5.0
@@ -1473,6 +1474,7 @@ Weapon ComancheRocketPodWeapon
   DelayBetweenShots       = 200    ; time between shots, msec
   ClipSize                = 20              ; how many shots in a Clip (0 == infinite)
   AutoReloadsClip         = Yes
+  AutoReloadWhenIdle      = 30100
   ClipReloadTime          = 30000                      ; how long to reload a Clip, msec
   FireSound               = ComancheRocketPodWeaponSound
   FireFX                  = None


### PR DESCRIPTION
With this change the USA Comanche Rocket Pod will always reload when idle.

This makes the unit much better in scenarios where it managed to only fire a few of its rockets and at least 30 seconds pass until the next attack.

This situation is common. There is a `ClipReloadTime` of 30000 ms vs a `DelayBetweenShots` of 200 ms with 20 clips. Comanche can shoot Rocket Pods for a total duration of 4000 ms in which the player can decide to cancel the attack for various reasons.

# Rationale

Eliminates situations where USA Comanche would fire less than 20 rockets on an entirely fresh engagement. This likely is what player would expect always. Also, this makes it consistent with the behavior of the standard rocket weapon of the Comanche, which also reloads its clips when idle.

This change is good news for Regular USA, Laser and Superweapon, as these factions seldom build and use Comanche.

As for USA Airforce, this makes the already good Stealth Comanche better for these particular idle situations. There are other changes to mitigate its significant strengths:

* #1553
* #1684

## Original

https://user-images.githubusercontent.com/4720891/218571468-684cf9f0-7c9b-478c-8d20-0403808a09ca.mp4