### PR TITLE
Fix: Stealth General Rebels no longer become or remain revealed when taking damage

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13672,7 +13672,7 @@ Object Slth_GLAInfantryRebel
   End
   Behavior = StealthUpdate ModuleTag_07
     StealthDelay                = 2500 ; msec
-    StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE
+    StealthForbiddenConditions  = ATTACKING USING_ABILITY
     MoveThresholdSpeed          = 3
     InnateStealth               = Yes ;doesnt Require upgrade first
     OrderIdleEnemiesToAttackMeUponReveal  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13670,6 +13670,8 @@ Object Slth_GLAInfantryRebel
   Behavior = PhysicsBehavior ModuleTag_05
     Mass = 5.0
   End
+
+  ; Patch104p @bugfix Stubbjax 14/02/2023 Removes TAKING_DAMAGE flag to no longer reveal unit when taking damage.
   Behavior = StealthUpdate ModuleTag_07
     StealthDelay                = 2500 ; msec
     StealthForbiddenConditions  = ATTACKING USING_ABILITY


### PR DESCRIPTION
Stealth General Rebels no longer become or remain revealed when taking damage. It is strange and counterintuitive that the Stealth variant is the only Rebel to reveal itself when receiving damage. Moreover, no other stealth-capable unit in the game exhibits this behaviour.

After this change, all Rebel variants share the same stealth forbidden conditions of `ATTACKING` and `USING_ABILITY`.
```
Behavior = StealthUpdate ModuleTag_07
  StealthForbiddenConditions = ATTACKING USING_ABILITY
End
```
## 1.04:
From left to right: `Chem_GLAInfantryRebel`, `Demo_GLAInfantryRebel`, `GLAInfantryRebel`, `Slth_GLAInfantryRebel`. Only `Slth_GLAInfantryRebel` is revealed when fired upon.

https://user-images.githubusercontent.com/11547761/218680680-3adba079-fde4-4b2c-b25f-5cbe949b086b.mp4