### PR TITLE
Fix: Remove duplicate crush effects from all variants of the China Listening Outpost

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2953,11 +2953,6 @@ Object ChinaVehicleListeningOutpost
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
-  Behavior = FXListDie ModuleTag_10
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_CarCrush
-  End
-
   ; A crushing defeat
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2954,6 +2954,7 @@ Object ChinaVehicleListeningOutpost
   End
 
   ; A crushing defeat
+  ; Patch104p @bugfix Stubbjax 14/02/2023 Removes duplicate crush effect.
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED
     DeathFX = FX_CarCrush

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16247,11 +16247,6 @@ Object Infa_ChinaVehicleListeningOutpost
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
-  Behavior = FXListDie ModuleTag_10
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_CarCrush
-  End
-
   ; A crushing defeat
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16248,6 +16248,7 @@ Object Infa_ChinaVehicleListeningOutpost
   End
 
   ; A crushing defeat
+  ; Patch104p @bugfix Stubbjax 14/02/2023 Removes duplicate crush effect.
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED
     DeathFX = FX_CarCrush

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4944,11 +4944,6 @@ Object Nuke_ChinaVehicleListeningOutpost
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
-  Behavior = FXListDie ModuleTag_10
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_CarCrush
-  End
-
   ; A crushing defeat
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4945,6 +4945,7 @@ Object Nuke_ChinaVehicleListeningOutpost
   End
 
   ; A crushing defeat
+  ; Patch104p @bugfix Stubbjax 14/02/2023 Removes duplicate crush effect.
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED
     DeathFX = FX_CarCrush

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5211,11 +5211,6 @@ Object Tank_ChinaVehicleListeningOutpost
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
-  Behavior = FXListDie ModuleTag_10
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_CarCrush
-  End
-
   ; A crushing defeat
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5212,6 +5212,7 @@ Object Tank_ChinaVehicleListeningOutpost
   End
 
   ; A crushing defeat
+  ; Patch104p @bugfix Stubbjax 14/02/2023 Removes duplicate crush effect.
   Behavior = FXListDie ModuleTag_11
     DeathTypes = NONE +CRUSHED +SPLATTED
     DeathFX = FX_CarCrush


### PR DESCRIPTION
Removed duplicate crush effects from all variants of the Listening Outpost (`ModuleTag_10`). It's hard to tell the difference but it is definitely playing the same effect twice. The respective `CarCrush` audio event has a limit of 2.

```
Behavior = FXListDie ModuleTag_10
  DeathTypes = NONE +CRUSHED +SPLATTED
  DeathFX = FX_CarCrush
End

; A crushing defeat
Behavior = FXListDie ModuleTag_11
  DeathTypes = NONE +CRUSHED +SPLATTED
  DeathFX = FX_CarCrush
End
```

## 1.04:
The crush sound can be heard twice.

https://user-images.githubusercontent.com/11547761/218795318-697e8595-06ef-4538-8d0c-6854f4ef7577.mp4

## Patch:
The crush sound is only played once. Particle effects are harder to distinguish.

https://user-images.githubusercontent.com/11547761/218795290-4a9e72c3-3f8a-4332-89d3-beb5914b024d.mp4