### PR TITLE
Change: Enable kill on resting and set consistent lifetime for hulks

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -2275,10 +2275,11 @@ Object CarLimo03DeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -5615,10 +5616,11 @@ Object Humvee1DeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -2282,9 +2282,10 @@ Object CarLimo03DeadHull
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 0, MaxLifetime from 0.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 0   ; min lifetime in msec
-    MaxLifetime = 0   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
@@ -5623,9 +5624,10 @@ Object Humvee1DeadHull
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 0, MaxLifetime from 0.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 0   ; min lifetime in msec
-    MaxLifetime = 0   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -28,10 +28,11 @@ Object DeadMicrowaveHulk
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -87,10 +88,11 @@ Object AmericaVehicleHumveeDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -415,9 +417,11 @@ Object ComancheRubbleHull
   KindOf = CAN_CAST_REFLECTIONS IMMOBILE NO_COLLIDE HULK
 
   ; Patch104p @fix xezon 28/01/2023 Disable bouncing.
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_02
     Mass           = 25.0
     AllowBouncing  = No
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_03
@@ -585,10 +589,11 @@ Object ChinaVehicleBattleMasterDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -643,10 +648,11 @@ Object ChinaTankOverlordDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04
@@ -703,10 +709,11 @@ Object ChinaTankDragonDeadHull
     InitialHealth   = 1.0
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Enable kill when resting.
   Behavior = PhysicsBehavior ModuleTag_03
     Mass = 50
     AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
   End
 
   Behavior = LifetimeUpdate ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -35,9 +35,10 @@ Object DeadMicrowaveHulk
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 0, MaxLifetime from 0.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 0   ; min lifetime in msec
-    MaxLifetime = 0   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
@@ -95,9 +96,10 @@ Object AmericaVehicleHumveeDeadHull
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 0, MaxLifetime from 0.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 0   ; min lifetime in msec
-    MaxLifetime = 0   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05
@@ -596,9 +598,10 @@ Object ChinaVehicleBattleMasterDeadHull
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 0, MaxLifetime from 0.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 0   ; min lifetime in msec
-    MaxLifetime = 0   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
 
@@ -655,9 +658,10 @@ Object ChinaTankOverlordDeadHull
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 0, MaxLifetime from 0.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 0   ; min lifetime in msec
-    MaxLifetime = 0   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
 
@@ -716,9 +720,10 @@ Object ChinaTankDragonDeadHull
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 0, MaxLifetime from 0.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 0   ; min lifetime in msec
-    MaxLifetime = 0   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
 
@@ -1655,9 +1660,11 @@ Object DestroyedMilitiaTank
     AllowBouncing = Yes
     KillWhenRestingOnGround = Yes
   End
+
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 10000, MaxLifetime from 15000.
   Behavior = LifetimeUpdate ModuleTag_04
-    MinLifetime = 10000   ; min lifetime in msec
-    MaxLifetime = 15000   ; max lifetime in msec
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
   End
 
   Behavior = SlowDeathBehavior ModuleTag_05

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -426,9 +426,10 @@ Object ComancheRubbleHull
     KillWhenRestingOnGround = Yes
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Change MinLifetime from 3000, MaxLifetime from 3000.
   Behavior = LifetimeUpdate ModuleTag_03
-    MinLifetime    = 3000   ; min lifetime in msec
-    MaxLifetime    = 3000   ; max lifetime in msec
+    MinLifetime    = 20000   ; min lifetime in msec
+    MaxLifetime    = 20000   ; max lifetime in msec
   End
 
   ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 4 to 2, Destruction Delay from 10000 to 9500, to be consistent with other hulks.


### PR DESCRIPTION
**Merge with Rebase**

This change enables `KillWhenRestingOnGround` on all vehicle hulks where it is missing. Additionally, all ground vehicles and helicopters now have consistent life times. User facing this has no tangible effect, however it does affect when exactly hulk object is pushed into dead state.

What `KillWhenRestingOnGround` does in code:

```c++
UpdateSleepTime PhysicsBehavior::Update()
{
    ...
    if (data->m_killWhenRestingOnGround && !above && Is_Low_Velocity(m_vel)) {
        if ((!obj->Is_KindOf(KINDOF_DRONE) || obj->Is_Effectively_Dead()
                || obj->Get_Disabled_State(DISABLED_TYPE_DISABLED_UNMANNED))) {
            obj->Kill(DAMAGE_UNRESISTABLE, DEATH_NORMAL);
        }
    }
    ...
}
```

It kills an object when resting as the name implies.

With a life time such as
```
  Behavior = LifetimeUpdate ModuleTag_04
    MinLifetime = 1500   ; min lifetime in msec
    MaxLifetime = 1600   ; max lifetime in msec
  End
```
it means that vehicle is set dead either after 1500 to 1600 ms or when it is resting on ground.

This setup is now consistent on all hulks. Helicopter hulks have longer life times because they slowly fall to ground and their death is supposed to begin after the crash landing.

Vehicles: 1500 to 1600
Helicopters: 20000 to 20000