### PR TITLE
Fix: Increase destruction delays for hulks of USA Dozer, Avenger, China Dozer, Supply Truck, Inferno Cannon, Overlord, Nuke Cannon, Helix, GLA Combat Bike, Scud Launcher to avoid deletion before object is sunk into terrain

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
@@ -148,10 +148,12 @@ Object GLACombatBikeToppledHulk
     MaxLifetime = 0   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Remove obsolete Sink Delay of 1.
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 3000 to 8000 (+5000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_06
-    SinkDelay = 1
+    SinkDelay = 0
     SinkRate = 1.0
-    DestructionDelay = 3000
+    DestructionDelay = 8000
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -186,10 +186,11 @@ Object ChinaVehicleNukeCannonHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 10000
   End
 End
 
@@ -513,10 +514,11 @@ Object HelixRubbleHull
   End
 
   ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 14500 (+8000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 16000
   End
 
 End
@@ -665,11 +667,11 @@ Object ChinaTankOverlordDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
-
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6000 to 9000 (+3000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay = 14000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 23000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -919,10 +921,11 @@ Object InfernoCannonHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 10000
   End
 
 End
@@ -954,10 +957,11 @@ Object DeadChinaSupplyTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -1112,10 +1116,11 @@ Object DeadSCUDLauncherHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -1366,7 +1371,7 @@ Object DeadRocketBuggyHulk
 End
 
 ;------------------------------------------------------------------------------
-Object DeadCombatBikeHulk
+Object DeadCombatBikeHulk ; Unused, see GLACombatBikeToppledHulk
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -1529,10 +1534,11 @@ Object DeadAvengerHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9000
   End
 End
 
@@ -1668,10 +1674,11 @@ Object DestroyedMilitiaTank
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 8000 to 10500 (+2500) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay = 4000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 10500
   End
 End
 
@@ -1737,10 +1744,11 @@ Object ChinaDeadDozerHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9000
   End
 
 End
@@ -1772,10 +1780,11 @@ Object AmericaDeadDozerHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9000
   End
 
 End


### PR DESCRIPTION
This change increase destruction delays of various hulks to avoid deletion before object is sunk into terrain.

Affects

* USA Dozer
* USA Avenger
* China Dozer
* China Supply Truck
* China Inferno Cannon
* China Overlord
* China Nuke Cannon
* China Helix
* GLA Combat Bike
* GLA Scud Launcher

Note: The destruction delay of China Nuke Cannon was optimized for its Hulk prior change #1618. With the D1 model tweaked, it no longer takes as much height.

Note 2: The destruction delays are not optimized for sideway wrecks on slope. For that the long models would require much longer destruction delays. Ideally in future we will have hulks aligned to terrain properly, which will avoid such destruction before complete sink.

## Original Deletion Delay Sample

https://user-images.githubusercontent.com/4720891/218875893-3fa368ad-dd83-43dc-b8bd-4023cbfd5f39.mp4

