### PR TITLE
Fix: Decrease destruction delays for hulks of USA Dozer, Humvee, Ambulance, Scout Drone, Battle Drone, China Gattling, ECM, GLA Technical(s), Quad Cannon, Scorpion, Toxin Truck, Radar Van, Rocket Buggy

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -994,10 +994,11 @@ Object DeadChinaGattlingTankHulk
   End
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 10000 (-2000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
+    DestructionDelay          = 10000
   End
 
 End
@@ -1030,10 +1031,11 @@ Object DeadChinaECMTankHulk
   End
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
+    DestructionDelay          = 8000
   End
 
 End
@@ -1066,10 +1068,11 @@ Object AmericaVehicleAmbulanceDeadHull
   End
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 7500 (-4500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay                 = 1500
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 12000
+    DestructionDelay          = 7500
   End
 
 
@@ -1152,10 +1155,11 @@ Object DeadToxinTractorHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10000 (-6000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 10000
   End
 
 End
@@ -1187,10 +1191,11 @@ Object DeadQuadCannonHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 8000 (-8000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 8000
   End
 
 End
@@ -1222,10 +1227,11 @@ Object DeadBombTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10500 (-5500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 10500
   End
 
 End
@@ -1257,10 +1263,11 @@ Object DeadTechnicalVanHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1292,10 +1299,11 @@ Object DeadTechnicalJeepHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1327,10 +1335,11 @@ Object DeadTechnicalTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1362,10 +1371,11 @@ Object DeadRocketBuggyHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 6500 (-9500) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 6500
   End
 
 End
@@ -1637,10 +1647,11 @@ Object DeadScorpionHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 8000
   End
 End
 
@@ -1709,10 +1720,11 @@ Object DeadRadarVanHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 12000 (-4000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay         = 1500
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 16000
+    DestructionDelay  = 12000
   End
 
 End
@@ -1790,6 +1802,8 @@ Object AmericaDeadDozerHulk
 End
 
 ;------------------------------------------------------------------------------
+; Note: AmericaScoutDroneHulk is used for Hellfire Drone too.
+;------------------------------------------------------------------------------
 Object AmericaScoutDroneHulk
   ; *** ART Parameters ***
   Draw                = W3DModelDraw ModuleTag_01
@@ -1815,10 +1829,11 @@ Object AmericaScoutDroneHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 8000 to 6000 (-2000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 6000
   End
 End
 
@@ -1848,10 +1863,11 @@ Object AmericaBattleDroneHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 8000 to 6000 (-2000) to delete object earlier after it sunk into terrain.
   Behavior = SlowDeathBehavior ModuleTag_05
     SinkDelay        = 1500
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 6000
   End
 End
 


### PR DESCRIPTION
This change decreases destruction delays of some hulks to delete them earlier. By the time of deletion they are already sunk under sloped terrain.

Affects

* ~~USA Dozer~~
* ~~USA Humvee~~
* USA Ambulance
* USA Scout Drone, Battle Drone
* China Gattling Tank
* China ECM Tank
* GLA Technical(s)
* GLA Quad Cannon
* GLA Scorpion Tank
* GLA Toxin Truck
* GLA Radar Van
* GLA Rocket Buggy
