### PR TITLE
Fix: Super Weapon General now uses the correct Command Center model during construction and deconstruction

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7792,74 +7792,74 @@ Object SupW_AmericaCommandCenter
     ;This block handles every possible case with construction process, selling process, awaiting construction, and sold states
     ;for this draw module
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
-      Model              = ABBtCmdHQ
-      Animation          = ABBtCmdHQ.ABBtCmdHQ
+      Model              = ABBtCmdHQS
+      Animation          = ABBtCmdHQS.ABBtCmdHQS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED DAMAGED
-      Model              = ABBtCmdHQ_D
-      Animation          = ABBtCmdHQ_D.ABBtCmdHQ_D
+      Model              = ABBtCmdHQS_D
+      Animation          = ABBtCmdHQS_D.ABBtCmdHQS_D
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED REALLYDAMAGED
-      Model              = ABBtCmdHQ_E
-      Animation          = ABBtCmdHQ_E.ABBtCmdHQ_E
+      Model              = ABBtCmdHQS_E
+      Animation          = ABBtCmdHQS_E.ABBtCmdHQS_E
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT
-      Model              = ABBtCmdHQ_N
-      Animation          = ABBtCmdHQ_N.ABBtCmdHQ_N
+      Model              = ABBtCmdHQS_N
+      Animation          = ABBtCmdHQS_N.ABBtCmdHQS_N
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT DAMAGED
-      Model              = ABBtCmdHQ_DN
-      Animation          = ABBtCmdHQ_DN.ABBtCmdHQ_DN
+      Model              = ABBtCmdHQS_DN
+      Animation          = ABBtCmdHQS_DN.ABBtCmdHQS_DN
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT REALLYDAMAGED
-      Model              = ABBtCmdHQ_EN
-      Animation          = ABBtCmdHQ_EN.ABBtCmdHQ_EN
+      Model              = ABBtCmdHQS_EN
+      Animation          = ABBtCmdHQS_EN.ABBtCmdHQS_EN
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED SNOW
-      Model              = ABBtCmdHQ_S
-      Animation          = ABBtCmdHQ_S.ABBtCmdHQ_S
+      Model              = ABBtCmdHQS_S
+      Animation          = ABBtCmdHQS_S.ABBtCmdHQS_S
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED SNOW DAMAGED
-      Model              = ABBtCmdHQ_DS
-      Animation          = ABBtCmdHQ_DS.ABBtCmdHQ_DS
+      Model              = ABBtCmdHQS_DS
+      Animation          = ABBtCmdHQS_DS.ABBtCmdHQS_DS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED SNOW REALLYDAMAGED
-      Model              = ABBtCmdHQ_ES
-      Animation          = ABBtCmdHQ_ES.ABBtCmdHQ_ES
+      Model              = ABBtCmdHQS_ES
+      Animation          = ABBtCmdHQS_ES.ABBtCmdHQS_ES
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW
-      Model              = ABBtCmdHQ_NS
-      Animation          = ABBtCmdHQ_NS.ABBtCmdHQ_NS
+      Model              = ABBtCmdHQS_NS
+      Animation          = ABBtCmdHQS_NS.ABBtCmdHQS_NS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW DAMAGED
-      Model              = ABBtCmdHQ_DNS
-      Animation          = ABBtCmdHQ_DNS.ABBtCmdHQ_DNS
+      Model              = ABBtCmdHQS_DNS
+      Animation          = ABBtCmdHQS_DNS.ABBtCmdHQS_DNS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED NIGHT SNOW REALLYDAMAGED
-      Model              = ABBtCmdHQ_ENS
-      Animation          = ABBtCmdHQ_ENS.ABBtCmdHQ_ENS
+      Model              = ABBtCmdHQS_ENS
+      Animation          = ABBtCmdHQS_ENS.ABBtCmdHQS_ENS
       AnimationMode      = LOOP
       Flags              = ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7791,6 +7791,9 @@ Object SupW_AmericaCommandCenter
     ;**************************************************************************************************************************
     ;This block handles every possible case with construction process, selling process, awaiting construction, and sold states
     ;for this draw module
+
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Uses the correct ABBtCmdHQS model family instead of ABBtCmdHQ.
+  
     ConditionState       = AWAITING_CONSTRUCTION PARTIALLY_CONSTRUCTED ACTIVELY_BEING_CONSTRUCTED
       Model              = ABBtCmdHQS
       Animation          = ABBtCmdHQS.ABBtCmdHQS


### PR DESCRIPTION
Super Weapon General now uses the correct Command Center model during construction / sold states. This is only noticeable when construction nears 100% or for the first ~44 frames when sold (the faction logo is now visible during these times).

Before:
![image](https://user-images.githubusercontent.com/11547761/218992559-6bd7e979-4230-434f-904f-23560bd6e1a5.png)

After:
![image](https://user-images.githubusercontent.com/11547761/218992601-33277933-f01a-4715-842a-ccdca5b70e7e.png)