### PR TITLE
Fix: All Scud Launcher variants now correctly show their salvage upgrades during their rubble state

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18887,6 +18887,7 @@ Object Chem_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
@@ -18908,6 +18909,7 @@ Object Chem_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18887,6 +18887,7 @@ Object Chem_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVScudLchr
@@ -18907,6 +18908,7 @@ Object Chem_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20289,6 +20289,7 @@ Object Demo_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVScudLchr
@@ -20309,6 +20310,7 @@ Object Demo_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20289,6 +20289,7 @@ Object Demo_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
@@ -20310,6 +20311,7 @@ Object Demo_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -9093,6 +9093,7 @@ Object CINE_GLAVehicleScudLauncherHd
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVScudLchr
@@ -9113,6 +9114,7 @@ Object CINE_GLAVehicleScudLauncherHd
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -9093,6 +9093,7 @@ Object CINE_GLAVehicleScudLauncherHd
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
@@ -9114,6 +9115,7 @@ Object CINE_GLAVehicleScudLauncherHd
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20405,6 +20405,7 @@ Object Slth_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
       Model = UVScudLchr
@@ -20425,6 +20426,7 @@ Object Slth_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20405,6 +20405,7 @@ Object Slth_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponB
       WeaponLaunchBone = SECONDARY WeaponB
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_ONE RUBBLE
 
     ConditionState = WEAPONSET_CRATEUPGRADE_TWO
@@ -20426,6 +20427,7 @@ Object Slth_GLAVehicleScudLauncher
       WeaponLaunchBone = PRIMARY WeaponC
       WeaponLaunchBone = SECONDARY WeaponC
     End
+    ; Patch104p @bugfix Stubbjax 15/02/2023 Adds rubble state for scrap upgrade.
     AliasConditionState = WEAPONSET_CRATEUPGRADE_TWO RUBBLE
 
     TrackMarks = EXTireTrack.tga


### PR DESCRIPTION
All Scud Launcher variants now correctly show their salvage upgrades during their rubble state. In 1.04, only the vGLA Scud Launcher shows its salvage upgrades during its rubble state.

Below is some 1.04 footage from before this change. Note that the salvage upgrade disappears from the top Scud Launcher (`Demo_GLAVehicleScudLauncher`) upon destruction:

https://user-images.githubusercontent.com/11547761/219004446-16e1234c-556f-4167-90d5-85d1a046e3e2.mp4

