### PR TITLE
Fix: Condition state formatting

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -21939,7 +21939,7 @@ Object Boss_VehicleCombatBikeTerrorist
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -14206,7 +14206,7 @@ Object Chem_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB01_SKN
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD1 0 6
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD2 0 6
@@ -14566,7 +14566,7 @@ Object Chem_GLAInfantryAngryMobRock02
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB02_SKN
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD1 0 6
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD2 0 6
@@ -14896,7 +14896,7 @@ ObjectReskin Chem_GLAInfantryAngryMobPistol03 Chem_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB03_SKN
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD1 0 6
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD2 0 6
@@ -15136,7 +15136,7 @@ ObjectReskin Chem_GLAInfantryAngryMobRock04 Chem_GLAInfantryAngryMobRock02
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB04_SKN
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD1 0 6
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD2 0 6
@@ -15330,7 +15330,7 @@ ObjectReskin Chem_GLAInfantryAngryMobPistol05 Chem_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB05_SKN
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD1 0 6
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD2 0 6

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -16876,7 +16876,7 @@ Object Chem_GLAVehicleCombatBike
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14682,7 +14682,7 @@ Object Demo_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB01_SKN
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD1 0 6
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD2 0 6
@@ -15066,7 +15066,7 @@ Object Demo_GLAInfantryAngryMobRock02
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB02_SKN
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD1 0 6
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD2 0 6
@@ -15420,7 +15420,7 @@ ObjectReskin Demo_GLAInfantryAngryMobPistol03 Demo_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB03_SKN
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD1 0 6
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD2 0 6
@@ -15660,7 +15660,7 @@ ObjectReskin Demo_GLAInfantryAngryMobRock04 Demo_GLAInfantryAngryMobRock02
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB04_SKN
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD1 0 6
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD2 0 6
@@ -15854,7 +15854,7 @@ ObjectReskin Demo_GLAInfantryAngryMobPistol05 Demo_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB05_SKN
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD1 0 6
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD2 0 6

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -18119,7 +18119,7 @@ Object Demo_GLAVehicleCombatBike
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -4382,7 +4382,7 @@ Object GC_Slth_GLAVehicleCombatBike
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
@@ -5326,7 +5326,7 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
@@ -6270,7 +6270,7 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -3562,7 +3562,7 @@ Object CINE_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB01_SKN
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD1 0 6
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD2 0 6
@@ -3642,7 +3642,7 @@ Object CINE_GLAInfantryAngryMobPistol01
     End
     AliasConditionState = FIRING_C BETWEEN_FIRING_SHOTS_A
 
-    ConditionState RELOADING_C
+    ConditionState = RELOADING_C
       Animation =UIMOB01_SKL.UIMOB01_IDA1
       WaitForStateToFinishIfPossible = TRANS_THROW ; universal hub for follow-thru
     End
@@ -3954,7 +3954,7 @@ Object CINE_GLAInfantryAngryMobPistol03
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB03_SKN
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD1 0 6
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD2 0 6
@@ -4034,7 +4034,7 @@ Object CINE_GLAInfantryAngryMobPistol03
     End
     AliasConditionState = FIRING_C BETWEEN_FIRING_SHOTS_A
 
-    ConditionState RELOADING_C
+    ConditionState = RELOADING_C
       Animation =UIMOB03_SKL.UIMOB03_IDA1
       WaitForStateToFinishIfPossible = TRANS_THROW ; universal hub for follow-thru
 
@@ -4339,7 +4339,7 @@ Object CINE_GLAInfantryAngryMobPistol05
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB05_SKN
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD1 0 6
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD2 0 6
@@ -4418,7 +4418,7 @@ Object CINE_GLAInfantryAngryMobPistol05
     End
     AliasConditionState = FIRING_C BETWEEN_FIRING_SHOTS_A
 
-    ConditionState RELOADING_C
+    ConditionState = RELOADING_C
       Animation =UIMOB05_SKL.UIMOB05_IDA1
       WaitForStateToFinishIfPossible = TRANS_THROW ; universal hub for follow-thru
     End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -699,7 +699,7 @@ Object GLAVehicleCombatBike
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
@@ -1654,7 +1654,7 @@ Object GLAVehicleCombatBikeRocket
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03
@@ -2597,7 +2597,7 @@ Object GLAVehicleCombatBikeTerrorist
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18361,7 +18361,7 @@ Object Slth_GLAVehicleCombatBike
 
     ;Terror Bike
     ;------------------------------
-    ConditionState  RIDER5
+    ConditionState = RIDER5
       Model = UVComBike
       WeaponFireFXBone    = PRIMARY Muzzle_B
       WeaponLaunchBone    = PRIMARY RocketFX03

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -15168,7 +15168,7 @@ Object Slth_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB01_SKN
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD1 0 6
       IdleAnimation = UIMOB01_SKL.UIMOB01_IDD2 0 6
@@ -15528,7 +15528,7 @@ Object Slth_GLAInfantryAngryMobRock02
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB02_SKN
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD1 0 6
       IdleAnimation = UIMOB02_SKL.UIMOB02_IDD2 0 6
@@ -15858,7 +15858,7 @@ ObjectReskin Slth_GLAInfantryAngryMobPistol03 Slth_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB03_SKN
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD1 0 6
       IdleAnimation = UIMOB03_SKL.UIMOB03_IDD2 0 6
@@ -16098,7 +16098,7 @@ ObjectReskin Slth_GLAInfantryAngryMobRock04 Slth_GLAInfantryAngryMobRock02
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB04_SKN
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD1 0 6
       IdleAnimation = UIMOB04_SKL.UIMOB04_IDD2 0 6
@@ -16292,7 +16292,7 @@ ObjectReskin Slth_GLAInfantryAngryMobPistol05 Slth_GLAInfantryAngryMobPistol01
 
     ; WHILE CARRYING AK47
     ;---------------------------------------------------------
-    ConditionState WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
+    ConditionState = WEAPONSET_PLAYER_UPGRADE ;Idle with AK Slung
       Model = UIMOB05_SKN
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD1 0 6
       IdleAnimation = UIMOB05_SKL.UIMOB05_IDD2 0 6


### PR DESCRIPTION
Fixed various condition state formatting. Equals signs were missing in various places in the Angry Mob and Combat Cycle draw modules.