### PR TITLE
Fix: The GLA Angry Mob Nexus no longer appears on the radar

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19455,9 +19455,6 @@ Object Boss_InfantryAngryMobNexus
 
   DisplayName      = OBJECT:AngryMobNexus
   Side = Boss
-
-  RadarPriority       = NOT_ON_RADAR
-
   EditorSorting   = INFANTRY
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
 
@@ -19512,7 +19509,7 @@ Object Boss_InfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
-  RadarPriority = UNIT
+  RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02
     MaxHealth       = 99999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19509,6 +19509,7 @@ Object Boss_InfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
+  ; Patch104p @bugfix Stubbjax 15/02/2023 Nexus no longer shows on radar.
   RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -14045,6 +14045,7 @@ Object Chem_GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
+  ; Patch104p @bugfix Stubbjax 15/02/2023 Nexus no longer shows on radar.
   RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13995,9 +13995,6 @@ Object Chem_GLAInfantryAngryMobNexus
 
   DisplayName      = OBJECT:AngryMobNexus
   Side = GLAToxinGeneral
-
-  RadarPriority       = NOT_ON_RADAR
-
   EditorSorting   = INFANTRY
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
 
@@ -14048,7 +14045,7 @@ Object Chem_GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
-  RadarPriority = UNIT
+  RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02
     MaxHealth       = 99999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14471,9 +14471,6 @@ Object Demo_GLAInfantryAngryMobNexus
 
   DisplayName      = OBJECT:AngryMobNexus
   Side = GLADemolitionGeneral
-
-  RadarPriority       = NOT_ON_RADAR
-
   EditorSorting   = INFANTRY
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
 
@@ -14524,7 +14521,7 @@ Object Demo_GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
-  RadarPriority = UNIT
+  RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02
     MaxHealth       = 99999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14521,6 +14521,7 @@ Object Demo_GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
+  ; Patch104p @bugfix Stubbjax 15/02/2023 Nexus no longer shows on radar.
   RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -3397,7 +3397,8 @@ Object CINE_GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
-  RadarPriority = UNIT
+  ; Patch104p @bugfix Stubbjax 15/02/2023 Nexus no longer shows on radar.
+  RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE
   Body = ImmortalBody ModuleTag_02
     MaxHealth       = 99999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1570,6 +1570,7 @@ Object GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
+  ; Patch104p @bugfix Stubbjax 15/02/2023 Nexus no longer shows on radar.
   RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1520,9 +1520,6 @@ Object GLAInfantryAngryMobNexus
 
   DisplayName      = OBJECT:AngryMobNexus
   Side = GLA
-
-  RadarPriority       = NOT_ON_RADAR
-
   EditorSorting   = INFANTRY
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
 
@@ -1573,7 +1570,7 @@ Object GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
-  RadarPriority = UNIT
+  RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02
     MaxHealth       = 99999.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -15007,6 +15007,7 @@ Object Slth_GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
+  ; Patch104p @bugfix Stubbjax 15/02/2023 Nexus no longer shows on radar.
   RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14957,9 +14957,6 @@ Object Slth_GLAInfantryAngryMobNexus
 
   DisplayName      = OBJECT:AngryMobNexus
   Side = GLAStealthGeneral
-
-  RadarPriority       = NOT_ON_RADAR
-
   EditorSorting   = INFANTRY
   TransportSlotCount = 0                 ;how many "slots" we take in a transport (0 == not transportable)
 
@@ -15010,7 +15007,7 @@ Object Slth_GLAInfantryAngryMobNexus
 
 ;**** ENGINEERING Parameters ******************************
 
-  RadarPriority = UNIT
+  RadarPriority = NOT_ON_RADAR
   KindOf = PRELOAD CAN_ATTACK INFANTRY MOB_NEXUS ATTACK_NEEDS_LINE_OF_SIGHT NO_COLLIDE SELECTABLE SCORE
   Body = ImmortalBody ModuleTag_02
     MaxHealth       = 99999.0


### PR DESCRIPTION
The Angry Mob Nexus no longer appears on the radar. This is most noticeable in 1.04 when only a single Angry Mob member remains, and yet two units show on the radar.

https://user-images.githubusercontent.com/11547761/219037811-de3a166c-1a7f-42a6-a792-d17683baf8e9.mp4