### PR TITLE
Change: Remove superfluous upgrade modules

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -21799,7 +21799,7 @@ End
 
 
 ; Patch104p @bugfix commy2 04/09/2021 Fixed sounds, animations and colors to work like Skirmish / MP bike.
-
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike with Terrorist
 Object Boss_VehicleCombatBikeTerrorist
@@ -22616,10 +22616,6 @@ Object Boss_VehicleCombatBikeTerrorist
     HealingAmount = 2
     HealingDelay = 1000 ; msec
     TriggeredBy = Upgrade_GLAJunkRepair
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
   End
 
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -22057,8 +22057,8 @@ End
 
 
 
+; Patch104p @tweak Stubbjax 15/08/2023 Removes superfluous AP Bullets weapon set upgrade module.
 ;------------------------------------------------
-
 Object Chem_GLAInfantryRebel
 
   ; *** ART Parameters ***
@@ -22313,9 +22313,6 @@ Object Chem_GLAInfantryRebel
     TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
 
-  Behavior = WeaponBonusUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLAAPBullets
-  End
   Behavior = StealthUpgrade ModuleTag_10
     TriggeredBy = Upgrade_GLACamouflage
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17980,6 +17980,7 @@ End
 
 
 
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike
 Object Demo_GLAVehicleCombatBike
@@ -18836,10 +18837,6 @@ Object Demo_GLAVehicleCombatBike
     HealingAmount = 2
     HealingDelay = 1000 ; msec
     TriggeredBy = Upgrade_GLAJunkRepair
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
   End
 
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -377,6 +377,8 @@ Object GC_Chem_GLAInfantryStingerSoldier
 End
 
 
+; Patch104p @tweak Stubbjax 15/08/2023 Removes superfluous AP Bullets weapon set upgrade module.
+;-------------------------------------------------------------------------
 Object GC_Chem_GLAInfantryRebel
 
   ; *** ART Parameters ***
@@ -632,9 +634,6 @@ Object GC_Chem_GLAInfantryRebel
     TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End
 
-  Behavior = WeaponBonusUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLAAPBullets
-  End
   Behavior = StealthUpgrade ModuleTag_10
     TriggeredBy = Upgrade_GLACamouflage
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -4244,7 +4244,7 @@ End
 
 
 ; Patch104p @bugfix commy2 04/09/2021 Fixed animations and colors to work like Skirmish / MP bike.
-
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike
 Object GC_Slth_GLAVehicleCombatBike
@@ -5058,10 +5058,6 @@ Object GC_Slth_GLAVehicleCombatBike
     TriggeredBy = Upgrade_GLAJunkRepair
   End
 
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
-  End
-
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).
   Behavior = CreateObjectDie ModuleTag_10
     DeathTypes = NONE +TOPPLED
@@ -5188,7 +5184,7 @@ End
 
 
 ; Patch104p @bugfix commy2 04/09/2021 Fixed animations and colors to work like Skirmish / MP bike.
-
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike Rocket
 Object GC_Slth_GLAVehicleCombatBikeRocket
@@ -6002,10 +5998,6 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
     TriggeredBy = Upgrade_GLAJunkRepair
   End
 
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
-  End
-
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).
   Behavior = CreateObjectDie ModuleTag_10
     DeathTypes = NONE +TOPPLED
@@ -6132,7 +6124,7 @@ End
 
 
 ; Patch104p @bugfix commy2 04/09/2021 Fixed animations and colors to work like Skirmish / MP bike.
-
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike Terrorist
 Object GC_Slth_GLAVehicleCombatBikeTerrorist
@@ -6944,10 +6936,6 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
     HealingAmount = 2
     HealingDelay = 1000 ; msec
     TriggeredBy = Upgrade_GLAJunkRepair
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
   End
 
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -806,6 +806,7 @@ End
 
 
 
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;************************* Cinematic-only unit ********************************
 ;GLA Combat Bike
@@ -1439,10 +1440,6 @@ Object CINE_GLAVehicleCombatBike
     HealingAmount = 2
     HealingDelay = 1000 ; msec
     TriggeredBy = Upgrade_GLAJunkRepair
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
   End
 
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAMiscUnit.ini
@@ -1,6 +1,7 @@
 ; Patch104p @bugfix commy2 09/09/2021 Add UNATTACKABLE to fix units attacking wrecks.
 
 
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 Object GLARocketBuggyFullDebris
 
@@ -37,10 +38,6 @@ Object GLARocketBuggyFullDebris
   Behavior = LifetimeUpdate ModuleTag_04
     MinLifetime = 0   ; min lifetime in msec
     MaxLifetime = 0   ; max lifetime in msec
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_05
-    TriggeredBy = Upgrade_GLABuggyAmmo
   End
 
   Behavior = SlowDeathBehavior ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -562,6 +562,7 @@ End
 
 
 
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike
 Object GLAVehicleCombatBike
@@ -1380,10 +1381,6 @@ Object GLAVehicleCombatBike
     TriggeredBy = Upgrade_GLAJunkRepair
   End
 
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
-  End
-
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).
   Behavior = CreateObjectDie ModuleTag_10
     DeathTypes = NONE +TOPPLED
@@ -1516,7 +1513,7 @@ Object GLAVehicleCombatBike
 End
 
 ; Patch104p @bugfix commy2 04/09/2021 Fixed animations and colors to work like Skirmish / MP bike.
-
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike with Tunnel Defender
 Object GLAVehicleCombatBikeRocket
@@ -2335,10 +2332,6 @@ Object GLAVehicleCombatBikeRocket
     TriggeredBy = Upgrade_GLAJunkRepair
   End
 
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
-  End
-
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).
   Behavior = CreateObjectDie ModuleTag_10
     DeathTypes = NONE +TOPPLED
@@ -2459,7 +2452,7 @@ Object GLAVehicleCombatBikeRocket
 End
 
 ; Patch104p @bugfix commy2 04/09/2021 Fixed animations and colors to work like Skirmish / MP bike.
-
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike with Terrorist
 Object GLAVehicleCombatBikeTerrorist
@@ -3276,10 +3269,6 @@ Object GLAVehicleCombatBikeTerrorist
     HealingAmount = 2
     HealingDelay = 1000 ; msec
     TriggeredBy = Upgrade_GLAJunkRepair
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
   End
 
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -269,6 +269,7 @@ End
 
 
 ; Patch104p @feature commy2 13/08/2022 Implement previously unused Nuke Helix texture.
+; Patch104p @tweak Stubbjax 15/08/2023 Removes superfluous Black Napalm weapon set upgrade module.
 ;----------------------------------------------------------------------------------------------------------
 Object Nuke_ChinaVehicleHelix
 
@@ -519,12 +520,6 @@ Object Nuke_ChinaVehicleHelix
     NumberOfExitPaths       = 1
     PassengersAllowedToFire = No ; the
   End
-
-
-  Behavior = WeaponSetUpgrade ModuleTag_30
-    TriggeredBy = Upgrade_ChinaBlackNapalm
-  End
-
 
   Behavior = SpecialAbility ModuleTag_32
     SpecialPowerTemplate = Nuke_SpecialAbilityHelixNukeBomb

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -18222,6 +18222,7 @@ End
 
 
 
+; Patch104p @fix Stubbjax 15/08/2023 Removes superfluous Buggy Ammo weapon set upgrade module.
 ;------------------------------------------------------------------------------
 ;GLA Combat Bike
 Object Slth_GLAVehicleCombatBike
@@ -19033,10 +19034,6 @@ Object Slth_GLAVehicleCombatBike
     HealingAmount = 2
     HealingDelay = 1000 ; msec
     TriggeredBy = Upgrade_GLAJunkRepair
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_09
-    TriggeredBy = Upgrade_GLABuggyAmmo
   End
 
   ;Create the hulk after the toppling is complete (not killed until topple anim finished).


### PR DESCRIPTION
Removed superfluous upgrade modules from various units:

- Black Napalm upgrade from the Nuke Helix
- AP Bullets upgrade from the Toxin Rebel
- Rocket Buggy Ammo upgrade from the Combat Cycle

This is just a minor cleanup and has no effect in-game.