### PR TITLE
Change: Add damage effects to the China and GLA cargo planes

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -968,7 +968,7 @@ Object ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = TankDamageFX
+    DamageFX        = TankDamageFX ; Patch104p @bugfix Stubbjax 15/02/2023 Adds missing hit effects.
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -968,7 +968,7 @@ Object ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = None
+    DamageFX        = TankDamageFX
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAAir.ini
@@ -85,7 +85,7 @@ Object GLAJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = TankDamageFX
+    DamageFX        = TankDamageFX ; Patch104p @bugfix Stubbjax 15/02/2023 Adds missing hit effects.
   End
   CommandSet          = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAAir.ini
@@ -85,7 +85,7 @@ Object GLAJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = None
+    DamageFX        = TankDamageFX
   End
   CommandSet          = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -306,7 +306,7 @@ Object Infa_ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = TankDamageFX
+    DamageFX        = TankDamageFX ; Patch104p @bugfix Stubbjax 15/02/2023 Adds missing hit effects.
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -306,7 +306,7 @@ Object Infa_ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = None
+    DamageFX        = TankDamageFX
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1251,7 +1251,7 @@ Object Nuke_ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = TankDamageFX
+    DamageFX        = TankDamageFX ; Patch104p @bugfix Stubbjax 15/02/2023 Adds missing hit effects.
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1251,7 +1251,7 @@ Object Nuke_ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = None
+    DamageFX        = TankDamageFX
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -986,7 +986,7 @@ Object Tank_ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = None
+    DamageFX        = TankDamageFX
   End
   CommandSet        = Command_ScriptedTransportDrops
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -986,7 +986,7 @@ Object Tank_ChinaJetCargoPlane
   ArmorSet
     Conditions      = None
     Armor           = AirplaneArmor
-    DamageFX        = TankDamageFX
+    DamageFX        = TankDamageFX ; Patch104p @bugfix Stubbjax 15/02/2023 Adds missing hit effects.
   End
   CommandSet        = Command_ScriptedTransportDrops
 


### PR DESCRIPTION
Added damage effects to the China and GLA cargo planes. This effect already exists for the USA cargo planes.

https://user-images.githubusercontent.com/11547761/219059986-e4637d68-3886-4eab-b94e-2ea4962e7653.mp4

---

https://user-images.githubusercontent.com/11547761/219060004-565729c7-a112-4933-97ba-8b126c13af06.mp4