### PR TITLE
Fix: Demo GLA vehicle suicide disposition issues

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17659,16 +17659,13 @@ Object Demo_GLATankScorpion
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death17
     DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_ScorpionTankDeathEffect
     ;FX                  = FINAL   FX_BattleMasterExplosionOneFinal
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -17927,16 +17924,13 @@ Object Demo_GLAVehicleRocketBuggy
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @tweak Changes FX from FX_DEMOBuggyNewDeathExplosion because FireWeaponWhenDeadBehavior effects will complement it.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death17
     DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   OCL_RocketBuggyAirDeathStart
     FX                  = FINAL   ScorchlessFX_DEMOBuggyNewDeathExplosion
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -19436,16 +19430,13 @@ Object Demo_GLAVehicleQuadCannon
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death_14
     DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_QuadCannonDeathEffect
     ;FX                  = FINAL   FX_BattleMasterExplosionOneFinal
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -19902,16 +19893,13 @@ Object Demo_GLAVehicleToxinTruck
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death_14
     DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_ToxinTractorDeathEffect
     ;FX                  = FINAL   FX_ToxinTruckExplosionOneFinal
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -20496,16 +20484,13 @@ Object Demo_GLAVehicleScudLauncher
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death24
     DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_SCUDLauncherDeathEffect
     ;FX                  = FINAL   FX_ScudLauncherExplosionOneFinal
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
 ;  Behavior = FireWeaponWhenDeadBehavior ModuleTag_Death24
@@ -21017,6 +21002,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @tweak Changes FX from FX_TechnicalAirDeathGroundPart because FireWeaponWhenDeadBehavior effects will complement it.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death_18
     DeathTypes          = NONE +SUICIDED
@@ -21026,10 +21012,6 @@ Object Demo_GLAVehicleTechnicalChassisOne
     FX                  = INITIAL ScorchlessFX_TechnicalAirDeathGroundPart
     OCL                 = FINAL   OCL_RocketBuggyAirDeath
     FX                  = FINAL   FX_RocketBuggyAirDeathAirPart
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -21858,16 +21840,13 @@ Object Demo_GLATankMarauder
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death_22
     DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_MarauderTankDeathEffect
     ;FX                  = FINAL   FX_BattleMasterExplosionOneFinal
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -22104,16 +22083,13 @@ Object Demo_GLAVehicleRadarVan
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_Death_20
     DeathTypes          = NONE +SUICIDED
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL Demo_OCL_RadarVanDeathEffect
     ;FX                  = FINAL FX_BuggyNewDeathExplosion
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
@@ -22524,6 +22500,7 @@ Object Demo_GLAVehicleBattleBus
 
   ; Patch104p @bugfix commy2 29/08/2021 Fix bus disappearing when SUICIDED.
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
+  ; Patch104p @bugfix xezon 16/02/2022 Removes all fling force and fling pitch settings to avoid disposition issues.
 
   Behavior = SlowDeathBehavior ModuleTag_35 ; Sorry, because the terrorist does Suicide damage to others, we cannot tell if it is a legit suicide (us killing self)
     DeathTypes          = NONE +SUICIDED
@@ -22531,10 +22508,6 @@ Object Demo_GLAVehicleBattleBus
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_BattleBusDeath
     ;FX                  = FINAL   FX_BattleBusDeathExplosion
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior                 = TransitionDamageFX ModuleTag_36


### PR DESCRIPTION
* Fixes #1696

This change fixes Demo GLA vehicle suicide disposition issues by removing `FlingForce` and `FlingPitch` settings. These settings appear to be intended for infantry units.