### PR TITLE
Change: China Nuke Cannon can no longer be crushed by Overlord

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1748,8 +1748,10 @@ Object ChinaVehicleNukeLauncher ; Alias ChinaVehicleNukeCannon
   ExperienceValue = 50 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 400 600 1000  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
+
+  ; Patch104p @tweak xezon 16/02/2023 Nuke Cannon is no longer crushable by Overlord.
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CrushableLevel         = 3  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = ChinaVehicleNukeCannonCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2216,8 +2216,10 @@ Object Infa_ChinaVehicleNukeLauncher ; Alias Infa_ChinaVehicleNukeCannon
   ExperienceValue = 50 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 400 600 1000  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
+
+  ; Patch104p @tweak xezon 16/02/2023 Nuke Cannon is no longer crushable by Overlord.
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CrushableLevel         = 3  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = ChinaVehicleNukeCannonCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3737,8 +3737,10 @@ Object Nuke_ChinaVehicleNukeLauncher ; Alias Nuke_ChinaVehicleNukeCannon
   ExperienceValue = 50 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 400 600 1000  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
+
+  ; Patch104p @tweak xezon 16/02/2023 Nuke Cannon is no longer crushable by Overlord.
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CrushableLevel         = 3  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = ChinaVehicleNukeCannonCommandSet
 
   ; *** AUDIO Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17365,8 +17365,10 @@ Object Tank_ChinaVehicleNukeLauncher ; Alias Tank_ChinaVehicleNukeCannon
   ExperienceValue = 50 100 200 400    ;Experience point value at each level
   ExperienceRequired = 0 400 600 1000  ;Experience points needed to gain each level
   IsTrainable = Yes             ;Can gain experience
+
+  ; Patch104p @tweak xezon 16/02/2023 Nuke Cannon is no longer crushable by Overlord.
   CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
-  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CrushableLevel         = 3  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet    = ChinaVehicleNukeCannonCommandSet
 
   ; *** AUDIO Parameters ***


### PR DESCRIPTION
With this change the China Nuke Cannon can no longer be crushed by Overlord.

## Original

https://user-images.githubusercontent.com/4720891/219507841-4719b7a0-b410-45c3-9384-cfe866b87786.mp4

# Rationale

The Nuke Cannon is as large as the Overlord. In deployed state it towers higher than all other vehicles. Yet the Overlord can crush it as if it was a small vehicle.

Naturally one could expect that the Nuke Cannon is not crushable. This change delivers. It makes the Nuke Cannon a bit more unique and distinct from the Inferno Cannon and other tanks. It also rewards the high cost and inaccessibility of this unit.

For most battle situations this has no tangible consequences, because the Nuke Cannon will likely be shot dead before the enemy Overlord gets the chance to crush it.

