### PR TITLE
Fix: Remove destruction delay variance on death of GLA Bomb Truck

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18681,7 +18681,7 @@ Object Chem_GLAVehicleBombTruck
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0 ; Patch104p @bugfix xezon 16/02/2023 From 200, because this unit explodes immediately on death.
     FX = FINAL FX_BombTruckDeathExplosion
     OCL = FINAL OCL_BombTruckDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20080,7 +20080,7 @@ Object Demo_GLAVehicleBombTruck
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0 ; Patch104p @bugfix xezon 16/02/2023 From 200, because this unit explodes immediately on death.
     FX = FINAL FX_BombTruckDeathExplosion
     OCL = FINAL OCL_BombTruckDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2074,7 +2074,7 @@ Object GC_Chem_GLAVehicleBombTruck
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0 ; Patch104p @bugfix xezon 16/02/2023 From 200, because this unit explodes immediately on death.
     FX = FINAL FX_BombTruckDeathExplosion
     OCL = FINAL OCL_BombTruckDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -5257,7 +5257,7 @@ Object CINE_GLAVehicleBombTruck
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0 ; Patch104p @bugfix xezon 16/02/2023 From 200, because this unit explodes immediately on death.
     FX = FINAL FX_BattleBusDeathExplosion
     OCL = FINAL OCL_BombTruckDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4348,7 +4348,7 @@ Object GLAVehicleBombTruck
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0 ; Patch104p @bugfix xezon 16/02/2023 From 200, because this unit explodes immediately on death.
     FX = FINAL FX_BombTruckDeathExplosion
     OCL = FINAL OCL_BombTruckDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20112,7 +20112,7 @@ Object Slth_GLAVehicleBombTruck
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0 ; Patch104p @bugfix xezon 16/02/2023 From 200, because this unit explodes immediately on death.
     FX = FINAL FX_BombTruckDeathExplosion
     OCL = FINAL OCL_BombTruckDeathEffect
   End


### PR DESCRIPTION
There is a random 200 ms destruction delay on death of GLA Bomb Truck. This means that the hulk and effects spawns a bit later than the death explosion. This change fixes that.