### PR TITLE
Fix: Set better spawn positions of USA Humvee debris

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6818,10 +6818,12 @@ ObjectCreationList OCL_InitialHumveeDebris
   End
 End
 
+; Patch104p @fix xezon 18/02/2023 From Z:2.9 to spawn tires at better height.
+
 ObjectCreationList OCL_FinalHumveeDebris
   CreateDebris
     ModelNames        = AVHUMMER_D2 ;tire
-    Offset            = X:-7.098 Y:5.7 Z:2.9
+    Offset            = X:-7.098 Y:5.7 Z:0.0
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE
@@ -6835,7 +6837,7 @@ ObjectCreationList OCL_FinalHumveeDebris
 
   CreateDebris
     ModelNames        = AVHUMMER_D2 ;tire
-    Offset            = X:10.407 Y:-5.7 Z:2.9
+    Offset            = X:10.407 Y:-5.7 Z:0.0
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE
@@ -6847,9 +6849,11 @@ ObjectCreationList OCL_FinalHumveeDebris
     BounceSound       = VehicleDebris
   End
 
+  ; Patch104p @fix xezon 18/02/2023 From Y:6.73 Z:7.273 to spawn doors at better height and distance.
+
   CreateDebris
     ModelNames        = AVHUMMER_D3 ;door
-    Offset            = X:.071 Y:6.73 Z:7.273
+    Offset            = X:.071 Y:7.0 Z:5.5
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE
@@ -6864,7 +6868,7 @@ ObjectCreationList OCL_FinalHumveeDebris
   ; Random debris
   CreateDebris
     ModelNames        = AVHUMMER_D3 ;door
-    Offset            = X:.071 Y:-6.73 Z:7.273
+    Offset            = X:.071 Y:-7.5 Z:5.5
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE


### PR DESCRIPTION
This change sets better spawn positions of USA Humvee debris.

* The tires now spawn at the right height
* The doors now spawn at better heights and no longer inside the chassis