### PR TITLE
Fix: Add missing rubble model state to USA Humvee

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5113,6 +5113,8 @@ Object AirF_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -5139,6 +5141,8 @@ Object AirF_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -763,6 +763,8 @@ Object CINE_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -789,6 +791,8 @@ Object CINE_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -32,6 +32,8 @@ Object AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -58,6 +60,8 @@ Object AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -19411,6 +19411,8 @@ Object CINE_U05_AmericaVehicleHumveeXYZ
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -19437,6 +19439,8 @@ Object CINE_U05_AmericaVehicleHumveeXYZ
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 
@@ -19673,6 +19677,8 @@ Object CINE_U05_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -19699,6 +19705,8 @@ Object CINE_U05_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 
@@ -19936,6 +19944,8 @@ Object CINE_U05_AmericaVehicleHumvee_BRAKE
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -19962,6 +19972,8 @@ Object CINE_U05_AmericaVehicleHumvee_BRAKE
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 
@@ -20200,6 +20212,8 @@ Object CINE_U05_AmericaVehicleHumvee_Hulk
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -20226,6 +20240,8 @@ Object CINE_U05_AmericaVehicleHumvee_Hulk
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4343,6 +4343,8 @@ Object Lazr_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -4369,6 +4371,8 @@ Object Lazr_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4828,6 +4828,8 @@ Object SupW_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -4854,6 +4856,8 @@ Object SupW_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 


### PR DESCRIPTION
This change adds missing rubble model state to USA Humvee. Originally the undamaged Humvee would show for one frame after death.