### PR TITLE
Fix USA Sentry Drone death model setup

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1731_sentry_drone_death.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1731_sentry_drone_death.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-02-18
+
+title: Fixes death setup of USA Sentry Drone
+
+changes:
+  - fix: The USA Sentry Drone no longer shows its wreck model before the final death explosion.
+  - fix: The USA Sentry Drone wreck no longer looks oddly shaped.
+  - fix: The USA Sentry Drone now spawns the correct amount of debris pieces at appropriate positions on death.
+
+labels:
+  - bug
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1731
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1746_wreck_sink_delays.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1746_wreck_sink_delays.yaml
@@ -10,6 +10,7 @@ changes:
 subchanges:
   - tweak: Sets sink delay of Generic Tank wreck from 1500 ms to 3000 ms.
   - tweak: Sets sink delay of USA Dozer wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Sentry Drone wreck from 1500 ms to 3000 ms.
   - tweak: Sets sink delay of USA Humvee wreck from 14000 ms to 3000 ms.
   - tweak: Sets sink delay of USA Ambulance wreck from 1500 ms to 3000 ms.
   - tweak: Sets sink delay of USA Avenger wreck from 1500 ms to 3000 ms.
@@ -57,6 +58,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1746
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1731
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6758,6 +6758,11 @@ Object AirF_AmericaVehicleSentryDrone
     End
     AliasConditionState = REALLYDAMAGED MOVING
     AliasConditionState = REALLYDAMAGED NIGHT
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = RUBBLE
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE NIGHT
+    AliasConditionState = RUBBLE NIGHT MOVING
 
     ; damaged light on
     ConditionState                    = REALLYDAMAGED MOVING NIGHT
@@ -6767,19 +6772,6 @@ Object AirF_AmericaVehicleSentryDrone
       HideSubObject                   = TURRETUP09  ;Hide controlled turret
       ShowSubObject                   = ManualLight
     End
-
-    ; destryoed
-    ConditionState                    = RUBBLE
-      Model                           = AVSENTRY_D1
-      HideSubObject                   = TURRETUP09      ;Hide controlled turret
-    End
-    AliasConditionState = RUBBLE MOVING
-    AliasConditionState = RUBBLE NIGHT
-    AliasConditionState = RUBBLE NIGHT MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT MOVING
 
     ; pristine light off --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE
@@ -6816,6 +6808,11 @@ Object AirF_AmericaVehicleSentryDrone
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED NIGHT
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING MOVING
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE MOVING
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT MOVING
 
     ; damaged light on --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED MOVING NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -1834,10 +1834,9 @@ Object MISSION_AmericaVehicleSentryDrone
       AnimationMode                   = LOOP
       HideSubObject                   = TURRETUP09      ;Hide controlled turret
     End
-    ConditionState                    = RUBBLE
-      Model                           = AVSENTRY_D1
-      HideSubObject                   = TURRETUP09      ;Hide controlled turret
-    End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = RUBBLE
+  
     TrackMarks              = EXTnkTrack.tga
     TreadAnimationRate      = 4.0  ; amount of tread texture to move per second
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2139,6 +2139,11 @@ Object AmericaVehicleSentryDrone
     End
     AliasConditionState = REALLYDAMAGED MOVING
     AliasConditionState = REALLYDAMAGED NIGHT
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = RUBBLE
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE NIGHT
+    AliasConditionState = RUBBLE NIGHT MOVING
 
     ; damaged light on
     ConditionState                    = REALLYDAMAGED MOVING NIGHT
@@ -2148,19 +2153,6 @@ Object AmericaVehicleSentryDrone
       HideSubObject                   = TURRETUP09  ;Hide controlled turret
       ShowSubObject                   = ManualLight
     End
-
-    ; destryoed
-    ConditionState                    = RUBBLE
-      Model                           = AVSENTRY_D1
-      HideSubObject                   = TURRETUP09      ;Hide controlled turret
-    End
-    AliasConditionState = RUBBLE MOVING
-    AliasConditionState = RUBBLE NIGHT
-    AliasConditionState = RUBBLE NIGHT MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT MOVING
 
     ; pristine light off --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE
@@ -2197,6 +2189,11 @@ Object AmericaVehicleSentryDrone
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED NIGHT
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING MOVING
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE MOVING
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT MOVING
 
     ; damaged light on --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED MOVING NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20369,6 +20369,11 @@ Object Boss_VehicleSentryDrone
     End
     AliasConditionState = REALLYDAMAGED MOVING
     AliasConditionState = REALLYDAMAGED NIGHT
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = RUBBLE
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE NIGHT
+    AliasConditionState = RUBBLE NIGHT MOVING
 
     ; damaged light on
     ConditionState                    = REALLYDAMAGED MOVING NIGHT
@@ -20378,19 +20383,6 @@ Object Boss_VehicleSentryDrone
       HideSubObject                   = TURRETUP09  ;Hide controlled turret
       ShowSubObject                   = ManualLight
     End
-
-    ; destryoed
-    ConditionState                    = RUBBLE
-      Model                           = AVSENTRY_D1
-      HideSubObject                   = TURRETUP09      ;Hide controlled turret
-    End
-    AliasConditionState = RUBBLE MOVING
-    AliasConditionState = RUBBLE NIGHT
-    AliasConditionState = RUBBLE NIGHT MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT MOVING
 
     ; pristine light off --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE
@@ -20427,6 +20419,11 @@ Object Boss_VehicleSentryDrone
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED NIGHT
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING MOVING
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE MOVING
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT MOVING
 
     ; damaged light on --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED MOVING NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -1957,8 +1957,11 @@ End
 Object AmericaVehicleSentryDroneHulk
   ; *** ART Parameters ***
   Draw                = W3DModelDraw ModuleTag_01
+    ; Patch104p @tweak xezon 18/02/2023 Changes model from AVSENTRY_D1, because model looks jank. (#1731)
+    ; Patch104p @tweak xezon 18/02/2023 Hides turret pieces because they spawn as debris. (#1731)
     ConditionState    = NONE
-      Model           = AVSENTRY_D1
+      Model           = AVSENTRY_D
+      HideSubObject   = Turret01 TurretFX01 TurretUP09
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -1982,10 +1982,11 @@ Object AmericaVehicleSentryDroneHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 04/06/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units. (#1731)
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6461,6 +6461,11 @@ Object Lazr_AmericaVehicleSentryDrone
     End
     AliasConditionState = REALLYDAMAGED MOVING
     AliasConditionState = REALLYDAMAGED NIGHT
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = RUBBLE
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE NIGHT
+    AliasConditionState = RUBBLE NIGHT MOVING
 
     ; damaged light on
     ConditionState                    = REALLYDAMAGED MOVING NIGHT
@@ -6470,19 +6475,6 @@ Object Lazr_AmericaVehicleSentryDrone
       HideSubObject                   = TURRETUP09  ;Hide controlled turret
       ShowSubObject                   = ManualLight
     End
-
-    ; destryoed
-    ConditionState                    = RUBBLE
-      Model                           = AVSENTRY_D1
-      HideSubObject                   = TURRETUP09      ;Hide controlled turret
-    End
-    AliasConditionState = RUBBLE MOVING
-    AliasConditionState = RUBBLE NIGHT
-    AliasConditionState = RUBBLE NIGHT MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT MOVING
 
     ; pristine light off --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE
@@ -6519,6 +6511,11 @@ Object Lazr_AmericaVehicleSentryDrone
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED NIGHT
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING MOVING
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE MOVING
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT MOVING
 
     ; damaged light on --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED MOVING NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6932,6 +6932,11 @@ Object SupW_AmericaVehicleSentryDrone
     End
     AliasConditionState = REALLYDAMAGED MOVING
     AliasConditionState = REALLYDAMAGED NIGHT
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = RUBBLE
+    AliasConditionState = RUBBLE MOVING
+    AliasConditionState = RUBBLE NIGHT
+    AliasConditionState = RUBBLE NIGHT MOVING
 
     ; damaged light on
     ConditionState                    = REALLYDAMAGED MOVING NIGHT
@@ -6941,19 +6946,6 @@ Object SupW_AmericaVehicleSentryDrone
       HideSubObject                   = TURRETUP09  ;Hide controlled turret
       ShowSubObject                   = ManualLight
     End
-
-    ; destryoed
-    ConditionState                    = RUBBLE
-      Model                           = AVSENTRY_D1
-      HideSubObject                   = TURRETUP09      ;Hide controlled turret
-    End
-    AliasConditionState = RUBBLE MOVING
-    AliasConditionState = RUBBLE NIGHT
-    AliasConditionState = RUBBLE NIGHT MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE MOVING
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT
-    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE NIGHT MOVING
 
     ; pristine light off --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE
@@ -6990,6 +6982,11 @@ Object SupW_AmericaVehicleSentryDrone
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED NIGHT
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING
     AliasConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED ATTACKING MOVING
+    ; Patch104p @bugfix xezon 18/02/2023 Shows correct model with animation before final death. (#1731)
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE MOVING
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT
+    AliasConditionState = WEAPONSET_PLAYER_UPGRADE RUBBLE NIGHT MOVING
 
     ; damaged light on --- with gun
     ConditionState = WEAPONSET_PLAYER_UPGRADE REALLYDAMAGED MOVING NIGHT

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -9224,32 +9224,51 @@ ObjectCreationList OCL_AmericaVehicleSentryDroneDie
     Disposition = LIKE_EXISTING
     DispositionIntensity = 0.5
   End
+
+  ; Patch104p @tweak xezon 18/02/2023 Changes offset from X:-3.001 Y:5.79 Z:12.829 (#1731)
+  ; Patch104p @tweak xezon 04/06/2023 Changes Disposition from SEND_IT_FLYING INHERIT_VELOCITY to give greater control over debris physics. (#1731)
+  ; Patch104p @tweak xezon 04/06/2023 Increases mass from 2.5 to accommodate the new physic forces. (#1731)
   CreateDebris
-    ModelNames  = AVSENTRY_D2
-    Offset      = X:-3.001 Y:5.79 Z:12.829
-    Mass        = 2.5
+    ModelNames  = AVSENTRY_D2 ;light
+    Offset      = X:0.0 Y:0.0 Z:11.04
+    Mass        = 33
     Count       = 1
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
-    BounceSound       = DebrisBigMetal
+    BounceSound = DebrisBigMetal
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 30
   End
+
+  ; Patch104p @tweak xezon 18/02/2023 Removes obsolete debris piece. (#1731)
+  ;CreateDebris
+  ;  ModelNames  = AVSENTRY_D3
+  ;  Offset      = X:-2.643 Y:-0.349 Z:9.954
+  ;  Mass        = 2.2
+  ;  Count       = 1
+  ;  Disposition = SEND_IT_FLYING INHERIT_VELOCITY
+  ;  DispositionIntensity = 0.7
+  ;  BounceSound       = DebrisBigMetal
+  ;End
+
+  ; Patch104p @tweak xezon 18/02/2023 Reduces count from 2 (#1731)
+  ; Patch104p @tweak xezon 18/02/2023 Changes offset from X:-3.499 Y:-3.779 Z:8.132 (#1731)
+  ; Patch104p @tweak xezon 04/06/2023 Changes Disposition from SEND_IT_FLYING INHERIT_VELOCITY to give greater control over debris physics. (#1731)
+  ; Patch104p @tweak xezon 04/06/2023 Increases mass from 2 to accommodate the new physic forces. (#1731)
   CreateDebris
-    ModelNames  = AVSENTRY_D3
-    Offset      = X:-2.643 Y:-0.349 Z:9.954
-    Mass        = 2.2
+    ModelNames  = AVSENTRY_D4 ;plate
+    Offset      = X:-2.22 Y:0.0 Z:4.9
+    Mass        = 35
     Count       = 1
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
-    BounceSound       = DebrisBigMetal
-  End
-  CreateDebris
-    ModelNames  = AVSENTRY_D4
-    Offset      = X:-3.499 Y:-3.779 Z:8.132
-    Mass        = 2
-    Count       = 2
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
-    BounceSound       = DebrisBigMetal
+    BounceSound = DebrisBigMetal
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 30
   End
 End
 


### PR DESCRIPTION
**Merge with Rebase**

This change fixes USA Sentry Drone death model setup.

* Adds proper rubble states
* Sets up better hulk object fit for the debris and upgrade variants
* Sets correct debris positions and counts

## Original

https://user-images.githubusercontent.com/4720891/219867081-53901572-7c47-42d8-9337-4f2da61c644b.mp4

## Patched

https://user-images.githubusercontent.com/4720891/219867094-18421b7f-6d16-4889-856d-39e58825350f.mp4
