### PR TITLE
Fix USA Avenger death states and debris

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7138,6 +7138,18 @@ Object AirF_AmericaTankAvenger
     Mass = 50.0
   End
 
+  ; Patch104p @tweak xezon 21/02/2023 Replaces original slow death behaviours with sudden death to
+  ;   a) be consistent with Humvee death
+  ;   b) mask the executable issue that allows for no rubble state of the slaved laser turret
+  Behavior = SlowDeathBehavior ModuleTag_05
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 100
+    DestructionDelay = 0
+    DestructionDelayVariance = 0
+    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+    OCL = FINAL    OCL_AvengerTankDeathEffect
+  End
+
   ; Turret fly off death
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7031,8 +7031,10 @@ Object AirF_AmericaTankAvenger
       HideSubObject       = TURRET01
     End
 
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
-      Model               = AVAVNGER_D1
+      Model               = AVAVNGER_D
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!
@@ -7042,7 +7044,7 @@ Object AirF_AmericaTankAvenger
     End
     ConditionState        = REALLYDAMAGED DISGUISED
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Hide controlled turret
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6944,6 +6944,8 @@ Object AirF_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
       Turret              = TURRET01
       TurretPitch         = TURRETEL01
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
+    AliasConditionState = RUBBLE
   End
 
   ; ***DESIGN parameters ***
@@ -7034,7 +7036,7 @@ Object AirF_AmericaTankAvenger
     ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Show static turret
+      HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7151,27 +7151,26 @@ Object AirF_AmericaTankAvenger
   End
 
   ; Turret fly off death
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-;    ModifierBonusPerOverkillPercent = 30%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 500
-    DestructionDelayVariance = 100
-    FX  = INITIAL  FX_GenericTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_05
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 500
+  ;  DestructionDelayVariance = 100
+  ;  FX  = INITIAL  FX_GenericTankDeathEffect
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   ; Catch fire, and explode death
-  Behavior = SlowDeathBehavior ModuleTag_06
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-    DestructionDelay = 2000
-    DestructionDelayVariance = 300
-    FX  = INITIAL  FX_CrusaderCatchFire
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_06
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 2000
+  ;  DestructionDelayVariance = 300
+  ;  FX  = INITIAL  FX_CrusaderCatchFire
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
     WeaponTemplate        = AvengerPointDefenseLaserOne

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2546,27 +2546,26 @@ Object AmericaTankAvenger
   End
 
   ; Turret fly off death
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-;    ModifierBonusPerOverkillPercent = 30%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 500
-    DestructionDelayVariance = 100
-    FX  = INITIAL  FX_GenericTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_05
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 500
+  ;  DestructionDelayVariance = 100
+  ;  FX  = INITIAL  FX_GenericTankDeathEffect
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   ; Catch fire, and explode death
-  Behavior = SlowDeathBehavior ModuleTag_06
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-    DestructionDelay = 2000
-    DestructionDelayVariance = 300
-    FX  = INITIAL  FX_CrusaderCatchFire
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_06
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 2000
+  ;  DestructionDelayVariance = 300
+  ;  FX  = INITIAL  FX_CrusaderCatchFire
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
     WeaponTemplate        = AvengerPointDefenseLaserOne

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2533,6 +2533,18 @@ Object AmericaTankAvenger
     Mass = 50.0
   End
 
+  ; Patch104p @tweak xezon 21/02/2023 Replaces original slow death behaviours with sudden death to
+  ;   a) be consistent with Humvee death
+  ;   b) mask the executable issue that allows for no rubble state of the slaved laser turret
+  Behavior = SlowDeathBehavior ModuleTag_05
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 100
+    DestructionDelay = 0
+    DestructionDelayVariance = 0
+    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+    OCL = FINAL    OCL_AvengerTankDeathEffect
+  End
+
   ; Turret fly off death
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2426,8 +2426,10 @@ Object AmericaTankAvenger
       HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
-      Model               = AVAVNGER_D1
+      Model               = AVAVNGER_D
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!
@@ -2437,7 +2439,7 @@ Object AmericaTankAvenger
     End
     ConditionState        = REALLYDAMAGED DISGUISED
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Hide controlled turret
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2339,6 +2339,8 @@ Object AmericaTankAvengerLaserTurret ; Seperate turret object so it can attack i
       Turret              = TURRET01
       TurretPitch         = TURRETEL01
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
+    AliasConditionState = RUBBLE
   End
 
   ; ***DESIGN parameters ***
@@ -2429,7 +2431,7 @@ Object AmericaTankAvenger
     ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Show static turret
+      HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20488,27 +20488,26 @@ Object Boss_TankAvenger
   End
 
   ; Turret fly off death
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-;    ModifierBonusPerOverkillPercent = 30%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 500
-    DestructionDelayVariance = 100
-    FX  = INITIAL  FX_GenericTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_05
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 500
+  ;  DestructionDelayVariance = 100
+  ;  FX  = INITIAL  FX_GenericTankDeathEffect
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   ; Catch fire, and explode death
-  Behavior = SlowDeathBehavior ModuleTag_06
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-    DestructionDelay = 2000
-    DestructionDelayVariance = 300
-    FX  = INITIAL  FX_CrusaderCatchFire
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_06
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 2000
+  ;  DestructionDelayVariance = 300
+  ;  FX  = INITIAL  FX_CrusaderCatchFire
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
     WeaponTemplate        = AvengerPointDefenseLaserOne

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20371,8 +20371,10 @@ Object Boss_TankAvenger
       HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
-      Model               = AVAVNGER_D1
+      Model               = AVAVNGER_D
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!
@@ -20382,7 +20384,7 @@ Object Boss_TankAvenger
     End
     ConditionState        = REALLYDAMAGED DISGUISED
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Hide controlled turret
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20374,7 +20374,7 @@ Object Boss_TankAvenger
     ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Show static turret
+      HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -20475,6 +20475,18 @@ Object Boss_TankAvenger
     Mass = 50.0
   End
 
+  ; Patch104p @tweak xezon 21/02/2023 Replaces original slow death behaviours with sudden death to
+  ;   a) be consistent with Humvee death
+  ;   b) mask the executable issue that allows for no rubble state of the slaved laser turret
+  Behavior = SlowDeathBehavior ModuleTag_05
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 100
+    DestructionDelay = 0
+    DestructionDelayVariance = 0
+    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+    OCL = FINAL    OCL_AvengerTankDeathEffect
+  End
+
   ; Turret fly off death
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -1522,8 +1522,10 @@ Object DeadAvengerHulk
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
+    ; Patch104p @tweak xezon 18/02/2023 Hides turret pieces so they can be spawned as debris.
     ConditionState = NONE
       Model = AVAVNGER_D1
+      HideSubObject = Turret12 HouseColor02 Guns
     End
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6733,8 +6733,10 @@ Object Lazr_AmericaTankAvenger
       HideSubObject = TURRET01
     End
 
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
-      Model               = AVAVNGER_D1
+      Model               = AVAVNGER_D
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!
@@ -6744,7 +6746,7 @@ Object Lazr_AmericaTankAvenger
     End
     ConditionState        = REALLYDAMAGED DISGUISED
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Hide controlled turret
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6852,27 +6852,26 @@ Object Lazr_AmericaTankAvenger
   End
 
   ; Turret fly off death
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-;    ModifierBonusPerOverkillPercent = 30%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 500
-    DestructionDelayVariance = 100
-    FX  = INITIAL  FX_GenericTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_05
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 500
+  ;  DestructionDelayVariance = 100
+  ;  FX  = INITIAL  FX_GenericTankDeathEffect
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   ; Catch fire, and explode death
-  Behavior = SlowDeathBehavior ModuleTag_06
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-    DestructionDelay = 2000
-    DestructionDelayVariance = 300
-    FX  = INITIAL  FX_CrusaderCatchFire
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_06
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 2000
+  ;  DestructionDelayVariance = 300
+  ;  FX  = INITIAL  FX_CrusaderCatchFire
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
     WeaponTemplate        = AvengerPointDefenseLaserOne

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6646,6 +6646,8 @@ Object Lazr_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
       Turret              = TURRET01
       TurretPitch         = TURRETEL01
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
+    AliasConditionState = RUBBLE
   End
 
   ; ***DESIGN parameters ***
@@ -6736,7 +6738,7 @@ Object Lazr_AmericaTankAvenger
     ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Show static turret
+      HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -6839,6 +6839,18 @@ Object Lazr_AmericaTankAvenger
     Mass = 50.0
   End
 
+  ; Patch104p @tweak xezon 21/02/2023 Replaces original slow death behaviours with sudden death to
+  ;   a) be consistent with Humvee death
+  ;   b) mask the executable issue that allows for no rubble state of the slaved laser turret
+  Behavior = SlowDeathBehavior ModuleTag_05
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 100
+    DestructionDelay = 0
+    DestructionDelayVariance = 0
+    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+    OCL = FINAL    OCL_AvengerTankDeathEffect
+  End
+
   ; Turret fly off death
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7203,8 +7203,10 @@ Object SupW_AmericaTankAvenger
       HideSubObject = TURRET01
     End
 
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
-      Model               = AVAVNGER_D1
+      Model               = AVAVNGER_D
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!
@@ -7214,7 +7216,7 @@ Object SupW_AmericaTankAvenger
     End
     ConditionState        = REALLYDAMAGED DISGUISED
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01
+      ShowSubObject       = TURRET01  ;Show static turret
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7323,27 +7323,26 @@ Object SupW_AmericaTankAvenger
   End
 
   ; Turret fly off death
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-;    ModifierBonusPerOverkillPercent = 30%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 500
-    DestructionDelayVariance = 100
-    FX  = INITIAL  FX_GenericTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_05
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 500
+  ;  DestructionDelayVariance = 100
+  ;  FX  = INITIAL  FX_GenericTankDeathEffect
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   ; Catch fire, and explode death
-  Behavior = SlowDeathBehavior ModuleTag_06
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    ProbabilityModifier = 50
-    DestructionDelay = 2000
-    DestructionDelayVariance = 300
-    FX  = INITIAL  FX_CrusaderCatchFire
-    OCL = FINAL    OCL_AvengerTankDeathEffect
-    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
-  End
+  ;Behavior = SlowDeathBehavior ModuleTag_06
+  ;  DeathTypes = ALL -CRUSHED -SPLATTED
+  ;  ProbabilityModifier = 50
+  ;  DestructionDelay = 2000
+  ;  DestructionDelayVariance = 300
+  ;  FX  = INITIAL  FX_CrusaderCatchFire
+  ;  FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+  ;  OCL = FINAL    OCL_AvengerTankDeathEffect
+  ;End
 
   Behavior = PointDefenseLaserUpdate ModuleTag_Laser_One
     WeaponTemplate        = AvengerPointDefenseLaserOne

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7310,6 +7310,18 @@ Object SupW_AmericaTankAvenger
     Mass = 50.0
   End
 
+  ; Patch104p @tweak xezon 21/02/2023 Replaces original slow death behaviours with sudden death to
+  ;   a) be consistent with Humvee death
+  ;   b) mask the executable issue that allows for no rubble state of the slaved laser turret
+  Behavior = SlowDeathBehavior ModuleTag_05
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 100
+    DestructionDelay = 0
+    DestructionDelayVariance = 0
+    FX  = FINAL    FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+    OCL = FINAL    OCL_AvengerTankDeathEffect
+  End
+
   ; Turret fly off death
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7116,6 +7116,8 @@ Object SupW_AmericaTankAvengerLaserTurret ; Seperate turret object so it can att
       Turret              = TURRET01
       TurretPitch         = TURRETEL01
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
+    AliasConditionState = RUBBLE
   End
 
   ; ***DESIGN parameters ***
@@ -7206,7 +7208,7 @@ Object SupW_AmericaTankAvenger
     ; Patch104p @bugfix xezon 18/02/2023 Shows currect model before final death.
     ConditionState        = RUBBLE
       Model               = AVAVNGER_D
-      ShowSubObject       = TURRET01  ;Show static turret
+      HideSubObject       = TURRET01  ;Hide controlled turret
     End
 
     ;When a bombtruck disguises as an avenger, show the turret!

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -1822,40 +1822,56 @@ ObjectCreationList OCL_AvengerTankDeathEffect
   CreateDebris
     ModelNames = AVAVNGER_D2 ;turret
     Offset = X:-7.2 Y:0.0 Z:6.9
-    Mass = 2.0
     Count = 1
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
+    Mass = 20.0
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 40
+    MaxForceMagnitude = 50
+    MinForcePitch = 85
+    MaxForcePitch = 90
+    SpinRate = 90
     BounceSound = DebrisBigMetal
   End
 
   CreateDebris
     ModelNames = AVAVNGER_D3 ;gun barrel
     Offset = X:-4.59 Y:5.28 Z:7.07
-    Mass = 1.5
     Count = 1
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
+    Mass = 20.0
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 40
+    MaxForceMagnitude = 50
+    MinForcePitch = 85
+    MaxForcePitch = 90
+    SpinRate = 90
     BounceSound = VehicleDebris
   End
 
   CreateDebris
     ModelNames = AVAVNGER_D3 ;gun barrel
     Offset = X:-4.59 Y:-3.83 Z:9.16
-    Mass = 1.5
     Count = 1
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
+    Mass = 20.0
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 40
+    MaxForceMagnitude = 50
+    MinForcePitch = 85
+    MaxForcePitch = 90
+    SpinRate = 90
     BounceSound = VehicleDebris
   End
 
   CreateDebris
     ModelNames = AVAVNGER_D4 ;turret attachment
     Offset = X:-12.05 Y:0.77 Z:8.99
-    Mass = 1.5
     Count = 1
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
+    Mass = 20.0
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 40
+    MaxForceMagnitude = 50
+    MinForcePitch = 85
+    MaxForcePitch = 90
+    SpinRate = 90
     BounceSound = VehicleDebris
   End
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -1802,6 +1802,62 @@ ObjectCreationList OCL_AvengerTankDeathEffect
     Disposition = SEND_IT_FLYING
     DispositionIntensity = 0.1
   End
+
+  ; Patch104p @fix xezon 18/02/2023 Adds original debris.
+
+  CreateDebris
+    ModelNames = AVAVNGER_D5 ;tire
+    Offset = X:9.86 Y:5.74 Z:0.0
+    Count = 1
+    Mass = 20.0
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 40
+    MaxForceMagnitude = 50
+    MinForcePitch = 85
+    MaxForcePitch = 90
+    SpinRate = 90
+    BounceSound = VehicleDebris
+  End
+
+  CreateDebris
+    ModelNames = AVAVNGER_D2 ;turret
+    Offset = X:-7.2 Y:0.0 Z:6.9
+    Mass = 2.0
+    Count = 1
+    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
+    DispositionIntensity = 0.7
+    BounceSound = DebrisBigMetal
+  End
+
+  CreateDebris
+    ModelNames = AVAVNGER_D3 ;gun barrel
+    Offset = X:-4.59 Y:5.28 Z:7.07
+    Mass = 1.5
+    Count = 1
+    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
+    DispositionIntensity = 0.7
+    BounceSound = VehicleDebris
+  End
+
+  CreateDebris
+    ModelNames = AVAVNGER_D3 ;gun barrel
+    Offset = X:-4.59 Y:-3.83 Z:9.16
+    Mass = 1.5
+    Count = 1
+    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
+    DispositionIntensity = 0.7
+    BounceSound = VehicleDebris
+  End
+
+  CreateDebris
+    ModelNames = AVAVNGER_D4 ;turret attachment
+    Offset = X:-12.05 Y:0.77 Z:8.99
+    Mass = 1.5
+    Count = 1
+    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
+    DispositionIntensity = 0.7
+    BounceSound = VehicleDebris
+  End
 End
 
 ObjectCreationList OCL_ScorpionTankDead


### PR DESCRIPTION
**Merge with Rebase**

This change fixes USA Avenger death states and debris.

* Sets proper model for rubble state
* Adds proper debris

The turret will reset on rubble state. I currently see no way to fix it. It appears the `OverlordContain` module simply stops update in Rubble, therefore will disappear, even if laser turret also has a rubble state added.

Debris physics will need some tweaking. That is something for follow up change(s).

### TODO

- [x] Setup rubble state as if code bug did not exist
- [x] Remove destruction delay to hide rubble state
- [ ] Close the hole at the bottom of the turret debris TheSuperHackers/GeneralsGamePatch#1734

## Original

https://user-images.githubusercontent.com/4720891/219878728-4c9bc2b9-3927-45bf-b7eb-332af0f20bb7.mp4
