### PR TITLE
Fix USA Humvee death model states and debris positions

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5113,6 +5113,8 @@ Object AirF_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -5139,6 +5141,8 @@ Object AirF_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -763,6 +763,8 @@ Object CINE_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -789,6 +791,8 @@ Object CINE_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -32,6 +32,8 @@ Object AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -58,6 +60,8 @@ Object AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -19411,6 +19411,8 @@ Object CINE_U05_AmericaVehicleHumveeXYZ
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -19437,6 +19439,8 @@ Object CINE_U05_AmericaVehicleHumveeXYZ
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 
@@ -19673,6 +19677,8 @@ Object CINE_U05_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -19699,6 +19705,8 @@ Object CINE_U05_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 
@@ -19936,6 +19944,8 @@ Object CINE_U05_AmericaVehicleHumvee_BRAKE
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -19962,6 +19972,8 @@ Object CINE_U05_AmericaVehicleHumvee_BRAKE
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 
@@ -20200,6 +20212,8 @@ Object CINE_U05_AmericaVehicleHumvee_Hulk
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -20226,6 +20240,8 @@ Object CINE_U05_AmericaVehicleHumvee_Hulk
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4343,6 +4343,8 @@ Object Lazr_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -4369,6 +4371,8 @@ Object Lazr_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -4828,6 +4828,8 @@ Object SupW_AmericaVehicleHumvee
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE
 
     ConditionState = WEAPONSET_PLAYER_UPGRADE
       Model = AVHUMMER
@@ -4854,6 +4856,8 @@ Object SupW_AmericaVehicleHumvee
       WeaponFireFXBone = TERTIARY WeaponB
       WeaponLaunchBone = TERTIARY WeaponB
     End
+    ; Patch104p @bugfix xezon 18/02/2023 Shows damaged model before final death.
+    AliasConditionState = RUBBLE WEAPONSET_PLAYER_UPGRADE
 
     TrackMarks = EXTireTrack.tga
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6818,10 +6818,11 @@ ObjectCreationList OCL_InitialHumveeDebris
   End
 End
 
+; Patch104p @fix xezon 18/02/2023 Change offset from X:-7.098 Y:5.7 Z:2.9
 ObjectCreationList OCL_FinalHumveeDebris
   CreateDebris
     ModelNames        = AVHUMMER_D2 ;tire
-    Offset            = X:-7.098 Y:5.7 Z:2.9
+    Offset            = X:-7.41 Y:6.43 Z:0.0
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE
@@ -6833,9 +6834,10 @@ ObjectCreationList OCL_FinalHumveeDebris
     BounceSound       = VehicleDebris
   End
 
+  ; Patch104p @fix xezon 18/02/2023 Change offset from X:10.407 Y:-5.7 Z:2.9
   CreateDebris
     ModelNames        = AVHUMMER_D2 ;tire
-    Offset            = X:10.407 Y:-5.7 Z:2.9
+    Offset            = X:10.22 Y:-6.25 Z:0.0
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE
@@ -6847,9 +6849,10 @@ ObjectCreationList OCL_FinalHumveeDebris
     BounceSound       = VehicleDebris
   End
 
+  ; Patch104p @fix xezon 18/02/2023 Change offset from X:.071 Y:6.73 Z:7.273
   CreateDebris
     ModelNames        = AVHUMMER_D3 ;door
-    Offset            = X:.071 Y:6.73 Z:7.273
+    Offset            = X:0.32 Y:6.63 Z:3.07
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE
@@ -6861,10 +6864,10 @@ ObjectCreationList OCL_FinalHumveeDebris
     BounceSound       = VehicleDebris
   End
 
-  ; Random debris
+  ; Patch104p @fix xezon 18/02/2023 Change offset from X:.071 Y:-6.73 Z:7.273
   CreateDebris
     ModelNames        = AVHUMMER_D3 ;door
-    Offset            = X:.071 Y:-6.73 Z:7.273
+    Offset            = X:-1.40 Y:-7.67 Z:4.16
     Count             = 1
     Mass              = 20.0
     Disposition       = RANDOM_FORCE


### PR DESCRIPTION
This change fixes USA Humvee death model states and debris positions.

Originally the undamaged Humvee would show for one frame after death.

* Debris tires now spawn at more accurate spot
* Doors now spawn at better heights and no longer inside the chassis

### TODO

- [ ] Remove Slow Death delay? Needs testing.