### PR TITLE
Fix USA Crusader death effects

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -2224,7 +2224,7 @@ Object CINE_AmericaTankCrusader
     DestructionDelay  = 2000
     DestructionDelayVariance  = 300
     FX  = INITIAL  FX_CrusaderCatchFire
-    OCL = FINAL    OCL_GenericTankDeathEffect
+    OCL = FINAL    OCL_CrusaderTurret ; Patch104p @tweak xezon 18/02/2023 From OCL_GenericTankDeathEffect
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1546,7 +1546,7 @@ Object AmericaTankCrusader
     DestructionDelay  = 2000
     DestructionDelayVariance  = 300
     FX  = INITIAL  FX_CrusaderCatchFire
-    OCL = FINAL    OCL_GenericTankDeathEffect
+    OCL = FINAL    OCL_CrusaderTurret ; Patch104p @tweak xezon 18/02/2023 From OCL_GenericTankDeathEffect
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6339,7 +6339,7 @@ Object SupW_AmericaTankCrusader
     DestructionDelay  = 2000
     DestructionDelayVariance  = 300
     FX  = INITIAL  FX_CrusaderCatchFire
-    OCL = FINAL    OCL_GenericTankDeathEffect
+    OCL = FINAL    OCL_CrusaderTurret ; Patch104p @tweak xezon 18/02/2023 From OCL_GenericTankDeathEffect
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -4503,8 +4503,9 @@ ObjectCreationList OCL_BurningEmbers
 End
 
 ; Patch104p @bugfix commy2 08/09/2022 Spawns wreck and turret at the same time.
+; Patch104p @fix xezon 18/02/2023 Removes all Mammoth Tank debris pieces.
 ; -----------------------------------------------------------------------------
-ObjectCreationList OCL_CrusaderTurret
+ObjectCreationList OCL_CrusaderTurret ; Alias OCL_CrusaderTankDeathEffect
   CreateObject
     ObjectNames = DeadCrusaderHulk
     Offset = X:0 Y:0 Z:0
@@ -4537,108 +4538,6 @@ ObjectCreationList OCL_CrusaderTurret
     MaxForcePitch     = 90
     SpinRate          = 300
     BounceSound = DebrisBigMetal
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D01
-    Offset = X:17.58 Y:1.971 Z:10.282
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.5
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D02
-    Offset = X:8.581 Y:1.943 Z:9.081
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.5
-    BounceSound = VehicleDebris
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D03
-    Offset = X:19.641 Y:2.261 Z:10.569
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.5
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D04
-    Offset = X:13.587 Y:-2.29 Z:9.715
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.5
-    BounceSound = VehicleDebris
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D05
-    Offset = X:6.764 Y:-2.233 Z:8.873
-    Mass = 7.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.4
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D06
-    Offset = X:2.755 Y:-0.99 Z:8.462
-    Mass = 7.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.3
-    BounceSound = VehicleDebris
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D07
-    Offset = X:-1.818 Y:-3.702 Z:8.837
-    Mass = 7.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.3
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D08
-    Offset = X:-2.867 Y:-3.701 Z:8.741
-    Mass = 7.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.3
-    BounceSound = VehicleDebris
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D09
-    Offset = X:-3.894 Y:0.942 Z:8.463
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.3
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D10
-    Offset = X:2.963 Y:2.839 Z:8.454
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.3
-    BounceSound = VehicleDebris
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D11
-    Offset = X:-4.679 Y:2.206 Z:9.613
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.5
-  End
-  CreateDebris
-    ModelNames = GXMammoth_D12
-    Offset = X:-3.606 Y:-3.174 Z:10.986
-    Mass = 5.0
-    Count = 1
-    Disposition = SEND_IT_FLYING
-    DispositionIntensity = 2.5
-    BounceSound = VehicleDebris
   End
 End
 


### PR DESCRIPTION
**Merge with Rebase**

This change fixes USA Crusader death effects.

* Removes all Mammoth Tank debris from Crusader death
* Always spawns Crusader Turret debris on death

Note: Crusader Tank has 2 Slow Death behaviors. One spawns a fire before final death and the other a generic explosion.

### TODO

- [ ] Add new USA vehicle debris pieces

## Original

https://user-images.githubusercontent.com/4720891/219944908-83b12d08-dd73-4764-99fa-c328d0696377.mp4

## Patched

https://user-images.githubusercontent.com/4720891/219944926-2d96f40b-7f3e-4c8b-b9cb-2620aaf7fc77.mp4
