### PR TITLE
Fix Civilian Limo death and crush effects

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1743_civilian_limo_death_effects.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1743_civilian_limo_death_effects.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-02-07
+
+title: Fixes death and crush effects of Civilian Limousines
+
+changes:
+  - fix: Adds death and crush particles and debris to Civilian CarLimo1, CarLimo2, CarLimo3, Shiek Limo.
+  - fix: Adds wreck model to Civilian Shiek Limo.
+
+labels:
+  - civilian
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1743
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -3366,6 +3366,23 @@ FXList FX_LimoExplode
 End
 
 ; ----------------------------------------------
+; Patch104p @feature xezon 07/02/2023
+; Based off of FX_LimoExplode
+; ----------------------------------------------
+FXList FX_LimoCrush
+  Sound
+    Name = CarDie
+  End
+  ParticleSystem
+    Name = LimoExplosionArms
+    Offset = X:6 Y:0 Z:0
+  End
+  ParticleSystem
+    Name = LimoExplosionSmoke
+  End
+End
+
+; ----------------------------------------------
 FXList FX_LimoDamageTransition
   Sound
     Name = CarDie

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -1794,14 +1794,28 @@ Object CarLimo1
     ;nothing
   End
 
+  ; Patch104p @tweak xezon 07/02/2023 Changes CreationList from OCL_GenericCarExplode. Flings debris into air.
   Behavior = CreateObjectDie ModuleTag_DeathTag04
-    CreationList = OCL_GenericCarExplode
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    CreationList = OCL_GenericLimoExplode
   End
 
+  ; Patch104p @tweak xezon 07/02/2023 Changes DeathFX from FX_GenericCarExplode.
   Behavior = FXListDie ModuleTag_DeathTag05
-    DeathFX = FX_GenericCarExplode
+    DeathTypes = ALL -CRUSHED -SPLATTED -FLOODED
+    DeathFX = FX_LimoExplode
   End
 
+  ; Patch104p @tweak xezon 07/02/2023 Adds different effects for crushing, splatting. Flings debris aside.
+  Behavior = CreateObjectDie ModuleTag_DeathTag06
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_GenericLimoCrush
+  End
+
+  Behavior = FXListDie ModuleTag_DeathTag07
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    DeathFX = FX_LimoCrush
+  End
 
   ;Behavior = DestroyDie ModuleTag_04
   ;  DeathTypes = ALL -CRUSHED -SPLATTED
@@ -1920,14 +1934,29 @@ Object CarLimo2
   Behavior = DestroyDie ModuleTag_DeathTag03
     ;nothing
   End
+
+  ; Patch104p @tweak xezon 07/02/2023 Changes CreationList from OCL_GenericCarExplode. Flings debris into air.
   Behavior = CreateObjectDie ModuleTag_DeathTag04
-    CreationList = OCL_GenericCarExplode
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    CreationList = OCL_GenericLimoExplode
   End
+
+  ; Patch104p @tweak xezon 07/02/2023 Changes DeathFX from FX_GenericCarExplode.
   Behavior = FXListDie ModuleTag_DeathTag05
-    DeathFX = FX_GenericCarExplode
+    DeathTypes = ALL -CRUSHED -SPLATTED -FLOODED
+    DeathFX = FX_LimoExplode
   End
 
+  ; Patch104p @tweak xezon 07/02/2023 Adds different effects for crushing, splatting. Flings debris aside.
+  Behavior = CreateObjectDie ModuleTag_DeathTag06
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_GenericLimoCrush
+  End
 
+  Behavior = FXListDie ModuleTag_DeathTag07
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    DeathFX = FX_LimoCrush
+  End
 
  ; Behavior = DestroyDie ModuleTag_04
  ;   DeathTypes = ALL -CRUSHED -SPLATTED
@@ -2067,22 +2096,27 @@ Object CarLimo3
     DestructionDelay = 20000
   End
 
+  ; Patch104p @tweak xezon 07/02/2023 Changes DeathFX from FX_CarCrush.
   Behavior = FXListDie ModuleTag_06
     DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_CarCrush
+    DeathFX = FX_LimoCrush
   End
+
   Behavior = CreateObjectDie ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
     CreationList = OCL_LimoExplode
   End
+
+  ; Patch104p @tweak xezon 07/02/2023 Adds different effects for crushing, splatting. Flings debris aside.
+  Behavior = CreateObjectDie ModuleTag_DeathTag06
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_GenericLimoCrush
+  End
+
   Behavior = FXListDie ModuleTag_08
     DeathTypes = ALL -CRUSHED -SPLATTED -FLOODED
     DeathFX = FX_LimoExplode
   End
-;  Behavior = CreateObjectDie
-;;    DeathTypes = NONE +SUICIDED
-;    CreationList = OCL_BurnedCarHull
-;  End
 
   Behavior = AIUpdateInterface ModuleTag_09
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -2232,22 +2232,28 @@ Object ShiekLimo
     DestructionDelay = 20000
   End
 
+  ; Patch104p @tweak xezon 07/02/2023 Changes DeathFX from FX_CarCrush.
   Behavior = FXListDie ModuleTag_06
     DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_CarCrush
+    DeathFX = FX_LimoCrush
   End
+
+  ; Patch104p @tweak xezon 07/02/2023 Changes CreationList from OCL_LimoExplode.
   Behavior = CreateObjectDie ModuleTag_07
     DeathTypes = ALL -CRUSHED -SPLATTED
-    CreationList = OCL_LimoExplode
+    CreationList = OCL_ShiekLimoExplode
   End
+
+  ; Patch104p @tweak xezon 07/02/2023 Adds different effects for crushing, splatting. Flings debris aside.
+  Behavior = CreateObjectDie ModuleTag_DeathTag06
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_ShiekLimoCrush
+  End
+
   Behavior = FXListDie ModuleTag_08
     DeathTypes = ALL -CRUSHED -SPLATTED -FLOODED
     DeathFX = FX_LimoExplode
   End
-;  Behavior = CreateObjectDie
-;;    DeathTypes = NONE +SUICIDED
-;    CreationList = OCL_BurnedCarHull
-;  End
 
   Behavior = AIUpdateInterface ModuleTag_09
   End
@@ -2276,6 +2282,66 @@ Object ShiekLimo
   GeometryMinorRadius = 5.0
   GeometryHeight  = 7.0
   Shadow          = SHADOW_VOLUME
+
+End
+
+;------------------------------------------------------------------------------
+; Patch104p @feature xezon 07/02/2023
+; Based off of CarLimo03DeadHull
+;------------------------------------------------------------------------------
+Object ShiekLimoDeadHull
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    OkToChangeModelColor = Yes
+
+    ConditionState = NONE
+      Model = CVShkLimo_D1
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName = OBJECT:Limo
+  EditorSorting = SYSTEM
+  TransportSlotCount = 3                 ;how many "slots" we take in a transport (0 == not transportable)
+
+  ; *** AUDIO Parameters ***
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = UNIT
+
+  KindOf = CAN_CAST_REFLECTIONS NO_COLLIDE HULK UNATTACKABLE
+
+  Body = ActiveBody ModuleTag_02
+    MaxHealth = 1.0
+    InitialHealth = 1.0
+  End
+
+  Behavior = PhysicsBehavior ModuleTag_03
+    Mass = 50
+    AllowBouncing = Yes
+    KillWhenRestingOnGround = Yes
+  End
+
+  Behavior = LifetimeUpdate ModuleTag_04
+    MinLifetime = 1500   ; min lifetime in msec
+    MaxLifetime = 1600   ; max lifetime in msec
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_05
+    SinkDelay = 14000
+    SinkRate = 2     ; in Dist/Sec
+    DestructionDelay = 20000
+  End
+
+  Behavior = TransitionDamageFX ModuleTag_06
+    RubbleParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+  End
+
+  Geometry = BOX
+  GeometryMajorRadius = 9.0
+  GeometryMinorRadius = 6.0
+  GeometryHeight = 7.5
+  GeometryIsSmall = Yes
 
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -2633,6 +2633,100 @@ ObjectCreationList OCL_GenericLimoCrush
 End
 
 ; ----------------------------------------------
+; Patch104p @feature xezon 07/02/2023
+; Based off of OCL_LimoExplode
+; ----------------------------------------------
+ObjectCreationList OCL_ShiekLimoExplode
+  CreateDebris
+    ModelNames = CVShkLimo_D2
+    Offset = X:-15.962 Y:0.019 Z:4.649
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 100
+    MaxForceMagnitude = 130
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVShkLimo_D3
+    Offset = X:13.202 Y:5.126 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 100
+    MaxForceMagnitude = 130
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVShkLimo_D4
+    Offset = X:-12.731 Y:-5.12 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 100
+    MaxForceMagnitude = 130
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 180
+  End
+  ; Patch104p @tweak xezon 07/02/2023 Fling hulk in air.
+  CreateObject
+    ObjectNames = ShiekLimoDeadHull
+    Offset = X:0 Y:0 Z:0
+    Count = 1
+    Disposition = RANDOM_FORCE
+  End
+End
+
+; ----------------------------------------------
+; Patch104p @feature xezon 07/02/2023
+; Based off of OCL_ShiekLimoExplode
+; Debris flings aside.
+; ----------------------------------------------
+ObjectCreationList OCL_ShiekLimoCrush
+  CreateDebris
+    ModelNames = CVShkLimo_D2
+    Offset = X:-15.962 Y:0.019 Z:4.649
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 0
+    MaxForcePitch = 20
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVShkLimo_D3
+    Offset = X:13.202 Y:5.126 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 0
+    MaxForcePitch = 20
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVShkLimo_D4
+    Offset = X:-12.731 Y:-5.12 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 0
+    MaxForcePitch = 20
+    SpinRate = 180
+  End
+End
+
+; ----------------------------------------------
 ObjectCreationList OCL_SmallStructureDebris
   CreateDebris
     ModelNames = ABPwrPlant_d01 ABPwrPlant_d02 ABPwrPlant_d03 ABPwrPlant_d04 ABPwrPlant_d05 ABPwrPlant_d06 ABPwrPlant_d07 ABPwrPlant_d08 ABPwrPlant_d09 ABPwrPlant_d10

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -2463,7 +2463,7 @@ ObjectCreationList OCL_GenericCarFloatDebris
 End
 
 ; ----------------------------------------------
-ObjectCreationList OCL_LimoExplode
+ObjectCreationList OCL_LimoExplode ; Alias OCL_Limo03Explode
   CreateDebris
     ModelNames = CVLimo3_D2
     Offset = X:-15.962 Y:0.019 Z:4.649
@@ -2517,6 +2517,118 @@ ObjectCreationList OCL_LimoExplode
     Offset = X:0 Y:0 Z:0
     Count = 1
     Disposition = RANDOM_FORCE
+  End
+End
+
+; ----------------------------------------------
+; Patch104p @feature xezon 07/02/2023
+; Based off of OCL_LimoExplode
+; Debris flings in air.
+; ----------------------------------------------
+ObjectCreationList OCL_GenericLimoExplode
+  CreateDebris
+    ModelNames = CVLimo3_D2
+    Offset = X:-15.962 Y:0.019 Z:4.649
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 100
+    MaxForceMagnitude = 130
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVLimo3_D3
+    Offset = X:13.202 Y:5.126 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 100
+    MaxForceMagnitude = 130
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVLimo3_D4
+    Offset = X:-12.731 Y:-5.12 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 100
+    MaxForceMagnitude = 130
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVLimo3_D5
+    Offset = X:13.62 Y:-0.013 Z:5.302
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 100
+    MaxForceMagnitude = 130
+    MinForcePitch = 70
+    MaxForcePitch = 90
+    SpinRate = 180
+  End
+End
+
+; ----------------------------------------------
+; Patch104p @feature xezon 07/02/2023
+; Based off of OCL_GenericLimoExplode
+; Debris flings aside.
+; ----------------------------------------------
+ObjectCreationList OCL_GenericLimoCrush
+  CreateDebris
+    ModelNames = CVLimo3_D2
+    Offset = X:-15.962 Y:0.019 Z:4.649
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 0
+    MaxForcePitch = 20
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVLimo3_D3
+    Offset = X:13.202 Y:5.126 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 0
+    MaxForcePitch = 20
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVLimo3_D4
+    Offset = X:-12.731 Y:-5.12 Z:1.975
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 0
+    MaxForcePitch = 20
+    SpinRate = 180
+  End
+  CreateDebris
+    ModelNames = CVLimo3_D5
+    Offset = X:13.62 Y:-0.013 Z:5.302
+    Mass = 40
+    Count = 1
+    Disposition = RANDOM_FORCE
+    MinForceMagnitude = 80
+    MaxForceMagnitude = 100
+    MinForcePitch = 0
+    MaxForcePitch = 20
+    SpinRate = 180
   End
 End
 


### PR DESCRIPTION
**Merge with Rebase**

This change fixes Civilian Limo death and crush effects.

* Adds new particle effects for Limo death and crush
* Adds new debris effects for Limo death and crush
* Adds hulk for ShiekLimo

### TODO

- [x] Add `KillWhenRestingOnGround = Yes` to ShiekLimo hulk
- [x] Set `MinLifetime = 1500`, `MaxLifetime = 1600` on ShiekLimo hulk
