### PR TITLE
Change: Begin sink China Dragon Tank hulk right after the fire effect vanished

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1745_dragon_tank_sink_delay.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1745_dragon_tank_sink_delay.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-01-29
+
+title: Reduces sink delay of China Dragon Tank wreck
+
+changes:
+  - fix: The wreck of the China Dragon Tank now sinks after 12 seconds instead of 14 seconds, right after the rubble flames ended.
+
+labels:
+  - china
+  - design
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1745
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -729,11 +729,11 @@ Object ChinaTankDragonDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay from 14000 to 12000 (-2000) to start sink right after the fire particle vanished.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 12000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 18000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06


### PR DESCRIPTION
This change begins to sink China Dragon Tank hulk right after the rubble fire effect vanished. It now sinks after 12000 instead of 14000 milliseconds. This way it does not stay in the world longer than necessary.