### PR TITLE
Change: Set consistent sink delays for faction vehicles

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1746_wreck_sink_delays.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1746_wreck_sink_delays.yaml
@@ -1,0 +1,62 @@
+---
+date: 2023-01-29
+
+title: Sets consistent sink delays for faction vehicle wrecks
+
+changes:
+  - tweak: Sets sink delays for wrecks of regular vehicles and aircraft to 3000 ms.
+  - tweak: Sets sink delays for wrecks of large vehicles and aircraft to 6000 ms.
+
+subchanges:
+  - tweak: Sets sink delay of Generic Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Dozer wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Humvee wreck from 14000 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Ambulance wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Avenger wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Crusader Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Paladin Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Laser Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Microwave wreck from 14000 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Tomahawk wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Chinook wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Raptor wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Aurora wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Stealth Fighter wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA A10 wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of USA Spectre wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Dozer wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Supply Truck wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Troop Crawler wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Assault Troop Crawler wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Listening Outpost wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Gattling Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Battlemaster wreck from 14000 ms to 3000 ms.
+  - tweak: Sets sink delay of China ECM Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Inferno Cannon wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of China Nuke Cannon wreck from 1500 ms to 6000 ms.
+  - tweak: Sets sink delay of China Overlord wreck from 14000 ms to 6000 ms.
+  - tweak: Sets sink delay of China Helix wreck from 1500 ms to 6000 ms.
+  - tweak: Sets sink delay of China Mig wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of GLA Radar Van wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of GLA Quad Cannon wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of GLA Scorpion Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of GLA Marauder Tank wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of GLA Toxin Tractor wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of GLA Bomb Truck wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of GLA Battle Bus wreck from 1500 ms to 3000 ms.
+  - tweak: Sets sink delay of Civilian Militia Tank wreck from 4000 ms to 3000 ms.
+  - tweak: Sets sink delay of Civilian Toxic Supply Truck wreck from 1500 ms to 3000 ms.
+
+labels:
+  - china
+  - design
+  - gla
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1746
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -190,10 +190,11 @@ Object ChinaVehicleNukeCannonHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of large vehicle/aircraft from 1500 to 6000 (+4500) to sink later than small vehicles/aircraft.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 6000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 10000
+    DestructionDelay = 14500
   End
 End
 
@@ -522,10 +523,11 @@ Object HelixRubbleHull
 
   ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 14500 (+8000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of large vehicle/aircraft from 1500 to 6000 (+4500) to sink later than small vehicles/aircraft.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 6000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 16000
+    DestructionDelay = 20500
   End
 
 End
@@ -676,10 +678,11 @@ Object ChinaTankOverlordDeadHull
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6000 to 9000 (+3000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of large vehicle/aircraft from 14000 to 6000 (-8000) to sink later than small vehicles/aircraft.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 6000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 23000
+    DestructionDelay = 15000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -41,10 +41,11 @@ Object DeadMicrowaveHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle/aircraft from 14000 to 3000 (-11000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 9000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -102,10 +103,11 @@ Object AmericaVehicleHumveeDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle from 14000 to 3000 (-11000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 9000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -151,10 +153,11 @@ Object AmericaVehicleTomahawkHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 End
 
@@ -227,10 +230,11 @@ Object AmericaJetRaptorHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -269,11 +273,11 @@ Object AmericaJetA10Hulk
   End
 
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -312,11 +316,11 @@ Object SpectreHulk
   End
 
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -351,10 +355,11 @@ Object AmericaJetStealthHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -389,10 +394,11 @@ Object AmericaJetAuroraHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -478,10 +484,11 @@ Object ChinookRubbleHull
   End
 
   ; Patch104p @fix xezon 29/01/2023 Change Sink Rate from 1 to 2, Destruction Delay from 16000 to 8000, to be consistent with other hulks.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate         = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -557,10 +564,11 @@ Object ChinaJetMIGHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 8000
+    DestructionDelay = 9500
   End
 
 End
@@ -607,11 +615,11 @@ Object ChinaVehicleBattleMasterDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
-
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle/aircraft from 14000 to 3000 (-11000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 14000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 20000
+    DestructionDelay = 9000
   End
 
   Behavior = TransitionDamageFX ModuleTag_06
@@ -790,10 +798,11 @@ Object ChinaVehicleTroopCrawlerDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -844,10 +853,11 @@ Object ChinaVehicleAssaultTroopCrawlerDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -886,10 +896,11 @@ Object DeadTankHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -922,10 +933,11 @@ Object InfernoCannonHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8500 (+2000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 10000
+    DestructionDelay  = 11500
   End
 
 End
@@ -958,10 +970,11 @@ Object DeadChinaSupplyTruckHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 9500
+    DestructionDelay  = 11000
   End
 
 End
@@ -995,10 +1008,11 @@ Object DeadChinaGattlingTankHulk
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 10000 (-2000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 10000
+    DestructionDelay          = 11500
   End
 
 End
@@ -1032,10 +1046,11 @@ Object DeadChinaECMTankHulk
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 8000
+    DestructionDelay          = 9500
   End
 
 End
@@ -1069,10 +1084,11 @@ Object AmericaVehicleAmbulanceDeadHull
 
   ; Patch104p @tweak xezon 29/01/2023 Remove Sink Delay Variance of 1500, Destruction Delay Variance of 4000.
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 7500 (-4500) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay                 = 1500
+    SinkDelay                 = 3000
     SinkRate                  = 2     ; in Dist/Sec
-    DestructionDelay          = 7500
+    DestructionDelay          = 9000
   End
 
 
@@ -1120,10 +1136,11 @@ Object DeadSCUDLauncherHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 8000 (+1500) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 9500
+    DestructionDelay  = 11000
   End
 
 End
@@ -1156,10 +1173,11 @@ Object DeadToxinTractorHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10000 (-6000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 10000
+    DestructionDelay  = 11500
   End
 
 End
@@ -1192,10 +1210,11 @@ Object DeadQuadCannonHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 8000 (-8000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End
@@ -1228,10 +1247,11 @@ Object DeadBombTruckHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 10500 (-5500) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2    ; in Dist/Sec
-    DestructionDelay  = 10500
+    DestructionDelay  = 12000
   End
 
 End
@@ -1442,10 +1462,11 @@ Object DeadCrusaderHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1476,10 +1497,11 @@ Object DeadLaserTankHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1510,10 +1532,11 @@ Object DeadPaladinHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1545,10 +1568,11 @@ Object DeadAvengerHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 9000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1579,10 +1603,11 @@ Object DeadMarauderHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 13500
   End
 End
 
@@ -1613,10 +1638,11 @@ Object DeadBattleBusHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 13500
   End
 End
 
@@ -1648,10 +1674,11 @@ Object DeadScorpionHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 12000 to 8000 (-4000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 End
 
@@ -1686,10 +1713,11 @@ Object DestroyedMilitiaTank
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 8000 to 10500 (+2500) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Decrease Sink Delay of small vehicle/aircraft from 4000 to 3000 (-1000) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 4000
+    SinkDelay = 3000
     SinkRate = 2     ; in Dist/Sec
-    DestructionDelay = 10500
+    DestructionDelay = 9500
   End
 End
 
@@ -1721,10 +1749,11 @@ Object DeadRadarVanHulk
   End
 
   ; Patch104p @performance xezon 29/01/2023 Decrease Destruction Delay from 16000 to 12000 (-4000) to delete object earlier after it sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 12000
+    DestructionDelay  = 13500
   End
 
 End
@@ -1757,10 +1786,11 @@ Object ChinaDeadDozerHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 9000
+    DestructionDelay = 10500
   End
 
 End
@@ -1793,10 +1823,11 @@ Object AmericaDeadDozerHulk
   End
 
   ; Patch104p @fix xezon 29/01/2023 Increase Destruction Delay offset from 6500 to 7500 (+1000) to avoid deletion before object is sunk into terrain.
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay        = 1500
+    SinkDelay        = 3000
     SinkRate            = 2     ; in Dist/Sec
-    DestructionDelay = 9000
+    DestructionDelay = 10500
   End
 
 End
@@ -1985,10 +2016,11 @@ Object ChinaVehicleListeningOutpostDeadHull
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_Hulk05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 
@@ -2035,10 +2067,11 @@ Object DeadGLAToxicSupplyTruckHulk
     MaxLifetime = 1600   ; max lifetime in msec
   End
 
+  ; Patch104p @tweak xezon 29/01/2023 Increase Sink Delay of small vehicle/aircraft from 1500 to 3000 (+1500) to sink as early as infantry units.
   Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay         = 1500
+    SinkDelay         = 3000
     SinkRate          = 2     ; in Dist/Sec
-    DestructionDelay  = 8000
+    DestructionDelay  = 9500
   End
 
 End


### PR DESCRIPTION
**Merge with Rebase**

* Fixes #1183

This change increases or decreases sink delays of

* all regular faction vehicles to 3000 ms
* all large faction vehicles to 6000 ms

Large vehicles are:

* China Overlord
* China Nuke Cannon
* China Helix

## Rationale

All faction things now sink after at least 3000 ms. Infantry already sinks after 3000 ms. This allows the observer to see the hulks for just a bit longer after the death effects disappeared.

Large vehicles are set to sink slower because the Original Overlord also stayed longer and they are big (and strong) vehicles, so their hulks can be presented for a bit longer to highlight the significance of the large vehicle kill for just a bit longer than regular smaller vehicles.