### PR TITLE
Change: Add 3D shadows to big bombs

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1750_bomb_shadows.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1750_bomb_shadows.yaml
@@ -1,0 +1,22 @@
+---
+date: 2023-02-24
+
+title: Adds 3D shadows to bomb objects
+
+changes:
+  - tweak: Adds 3D shadow to objects with EXCarptBmb model.
+  - tweak: Adds 3D shadow to objects with EXAMine_A model.
+  - tweak: Adds 3D shadow to objects with AVBomber_B model.
+
+labels:
+  - design
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1750
+
+authors:
+  - Stubbjax
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -184,6 +184,8 @@ Object AirF_AuroraBomb
   GeometryIsSmall = Yes
   GeometryMajorRadius = 2.0
 
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -184,8 +184,10 @@ Object AirF_AuroraBomb
   GeometryIsSmall = Yes
   GeometryMajorRadius = 2.0
 
+  ; Patch104p @tweak Stubbjax 24/02/2023 Adds bomb shadow.
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17881,8 +17881,10 @@ Object Nuke_ChinaCarpetBomb
     ;nothing
   End
 
+  ; Patch104p @tweak Stubbjax 24/02/2023 Adds bomb shadow.
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17881,6 +17881,8 @@ Object Nuke_ChinaCarpetBomb
     ;nothing
   End
 
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -393,8 +393,10 @@ Object ChinaCarpetBomb
     ;nothing
   End
 
+  ; Patch104p @tweak Stubbjax 24/02/2023 Adds bomb shadow.
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 
@@ -996,8 +998,10 @@ Object CarpetBomb
     ;nothing
   End
 
+  ; Patch104p @tweak Stubbjax 24/02/2023 Adds bomb shadow.
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 ;------------------------------------------------------------------------------
@@ -1056,8 +1060,10 @@ Object AuroraBomb
   GeometryIsSmall = Yes
   GeometryMajorRadius = 2.0
 
+  ; Patch104p @tweak Stubbjax 24/02/2023 Adds bomb shadow.
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 ;------------------------------------------------------------------------------
@@ -5906,8 +5912,10 @@ Object SupW_AuroraFuelAirBomb
   GeometryIsSmall = Yes
   GeometryMajorRadius = 12.0
 
+  ; Patch104p @tweak Stubbjax 24/02/2023 Adds bomb shadow.
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 ;------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1405,6 +1405,10 @@ Object ClusterMinesBomb
   GeometryHeight = 1.0                   ;Height for geometry
   GeometryIsSmall = Yes                  ;Is small geometry
 
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 
@@ -1480,6 +1484,10 @@ Object EMPPulseBomb
   GeometryHeight = 1.0                   ;Height for geometry
   GeometryIsSmall = Yes                  ;Is small geometry
 
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 
@@ -1553,6 +1561,10 @@ Object BlackMarketNuke
   Geometry = Sphere
   GeometryIsSmall = Yes
   GeometryMajorRadius = 12.0
+
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 
 End
 
@@ -1651,6 +1663,10 @@ Object AnthraxBomb
  ; GeometryIsSmall = Yes
   ;GeometryMajorRadius = 12.0
 
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 ;------------------------------------------------------------------------------
@@ -1739,6 +1755,10 @@ Object AnthraxBombGamma
  ; GeometryIsSmall = Yes
   ;GeometryMajorRadius = 12.0
 
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 ;------------------------------------------------------------------------------
@@ -1805,6 +1825,10 @@ Object DaisyCutterBomb
   Geometry = Sphere
   GeometryIsSmall = Yes
   GeometryMajorRadius = 12.0
+
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 
 End
 
@@ -5588,6 +5612,10 @@ Object NapalmBomb
   GeometryMajorRadius = 1.0
   Scale = 0.7
 
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
+
 End
 
 ;---------------------------------------------------------------------------------------
@@ -6165,6 +6193,10 @@ Object NukeBomb
   GeometryIsSmall = Yes
   GeometryMajorRadius = 1.0
   Scale = 0.7
+
+  ; Patch104p @tweak xezon 10/04/2023 Adds bomb shadow.
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -393,6 +393,8 @@ Object ChinaCarpetBomb
     ;nothing
   End
 
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 End
 
 
@@ -994,6 +996,8 @@ Object CarpetBomb
     ;nothing
   End
 
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 End
 
 ;------------------------------------------------------------------------------
@@ -1052,6 +1056,8 @@ Object AuroraBomb
   GeometryIsSmall = Yes
   GeometryMajorRadius = 2.0
 
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 End
 
 ;------------------------------------------------------------------------------
@@ -5900,6 +5906,8 @@ Object SupW_AuroraFuelAirBomb
   GeometryIsSmall = Yes
   GeometryMajorRadius = 12.0
 
+  Shadow = SHADOW_VOLUME
+  ShadowSizeX = 89 ; minimum elevation angle above horizon. Used to limit shadow length
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
This change adds shadows to all carpet bombs (all weapon objects using the `EXCarptBmb` model). This makes it much easier to determine the height and trajectory of the bomb.

Values were copied from other aircraft so that the shadow aligns with them.

---

Where is the bomb going to land?

![image](https://user-images.githubusercontent.com/11547761/221210849-00129a32-c094-4656-8acd-c678a2057287.png)

It's much clearer now!

![image](https://user-images.githubusercontent.com/11547761/221210994-64266af7-0fa0-4b79-ae12-0122bf16e1a0.png)

_I can see many shadows appearing in the distance._