### PR TITLE
Fix: Aurora Alpha bomb impact and detonation effect

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5969,7 +5969,7 @@ Object SupW_AuroraFuelAirGas
   ; Patch104p @tweak Stubbjax 24/02/2023 Removes the destruction delay variance of 100 ms.
   Behavior = SlowDeathBehavior ModuleTag_04
     DestructionDelay        = 1000
-    FX                  = INITIAL AirF_FX_AuroraBombIgnite
+    FX                  = INITIAL AirF_FX_AuroraBombExplode
     FX                  = FINAL   AirF_FX_AuroraBombDetonation
     Weapon              = MIDPOINT   DaisyCutterFlameWeapon    ; Just a spot of flame to light trees on fire
     Weapon              = FINAL   SupW_FuelBombDetonationWeapon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7682,7 +7682,7 @@ Weapon SupW_AuroraFuelBombWeapon ; Alias SupW_AuroraBombWeapon
   WeaponSpeed             = 99999
   ProjectileObject        = SupW_AuroraFuelAirBomb
   FireFX                  = FX_AuroraBombLaunch
-  ProjectileDetonationFX  = AirF_FX_AuroraBombExplode
+  ProjectileDetonationFX  = FX_AuroraBombDetonate
   ProjectileDetonationOCL = SupW_OCL_FuelAirBomb
   RadiusDamageAffects     = ALLIES ENEMIES NEUTRALS NOT_SIMILAR
   ClipSize                = 1                        ; how many shots in a Clip (0 == infinite)


### PR DESCRIPTION
This change adds a proper impact effect to the Alpha Aurora's bomb projectile, as well as rectifying an issue introduced by #292 that resulted in a double-up in the bomb's detonation effects. Essentially, the duplicate explosion effect is replaced with the correct detonation effect.

## Missing impact effect

In 1.04, there is an [impact effect](https://user-images.githubusercontent.com/11547761/221106044-c12064bf-70e4-432c-8e61-0b80020bde3e.mp4) that plays for the vanilla Aurora's bomb when it impacts the target, whereas it does not play for the Aurora Alpha's bomb. This is because the Alpha weapon's `ProjectileDetonationFX` field is mysteriously commented out, which is likely erroneous considering the mismatch with the vanilla Aurora, as well as the fact that the fire (whistle sound) effect is also commented out. Plus, it just feels and looks bad that the projectile silently disappears into the ground while still applying heavy impact damage.

```
Weapon AuroraBombWeapon
  FireFX = FX_AuroraBombLaunch
  ProjectileDetonationFX = FX_AuroraBombDetonate
End

Weapon SupW_AuroraFuelBombWeapon
  ; FireFX = FX_AuroraBombLaunch
  ; ProjectileDetonationFX = FX_AuroraBombDetonate
End
```

Solving this issue requires addressing the duplicate detonation effect for reasons explained below.

## Duplicate detonation effect

The other issue is that in 1.04, there are (incorrectly) two very similar Aurora Alpha bomb detonation effects assigned to play upon the bomb's detonation. However, it has never been much of a problem because the `SlowDeathBehaviour` of `SupW_AuroraFuelAirGas` _very rarely_ plays its `INITIAL AirF_FX_AuroraBombIgnite` effect (perhaps due to some funkiness with the `HeightDieUpdate` module), whereas `AirF_FX_AuroraBombExplode` almost always plays via the `FXListDie` module of `SupW_AuroraFuelAirBomb`. (The only time `AirF_FX_AuroraBombIgnite` seems to play in 1.04 is when the fuel ignition becomes disconnected from the projectile impact, such as when [firing through friendly buildings](https://user-images.githubusercontent.com/11547761/221205299-63ebb1a3-537e-48a6-8f3d-0a7fd322217c.mp4). This was the issue addressed by #292.)

The below `DeathFX` pretty much always plays in 1.04:

```
Object SupW_AuroraFuelAirBomb
  Behavior = FXListDie ModuleTag_04
    DeathFX = AirF_FX_AuroraBombExplode
  End
End
```

The below `FX` almost never plays in 1.04 (`INITIAL` does not work properly in this case):
```
Object SupW_AuroraFuelAirGas
  Behavior = SlowDeathBehavior ModuleTag_04
    FX = INITIAL AirF_FX_AuroraBombIgnite
  End
End
```

The fix introduced by #292 removed the dodgy `HeightDieUpdate` module of `SupW_AuroraFuelAirGas` and resolved the respective detonation issues, which has allowed the gas's `INITIAL` effect to always play as a consequence. (The fix also removed the `FXListDie` module of `SupW_AuroraFuelAirBomb` and instead moved the effect to the `SupW_AuroraFuelBombWeapon` via its `ProjectileDetonationFX`.)

So, after #292, both `AirF_FX_AuroraBombIgnite` (via `SupW_AuroraFuelAirGas`) and `AirF_FX_AuroraBombExplode` (via `SupW_AuroraFuelBombWeapon`) are now played as a result of the fuel-air bomb's detonation, but only one of these effects needs to be played.

`AirF_FX_AuroraBombExplode` is a much more comprehensive effect, and includes the initial detonation explosion, gas effects, gas sound, dust ring, and terrain scorch. This is in addition to the initial flares and explosion cloud, which both effects also play. This is the effect that plays in 1.04 and is what players are familiar with.

Below is a comparison of the two effects:

![FAB_COMP](https://user-images.githubusercontent.com/11547761/221106987-a4600042-9509-49ba-bfa2-c38eb87e2236.jpg)

Note that each flare goes on to spawn a sequence of additional effects, which is why `AirF_FX_AuroraBombExplode` looks bigger as it spawns 3 flares per frame instead of 1 flare per frame (over 15 frames). This may be a good candidate for performance optimisation in the future, because there is not a lot of visual difference between 1 and 3, and a lower burst count might better align with the damage radius.

## Summary

Both effects playing at the same time doesn't really do much other than make the effect look a bit more opaque / crowded and take up additional processing power. The solution was to simply move the weapon's effect to the gas by changing `INITIAL AirF_FX_AuroraBombIgnite` to `INITIAL AirF_FX_AuroraBombExplode`, and then matching the weapon's `ProjectileDetonationFX` with the vanilla Aurora's [impact effect](https://user-images.githubusercontent.com/11547761/221106044-c12064bf-70e4-432c-8e61-0b80020bde3e.mp4). This not only resolves the double-up of effects, but introduces consistency between the bomb projectile impacts, which also provides additional feedback to the player which previously never existed for the Alpha variant. This is really the way it should have been done originally, if the problem with the gas's `INITIAL` slow death effect had been known.

Below is a visual demonstration of the changes.

## 1.04:
The effect has a few issues with it in 1.04, such as the massive scorch immediately appearing and the fuel-air detonation beginning before the bomb even hits the ground. The fire (whistle sound) effect is also missing.

https://user-images.githubusercontent.com/11547761/221108654-9437f2b5-bb73-4e11-b526-c1a9c54b07b6.mp4

## After #292:
The fuel-air detonation is now in sync with the projectile colliding with the ground instead of igniting several frames early. Both `AirF_FX_AuroraBombIgnite` and `AirF_FX_AuroraBombExplode` are simultaneously played, but it is difficult to notice the slightly thicker / brighter effects. The extra crackling sound (`DaisyCutterIgnite`) is also apparent, which only really plays for the Fuel-Air Bomb promotion and _very rarely_ for the Aurora Alpha in 1.04.

https://user-images.githubusercontent.com/11547761/221109728-a6d68a2f-f82c-4571-b5e4-bbe664e33f56.mp4

## This change:
Only `AirF_FX_AuroraBombExplode` is played, and the vanilla [impact effect](https://user-images.githubusercontent.com/11547761/221106044-c12064bf-70e4-432c-8e61-0b80020bde3e.mp4) is played upon the bomb's impact, which aligns with the vanilla Aurora, obscures the scorch popping in and looks much nicer overall instead of the bomb just disappearing.

https://user-images.githubusercontent.com/11547761/221109578-1f4474f3-ca3c-451d-89f2-aa630a42b686.mp4