### PR TITLE
Change: Removes the destruction delay variance from the USA Alpha Aurora's bomb

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1752_alpha_aurora_bomb_random_delay.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1752_alpha_aurora_bomb_random_delay.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-02-24
+
+title: Removes destruction delay variance from USA Alpha Aurora bomb
+
+changes:
+  - fix: Removes the 100 ms destruction delay variance from the USA Alpha Aurora bomb. The delay is now a fixed 1000 ms and is deterministic.
+
+labels:
+  - buff
+  - design
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1752
+
+authors:
+  - Stubbjax

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5924,7 +5924,6 @@ Object SupW_AuroraFuelAirGas
   End
   Behavior = SlowDeathBehavior ModuleTag_04
     DestructionDelay        = 1000
-    DestructionDelayVariance = 100
     FX                  = INITIAL AirF_FX_AuroraBombIgnite
     FX                  = FINAL   AirF_FX_AuroraBombDetonation
     Weapon              = MIDPOINT   DaisyCutterFlameWeapon    ; Just a spot of flame to light trees on fire

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5922,6 +5922,8 @@ Object SupW_AuroraFuelAirGas
     MinLifetime = 0
     MaxLifetime = 0
   End
+
+  ; Patch104p @tweak Stubbjax 24/02/2023 Removes the destruction delay variance of 100 ms.
   Behavior = SlowDeathBehavior ModuleTag_04
     DestructionDelay        = 1000
     FX                  = INITIAL AirF_FX_AuroraBombIgnite


### PR DESCRIPTION
This change removes the 100ms destruction delay variance from the Aurora Alpha's bomb weapon. It's not ideal that important gameplay elements (particularly arbitrary ones like this one) are randomised in such a way, and it's best to minimise them where possible.

After this change, the Aurora Alpha bomb's fuel-air explosion will always detonate exactly 1000ms (30 frames) after igniting, instead of a random time between 1000ms (30 frames) and 1100ms (33 frames).

Although this is technically a buff, it should be noted that this partially cancels out the increased detonation delay of 3 to 5 frames introduced by #292. (In 1.04, the fuel ignites 2 to 4 frames _before_ impact, whereas the fuel ignites one frame _after_ impact as of #292.)