### PR TITLE
Change: Decrease USA Alpha Aurora bomb drop speed to match the regular Aurora bomb drop speed

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1753_alpha_aurora_bomb_speed.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1753_alpha_aurora_bomb_speed.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-02-24
+
+title: Fixes Alpha Aurora bomb movement discrepancies
+
+changes:
+  - tweak: The Alpha Aurora bomb now travels as quickly as the original regular Aurora Bomb. Effectively it hits the ground around 5 frames slower than before.
+
+labels:
+  - controversial
+  - design
+  - nerf
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1753
+
+authors:
+  - Stubbjax

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5881,8 +5881,8 @@ Object SupW_AuroraFuelAirBomb
 
   Behavior = PhysicsBehavior ModuleTag_05
     Mass                = 75.0
-    AerodynamicFriction = 1  ; this is now friction-per-sec
-    ForwardFriction     = 33     ; this is now friction-per-sec
+    AerodynamicFriction = 2  ; this is now friction-per-sec
+    ForwardFriction     = 2     ; this is now friction-per-sec
     CenterOfMassOffset  = 2  ; Default of 0 means nothing tips as it falls.  Positive tips forward, negative tips back
   End
   Behavior = MissileAIUpdate ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5879,6 +5879,8 @@ Object SupW_AuroraFuelAirBomb
     InitialHealth   = 100.0
   End
 
+  ; Patch104p @tweak Stubbjax 09/04/2023 Changes AerodynamicFriction from 1, ForwardFriction from 33.
+  ;   Is now consistent with AuroraBomb physics. Causes Bomb to take 5 frames longer to hit.
   Behavior = PhysicsBehavior ModuleTag_05
     Mass                = 75.0
     AerodynamicFriction = 2  ; this is now friction-per-sec


### PR DESCRIPTION
This change slightly reduces the Aurora Alpha's bomb speed to match the vanilla Aurora. From maximum range, this increases the time to impact by roughly three frames. Based on several comments in #655, it seems reasonable to slightly nerf the Aurora Alpha in a subtle way that maintains the same feeling of 1.04 in terms of damage output, but with a higher skill requirement to use and greater potential for counterplay from attentive opponents. And what better way to do it than streamlining some counterintuitive differences?

## Before:
Bombs strangely travel at different speeds, which feels somewhat counterintuitive. It is evident that even though the bombs are dropped on the same frame, the Alpha Aurora's bomb travels slightly faster to the ground and impacts four frames earlier.

https://user-images.githubusercontent.com/11547761/221228395-8f99eb2a-0c36-4eb3-b8b0-695ea2e15948.mp4

## After:
Both bombs now have identical speed and impact the ground at roughly the same time (only one frame apart due to the slightly different travel distances). Note that the detonation from the vanilla Aurora bomb coincidentally destroys the Aurora Alpha bomb and stops it from detonating, which is a phenomenon that occurs with most if not all projectile weapons in 1.04.

https://user-images.githubusercontent.com/11547761/221228417-9aed8c4e-d475-4f6d-a301-1d768d983b92.mp4