### PR TITLE
Change: Assist weapons of USA Patriot will always reload when idle

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1178_patriot_battery_auto_reload.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1178_patriot_battery_auto_reload.yaml
@@ -1,13 +1,14 @@
 ---
 date: 2022-09-10
 
-title: Adds idle auto reload after 2100 ms for USA Patriot Battery.
+title: Adds idle auto reload after 2100 ms for USA Patriot Battery
 
 changes:
-  - fix: The USA Patriot Patriot will now reload the entire clip after being idle for around 2 seconds.
+  - fix: All weapons of the USA Patriot Battery will now reload the entire clip after being idle for around 2 seconds.
 
 labels:
   - buff
+  - controversial
   - design
   - minor
   - usa
@@ -15,6 +16,8 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1178
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1755
 
 authors:
   - commy2
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2052,6 +2052,7 @@ End
 
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
+; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
 Weapon PatriotMissileAssistWeapon
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
@@ -2069,6 +2070,7 @@ Weapon PatriotMissileAssistWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes
@@ -6724,6 +6726,7 @@ End
 
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
+; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
 Weapon Lazr_PatriotMissileAssistWeapon
   PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 3.0
@@ -6740,6 +6743,7 @@ Weapon Lazr_PatriotMissileAssistWeapon
   ClipSize                    = 3                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes
@@ -7779,6 +7783,7 @@ End
 
 ;------------------------------------------------------------------------------
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
+; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
 Weapon SupW_PatriotMissileAssistWeapon
   PrimaryDamage               = 25.0
   PrimaryDamageRadius         = 5.0
@@ -7796,6 +7801,7 @@ Weapon SupW_PatriotMissileAssistWeapon
   ClipSize                    = 4                        ; how many shots in a Clip (0 == infinite)
   ClipReloadTime              = 1000               ; how long to reload a Clip, msec
   AutoReloadsClip             = Yes
+  AutoReloadWhenIdle          = 2100
   AntiAirborneVehicle         = Yes
   AntiAirborneInfantry        = Yes
   AntiGround                  = Yes


### PR DESCRIPTION
* Related to #1580
* Related to #1178

With this change the assist weapons of USA Patriot will always reload when idle.

This makes the weapon a bit better in scenarios where it managed to only fire with a few of its rockets on its target and some time passes until the next target is attacked.

This situation is common. There is a `ClipReloadTime` of 2000 ms (from regular weapon to assist to) vs a `DelayBetweenShots` of 266 (250) ms. This means there is a 35% chance that assisted USA Patriot gets into state with just some rocket in its battery after attacking targets.

# Rationale

Eliminates situations where USA Patriot would only fire some rockets on a fresh engagement. This likely is what player would expect always.

This change also makes the assisted weapon behavior consistent with the patched non-assisted weapons. See
* #1178