### PR TITLE
Fix: Remove move voices from USA Spectre Gunship

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1759_spectre_move_voice_removal.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1759_spectre_move_voice_removal.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-03-05
+
+title: Removes move voices from USA Spectre Gunship
+
+changes:
+  - fix: The USA Spectre Gunship no longer plays voices on move, because it does not actually move anywhere when instructed to move.
+
+labels:
+  - design
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1759
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -508,9 +508,10 @@ Object AirF_AmericaJetSpectreGunship1
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  ; Patch104p @fix xezon 05/03/2023 Disable move voice because unit does not actually move on user command.
   VoiceSelect         = SpectreGunshipVoiceSelect
   VoiceAttack         = SpectreGunshipVoiceAttack
-  VoiceMove         = SpectreGunshipVoiceMove
+  ;VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds
@@ -834,9 +835,10 @@ Object AirF_AmericaJetSpectreGunship2
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  ; Patch104p @fix xezon 05/03/2023 Disable move voice because unit does not actually move on user command.
   VoiceSelect         = SpectreGunshipVoiceSelect
   VoiceAttack         = SpectreGunshipVoiceAttack
-  VoiceMove         = SpectreGunshipVoiceMove
+  ;VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds
@@ -1160,9 +1162,10 @@ Object AirF_AmericaJetSpectreGunship3
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  ; Patch104p @fix xezon 05/03/2023 Disable move voice because unit does not actually move on user command.
   VoiceSelect         = SpectreGunshipVoiceSelect ; Patch104p @bugfix Stubbjax 25/09/2022 Added missing audio.
   VoiceAttack         = SpectreGunshipVoiceAttack
-  VoiceMove         = SpectreGunshipVoiceMove
+  ;VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -177,9 +177,10 @@ Object AmericaJetSpectreGunship
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  ; Patch104p @fix xezon 05/03/2023 Disable move voice because unit does not actually move on user command.
   VoiceSelect         = SpectreGunshipVoiceSelect
   VoiceAttack         = SpectreGunshipVoiceAttack
-  VoiceMove         = SpectreGunshipVoiceMove
+  ;VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15151,9 +15151,10 @@ Object Boss_JetSpectreGunship
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  ; Patch104p @fix xezon 05/03/2023 Disable move voice because unit does not actually move on user command.
   VoiceSelect         = SpectreGunshipVoiceSelect
   VoiceAttack         = SpectreGunshipVoiceAttack
-  VoiceMove         = SpectreGunshipVoiceMove
+  ;VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -177,9 +177,10 @@ Object Lazr_AmericaJetSpectreGunship
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  ; Patch104p @fix xezon 05/03/2023 Disable move voice because unit does not actually move on user command.
   VoiceSelect         = SpectreGunshipVoiceSelect
   VoiceAttack         = SpectreGunshipVoiceAttack
-  VoiceMove         = SpectreGunshipVoiceMove
+  ;VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -655,9 +655,10 @@ Object SupW_AmericaJetSpectreGunship
   IsTrainable = No             ;Not Player built, so no veterancy..............................
 
   ; *** AUDIO Parameters ***
+  ; Patch104p @fix xezon 05/03/2023 Disable move voice because unit does not actually move on user command.
   VoiceSelect         = SpectreGunshipVoiceSelect
   VoiceAttack         = SpectreGunshipVoiceAttack
-  VoiceMove         = SpectreGunshipVoiceMove
+  ;VoiceMove         = SpectreGunshipVoiceMove
   SoundAmbient = SpectreGunshipAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds


### PR DESCRIPTION
This change removes the move voices from USA Spectre Gunship. They can be triggered after the shooting, but the Gunship will not move where ordered contrary to what the voices imply.

## Original

https://user-images.githubusercontent.com/4720891/222984064-1d4392b2-a0fd-4227-8c58-df70dc1f7857.mp4
