### PR TITLE
Increase Cash Bounty Dummy spawn interval from 250 to 1000 ms

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1764_cash_bounty_dummy_spawn_interval.txt
+++ b/Patch104pZH/Design/Changes/v1.0/1764_cash_bounty_dummy_spawn_interval.txt
@@ -1,0 +1,1 @@
+595_cash_bounty_activation.yaml

--- a/Patch104pZH/Design/Changes/v1.0/595_cash_bounty_activation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/595_cash_bounty_activation.yaml
@@ -5,6 +5,7 @@ title: Fixes GLA Cash Bounty activation with an unfinished Command Center scaffo
 
 changes:
   - fix: The GLA Cash Bounty is no longer activated with an unfinished Command Center. The Command Center construction must finish to complete the activation process. After activation is completed, the Command Center can be demolished and the Cash Bounty will stay active. A new Cash Bounty level will require a new Command Center for activation however.
+  - optimization: The GLA Cash Bounty dummy object spawn interval is set to 1000 ms.
 
 labels:
   - bug
@@ -17,6 +18,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/595
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1764
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3067,8 +3067,8 @@ Object CashBountyDummy
   End
 
   Behavior = DeletionUpdate ModuleTag_02
-    MinLifetime = 250   ; min lifetime in msec
-    MaxLifetime = 250   ; max lifetime in msec
+    MinLifetime = 1000   ; min lifetime in msec
+    MaxLifetime = 1000   ; max lifetime in msec
   End
 
   Behavior = CashBountyPower ModuleTag_15

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8975,9 +8975,10 @@ Weapon Demo_ScudStormDeathWeapon
 End
 
 ; Patch104p @bugfix commy2 24/10/2021 Spawns temporary object with cash bounty logic over and over.
+; Patch104p @optimization xezon 10/03/2023 Increases creation interval from 250 to 1000.
 ;------------------------------------------------------------------------------
 Weapon CashBountyDummyWeapon
-  DelayBetweenShots = 250                ; time between shots, msec
+  DelayBetweenShots = 1000                ; time between shots, msec
   FireOCL = OCL_CashBountyDummy
 End
 


### PR DESCRIPTION
* Follow up to #595

Spawning objects in Engine is not free. It allocates several class instances and registers to some systems. Additionally it increases the size of the object lookup table.

* See TheAssemblyArmada/Thyme#887

This change cuts overhead of the workaround by 75%.

The effective consequence is that the Cash Bounty can still be acquired up to 1 second after the last GLA Command Center has been sold, captured or destroyed.

In future we should look for different fix with Thyme, as the current way we do this is a hack.