### PR TITLE
Fix: Listening Outpost Damaged Smoke Effect Sticks After Repair (2)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/261_outpost_smoke_effect.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/261_outpost_smoke_effect.yaml
@@ -14,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/261
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1774
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2945,6 +2945,7 @@ Object ChinaVehicleListeningOutpost
     OCL = FINAL    OCL_FinalListeningOutpostDebris
   End
 
+  ; Patch104p @fix commy 09/09/2021 Removes damage smoke effects that remains visible after repair (#261).
   Behavior = TransitionDamageFX ModuleTag_08
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_NukeCannonDamageTransition
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15938,6 +15938,7 @@ Object Infa_ChinaVehicleTroopCrawler
   End
 
   Behavior                 = TransitionDamageFX ModuleTag_08
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_NukeCannonDamageTransition
   End
 
@@ -16238,8 +16239,8 @@ Object Infa_ChinaVehicleListeningOutpost
     OCL = FINAL    OCL_FinalListeningOutpostDebris
   End
 
+  ; Patch104p @fix commy 09/09/2021 Removes damage smoke effects that remains visible after repair (#261).
   Behavior                 = TransitionDamageFX ModuleTag_08
-    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_NukeCannonDamageTransition
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4931,6 +4931,7 @@ Object Nuke_ChinaVehicleListeningOutpost
     OCL = FINAL    OCL_FinalListeningOutpostDebris
   End
 
+  ; Patch104p @fix commy 09/09/2021 Removes damage smoke effects that remains visible after repair (#261).
   Behavior                 = TransitionDamageFX ModuleTag_08
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_NukeCannonDamageTransition
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5203,6 +5203,7 @@ Object Tank_ChinaVehicleListeningOutpost
     OCL = FINAL    OCL_FinalListeningOutpostDebris
   End
 
+  ; Patch104p @fix commy 09/09/2021 Removes damage smoke effects that remains visible after repair (#261).
   Behavior                 = TransitionDamageFX ModuleTag_08
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_NukeCannonDamageTransition
   End


### PR DESCRIPTION
* follow up for #261

Adds missing comments and corrects the smoke effect removal on
* Infa_ChinaVehicleTroopCrawler
* Infa_ChinaVehicleListeningOutpost
