### PR TITLE
Change: Set lowest audio priority on USA Battle Drone RepairSparks

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1413_battle_drone_repair_sound.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1413_battle_drone_repair_sound.yaml
@@ -15,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1413
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1785
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -4205,14 +4205,16 @@ AudioEvent NukeCannonUnDeploy
   Type = world shrouded everyone
 End
 
-
-AudioEvent RepairSparks ; Patch104p
+; Patch104p @fix xezon 06/11/2022 Enables and fixes repair sparks audio. (#1413)
+; Patch104p @tweak xezon 23/03/2023 Sets lowest priority. (#1785)
+AudioEvent RepairSparks
   Sounds = gsparksa gsparksb
   Control = random
   Limit = 3
   Volume = 50
   PitchShift = -10 10
   VolumeShift = -20
+  Priority = lowest
   Type = world shrouded everyone
 End
 


### PR DESCRIPTION
* Follow up for #1413

Sets lowest audio limit for Battle Drone repair sparks. This way it does not mask more important sounds.