### PR TITLE
Change: Add buttons for Guard Mode and Attack Move to USA Airforce Combat Chinook

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1787_combat_chinook_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1787_combat_chinook_buttons.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-03-26
+
+title: Adds Guard Mode and Attack Move buttons to USA Airforce Combat Chinook
+
+changes:
+  - feature: The USA Airforce Combat Chinook now has buttons for Guard Mode and Attack Move. This is consistent with other units, like the China Helix.
+
+labels:
+  - enhancement
+  - gui
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1787
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1914,6 +1914,24 @@ CommandSet AirF_AmericaVehicleComancheCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @feature 26/03/2023 Adds new command set for Combat Chinook with Guard and AttackMove buttons.
+CommandSet AirF_AmericaVehicleChinookCommandSet
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  6 = Command_TransportExit
+  7 = Command_TransportExit
+  8 = Command_TransportExit
+  9 = Command_ChinookUnload
+ 10 = Command_CombatDrop
+ 11 = Command_AttackMove
+;12 = Command_GuardFlyingUnitsOnly ; Helix does not have air guard either.
+ 13 = Command_Guard
+ 14 = Command_Stop
+End
+
 CommandSet AirF_AmericaSupplyCenterCommandSet
   1 = AirF_Command_ConstructAFGChinook
   3 = AirF_Command_ConstructAmericaVehicleChinook

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -17548,7 +17548,7 @@ Object AirF_AmericaVehicleChinook
   End
   ExperienceValue     = 60 60 60 60 ;Experience point value at each level
   IsTrainable         = No
-  CommandSet          = AmericaVehicleChinookCommandSet
+  CommandSet          = AirF_AmericaVehicleChinookCommandSet ; Patch104p @tweak from AmericaVehicleChinookCommandSet
   WeaponSet
     Conditions          = None
     Weapon              = PRIMARY     NONE


### PR DESCRIPTION
This change adds buttons for guard and attack move to USA Airforce Combat Chinook.

It would also be possible to add the button for air guard, but the Helix does not have it - perhaps because of lack of space - so it was not added to Combat Chinook either.

Tested and worked.

![shot_20230326_121232_1](https://user-images.githubusercontent.com/4720891/227769229-e9ac9ae3-f34e-4b36-a913-8f656070c454.jpg)
