### PR TITLE
Change: Reduce audio range and volume of Remote Demo Charge

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1801_remote_demo_charge_audio.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1801_remote_demo_charge_audio.yaml
@@ -1,0 +1,23 @@
+---
+date: 2023-04-06
+
+title: Reduces audio range and volume of Remote Demo Charge
+
+changes:
+  - tweak: Reduces the Remote Demo Charge's maximum audio range from 800 to 250, minimum audio range from 175 to 100. This makes the presence of a demo charge much less obvious as it has its audible area reduced by 90%.
+  - tweak: Reduces the Remote Demo Charge's maximum volume from 65 to 40, minimum volume from 40 to 20. This makes the bomb beep sound much quieter.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - gla
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1801
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -3830,11 +3830,15 @@ AudioEvent BombTickTimed
   Type        = world shrouded everyone
 End
 
+; Patch104p @tweak xezon 06/04/2023 Reduces range and volume to make the presence of the remote charge less obvious.
 AudioEvent BombTickRemote
   Sounds      = icolbeep
   Control     = interrupt
   Limit       = 3
-  Volume      = 65
+  MinRange    = 100 ; Patch104p @tweak from 175
+  MaxRange    = 250 ; Patch104p @tweak from 800
+  Volume      = 40 ; Patch104p @tweak from 65
+  MinVolume   = 20 ; Patch104p @tweak from 40
   Priority    = low
   Type        = world shrouded everyone
 End


### PR DESCRIPTION
* Fixes #1793

This change reduces the audio range and volume of the Remote Demo Charge to make its presence less obvious.

| Sound                      | MinRange (*1)   | MaxRange (*1)   | MinVolume | MaxVolume |
|----------------------------|-----------------|-----------------|-----------|-----------|
| Original BombTickRemote    | 175             | 800             | 40        | 65        | 
| **Patched BombTickRemote** | 100 (-66%)      | 250 (-90%)      | 20        | 40        |

(*1) = Difference in area coverage in percent.

## Patched

https://user-images.githubusercontent.com/4720891/230464175-dde52016-584d-493e-91eb-4e77aac99231.mp4

# Rationale

Placing the original Remote Demo Charge with USA Colonel Burton or GLA Demo Jarmen Kell makes the presence of both the bomb and the instigator very obvious. At an audible range of 800 it can be heard over a very large area (see sample in #1793).

The massive reduction in range and volume makes the presence much less obvious and allows for more sneaky plays with Burton and Jarmen. The defender needs more attention over his base to hear the bomb(s).

GLA is generally less vulnerable to demo charges due the structure rebuild from hole and the common presence of stealth detecting Tunnel Network in key areas. China is able prevent demo charge placements by acquiring structure mines. Placing too many demo charges in the China base could be risky if the Hero unit steps on mines. All pending demo charges will be lost then. Both China and USA need stealth detection units to prevent enemy Hero units from causing damage.