### PR TITLE
Change: Reduce audio range of Timed Demo Charge

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1802_timed_demo_charge_audio.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1802_timed_demo_charge_audio.yaml
@@ -1,0 +1,23 @@
+---
+date: 2023-04-06
+
+title: Reduces audio range of Timed Demo Charge
+
+changes:
+  - tweak: Reduces the Timed Demo Charge's maximum audio range from 800 to 500. This makes the presence of a demo charge and its instigator much less obvious as it has its audible area reduced by 61%.
+
+labels:
+  - audio
+  - china
+  - controversial
+  - design
+  - gla
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1802
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -3820,10 +3820,13 @@ AudioEvent HackerCashPing
   Type        = world shrouded everyone
 End
 
+; Patch104p @tweak xezon 06/04/2023 Reduces range to make the presence of the timed charge less obvious.
 AudioEvent BombTickTimed
   Sounds      = icoltima icoltimb icoltimc
   Control     = random
   Limit       = 3
+  MinRange    = 175
+  MaxRange    = 500 ; Patch104p @tweak from 800
   VolumeShift = -10
   Volume      = 65
   Priority    = low


### PR DESCRIPTION
* Relates to #1793
* Relates to #1801

This change reduces the audio range of the Timed Demo Change to make its presence less obvious.

| Sound                      | MinRange        | MaxRange (*1)   | MinVolume | MaxVolume |
|----------------------------|-----------------|-----------------|-----------|-----------|
| Original BombTickTimed     | 175             | 800             | 40        | 65        | 
| **Patched BombTickTimed**  | 175             | 500 (-61%)      | 40        | 65        |

(*1) = Difference in area coverage in percent.

## Patched

https://user-images.githubusercontent.com/4720891/230466133-e5b86405-1b0c-4552-8210-9740feaaaf51.mp4

# Rationale

Placing the original Timed Demo Charge with USA Colonel Burton or GLA Demo Jarmen Kell or China Tank Hunter makes the presence of both the bomb and the instigator very obvious. At an audible range of 800 it can be heard over a very large area (see sample in #1793).

The reduction in range makes the presence much less obvious and allows for more sneaky plays with Burton, Jarmen and Tank Hunters. The defender needs more attention over his base to hear the bomb(s).

GLA is generally less vulnerable to demo charges due the structure rebuild from hole and the common presence of stealth detecting Tunnel Network in key areas. China is able prevent demo charge placements by acquiring structure mines. Placing too many demo charges in the China base could be risky if the Hero unit steps on mines. All pending demo charges will be lost then. Both China and USA need stealth detection units to prevent enemy Hero units from causing damage.

