### PR TITLE
Fix: Inaccurate tooltip text of GLA Booby Trap upgrade

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1804_booby_trap_upgrade_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1804_booby_trap_upgrade_text.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-07
+
+title: Fixes inaccurate tooltip text of GLA Booby Trap upgrade
+
+changes:
+  - fix: Fixes the inaccurate tooltip text of the GLA Booby Trap upgrade. It no longer claims it can be placed on neutral units.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1804
+
+authors:
+  - xezon


### PR DESCRIPTION
* Fixes #1794

This change fixes the inaccurate tooltip text of the GLA Booby Trap upgrade for all languages except Arabic. It no longer claims it can be placed on neutral units.