### PR TITLE
Change: Remove Rally Point button from all command sets

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1808_remove_rally_point_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1808_remove_rally_point_button.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-07
+
+title: Removes obsolete Rally Point button from all command sets
+
+changes:
+  - tweak: Removes the obsolete Rally Point button from all command sets. The functionality of the Rally Point feature is unchanged.
+
+labels:
+  - design
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1808
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -20,6 +20,7 @@
 ;------------------------------------------------------------------------------
 
 ; Patch104p @bugfix commy2 03/09/2021 Align evacuate buttons on same slot.
+; Patch104p @tweak xezon 07/04/2023 Removes Command_SetRallyPoint from all command sets because it has no use.
 
 ; Many things just want these three buttons.
 CommandSet GenericCommandSet
@@ -719,7 +720,7 @@ CommandSet AmericaCommandCenterCommandSet
   8  = Command_EmergencyRepair
   9  = Command_DaisyCutter       ;NOTE THIS GETS UPGRADED BELOW
  10  = Command_SpySatelliteScan
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -753,7 +754,7 @@ CommandSet AmericaAirfieldCommandSet
   8 = Command_UpgradeAmericaLaserMissiles
   9 = Command_UpgradeAmericaCountermeasures
  10 = Command_UpgradeAmericaBunkerBusters
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -776,7 +777,7 @@ CommandSet AmericaWarFactoryCommandSet
   8  = Command_ConstructAmericaVehicleMicrowave
   9  = Command_UpgradeAmericaSentryDroneGun
   11 = Command_UpgradeAmericaTOWMissile
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -788,13 +789,13 @@ CommandSet AmericaBarracksCommandSet
   6 = Command_ConstructAmericaInfantryBiohazardTech
   7 = Command_UpgradeAmericaRangerFlashBangGrenade
   8 = Command_UpgradeAmericaRangerCaptureBuilding
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 CommandSet AmericaSupplyCenterCommandSet
   1 = Command_ConstructAmericaVehicleChinook
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -851,7 +852,7 @@ CommandSet ChinaCommandCenterCommandSet
   9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -867,7 +868,7 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1031,7 +1032,7 @@ CommandSet ChinaBarracksCommandSet
   4 = Command_ConstructChinaInfantryBlackLotus
   7 = Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1042,7 +1043,7 @@ CommandSet ChinaBarracksCommandSetUpgrade
   4 = Command_ConstructChinaInfantryBlackLotus
   7 = Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1059,7 +1060,7 @@ CommandSet ChinaWarFactoryCommandSet
   10 = Command_ConstructChinaVehicleNukeLauncher
   11 = Command_ConstructChinaTankECM
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1076,21 +1077,21 @@ CommandSet ChinaWarFactoryCommandSetUpgrade
   10 = Command_ConstructChinaVehicleNukeLauncher
   11 = Command_ConstructChinaTankECM
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet ChinaSupplyCenterCommandSet
   1 = Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 CommandSet ChinaSupplyCenterCommandSetUpgrade
   1 = Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1099,7 +1100,7 @@ CommandSet ChinaAirfieldCommandSet
   2 = Command_UpgradeChinaAircraftArmor
   3 = Command_ConstructChinaVehicleHelix
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1108,7 +1109,7 @@ CommandSet ChinaAirfieldCommandSetUpgrade
   2 = Command_UpgradeChinaAircraftArmor
   3 = Command_ConstructChinaVehicleHelix
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1151,7 +1152,7 @@ CommandSet GLACommandCenterCommandSet
   6  = Command_EmergencyRepair
   7  = Command_AnthraxBomb
   8  = Command_SneakAttack
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1168,7 +1169,7 @@ CommandSet GLAArmsDealerCommandSet
   10 = Command_UpgradeGLAScorpionRocket
   11 = Command_ConstructGLAVehicleCombatBike
   12 = Command_ConstructGLAVehicleBattleBus
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1183,7 +1184,7 @@ CommandSet GLABarracksCommandSet
   8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
 ; camo net
   11  = Command_UpgradeGLARebelCaptureBuilding
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1234,7 +1235,7 @@ End
 
 CommandSet GLASupplyStashCommandSet
   1  = Command_ConstructGLAWorker
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1445,7 +1446,7 @@ CommandSet GLASneakAttackTunnelCommandSet
   9  = Command_StructureExit
   10 = Command_StructureExit
   11 = Command_Evacuate
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
 End
 
 CommandSet BattleShipCommandSet
@@ -1516,7 +1517,7 @@ CommandSet GC_Chem_GLABarracksCommandSet
   6  = GC_Chem_Command_ConstructGLAInfantryJarmenKell
   8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1542,7 +1543,7 @@ CommandSet GC_Chem_GLACommandCenterCommandSet
   4  = Command_EmergencyRepair
   5  = Command_AnthraxBomb
   6  = Command_SneakAttack
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1554,13 +1555,13 @@ CommandSet GC_Chem_GLAArmsDealerCommandSet
   8  = GC_Chem_Command_ConstructGLAVehicleBombTruck
   9  = GC_Chem_Command_ConstructGLAVehicleScudLauncher
   10 = Command_UpgradeGLAScorpionRocket
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet GC_Chem_GLASupplyStashCommandSet
   1  = GC_Chem_Command_ConstructGLAWorker
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1639,13 +1640,13 @@ CommandSet GC_Slth_GLACommandCenterCommandSet
   6  = Early_Command_EmergencyRepair
   7  = Command_AnthraxBomb
   8  = Command_SneakAttack
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet GC_Slth_GLASupplyStashCommandSet
   1  = GC_Slth_Command_ConstructGLAWorker
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1658,7 +1659,7 @@ CommandSet GC_Slth_GLABarracksCommandSet
   6  = GC_Slth_Command_ConstructGLAInfantryJarmenKell
   8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1691,7 +1692,7 @@ CommandSet GC_Slth_GLAArmsDealerCommandSet
   6  = Command_ConstructGLAVehicleRocketBuggy
   10 = GC_Slth_Command_ConstructGLAVehicleBattleBus
   11 = GC_Slth_Command_ConstructGLAVehicleCombatBike
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -1825,7 +1826,7 @@ CommandSet AirF_AmericaCommandCenterCommandSet
   8  = Early_Command_EmergencyRepair
   9  = Command_DaisyCutter
  10  = Command_SpySatelliteScan
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1873,7 +1874,7 @@ CommandSet AirF_AmericaBarracksCommandSet
   4 = AirF_Command_ConstructAmericaInfantryPathfinder
   7 = Command_UpgradeAmericaRangerFlashBangGrenade
   8 = Command_UpgradeAmericaRangerCaptureBuilding
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1898,7 +1899,7 @@ CommandSet AirF_AmericaAirfieldCommandSet
   9 = Command_UpgradeAmericaCountermeasures
  10 = Command_UpgradeAmericaBunkerBusters
  11 = AirF_Command_UpgradeStealthComanche
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1935,7 +1936,7 @@ End
 CommandSet AirF_AmericaSupplyCenterCommandSet
   1 = AirF_Command_ConstructAFGChinook
   3 = AirF_Command_ConstructAmericaVehicleChinook
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -1948,7 +1949,7 @@ CommandSet AirF_AmericaWarFactoryCommandSet
   8  = AirF_Command_ConstructAmericaVehicleMicrowave
   9  = Command_UpgradeAmericaSentryDroneGun
   11 = Command_UpgradeAmericaTOWMissile
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2065,13 +2066,13 @@ CommandSet Demo_GLACommandCenterCommandSet
   6  = Command_EmergencyRepair
   7  = Command_AnthraxBomb
   8  = Command_SneakAttack
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet Demo_GLASupplyStashCommandSet
   1  = Demo_Command_ConstructGLAWorker
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2099,7 +2100,7 @@ CommandSet Demo_GLABarracksCommandSet
   6  = Demo_Command_ConstructGLAInfantryJarmenKell
 ; 8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2154,7 +2155,7 @@ CommandSet Demo_GLAArmsDealerCommandSet
   10 = Command_UpgradeGLAScorpionRocket
   11 = Demo_Command_ConstructGLAVehicleCombatBike
   12 = Demo_Command_ConstructGLAVehicleBattleBus
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2389,14 +2390,14 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   7  = Command_AnthraxBomb
   8  = Command_SneakAttack
   12 = Demo_Command_TertiarySuicide
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
   1  = Demo_Command_ConstructGLAWorker
   12 = Demo_Command_TertiarySuicide
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2425,7 +2426,7 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
 ; 8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
   12 = Command_DetonateFakeBuilding
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2482,7 +2483,7 @@ CommandSet Demo_GLAArmsDealerCommandSetUpgrade
   10 = Command_UpgradeGLAScorpionRocket
   11 = Demo_Command_ConstructGLAVehicleCombatBike
   12 = Demo_Command_ConstructGLAVehicleBattleBus
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2668,7 +2669,7 @@ CommandSet Slth_GLACommandCenterCommandSet
   7  = Command_AnthraxBomb
   8  = Command_SneakAttack
   12 = Command_UpgradeGLACamoNetting
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2676,7 +2677,7 @@ End
 CommandSet Slth_GLASupplyStashCommandSet
   1  = Slth_Command_ConstructGLAWorker
   12 = Command_UpgradeGLACamoNetting
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2707,7 +2708,7 @@ CommandSet Slth_GLABarracksCommandSet
   7  = Slth_Command_ConstructGLAInfantrySaboteur
   11 = Command_UpgradeGLARebelCaptureBuilding
   12 = Command_UpgradeGLACamoNetting
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -2760,7 +2761,7 @@ CommandSet Slth_GLAArmsDealerCommandSet
   10 = Slth_Command_ConstructGLAVehicleBattleBus
   11 = Slth_Command_ConstructGLAVehicleCombatBike
   12 = Command_UpgradeGLACamoNetting
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
   15 = Command_ConstructGLAVehicleCombatBikeTerrorist ;??? is this for script then?
 End
@@ -2954,7 +2955,7 @@ CommandSet Chem_GLABarracksCommandSet
   4  = Chem_Command_ConstructGLAInfantryAngryMob
   6  = Chem_Command_ConstructGLAInfantryJarmenKell
   11 = Command_UpgradeGLARebelCaptureBuilding
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3014,7 +3015,7 @@ CommandSet Chem_GLACommandCenterCommandSet
   6  = Command_EmergencyRepair
   7  = Command_AnthraxBomb
   8  = Command_SneakAttack
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3031,13 +3032,13 @@ CommandSet Chem_GLAArmsDealerCommandSet
   10 = Command_UpgradeGLAScorpionRocket
   11 = Chem_Command_ConstructGLAVehicleCombatBike
   12 = Chem_Command_ConstructGLAVehicleBattleBus
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet Chem_GLASupplyStashCommandSet
   1  = Chem_Command_ConstructGLAWorker
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3144,14 +3145,14 @@ End
 CommandSet Nuke_ChinaSupplyCenterCommandSet
   1 = Nuke_Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3168,7 +3169,7 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3186,7 +3187,7 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3197,7 +3198,7 @@ CommandSet Nuke_ChinaBarracksCommandSet
   4 = Nuke_Command_ConstructChinaInfantryBlackLotus
   7 = Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3208,7 +3209,7 @@ CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   4 = Nuke_Command_ConstructChinaInfantryBlackLotus
   7 = Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3237,7 +3238,7 @@ CommandSet Nuke_ChinaWarFactoryCommandSet
   10 = Nuke_Command_ConstructChinaVehicleNukeLauncher
   11 = Nuke_Command_ConstructChinaTankECM
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3254,7 +3255,7 @@ CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   10 = Nuke_Command_ConstructChinaVehicleNukeLauncher
   11 = Nuke_Command_ConstructChinaTankECM
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3334,7 +3335,7 @@ CommandSet Nuke_ChinaAirfieldCommandSet
    3 = Nuke_Command_ConstructChinaVehicleHelix
 ; 11 = Command_UpgradeChinaTacticalNukeMig
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3343,7 +3344,7 @@ CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
   2 = Command_UpgradeChinaAircraftArmor
   3 = Nuke_Command_ConstructChinaVehicleHelix
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3536,7 +3537,7 @@ CommandSet SupW_AmericaBarracksCommandSet
   4 = SupW_Command_ConstructAmericaInfantryPathfinder
   7 = Command_UpgradeAmericaRangerFlashBangGrenade
   8 = Command_UpgradeAmericaRangerCaptureBuilding
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3551,7 +3552,7 @@ CommandSet SupW_AmericaCommandCenterCommandSet
   8  = Command_EmergencyRepair
   9  = Command_DaisyCutter
  10  = Command_SpySatelliteScan
- 13  = Command_SetRallyPoint
+;13  = Command_SetRallyPoint
  14  = Command_Sell
 End
 
@@ -3578,7 +3579,7 @@ End
 
 CommandSet SupW_AmericaSupplyCenterCommandSet
   1 = SupW_Command_ConstructAmericaVehicleChinook
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3592,7 +3593,7 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   8  = SupW_Command_ConstructAmericaVehicleMicrowave
   9  = Command_UpgradeAmericaSentryDroneGun
   11 = Command_UpgradeAmericaTOWMissile
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3629,7 +3630,7 @@ CommandSet SupW_AmericaAirfieldCommandSet
   9 = Command_UpgradeAmericaCountermeasures
  10 = Command_UpgradeAmericaBunkerBusters
 
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3896,21 +3897,21 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   9  = Command_UpgradeChinaRadar
   10 = Early_Command_Frenzy
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSet
   1 = Infa_Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
   1 = Infa_Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3927,7 +3928,7 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   9  = Command_UpgradeChinaRadar
   10 = Early_Command_Frenzy
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3938,7 +3939,7 @@ CommandSet Infa_ChinaBarracksCommandSet
   4 = Infa_Command_ConstructChinaInfantryBlackLotus
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3949,7 +3950,7 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   4 = Infa_Command_ConstructChinaInfantryBlackLotus
   7 = Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -3976,7 +3977,7 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   10 = Infa_Command_ConstructChinaVehicleNukeLauncher
   11 = Infa_Command_ConstructChinaTankECM
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -3991,7 +3992,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   10 = Infa_Command_ConstructChinaVehicleNukeLauncher
   11 = Infa_Command_ConstructChinaTankECM
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -4016,7 +4017,7 @@ CommandSet Infa_ChinaAirfieldCommandSet
   2 = Infa_Command_UpgradeChinaAircraftArmor
   3 = Infa_Command_ConstructChinaVehicleHelix
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4025,7 +4026,7 @@ CommandSet Infa_ChinaAirfieldCommandSetUpgrade
   2 = Infa_Command_UpgradeChinaAircraftArmor
   3 = Infa_Command_ConstructChinaVehicleHelix
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4345,7 +4346,7 @@ End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
   1 = Lazr_Command_ConstructAmericaVehicleChinook
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4359,7 +4360,7 @@ CommandSet Lazr_AmericaCommandCenterCommandSet
   8  = Command_EmergencyRepair
   9  = Command_DaisyCutter
  10  = Command_SpySatelliteScan
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4403,7 +4404,7 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   8  = Lazr_Command_ConstructAmericaVehicleMicrowave
   9  = Command_UpgradeAmericaSentryDroneGun
   11 = Command_UpgradeAmericaTOWMissile
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -4414,7 +4415,7 @@ CommandSet Lazr_AmericaBarracksCommandSet
   4 = Lazr_Command_ConstructAmericaInfantryPathfinder
   7 = Command_UpgradeAmericaRangerFlashBangGrenade
   8 = Command_UpgradeAmericaRangerCaptureBuilding
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4444,7 +4445,7 @@ CommandSet Lazr_AmericaAirfieldCommandSet
   8 = Command_UpgradeAmericaLaserMissiles
   9 = Command_UpgradeAmericaCountermeasures
  10 = Command_UpgradeAmericaBunkerBusters
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4679,14 +4680,14 @@ End
 CommandSet Tank_ChinaSupplyCenterCommandSet
   1 = Tank_Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
   1 = Tank_Command_ConstructChinaVehicleSupplyTruck
   12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4702,7 +4703,7 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -4718,7 +4719,7 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -4733,7 +4734,7 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   8  = Command_UpgradeChinaBlackNapalm
   11 = Tank_Command_ConstructChinaTankECM
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -4748,7 +4749,7 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   8  = Command_UpgradeChinaBlackNapalm
   11 = Tank_Command_ConstructChinaTankECM
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -4833,7 +4834,7 @@ CommandSet Tank_ChinaBarracksCommandSet
   4 = Tank_Command_ConstructChinaInfantryBlackLotus
   7 = Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4844,7 +4845,7 @@ CommandSet Tank_ChinaBarracksCommandSetUpgrade
   4 = Tank_Command_ConstructChinaInfantryBlackLotus
   7 = Command_UpgradeChinaRedguardCaptureBuilding
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4876,7 +4877,7 @@ CommandSet Tank_ChinaAirfieldCommandSet
   2 = Command_UpgradeChinaAircraftArmor
   3 = Tank_Command_ConstructChinaVehicleHelix
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -4885,7 +4886,7 @@ CommandSet Tank_ChinaAirfieldCommandSetUpgrade
   2 = Command_UpgradeChinaAircraftArmor
   3 = Tank_Command_ConstructChinaVehicleHelix
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -5047,7 +5048,7 @@ CommandSet Boss_ChinaCommandCenterCommandSet
   10  = Command_ChinaCarpetBomb
   11 = Command_UpgradeChinaRadar
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -5061,7 +5062,7 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   10 = Command_ChinaCarpetBomb
   11 = Command_UpgradeChinaRadar
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -5091,14 +5092,14 @@ End
 CommandSet Boss_ChinaSupplyCenterCommandSet
   1 = Boss_Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
   1 = Boss_Command_ConstructChinaVehicleSupplyTruck
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -5117,7 +5118,7 @@ CommandSet Boss_ChinaBarracksCommandSet
  10 = Command_UpgradeAmericaChemicalSuits
  11 = Command_UpgradeAmericaRangerFlashBangGrenade
  12 = Command_UpgradeChinaMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -5134,7 +5135,7 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
  10 = Command_UpgradeAmericaChemicalSuits
  11 = Command_UpgradeAmericaRangerFlashBangGrenade
  12 = Command_UpgradeEMPMines
- 13 = Command_SetRallyPoint
+;13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
@@ -5152,7 +5153,7 @@ CommandSet Boss_ChinaWarFactoryCommandSet
   10 = Command_UpgradeChinaBlackNapalm
   11 = Command_UpgradeChinaChainGuns
   12 = Command_UpgradeChinaMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
@@ -5169,7 +5170,7 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   10 = Command_UpgradeChinaBlackNapalm
   11 = Command_UpgradeChinaChainGuns
   12 = Command_UpgradeEMPMines
-  13 = Command_SetRallyPoint
+; 13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 


### PR DESCRIPTION
This change has been reverted with #1851

~~This change removes the Rally Point button from all command sets. It will not be missed.~~

## Rationale

~~The button is obsolete. Rally Point functionality is always enabled as long as structure is selected.~~

## Original

![shot_20230407_141859_1](https://user-images.githubusercontent.com/4720891/230608338-d6aeb126-eee4-4498-b0eb-da48fb784318.jpg)

## Patched

![shot_20230407_142002_1](https://user-images.githubusercontent.com/4720891/230608356-e3c2415a-5f07-451a-a532-a4612578ada9.jpg)
