### PR TITLE
Change: Increase China Overlord speed by 25%, upgraded speed by 16%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1813_overlord_speed.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1813_overlord_speed.yaml
@@ -1,0 +1,27 @@
+---
+date: 2023-04-08
+
+title: Increases movement speed of China Overlord by up to 25%
+
+changes:
+  - tweak: |
+      Increases regular China Overlord
+        - speed from 20 to 25
+        - acceleration from 15 to 20
+        - turn rate from 60 to 70
+        - upgraded speed from 30 to 35
+        - upgraded turn rate from 60 to 70
+
+labels:
+  - buff
+  - china
+  - controversial
+  - design
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1813
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -4559,14 +4559,40 @@ End
 ;------------------------------------------------------------------------------
 Locomotor Tank_OverlordLocomotor
   Surfaces            = GROUND
-  Speed               = 25   ; in dist/sec
-  SpeedDamaged        = 25   ; in dist/sec
-  TurnRate            = 60   ;25   ; in degrees/sec
-  TurnRateDamaged     = 60   ;20   ; in degrees/sec
+  Speed               = 20   ; in dist/sec
+  SpeedDamaged        = 20   ; in dist/sec
+  TurnRate            = 60   ; in degrees/sec
+  TurnRateDamaged     = 60   ; in degrees/sec
   Acceleration        = 15   ; in dist/(sec^2)
   AccelerationDamaged = 15   ; in dist/(sec^2)
   Braking             = 50   ; in dist/(sec^2)
   MinTurnSpeed        = 0    ; in dist/sec
+  ZAxisBehavior       = NO_Z_MOTIVE_FORCE
+  Appearance          = TREADS
+
+  AccelerationPitchLimit = 2              ; Angle limit how far chassis will lift or roll from acceleration.
+  DecelerationPitchLimit = 2              ; Angle limit how far chassis will dip from deceleration.
+  PitchStiffness = 0.05                   ;  stiffness of the "springs" in the suspension forward & back.
+  RollStiffness = 0.05                    ;  stiffness of the "springs" in the suspension side to side.
+  PitchDamping = 0.8                      ;  How fast it damps.  0=perfect spring, bounces forever.  1=glued to terrain.
+  RollDamping = 0.3                       ;  How fast it damps.  0=perfect spring, bounces forever.  1=glued to terrain.
+  ForwardAccelerationPitchFactor = 0.5    ; How much acceleration will cause the front to lift, or dip for stops.
+  LateralAccelerationRollFactor = 0.33    ;  How much cornering will cause the chassis to roll.
+End
+
+;------------------------------------------------------------------------------
+; Patch104p @feature Dedicated Locomotor for upgraded Emperor Tank. (#1813)
+;------------------------------------------------------------------------------
+Locomotor Tank_NuclearOverlordLocomotor
+  Surfaces            = GROUND
+  Speed               = 30   ; 50% faster than normal
+  SpeedDamaged        = 30   ; 50% faster than normal
+  TurnRate            = 60   ; in degrees/sec
+  TurnRateDamaged     = 60   ; in degrees/sec
+  Acceleration        = 30   ; 100% faster than normal
+  AccelerationDamaged = 30   ; 100% faster than normal
+  Braking             = 50  ; in dist/(sec^2)
+  MinTurnSpeed        = 0   ; in dist/sec
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE
   Appearance          = TREADS
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -742,12 +742,12 @@ End
 ;------------------------------------------------------------------------------
 Locomotor OverlordLocomotor
   Surfaces            = GROUND
-  Speed               = 20   ; in dist/sec
-  SpeedDamaged        = 20   ; in dist/sec
-  TurnRate            = 60   ;25   ; in degrees/sec
-  TurnRateDamaged     = 60   ;20   ; in degrees/sec
-  Acceleration        = 15   ; in dist/(sec^2)
-  AccelerationDamaged = 15   ; in dist/(sec^2)
+  Speed               = 25   ; in dist/sec ; Patch104p @tweak from 20 (#1813)
+  SpeedDamaged        = 25   ; in dist/sec ; Patch104p @tweak from 20 (#1813)
+  TurnRate            = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1813)
+  TurnRateDamaged     = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1813)
+  Acceleration        = 20   ; in dist/(sec^2) ; Patch104p @tweak from 15 (#1813)
+  AccelerationDamaged = 20   ; in dist/(sec^2) ; Patch104p @tweak from 15 (#1813)
   Braking             = 50   ; in dist/(sec^2)
   MinTurnSpeed        = 0    ; in dist/sec
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE
@@ -792,12 +792,12 @@ End
 ;------------------------------------------------------------------------------
 Locomotor NuclearOverlordLocomotor
   Surfaces            = GROUND
-  Speed               = 30   ; 33% faster than normal
-  SpeedDamaged        = 30   ; 33% faster than normal
-  TurnRate            = 60   ;32   ; 33% faster than normal
-  TurnRateDamaged     = 60   ;27   ; 33% faster than normal
-  Acceleration        = 30   ; 33% faster than normal
-  AccelerationDamaged = 30   ; 33% faster than normal
+  Speed               = 35   ; 40% faster than normal ; Patch104p @tweak from 30 (#1813)
+  SpeedDamaged        = 35   ; 40% faster than normal ; Patch104p @tweak from 30 (#1813)
+  TurnRate            = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1813)
+  TurnRateDamaged     = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1813)
+  Acceleration        = 30   ; 50% faster than normal
+  AccelerationDamaged = 30   ; 50% faster than normal
   Braking             = 50  ; in dist/(sec^2)
   MinTurnSpeed        = 0   ; in dist/sec
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3056,8 +3056,8 @@ Object Tank_ChinaTankEmperor ; Alias Tank_ChinaTankOverlord
     AutoAcquireEnemiesWhenIdle = Yes
   End
 
-  Locomotor = SET_NORMAL OverlordLocomotor
-  Locomotor = SET_NORMAL_UPGRADED NuclearOverlordLocomotor
+  Locomotor = SET_NORMAL Tank_OverlordLocomotor ; Patch104p @refactor from OverlordLocomotor (#1813)
+  Locomotor = SET_NORMAL_UPGRADED Tank_NuclearOverlordLocomotor ; Patch104p @refactor from NuclearOverlordLocomotor (#1813)
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_04
     DeathWeapon   = NuclearTankDeathWeapon


### PR DESCRIPTION
**Merge with Rebase**

* Closes #649
* Relates to #1809

This change increases the regular China Overlord speed by 25% and upgraded speed by 16%. The Emperor Tank speed is unchanged.

| Object                            | Speed | Dmg. Speed | Accel. | Turn | Upgr. Speed | Upgr. Dmg. Speed | Upgr. Accel. | Upgr. Turn |
|-----------------------------------|-------|------------|--------|------|-------------|------------------|--------------|------------|
| Original China Nuke Overlord      | 40    | 40         | 30     | 80   | -           | -                | -            | -          |
| Original China Emperor            | 20    | 20         | 15     | 60   | 30          | 30               | 30           | 60         |
| Original China Overlord           | 20    | 20         | 15     | 60   | 30          | 30               | 30           | 60         |
| **Patched China Overlord (this)** | 25    | 25         | 20     | 70   | 35          | 35               | 30           | 70         |


# Rationale

Regular China is the one of the weakest factions in the game. Overlords are rarely used, because they are expensive and slow. Mass Humvees and Buggies can kill them quickly. Jarmen Kell snipes them. A slight increase in movement speed can increase the utility of the Overlord Tank. With the increased speeds, before upgrade it still is 17% slower than regular tanks, 37.5% slower than GLA tanks and 37.5% slower than Nuke Overlord. After Nuclear Tanks upgrade it is just 12.5% slower than Nuke Overlord. The Nuclear Tanks upgrade costs 2000 and requires the Nuclear Silo, so it is rather inaccessible and late game only.