### PR TITLE
Change: Increase China Battlemaster speed by 20%, upgraded speed by 14%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1815_battlemaster_speed.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1815_battlemaster_speed.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-04-08
+
+title: Increases movement speed of China Battlemaster by up to 20%
+
+changes:
+  - tweak: Increases China Battlemaster speed from 25 to 30, upgraded speed 35 to 40. This affects regular China General and Tank General. Movement speed is now competitive with tank speeds of USA and GLA.
+
+labels:
+  - buff
+  - china
+  - controversial
+  - design
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1815
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -694,8 +694,8 @@ End
 ;------------------------------------------------------------------------------
 Locomotor BattleMasterLocomotor
   Surfaces            = GROUND
-  Speed               = 25   ; in dist/sec
-  SpeedDamaged        = 25   ; in dist/sec
+  Speed               = 30   ; in dist/sec ; Patch104p @tweak from 25 (#1815)
+  SpeedDamaged        = 25
   TurnRate            = 180  ;90   ; in degrees/sec
   TurnRateDamaged     = 180  ;60   ; in degrees/sec
   Acceleration        = 1000 ;240  ; in dist/(sec^2)
@@ -718,12 +718,12 @@ End
 ;------------------------------------------------------------------------------
 Locomotor NuclearBattleMasterLocomotor
   Surfaces            = GROUND
-  Speed               = 35   ; 33% faster than normal
-  SpeedDamaged        = 32   ; 33% faster than normal
-  TurnRate            = 180  ;120  ; 33% faster than normal
-  TurnRateDamaged     = 180  ;80   ; 33% faster than normal
-  Acceleration        = 1000 ;240  ; 33% faster than normal
-  AccelerationDamaged = 1000 ;240  ; 33% faster than normal
+  Speed               = 40   ; 33% faster than normal ; Patch104p @tweak from 35 (#1815)
+  SpeedDamaged        = 35   ; 40% faster than normal ; Patch104p @tweak from 32 (#1815)
+  TurnRate            = 180  ;120  ; in degrees/sec
+  TurnRateDamaged     = 180  ;80   ; in degrees/sec
+  Acceleration        = 1000 ;240  ; in dist/(sec^2)
+  AccelerationDamaged = 1000 ;240  ; in dist/(sec^2)
   Braking             = 1000 ;50  ; in dist/(sec^2)
   MinTurnSpeed        = 0   ; in dist/sec
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE
@@ -4510,8 +4510,8 @@ End
 ;------------------------------------------------------------------------------
 Locomotor Tank_BattleMasterLocomotor
   Surfaces            = GROUND
-  Speed               = 29   ; in dist/sec
-  SpeedDamaged        = 29   ; in dist/sec
+  Speed               = 30   ; in dist/sec ; Patch104p @tweak from 25 (Tank Battle Master used BattleMasterLocomotor originally) (#1815)
+  SpeedDamaged        = 25
   TurnRate            = 180  ;90   ; in degrees/sec
   TurnRateDamaged     = 180  ;60   ; in degrees/sec
   Acceleration        = 1000 ;240  ; in dist/(sec^2)
@@ -4535,12 +4535,12 @@ End
 ;------------------------------------------------------------------------------
 Locomotor Tank_NuclearBattleMasterLocomotor
   Surfaces            = GROUND
-  Speed               = 35   ; 33% faster than normal
-  SpeedDamaged        = 32   ; 33% faster than normal
-  TurnRate            = 180  ;120  ; 33% faster than normal
-  TurnRateDamaged     = 180  ;80   ; 33% faster than normal
-  Acceleration        = 1000 ;240  ; 33% faster than normal
-  AccelerationDamaged = 1000 ;240  ; 33% faster than normal
+  Speed               = 40   ; 33% faster than normal ; Patch104p @tweak from 35 (#1815)
+  SpeedDamaged        = 35   ; 40% faster than normal ; Patch104p @tweak from 32 (#1815)
+  TurnRate            = 180  ;120  ; in degrees/sec
+  TurnRateDamaged     = 180  ;80   ; in degrees/sec
+  Acceleration        = 1000 ;240  ; in dist/(sec^2)
+  AccelerationDamaged = 1000 ;240  ; in dist/(sec^2)
   Braking             = 1000 ;50  ; in dist/(sec^2)
   MinTurnSpeed        = 0   ; in dist/sec
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2810,8 +2810,8 @@ Object Tank_ChinaTankBattleMaster
     AutoAcquireEnemiesWhenIdle = Yes
   End
 
-  Locomotor = SET_NORMAL BattleMasterLocomotor
-  Locomotor = SET_NORMAL_UPGRADED NuclearBattleMasterLocomotor
+  Locomotor = SET_NORMAL Tank_BattleMasterLocomotor ; Patch104p @tweak from BattleMasterLocomotor (#1815)
+  Locomotor = SET_NORMAL_UPGRADED Tank_NuclearBattleMasterLocomotor ; Patch104p @tweak from NuclearBattleMasterLocomotor (#1815)
 
   Behavior = VeterancyGainCreate ModuleVet_01
     StartingLevel = ELITE


### PR DESCRIPTION
* Relates to #819
* Relates to #1809

This change increases China Battlemaster speed by 20%, upgraded speed by 14%.

| Object                                     | Speed | Dmg Speed | Upgr. Speed | Upgr. Dmg Speed |
|--------------------------------------------|-------|-----------|-------------|-----------------|
| Original China Nuke Battlemaster           | 45    | 37        | -           | -               |
| Original China Battlemaster                | 25    | 25        | 35          | 32              |
| **Patched China Battlemaster (this)**      | 30    | 25        | 40          | 35              |
| Original China Tank Battlemaster           | 25    | 25        | 35          | 32              |
| **Patched China Tank Battlemaster (this)** | 30    | 25        | 40          | 35              |

# Rationale

The original regular China Battlemaster is considered to be one of the worst units in the game. It drives very slow. The original China Tank Battlemaster is performing considerably better with its free Vet1 or Vet2 promotion, but is also this slow. It drives slower than the Dragon Tank (30). This change increases movement speed of the regular Battlemaster and Tank Battlemaster to elevate it to the same speeds as USA Crusader, Paladin (30). It will still be slower than GLA tanks however (40). After the Nuclear Tanks upgrade, which can be acquired from the Nuke Silo for 2000 cash, it will drive as quick as GLA tanks. This way the Battlemaster is more competitive.