### PR TITLE
Fix: Add Isotope Stability upgrade icon to China Nuke Overlord Tank

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1816_isotope_stability_cameo.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1816_isotope_stability_cameo.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-04-08
+
+title: Fixes Isotope Stability upgrade icon placements
+
+changes:
+  - fix: Adds the missing Isotope Stability upgrade icon to the China Nuke Overlord tank.
+  - tweak: Moves the Isotope Stability upgrade icon to a different cameo position on the China Nuke Battlemaster tank.
+
+labels:
+  - bug
+  - china
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1816
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -6478,7 +6478,7 @@ CommandButton Nuke_Command_ConstructChinaVehicleNukeLauncher
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildNukeLauncher
 End
 
-CommandButton Nuke_Command_UpgradeChinaWGUraniumShells
+CommandButton Nuke_Command_UpgradeChinaWGUraniumShells ; unused
   Command       = PLAYER_UPGRADE
   Upgrade       = Nuke_Upgrade_ChinaWGUraniumShells
   Options       = IGNORES_UNDERPOWERED
@@ -6488,7 +6488,7 @@ CommandButton Nuke_Command_UpgradeChinaWGUraniumShells
   DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaWGUraniumShells
 End
 
-CommandButton Nuke_Command_UpgradeChinaFusionReactors
+CommandButton Nuke_Command_UpgradeChinaFusionReactors ; unused
   Command       = PLAYER_UPGRADE
   Upgrade       = Nuke_Upgrade_ChinaFusionReactors
   Options       = IGNORES_UNDERPOWERED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16921,11 +16921,13 @@ Object Nuke_ChinaTankBattleMaster
   SelectPortrait         = SNNukeBattlemaster_L
   ButtonImage            = SNNukeBattlemaster
 
+  ; Patch104p @refactor xezon 08/04/2023 Comments the incorrect and unused Nuke upgrades.
+  ; Patch104p @bugfix xezon 08/04/2023 Moves IsotopeStability position from 4.
   UpgradeCameo1 = Upgrade_Nationalism
-  UpgradeCameo2 = Upgrade_ChinaWGUraniumShells
-  UpgradeCameo3 = Upgrade_ChinaFusionReactors
-  UpgradeCameo4 = Upgrade_ChinaIsotopeStability
-  ;UpgradeCameo5 = NONE
+  UpgradeCameo2 = Upgrade_ChinaIsotopeStability
+  ;UpgradeCameo2 = Nuke_Upgrade_ChinaWGUraniumShells
+  ;UpgradeCameo3 = Nuke_Upgrade_ChinaFusionReactors
+
 
   Draw = W3DTankDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -17138,8 +17140,11 @@ Object Nuke_ChinaTankOverlord
   SelectPortrait         = SNOverlord_L
   ButtonImage            = SNOverlord
 
-  UpgradeCameo1 = Upgrade_ChinaWGUraniumShells
-  UpgradeCameo2 = Upgrade_ChinaFusionReactors
+  ; Patch104p @refactor xezon 08/04/2023 Comments the incorrect and unused Nuke upgrades.
+  ; Patch104p @bugfix xezon 08/04/2023 Adds missing IsotopeStability icon.
+  ;UpgradeCameo1 = Nuke_Upgrade_ChinaWGUraniumShells
+  ;UpgradeCameo2 = Nuke_Upgrade_ChinaFusionReactors
+  UpgradeCameo2 = Upgrade_ChinaIsotopeStability
   UpgradeCameo3 = Upgrade_ChinaOverlordBattleBunker
   UpgradeCameo4 = Upgrade_ChinaOverlordGattlingCannon
   UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -746,7 +746,7 @@ Upgrade Demo_Upgrade_GLADemoTrapHighExplosiveBomb
   ButtonImage        = SUAdvDeTrap
 End
 
-Upgrade Nuke_Upgrade_ChinaWGUraniumShells
+Upgrade Nuke_Upgrade_ChinaWGUraniumShells ; unused
   DisplayName        = UPGRADE:WGUraniumShells
   BuildTime          = 60.0
   BuildCost          = 2500
@@ -761,7 +761,7 @@ Upgrade Upgrade_ChinaIsotopeStability
   ButtonImage        = SNIsoStab
 End
 
-Upgrade Nuke_Upgrade_ChinaFusionReactors
+Upgrade Nuke_Upgrade_ChinaFusionReactors ; unused
   DisplayName        = UPGRADE:FusionReactors
   BuildTime          = 60.0
   BuildCost          = 2000


### PR DESCRIPTION
This change adds the missing Isotope Stability upgrade icon to the China Nuke Overlord Tank. And it moves the position of the Isotope Stability icon on the Nuke Battlemaster from 4 to 2, so the icons share the same position on both units.

## Patched

![shot_20230408_134344_1](https://user-images.githubusercontent.com/4720891/230720276-2d125c15-985d-4f66-8730-2ff5d03f90d6.jpg)
