### PR TITLE
Fix: USA Avenger Target Designator audio loop gaps

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1821_avenger_loop_audio.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1821_avenger_loop_audio.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-09
+
+title: Fixes audible gaps in audio loop of USA Avenger Target Designator
+
+changes:
+  - fix: The USA Avenger Target Designator beam sound loop now sounds harmonic without gaps.
+
+labels:
+  - audio
+  - bug
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1820
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -492,6 +492,7 @@ Weapon AvengerAirLaserTwo
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 09/04/2023 Sets FireSoundLoopTime from 120 to avoid gaps in loops. (#1820)
 Weapon AvengerTargetDesignator
   PrimaryDamage       = 200.0       ; How long (msec) we put the status on the target (should equal or exceed DelayBetweenShots)
   PrimaryDamageRadius = 0.0
@@ -506,7 +507,7 @@ Weapon AvengerTargetDesignator
   LaserBoneName       = TurretFX03
   FireFX              = WeaponFX_AvengerTargetDesignator
   FireSound           = AvengerPaintWeaponLoop
-  FireSoundLoopTime = 120                ; loop the firing sound until there's this much delay between shots
+  FireSoundLoopTime   = 200 ; loop the firing sound until there's this much delay between shots
 End
 
 


### PR DESCRIPTION
This change fixes the gaps in the USA Avenger Target Designator fire sound loop.