### PR TITLE
Fix: USA Microwave weapon audio loop interval and frequency irregularities

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1821_microwave_loop_audio.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1821_microwave_loop_audio.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-09
+
+title: Fixes weapon audio loop interval and frequency irregularities of USA Microwave Tank
+
+changes:
+  - fix: The USA Microwave Tank beam sound loop now sounds harmonic. Interval and frequency loop is consistent without mismatching cuts.
+
+labels:
+  - audio
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1821
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -7681,9 +7681,10 @@ AudioEvent GPSScrambleActivate
   Type   = world global everyone
 End
 
+; Patch104p @fix xezon 09/04/2023 Disables loop sound variations to maintain consistent audio intervals and frequencies. (#1821)
 AudioEvent MicrowaveWeaponLoop
   Control = loop random
-  Sounds =  vmiclo2a vmiclo2b vmiclo2c vmiclo2d
+  Sounds =  vmiclo2a ; vmiclo2b vmiclo2c vmiclo2d
   Attack =  vmiclo1a
   VolumeShift= -10
   Volume = 90


### PR DESCRIPTION
This change fixes unpleasant audio loop sounds of Microwave beam.

I was unable to fix the sound files, so I opted to disable 3 of 4 sounds to get rid of the interval and frequency irregularities and maintain a consistent beam sound.