### PR TITLE
Fix: USA Alpha Aurora bomb freezing for 1 or 2 frames near ground before hit

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1828_alpha_aurora_bomb_impact.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1828_alpha_aurora_bomb_impact.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-10
+
+title: Fixes USA Alpha Aurora bomb freezing for 1 or 2 frames near ground before hit
+
+changes:
+  - fix: The bomb of the USA Alpha Aurora no longer freezes for 1 or 2 frames near the ground before hit. This issue does not happen with the bomb of the regular Aurora.
+
+labels:
+  - bug
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1828
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5885,7 +5885,7 @@ End
 ; Patch104p @bugfix commy2 11/09/2021 Fix bug where sometimes Fuel Air Bomb triggers before the bomb hits.
 
 ;------------------------------------------------------------------------------
-Object SupW_AuroraFuelAirBomb
+Object SupW_AuroraFuelAirBomb ; Alias SupW_AuroraBomb
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -5895,11 +5895,12 @@ Object SupW_AuroraFuelAirBomb
   End
 
   ; ***DESIGN parameters ***
+  ; Patch104p @tweak xezon 10/04/2023 Decreases VisionRange from 300. Removes TransportSlotCount. Adds Side.
+  ;   Is now consistent with AuroraBomb parameters.
+  Side                = America
   DisplayName         = OBJECT:FuelAirBomb
   EditorSorting       = SYSTEM
-  TransportSlotCount  = 10                 ;how many "slots" we take in a transport (0 == not transportable)
-  VisionRange         = 300.0
-  ShroudClearingRange = 0
+  VisionRange         = 0.0
   ArmorSet
     Conditions      = None
     Armor           = ProjectileArmor
@@ -5934,7 +5935,7 @@ Object SupW_AuroraFuelAirBomb
   Locomotor = SET_NORMAL AuroraBombLocomotor   ; yes, that's right.
   Geometry = Sphere
   GeometryIsSmall = Yes
-  GeometryMajorRadius = 12.0
+  GeometryMajorRadius = 2.0 ; Patch104p @bugfix xezon 10/04/2023 from 12.0 to prevent the bomb freezing for 1 or 2 frames near ground before hit.
 
   ; Patch104p @tweak Stubbjax 24/02/2023 Adds bomb shadow.
   Shadow = SHADOW_VOLUME

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7671,7 +7671,7 @@ End
 ; With this the Fuel Air Bomb no longer triggers the secondary explision before the bomb hits the ground or target.
 
 ;------------------------------------------------------------------------------
-Weapon SupW_AuroraFuelBombWeapon
+Weapon SupW_AuroraFuelBombWeapon ; Alias SupW_AuroraBombWeapon
   PrimaryDamage           = 400.0
   PrimaryDamageRadius     = 20.0
   AttackRange             = 300.0       ; this needs to be pretty high, since the Aurora moves so fast


### PR DESCRIPTION
* Follow up for #1753

This change fixes the USA Alpha Aurora bomb idling 2 frames near ground before hit. It is caused by the large geometry size. Geometry size is now decreased to match that of the regular Aurora bomb.

Additionally the design parameters have been streamlined with the regular Aurora bomb to further decrease setup discrepancies.