### PR TITLE
Fix: Optimize drop location of USA Daisy Cutter bomb

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5263,7 +5263,7 @@ ObjectCreationList SUPERWEAPON_DaisyCutter
     MaxAttempts             = 1
     DropOffset              = X:0 Y:0 Z:-10
     Payload                 = DaisyCutterBomb
-    DeliveryDistance        = 140
+    DeliveryDistance        = 180 ; Patch104p @fix xezon 10/04/2023 from 140 to optimize drop location.
     DeliveryDecalRadius     = 170
     DeliveryDecal
       Texture           = SCCFuelAirBomb_USA


### PR DESCRIPTION
This change optimizes the drop location of the USA Daisy Cutter bomb. It no longer falls as much behind the intended target when flying in vertically. And drops a bit before the target when flying in straight. ~~The distance matches the one of the MOAB.~~ The drop position is optimized for fix TheAssemblyArmada/Thyme#752.