### PR TITLE
Fix: Optimize drop location of USA MOAB

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5287,8 +5287,8 @@ ObjectCreationList SUPERWEAPON_MOAB
     MaxAttempts             = 1
     DropOffset              = X:0 Y:0 Z:-10
     Payload                 = MOAB
-    DeliveryDistance        = 160
-    PreOpenDistance         = 160
+    DeliveryDistance        = 170 ; Patch104p @fix xezon 10/04/2023 from 160 to optimize drop location.
+    PreOpenDistance         = 170
     DeliveryDecalRadius     = 170
     DeliveryDecal
       Texture           = SCCFuelAirBomb_USA


### PR DESCRIPTION
This change optimizes the drop location of the USA MOAB. It now falls at the very center of the target location. Optimized for fix https://github.com/TheAssemblyArmada/Thyme/pull/752.

## Patched

![shot_20230410_182903_1](https://user-images.githubusercontent.com/4720891/230946973-fc38aeac-8a0b-404a-80e8-9eaa3f437c99.jpg)
