### PR TITLE
Fix: Optimize drop location of China Cluster Mines

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -1391,7 +1391,7 @@ Object ClusterMinesBomb
 
 
   Behavior = HeightDieUpdate ModuleTag_06
-    TargetHeight = 60.0
+    TargetHeight = 35.0 ; Patch104p @tweak xezon 10/04/2023 From 60 to explode a bit later closer to the ground.
     TargetHeightIncludesStructures = No
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6431,7 +6431,7 @@ ObjectCreationList SUPERWEAPON_ClusterMines
     DropOffset              = X:0 Y:0 Z:-2
     DropVariance            = X:20 Y:20 Z:0
     Payload                 = ClusterMinesBomb 1
-    DeliveryDistance        = 140
+    DeliveryDistance        = 190 ; Patch104p @fix xezon 10/04/2023 from 140 to optimize drop location.
     DeliveryDecalRadius     = 100
     DeliveryDecal
       Texture           = SCCClusterMines_China


### PR DESCRIPTION
This change optimizes the drop location of the China Cluster Mines. It now falls at the very center of the target location. The drop location in practice makes no difference as to where the mines spawn, so this effectively is a small buff for China, because the plane eventually draws less enemy fire before the bomb drop. To compensate for the decreased bomb drop time, the explosion height has been roughly halved from 60 to 35, which also looks better in practice. The drop position is optimized for fix https://github.com/TheAssemblyArmada/Thyme/pull/752.

## Patched

Moment of explosion (with TargetHeight 30 instead of 35).

![shot_20230410_190015_1](https://user-images.githubusercontent.com/4720891/230952040-4e191623-d652-4fcd-b4cd-b4215f59bacd.jpg)
