### PR TITLE
Fix: Optimize drop location of China Carpet Bombers

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6559,7 +6559,7 @@ ObjectCreationList Nuke_SUPERWEAPON_ChinaCarpetBomb
     DropVariance = X:30 Y:40 Z:0
     DropDelay = 300  ;500       ; time in between each item dropped (if more than one)
     Payload = Nuke_ChinaCarpetBomb 10
-    DeliveryDistance = 350
+    DeliveryDistance = 400 ; Patch104p @fix xezon 10/04/2023 from 350 to optimize drop location.
     DeliveryDecalRadius = 180
     DeliveryDecal
       Texture           = SCCCarpBomb
@@ -6584,7 +6584,7 @@ ObjectCreationList SUPERWEAPON_ChinaCarpetBomb
     DropVariance = X:30 Y:40 Z:0
     DropDelay = 300  ;500       ; time in between each item dropped (if more than one)
     Payload = ChinaCarpetBomb 10
-    DeliveryDistance = 350
+    DeliveryDistance = 400 ; Patch104p @fix xezon 10/04/2023 from 350 to optimize drop location.
     DeliveryDecalRadius = 180
     DeliveryDecal
       Texture           = SCCCarpBomb


### PR DESCRIPTION
This change optimizes the drop location of the China Carpet Bombers. The bombs now fall better into the designated target circle. Optimized for fix https://github.com/TheAssemblyArmada/Thyme/pull/752.

## Patched

![shot_20230410_184058_1](https://user-images.githubusercontent.com/4720891/230956495-1fbc0a8f-7dd4-41d6-b76b-f41389b3bde5.jpg)

![shot_20230410_184118_2](https://user-images.githubusercontent.com/4720891/230956500-94062522-380c-4ce9-894b-8457c28ccaef.jpg)
