### PR TITLE
Fix: Optimize drop location of GLA Anthrax Bombs

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -5938,7 +5938,7 @@ ObjectCreationList SUPERWEAPON_AnthraxBomb
     MaxAttempts = 1
     DropOffset = X:0 Y:0 Z:-10
     Payload = AnthraxBomb
-    DeliveryDistance = 140
+    DeliveryDistance = 210 ; Patch104p @fix xezon 10/04/2023 from 140 to optimize drop location.
     DeliveryDecalRadius = 200
     DeliveryDecal
       Texture           = SCCAnthraxBomb_GLA
@@ -5960,7 +5960,7 @@ ObjectCreationList SUPERWEAPON_AnthraxBombGamma
     MaxAttempts = 1
     DropOffset = X:0 Y:0 Z:-10
     Payload = AnthraxBombGamma
-    DeliveryDistance = 140
+    DeliveryDistance = 210 ; Patch104p @fix xezon 10/04/2023 from 140 to optimize drop location.
     DeliveryDecalRadius = 200
     DeliveryDecal
       Texture           = SCCAnthraxBomb_GLA


### PR DESCRIPTION
This change optimizes the drop location of the GLA Anthrax Bombs. They now fall at the very center of the target location. Optimized for fix https://github.com/TheAssemblyArmada/Thyme/pull/752.

## Patched

![shot_20230410_194742_1](https://user-images.githubusercontent.com/4720891/230962444-218ef175-27b2-4052-ac89-42ac4b777d79.jpg)
