### PR TITLE
Fix: Remove SELECTABLE flag from SalvageCrate

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1675_salvage_crate_flags.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1675_salvage_crate_flags.yaml
@@ -1,18 +1,21 @@
 ---
 date: 2023-02-11
 
-title: Adds missing CRATE flag to SalvageCrate
+title: Fixes object flags of SalvageCrate
 
 changes:
   - fix: Adds missing CRATE flag to SalvageCrate.
+  - fix: Removes obsolete SELECTABLE flag from SalvageCrate.
 
 labels:
+  - design
   - gla
   - minor
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1675
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1836
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -193,7 +193,8 @@ Object SalvageCrate
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @fix xezon 11/02/2023 Adds missing crate flag.
-  KindOf = PARACHUTABLE CRATE SELECTABLE ;Only Salvage crates are marked Selectable so the Mouse can interact with them and give Salvage voices.  Being dead makes them not actually selectable
+  ; Patch104p @fix xezon 11/02/2023 Removes selectable flag to avoid crate eventually being selectable over terrain with non GLA faction.
+  KindOf = PARACHUTABLE CRATE
 
   Behavior = SalvageCrateCollide ModuleTag_02
     ForbiddenKindOf = PROJECTILE


### PR DESCRIPTION
This change was reverted by #1997

~~This change removes the SELECTABLE flag from SalvageCrate. Oddly the GLA faction cannot select the crate anyway, but the USA and China factions can if the SalvageCrate would show for them. Being able to select the crate means it is no longer possible to properly move a unit to it, because the terrain underneath cannot be clicked.~~