### PR TITLE
Fix: Add missing Rally Point button to Boss Airfield

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1852_boss_airfield_rally_point.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1852_boss_airfield_rally_point.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-16
+
+title: Adds missing Rally Point button to Boss Airfield
+
+changes:
+  - fix: The Boss Airfield now has a button for Rally Point. The click on the Rally Point allows to place the Rally Point on top of units, even if the mouse cursor does not indicate that.
+
+labels:
+  - boss
+  - bug
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1852
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5065,6 +5065,7 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell
 End
 
+; Patch104p @bugfix xezon 16/04/2023 Adds missing rally point button to Boss Airfield.
 CommandSet Boss_ChinaAirfieldCommandSet
  1  = Boss_Command_ConstructChinaJetMIG
  2  = Boss_Command_ConstructAmericaJetRaptor ; AirF version
@@ -5073,9 +5074,11 @@ CommandSet Boss_ChinaAirfieldCommandSet
  8  = Command_UpgradeChinaAircraftArmor
 ; 10 = Command_UpgradeAmericaBunkerBusters
  12 = Command_UpgradeChinaMines
+ 13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
+; Patch104p @bugfix xezon 16/04/2023 Adds missing rally point button to Boss Airfield.
 CommandSet Boss_ChinaAirfieldCommandSetUpgrade
  1  = Boss_Command_ConstructChinaJetMIG
  2  = Boss_Command_ConstructAmericaJetRaptor ; AirF version
@@ -5084,6 +5087,7 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
  8  = Command_UpgradeChinaAircraftArmor
 ; 10 = Command_UpgradeAmericaBunkerBusters
  12 = Command_UpgradeEMPMines
+ 13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 


### PR DESCRIPTION
This change adds the missing rally point button to the Boss Airfield.