### PR TITLE
Change: Increase China Emperor speed by 25%, upgraded speed by 16%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1854_tank_overlord_speed.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1854_tank_overlord_speed.yaml
@@ -1,0 +1,27 @@
+---
+date: 2023-04-17
+
+title: Increases movement speed of China Tank Overlord by up to 25%
+
+changes:
+  - tweak: |
+      Increases China Tank Overlord
+        - speed from 20 to 25
+        - acceleration from 15 to 20
+        - turn rate from 60 to 70
+        - upgraded speed from 30 to 35
+        - upgraded turn rate from 60 to 70
+
+labels:
+  - buff
+  - china
+  - controversial
+  - design
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1813
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -4559,12 +4559,12 @@ End
 ;------------------------------------------------------------------------------
 Locomotor Tank_OverlordLocomotor
   Surfaces            = GROUND
-  Speed               = 20   ; in dist/sec
-  SpeedDamaged        = 20   ; in dist/sec
-  TurnRate            = 60   ; in degrees/sec
-  TurnRateDamaged     = 60   ; in degrees/sec
-  Acceleration        = 15   ; in dist/(sec^2)
-  AccelerationDamaged = 15   ; in dist/(sec^2)
+  Speed               = 25   ; in dist/sec ; Patch104p @tweak from 20 (#1854)
+  SpeedDamaged        = 25   ; in dist/sec ; Patch104p @tweak from 20 (#1854)
+  TurnRate            = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1854)
+  TurnRateDamaged     = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1854)
+  Acceleration        = 20   ; in dist/(sec^2) ; Patch104p @tweak from 15 (#1854)
+  AccelerationDamaged = 20   ; in dist/(sec^2) ; Patch104p @tweak from 15 (#1854)
   Braking             = 50   ; in dist/(sec^2)
   MinTurnSpeed        = 0    ; in dist/sec
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE
@@ -4585,12 +4585,12 @@ End
 ;------------------------------------------------------------------------------
 Locomotor Tank_NuclearOverlordLocomotor
   Surfaces            = GROUND
-  Speed               = 30   ; 50% faster than normal
-  SpeedDamaged        = 30   ; 50% faster than normal
-  TurnRate            = 60   ; in degrees/sec
-  TurnRateDamaged     = 60   ; in degrees/sec
-  Acceleration        = 30   ; 100% faster than normal
-  AccelerationDamaged = 30   ; 100% faster than normal
+  Speed               = 35   ; 40% faster than normal ; Patch104p @tweak from 30 (#1854)
+  SpeedDamaged        = 35   ; 40% faster than normal ; Patch104p @tweak from 30 (#1854)
+  TurnRate            = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1854)
+  TurnRateDamaged     = 70   ; in degrees/sec ; Patch104p @tweak from 60 (#1854)
+  Acceleration        = 30   ; 50% faster than normal
+  AccelerationDamaged = 30   ; 50% faster than normal
   Braking             = 50  ; in dist/(sec^2)
   MinTurnSpeed        = 0   ; in dist/sec
   ZAxisBehavior       = NO_Z_MOTIVE_FORCE


### PR DESCRIPTION
* Relates to #1809
* Relates to #1813

This change increases the China Emperor speed by 25% and upgraded speed by 16%. The regular China Overlord already has the same setup.

| Object                            | Speed | Dmg. Speed | Accel. | Turn | Upgr. Speed | Upgr. Dmg. Speed | Upgr. Accel. | Upgr. Turn |
|-----------------------------------|-------|------------|--------|------|-------------|------------------|--------------|------------|
| Original China Nuke Overlord      | 40    | 40         | 30     | 80   | -           | -                | -            | -          |
| Original China Emperor            | 20    | 20         | 15     | 60   | 30          | 30               | 30           | 60         |
| Patched China Overlord            | 25    | 25         | 20     | 70   | 35          | 35               | 30           | 70         |
| **Patched China Emperor (this)**  | 25    | 25         | 20     | 70   | 35          | 35               | 30           | 70         |


# Rationale

The tanks of the Tank General are stronger and cheaper than those of other China factions, but come at the expense of considerably more expensive infantry and aircraft, and the absence of artillery ground units. Therefore it relies on its tanks as its primary source of attacking firepower. The Emperor Tank is generally not a favourite pick due its inability to break defensive lines in a limely manner. The opposition has ample time to react to the Emperor advances - can prepare aircraft, artillery units, rocket men, Demo bikes, mass tanks, mass humvees or a Jarmen Kell to stop it from advancing. The loss of an Emperor Tank (1900) with the Gattling upgrade (+1200) is a significant investment and a huge loss when taken out or taken over (!) by the opposition. It is common to see Tank General mass producing Battlemaster Tanks, Gattling Tanks and ECM Tanks instead.

The Battlemaster Tank already enjoyed a speed buff with change #1815. And the Emperor Tank enjoyed a Subliminal bonus buff with change #236. With this change the Emperor will enjoy a speed buff on top, elevating its usefulness further and giving Tank General the powerful tanks it deserves and needs.