### PR TITLE
Change: Optimize button placements of Boss Command Center

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1859_boss_commandcenter_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1859_boss_commandcenter_buttons.yaml
@@ -1,0 +1,25 @@
+---
+date: 2023-04-19
+
+title: Optimizes button placements of Boss Command Center
+
+changes:
+  - tweak: |
+      Optimizes button placements of Boss Command Center
+        - Boss and China now share same button position for Carpet Bomber
+        - Boss and China now share same button position for Cluster Mines
+        - Boss and China now share same button position for Artillery Barrage
+        - Boss and China now share same button position for EMP Pulse
+        - Spectre and Sneak Attack buttons are moved
+
+labels:
+  - boss
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1859
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5037,28 +5037,30 @@ CommandSet Boss_AmericaDozerCommandSet
   14  = Boss_Command_ConstructAmericaParticleCannonUplink
 End
 
+; Patch104p @tweak xezon 19/04/2023 Moves buttons into more familiar China button positions. (#1859)
 CommandSet Boss_ChinaCommandCenterCommandSet
   1  = Boss_Command_ConstructChinaDozer
-  5  = Command_ArtilleryBarrage
-  6  = Command_EMPPulse
-  7  = Command_ClusterMines
-  8  = Command_SpectreGunship
-  9  = Command_SneakAttack
-  10  = Command_ChinaCarpetBomb
+  2  = Command_ChinaCarpetBomb ; Patch104p @tweak from 10
+  4  = Command_ClusterMines ; Patch104p @tweak from 7
+  5  = Command_SpectreGunship ; Patch104p @tweak from 8
+  6  = Command_ArtilleryBarrage ; Patch104p @tweak from 5
+  7  = Command_SneakAttack ; Patch104p @tweak from 9
+  8  = Command_EMPPulse ; Patch104p @tweak from 6
   11 = Command_UpgradeChinaRadar
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
+; Patch104p @tweak xezon 19/04/2023 Moves buttons into more familiar China button positions. (#1859)
 CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   1  = Boss_Command_ConstructChinaDozer
-  5  = Command_ArtilleryBarrage
-  6  = Command_EMPPulse
-  7  = Command_ClusterMines
-  8  = Command_SpectreGunship
-  9  = Command_SneakAttack
-  10 = Command_ChinaCarpetBomb
+  2  = Command_ChinaCarpetBomb ; Patch104p @tweak from 10
+  4  = Command_ClusterMines ; Patch104p @tweak from 7
+  5  = Command_SpectreGunship ; Patch104p @tweak from 8
+  6  = Command_ArtilleryBarrage ; Patch104p @tweak from 5
+  7  = Command_SneakAttack ; Patch104p @tweak from 9
+  8  = Command_EMPPulse ; Patch104p @tweak from 6
   11 = Command_UpgradeChinaRadar
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint


### PR DESCRIPTION
This change optimizes button placements of Boss Command Center.

* Boss and China now share same button position for Carpet Bomber
* Boss and China now share same button position for Cluster Mines
* Boss and China now share same button position for Artillery Barrage
* Boss and China now share same button position for EMP Pulse
* Spectre and Sneak Attack buttons were moved

No image because unclear how to test.

### TODO

- [x] Move China Radar back to position 11


## Patched Boss Command Center Buttons

![shot_20230422_140220_1](https://user-images.githubusercontent.com/4720891/233783655-2ffad22d-54e3-4d71-8d46-7b25605f4fe1.jpg)

## Patched China Command Center Buttons (Reference Only)

![shot_20230422_140307_2](https://user-images.githubusercontent.com/4720891/233783657-e8b3cc14-cd22-49ec-bcc9-6b9ba31b6073.jpg)
