### PR TITLE
Change: Move Radar upgrade button above Mines upgrade button on China Command Center

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1861_china_radar_button_placement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1861_china_radar_button_placement.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-21
+
+title: Moves Radar upgrade button above Mines upgrade button on China Command Center
+
+changes:
+  - tweak: Moves the Radar upgrade button one field to the right, above the Mines upgrade button on the China Command Center. It is now consistent with the placement on the Boss Command Center.
+
+labels:
+  - china
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1861
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -848,8 +848,8 @@ CommandSet ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -864,8 +864,8 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3165,8 +3165,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3183,8 +3183,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3893,8 +3893,8 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Early_Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3924,8 +3924,8 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Early_Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -4699,8 +4699,8 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -4715,8 +4715,8 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
-  9  = Command_UpgradeChinaRadar
   10 = Command_Frenzy
+  11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell


### PR DESCRIPTION
This change moves the Radar upgrade button one field to the right, above the Mines upgrade button on the China Command Center. It is now consistent with the placement on the Boss Command Center.

## Patched

![shot_20230421_210806_1](https://user-images.githubusercontent.com/4720891/233715815-f373e877-401d-4ac5-a186-9735ffedace6.jpg)
