### PR TITLE
Change: Add Starting Money options for 30000 and 40000

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1862_start_money_options.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1862_start_money_options.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-04-22
+
+title: Adds Starting Money options for 30000 and 40000
+
+changes:
+  - feature: Adds Starting Money options for 30000 and 40000, because the original gap between 20000 and 50000 is quite wide.
+
+labels:
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1862
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/multiplayer.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/multiplayer.ini
@@ -102,6 +102,15 @@ MultiplayerStartingMoneyChoice
   Value = 20000
 End
 
+; Patch104p @feature xezon 22/04/2023 Adds more starting money options. (#1862)
+MultiplayerStartingMoneyChoice
+  Value = 30000
+End
+
+MultiplayerStartingMoneyChoice
+  Value = 40000
+End
+
 MultiplayerStartingMoneyChoice
   Value = 50000
 End

--- a/Patch104pZH/GameFilesEdited/Window/Menus/GameSpyGameOptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/GameSpyGameOptionsMenu.wnd
@@ -748,7 +748,7 @@ WINDOW
                        IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
       COMBOBOXDATA = ISEDITABLE: 0,
                     MAXCHARS: 16,
-                    MAXDISPLAY: 5,
+                    MAXDISPLAY: 6,
                     ASCIIONLY: 0,
                     LETTERSANDNUMBERS: 0;
       COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA = IMAGE: VSliderDownButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,

--- a/Patch104pZH/GameFilesEdited/Window/Menus/LanGameOptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/LanGameOptionsMenu.wnd
@@ -554,7 +554,7 @@ WINDOW
                        IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
       COMBOBOXDATA = ISEDITABLE: 0,
                     MAXCHARS: 16,
-                    MAXDISPLAY: 5,
+                    MAXDISPLAY: 6,
                     ASCIIONLY: 0,
                     LETTERSANDNUMBERS: 0;
       COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA = IMAGE: VSliderDownButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,

--- a/Patch104pZH/GameFilesEdited/Window/Menus/SkirmishGameOptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/SkirmishGameOptionsMenu.wnd
@@ -670,7 +670,7 @@ WINDOW
                        IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
       COMBOBOXDATA = ISEDITABLE: 0,
                     MAXCHARS: 16,
-                    MAXDISPLAY: 5,
+                    MAXDISPLAY: 6,
                     ASCIIONLY: 0,
                     LETTERSANDNUMBERS: 0;
       COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA = IMAGE: VSliderDownButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,


### PR DESCRIPTION
This change adds Starting Money options for 30000 and 40000, because the original gap between 20000 and 50000 is quite wide.

![shot_20230422_132735_1](https://user-images.githubusercontent.com/4720891/233781814-802309c6-bb99-4adf-befe-ca466cf877ea.jpg)
