### PR TITLE
Fix: Boss Dozer button image and text

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1863_boss_dozer_button_image_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1863_boss_dozer_button_image_text.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-04-22
+
+title: Fixes button image and text of Boss Dozer
+
+changes:
+  - fix: The production button of the Boss Dozer now shows the correct USA Dozer image instead of the China Dozer image.
+  - fix: The production tooltip of the Boss Dozer now shows an appropriate description for the Boss General.
+
+labels:
+  - boss
+  - bug
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1863
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -8145,13 +8145,16 @@ CommandButton Boss_Command_ConstructChinaGattlingCannon
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildGattlingCannon
 End
 
+; Patch104p @bugfix xezon 22/04/2023 Changes ButtonImage from 'SNDozer' to show Boss (USA) Dozer image.
+; Patch104p @bugfix xezon 22/04/2023 Changes TextLabel from 'CONTROLBAR:ConstructChinaDozer' to show Boss Dozer text.
+; Patch104p @bugfix xezon 22/04/2023 Changes DescriptLabel from 'CONTROLBAR:ToolTipChinaBuildDozer' to show Boss Dozer description.
 CommandButton Boss_Command_ConstructChinaDozer
   Command       = UNIT_BUILD
   Object        = Boss_VehicleDozer
-  TextLabel     = CONTROLBAR:ConstructChinaDozer
-  ButtonImage   = SNDozer
+  TextLabel     = CONTROLBAR:ConstructBossDozer
+  ButtonImage   = SACDozer
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipChinaBuildDozer
+  DescriptLabel           = CONTROLBAR:ToolTipBossBuildDozer
 End
 
 CommandButton Boss_Command_ConstructChinaVehicleSupplyTruck


### PR DESCRIPTION
This change fixes Boss Dozer button image and text. It no longer shows the China Dozer picture and China specific tooltip text.

## Patched Boss Dozer GUI

![shot_20230422_144509_1](https://user-images.githubusercontent.com/4720891/233785613-3f0c2848-6324-44ae-b60d-bafe908f2c4e.jpg)
