### PR TITLE
Fix: Set unique default house color for Boss General

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1864_boss_color.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1864_boss_color.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-04-22
+
+title: Sets unique default house color for Boss General
+
+changes:
+  - tweak: Changes default house color of Boss General from green to gold.
+
+labels:
+  - boss
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1864
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ChallengeMode.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ChallengeMode.ini
@@ -275,7 +275,7 @@ ChallengeGenerals
 
   GeneralPersona9
     PlayerTemplate = FactionBossGeneral
-    StartsEnabled = no
+    StartsEnabled = no ; Set yes to enable Boss General
     BioNameString = GUI:BioNameEntry_Pos9
     BioDOBString = GUI:BioDOBEntry_Pos9
     BioBirthplaceString = GUI:BioBirthplaceEntry_Pos9

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -461,7 +461,7 @@ PlayerTemplate FactionBossGeneral
   BaseSide          = China ;Not sure if this is the best choice....(for academy)
   PlayableSide      = Yes
   StartMoney        = 0
-  PreferredColor    = R:0 G:255 B:0
+  PreferredColor    = R:221 G:226 B:13 ; Patch104p @tweak from green to gold color. (#1864)
   IntrinsicSciences = SCIENCE_GLA SCIENCE_AMERICA SCIENCE_CHINA
   PurchaseScienceCommandSetRank1 = Boss_SCIENCE_CHINA_CommandSetRank1
   PurchaseScienceCommandSetRank3 = Boss_SCIENCE_CHINA_CommandSetRank3


### PR DESCRIPTION
This change sets a more appropriate default color for Boss General. Was green, is now gold, matching the red/yellow China GUI theme of Boss General better.