### PR TITLE
Change: Optimize button placements of Boss War Factory

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1865_boss_warfactory_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1865_boss_warfactory_buttons.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-22
+
+title: Optimizes button placements of Boss War Factory
+
+changes:
+  - tweak: Optimizes button placements of Boss War Factory. The production buttons are now located at more familiar positions. All China related buttons take native China positions. And GLA and USA related buttons are close to where they are with the respective native faction.
+
+labels:
+  - boss
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1865
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5144,36 +5144,37 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
  14 = Command_Sell
 End
 
-
+; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar faction button positions. (#1865)
 CommandSet Boss_ChinaWarFactoryCommandSet
   1 = Boss_Command_ConstructAmericaVehiclePaladin
-  2 = Boss_Command_ConstructChinaTankGattling
-  3 = Boss_Command_ConstructChinaTankDragon
-  4 = Boss_Command_ConstructAmericaVehicleAvenger
-  5 = Boss_Command_ConstructChinaTankOverlord
-  6 = Boss_Command_ConstructAmericaVehicleTomahawk
-  7 = Boss_Command_ConstructGLAVehicleCombatBikeTerrorist
-  8 = Boss_Command_ConstructGLAVehicleRocketBuggy
-  9 = Boss_Command_ConstructAmericaVehicleSentryDrone
-  10 = Command_UpgradeChinaBlackNapalm
-  11 = Command_UpgradeChinaChainGuns
+  2 = Boss_Command_ConstructChinaTankOverlord ; Patch104p @tweak from 5
+  3 = Boss_Command_ConstructAmericaVehicleAvenger ; Patch104p @tweak from 4
+  4 = Boss_Command_ConstructAmericaVehicleSentryDrone ; Patch104p @tweak from 9
+  5 = Boss_Command_ConstructChinaTankGattling ; Patch104p @tweak from 2
+  6 = Command_UpgradeChinaChainGuns ; Patch104p @tweak from 11
+  7 = Boss_Command_ConstructChinaTankDragon ; Patch104p @tweak from 3
+  8 = Command_UpgradeChinaBlackNapalm ; Patch104p @tweak from 10
+  9 = Boss_Command_ConstructAmericaVehicleTomahawk ; Patch104p @tweak from 6
+  10 = Boss_Command_ConstructGLAVehicleRocketBuggy ; Patch104p @tweak from 8
+  11 = Boss_Command_ConstructGLAVehicleCombatBikeTerrorist ; Patch104p @tweak from 7
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
+; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar faction button positions. (#1865)
 CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   1 = Boss_Command_ConstructAmericaVehiclePaladin
-  2 = Boss_Command_ConstructChinaTankGattling
-  3 = Boss_Command_ConstructChinaTankDragon
-  4 = Boss_Command_ConstructAmericaVehicleAvenger
-  5 = Boss_Command_ConstructChinaTankOverlord
-  6 = Boss_Command_ConstructAmericaVehicleTomahawk
-  7 = Boss_Command_ConstructGLAVehicleCombatBikeTerrorist
-  8 = Boss_Command_ConstructGLAVehicleRocketBuggy
-  9 = Boss_Command_ConstructAmericaVehicleSentryDrone
-  10 = Command_UpgradeChinaBlackNapalm
-  11 = Command_UpgradeChinaChainGuns
+  2 = Boss_Command_ConstructChinaTankOverlord ; Patch104p @tweak from 5
+  3 = Boss_Command_ConstructAmericaVehicleAvenger ; Patch104p @tweak from 4
+  4 = Boss_Command_ConstructAmericaVehicleSentryDrone ; Patch104p @tweak from 9
+  5 = Boss_Command_ConstructChinaTankGattling ; Patch104p @tweak from 2
+  6 = Command_UpgradeChinaChainGuns ; Patch104p @tweak from 11
+  7 = Boss_Command_ConstructChinaTankDragon ; Patch104p @tweak from 3
+  8 = Command_UpgradeChinaBlackNapalm ; Patch104p @tweak from 10
+  9 = Boss_Command_ConstructAmericaVehicleTomahawk ; Patch104p @tweak from 6
+  10 = Boss_Command_ConstructGLAVehicleRocketBuggy ; Patch104p @tweak from 8
+  11 = Boss_Command_ConstructGLAVehicleCombatBikeTerrorist ; Patch104p @tweak from 7
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell


### PR DESCRIPTION
This change optimizes button placements of Boss War Factory. The units are now located at more familiar positions, with all China units taking China positions and GLA and USA buttons being close to where they are with the respective original faction.

## Original

![shot_20230422_173224_2](https://user-images.githubusercontent.com/4720891/233795518-6f2a219f-5920-43b4-9395-2e0f9c762e6e.jpg)

## Patched

![shot_20230422_180807_1](https://user-images.githubusercontent.com/4720891/233795538-d805c343-6989-46d2-ab4e-722d68f0be5f.jpg)
