### PR TITLE
Change: Optimize button placements of Boss Nuke Silo, Remove obsolete Neutron Shell button from Boss Nuke Silo

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1866_boss_nukesilo_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1866_boss_nukesilo_buttons.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-22
+
+title: Optimizes button placements of Boss Nuke Silo
+
+changes:
+  - tweak: Optimizes button placements of Boss Nuke Silo. The Nuke upgrade buttons now take the same position as they do on the native China Nuke Silo. And the Propaganda buttons now have the same order as they do on the native China Propaganda Center.
+
+labels:
+  - boss
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1866
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1866_boss_nukesilo_nukeshells_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1866_boss_nukesilo_nukeshells_button.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-22
+
+title: Removes obsolete Neutron Shells upgrade button from Boss Nuke Silo
+
+changes:
+  - fix: Removes the obsolete Neutron Shells upgrade button from the Boss Nuke Silo, because Boss General cannot build Nuke Cannons.
+
+labels:
+  - boss
+  - bug
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1866
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5218,27 +5218,29 @@ CommandSet Boss_GLAScudStormCommandSetUpgrade
   14 = Command_Sell
 End
 
-; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions.
+; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions. (#1866)
+; Patch104p @bugfix xezon 22/04/2023 Removes Neutron Shells upgrade button because Boss cannot build Nuke Cannon. (#1866)
 CommandSet Boss_ChinaNuclearMissileCommandSet
   1 = Command_NeutronMissile
   4 = Boss_Command_UpgradeChinaNationalism ; Patch104p @tweak from 6
   6 = Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
   7 = Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
   8 = Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
- 10 = Command_UpgradeChinaNeutronShells
+; 10 = Command_UpgradeChinaNeutronShells
  12 = Command_UpgradeChinaMines
  14 = Command_Sell
 End
 
 ; Patch104p @bugfix commy2 18/09/2021 Fix Nationalism upgrade changing description after Landmines upgrade.
-; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions.
+; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions. (#1866)
+; Patch104p @bugfix xezon 22/04/2023 Removes Neutron Shells upgrade button because Boss cannot build Nuke Cannon. (#1866)
 CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   1 = Command_NeutronMissile
   4 = Boss_Command_UpgradeChinaNationalism ; Patch104p @tweak from 6
   6 = Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
   7 = Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
   8 = Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
- 10 = Command_UpgradeChinaNeutronShells
+; 10 = Command_UpgradeChinaNeutronShells
  12 = Command_UpgradeEMPMines
  14 = Command_Sell
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5218,24 +5218,26 @@ CommandSet Boss_GLAScudStormCommandSetUpgrade
   14 = Command_Sell
 End
 
-
+; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions.
 CommandSet Boss_ChinaNuclearMissileCommandSet
   1 = Command_NeutronMissile
-  4 = Command_UpgradeChinaSubliminalMessaging
-  6 = Boss_Command_UpgradeChinaNationalism
-  7 = Command_UpgradeChinaNuclearTanks
-  9 = Command_UpgradeChinaUraniumShells
+  4 = Boss_Command_UpgradeChinaNationalism ; Patch104p @tweak from 6
+  6 = Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
+  7 = Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
+  8 = Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
  10 = Command_UpgradeChinaNeutronShells
  12 = Command_UpgradeChinaMines
  14 = Command_Sell
 End
 
+; Patch104p @bugfix commy2 18/09/2021 Fix Nationalism upgrade changing description after Landmines upgrade.
+; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions.
 CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   1 = Command_NeutronMissile
-  4 = Command_UpgradeChinaSubliminalMessaging
-  6 = Boss_Command_UpgradeChinaNationalism  ; Patch104p @bugfix commy2 18/09/2021 Fix upgrade changing description after Landmines upgrade.
-  7 = Command_UpgradeChinaNuclearTanks
-  9 = Command_UpgradeChinaUraniumShells
+  4 = Boss_Command_UpgradeChinaNationalism ; Patch104p @tweak from 6
+  6 = Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
+  7 = Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
+  8 = Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
  10 = Command_UpgradeChinaNeutronShells
  12 = Command_UpgradeEMPMines
  14 = Command_Sell


### PR DESCRIPTION
**Merge with Rebase**

This change optimizes button placements of Boss Nuke Silo. The Nuke upgrade buttons now share the same position as they do on the China Nuke Silo. And the Propaganda buttons now have the same order as they do on the China Propaganda Center.

(Version 2) Also removes the Neutron Shells upgrade button because Boss cannot build the Nuke Cannon.

## Original

![shot_20230422_174536_4](https://user-images.githubusercontent.com/4720891/233795689-0d2cd506-dfbe-416d-ba51-99b9eb989762.jpg)

## Patched (Version 1)

![shot_20230422_180833_2](https://user-images.githubusercontent.com/4720891/233795696-df7f09c4-4b22-41bf-a149-9961ee6d13a0.jpg)
