### PR TITLE
Change: Improve USA Daisy Cutter bomb explosion effects (2)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1800_daisy_cutter_explosion_effects.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1800_daisy_cutter_explosion_effects.yaml
@@ -8,8 +8,12 @@ changes:
   - fix: Adds smooth fade out to the USA Daisy Cutter explosion audio effect.
   - fix: Syncs the ignition particles of the USA Daisy Cutter with the ignition sound.
   - fix: Syncs the explosion effects of the USA Daisy Cutter with the explosion sound.
+  - tweak: Removes non-linear gap sizes in shock wave smoke circles of USA Daisy Cutter bomb explosion.
+  - tweak: Randomizes position and size of second ignition sparks of USA Daisy Cutter bomb.
+  - tweak: Slightly reduces number and size of second ignition sparks of USA Daisy Cutter bomb.
 
 labels:
+  - art
   - audio
   - enhancement
   - minor
@@ -18,6 +22,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1800
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1870
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1870_daisy_cutter_explosion_effects.txt
+++ b/Patch104pZH/Design/Changes/v1.0/1870_daisy_cutter_explosion_effects.txt
@@ -1,0 +1,1 @@
+1800_daisy_cutter_explosion_effects.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -4449,6 +4449,7 @@ End
 ; DaisyCutter gas ignition sequence
 ; ----------------------------------------------------------------------------
 FXList FX_DaisyCutterIgnite
+  ; Note: Both Ignite1 and Ignite2 spawn one big explosion effect each.
   ParticleSystem
     Name         = DaisyExplosionScatterIgnite1
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -42381,9 +42381,9 @@ ParticleSystem DaisyExplosionScatterIgnite2
   PerParticleAttachedSystem = DaisyExplosion
   Lifetime = 25.00 25.00
   SystemLifetime = 15
-  Size = 1.00 1.00
+  Size = 0.75 1.00 ; Patch104p @tweak from 1.00 1.00 to slightly randomize sizing
   StartSizeRate = 0.00 0.00
-  SizeRate = 2.00 2.00
+  SizeRate = 1.50 2.00 ; Patch104p @tweak from 2.00 2.00 to slightly randomize sizing
   SizeRateDamping = 1.00 1.00
   Alpha1 = 0.25 0.25 0
   Alpha2 = 0.00 0.00 25
@@ -42403,11 +42403,11 @@ ParticleSystem DaisyExplosionScatterIgnite2
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
   BurstDelay = 1.00 1.00
-  BurstCount = 3.00 3.00
+  BurstCount = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to reduce the number of ignition sparks
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
   VelocityType = OUTWARD
-  VelOutward = 40.00 40.00
+  VelOutward = 10.00 30.00 ; Patch104p @tweak from 40.00 40.00 to randomize the positioning of ignition sparks
   VelOutwardOther = 10.00 10.00
   VolumeType = CYLINDER
   VolCylinderRadius = 1.00
@@ -51220,7 +51220,7 @@ ParticleSystem DaisyFlameShockwaveSmoke
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
-  BurstDelay = 3.00 4.00
+  BurstDelay = 3.00 3.00 ; Patch104p @tweak from 3.00 4.00 to avoid non-linear gap sizes in smoke circles
   BurstCount = 1.00 1.00
   InitialDelay = 4.00 4.00
   DriftVelocity = X:0.10 Y:0.10 Z:0.10


### PR DESCRIPTION
* Follow up for #1800

This change improves USA Daisy Cutter bomb explosion effects.

* Removes non-linear gap sizes in shock wave smoke circles of USA Daisy Cutter bomb explosion
* Randomizes position and size of second ignition sparks
* Slightly reduces number and size of second ignition sparks

## Patched

https://user-images.githubusercontent.com/4720891/233843780-8b904e10-3c16-4f45-aa8d-e9d4cad3c396.mp4
