### PR TITLE
Fix: Improve USA Alpha Aurora bomb explosion effects

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1871_alpha_aurora_bomb_effects.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1871_alpha_aurora_bomb_effects.yaml
@@ -1,0 +1,35 @@
+---
+date: 2023-04-23
+
+title: Fixes and improves explosion effects of USA Alpha Aurora bomb
+
+changes:
+  - tweak: Fixes and improves the USA Alpha Aurora bomb explosion effects.
+
+subchanges:
+  - tweak: The initial Aurora bomb hit now shows the hit particle effects and sound. Is consistent with regular Aurora bomb hit effects.
+  - tweak: The initial Aurora bomb hit no longer draws a scorch, because it is covered by the particles at the time of the impact and would be overdrawn soon after by the bigger scorch for the gas explosion. Total explosion scorch count is 1 (optimal).
+  - tweak: The ignite sound effect is preserved, but is made a bit quieter than the one of the Daisy Cutter ignition, because the sparks are smaller and there is now the other explosion sound triggered at the same time.
+  - tweak: The first ignition sparks are now visible earlier and spread further apart.
+  - tweak: The second ignition sparks are now less in numbers and spread further apart.
+  - tweak: The second ignition sparks now properly fade out.
+  - tweak: The second ignition sparks now have random size.
+  - tweak: The lingering green gas clouds are removed.
+  - tweak: The final gas explosion is now just one explosion instance instead of 2 to 4.
+  - tweak: The final gas explosion is now synced better with the actual damage and sound event.
+  - tweak: The final gas explosion now has much less random size variation, so it never looks too small.
+  - tweak: The original Alpha bomb shock wave effect is now a smaller copy of the Daisy Cutter shock wave.
+
+labels:
+  - art
+  - enhancement
+  - minor
+  - performance
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1871
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -4484,7 +4484,10 @@ End
 ; ----------------------------------------------------------------------------
 ; Patch104p @feature A copy of FX_DaisyCutterFinalExplosion
 ; ----------------------------------------------------------------------------
-FXList AirF_FX_AuroraBombDetonation
+FXList AirF_FX_AuroraBombDetonation ; Alias SupW_FX_AuroraBombDetonation
+  ParticleSystem
+    Name = AuroraFuelBombShockwave
+  End
   Sound
     Name = ExplosionDaisyCutter
   End
@@ -6041,7 +6044,34 @@ FXList FX_AuroraBombDetonate
   End
 End
 
+; ----------------------------------------------
+; Patch104p @feature A copy of FX_AuroraBombDetonate (#1871)
+;   The Aurora fuel explosion will spawn the scorch.
+; ----------------------------------------------
+FXList SupW_FX_AuroraBombDetonate
 
+  ParticleSystem
+    Name = CarpetBombExplosion
+    InitialDelay = 0 0 UNIFORM   ;In milliseconds
+    Offset = X:0.0 Y:0.0 Z:0.0
+  End
+
+  ParticleSystem
+    Name = CarpetBombWave
+    InitialDelay = 0 0 UNIFORM   ;In milliseconds
+    Offset = X:0.0 Y:0.0 Z:0.0
+  End
+
+  ParticleSystem
+    Name = CarpetBombExplosionPuff
+    InitialDelay = 0 0 UNIFORM   ;In milliseconds
+    Offset = X:0.0 Y:0.0 Z:0.0
+  End
+
+  Sound
+    Name = ExplosionCarpetBomb
+  End
+End
 
 ; ----------------------------------------------
 FXList FX_A10ThunderboltMissileExplosion
@@ -9323,9 +9353,13 @@ End
 ; ----------------------------------------------------------------------------
 ; AuroraBomb gas ignition sequence
 ; ----------------------------------------------------------------------------
-FXList AirF_FX_AuroraBombIgnite
+FXList AirF_FX_AuroraBombIgnite ; Alias SupW_FX_AuroraBombIgnite
   ParticleSystem
-    Name         = AirF_AuroraBombScatterIgnite1
+    Name = AirF_AuroraBombScatterIgnite1
+  End
+  ; Patch104p @tweak Adds second ignition effect.
+  ParticleSystem
+    Name = AirF_AuroraBombScatterIgnite2
   End
 ;  ParticleSystem
 ;    Name         = AirF_AuroraBombScatterIgnite2
@@ -9336,7 +9370,7 @@ FXList AirF_FX_AuroraBombIgnite
 ;    InitialDelay = 1000 1000 UNIFORM
 ;  End
   Sound
-    Name = DaisyCutterIgnite
+    Name = AuroraFuelBombIgnite ; Patch @tweak from DaisyCutterIgnite
   End
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -124,7 +124,7 @@ End
 
 
 ;------------------------------------------------------------------------------
-Object AirF_AuroraBomb
+Object AirF_AuroraBomb ; unused
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -24282,7 +24282,7 @@ ParticleSystem StructureTransitionSmallFlare
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AirF_AuroraBombScatterIgnite1
+ParticleSystem AirF_AuroraBombScatterIgnite1 ; Alias SupW_AuroraBombScatterIgnite1
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -24294,7 +24294,7 @@ ParticleSystem AirF_AuroraBombScatterIgnite1
   VelocityDamping = 0.23 0.20
   Gravity = 0.25
   PerParticleAttachedSystem = AirF_AuroraBombExplosion
-  Lifetime = 25.00 25.00
+  Lifetime = 27.00 27.00 ; Patch104p @tweak from 25.00 25.00 to be able to spawn explosion effect 2 frames later
   SystemLifetime = 15
   Size = 1.00 1.00
   StartSizeRate = 0.00 0.00
@@ -24308,11 +24308,11 @@ ParticleSystem AirF_AuroraBombScatterIgnite1
   Alpha6 = 0.00 0.00 0
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
-  Color1 = R:0 G:0 B:0 0
-  Color2 = R:0 G:0 B:0 12
-  Color3 = R:128 G:128 B:255 14
-  Color4 = R:255 G:218 B:106 17
-  Color5 = R:0 G:0 B:0 26
+  Color1 = R:0 G:0 B:0 0 ; Patch104p @tweak From 12 to show the ignition much earlier.
+  Color2 = R:128 G:128 B:255 5 ; Patch104p @tweak From 14 to fade in sooner.
+  Color3 = R:255 G:218 B:106 17
+  Color4 = R:0 G:0 B:0 26
+  Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
@@ -24322,8 +24322,8 @@ ParticleSystem AirF_AuroraBombScatterIgnite1
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
   VelocityType = OUTWARD
-  VelOutward = 20.00 20.00
-  VelOutwardOther = 20.00 40.00
+  VelOutward = 40.00 40.00 ; Patch104p @tweak from 20.00 20.00 to spread the ignition sparks further apart
+  VelOutwardOther = 40.00 60.00 ; Patch104p @tweak from 20.00 40.00 to spread the ignition sparks further apart
   VolumeType = CYLINDER
   VolCylinderRadius = 1.00
   VolCylinderLength = 0.00
@@ -24396,7 +24396,7 @@ ParticleSystem WaveHit01
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AirF_AuroraBombScatterIgnite2
+ParticleSystem AirF_AuroraBombScatterIgnite2 ; Alias SupW_AuroraBombScatterIgnite2
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -24407,12 +24407,12 @@ ParticleSystem AirF_AuroraBombScatterIgnite2
   AngularDamping = 1.00 1.00
   VelocityDamping = 0.65 0.65
   Gravity = 0.25
-  PerParticleAttachedSystem = AirF_AuroraBombExplosion
+  ;PerParticleAttachedSystem = AirF_AuroraBombExplosion ; Patch104p @tweak Removes this to trigger just one explosion effect via Ignite1
   Lifetime = 25.00 25.00
   SystemLifetime = 15
-  Size = 1.00 1.00
+  Size = 0.75 1.00 ; Patch104p @tweak from 1.00 1.00 to slightly randomize sizing
   StartSizeRate = 0.00 0.00
-  SizeRate = 2.00 2.00
+  SizeRate = 1.50 2.00 ; Patch104p @tweak from 2.00 2.00 to slightly randomize sizing
   SizeRateDamping = 1.00 1.00
   Alpha1 = 0.25 0.25 0
   Alpha2 = 0.00 0.00 25
@@ -24425,19 +24425,19 @@ ParticleSystem AirF_AuroraBombScatterIgnite2
   Color1 = R:0 G:0 B:0 0
   Color2 = R:0 G:0 B:0 12
   Color3 = R:126 G:126 B:255 14
-  Color4 = R:255 G:218 B:106 25
-  Color5 = R:0 G:0 B:0 30
+  Color4 = R:255 G:218 B:106 20 ; Patch104p @fix from 25 to leave time for graceful fadeout
+  Color5 = R:0 G:0 B:0 26 ; Patch104p @fix from 30 to leave time for graceful fadeout
   Color6 = R:0 G:0 B:0 0
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
   BurstDelay = 1.00 1.00
-  BurstCount = 3.00 3.00
+  BurstCount = 1.00 1.00 ; Patch104p @tweak from 3.00 3.00 to reduce the number of ignition sparks
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
   VelocityType = OUTWARD
-  VelOutward = 10.00 10.00
-  VelOutwardOther = 5.00 5.00
+  VelOutward = 10.00 15.00 ; Patch104p @tweak from 10.00 10.00 to spread the ignition sparks further apart
+  VelOutwardOther = 10.00 10.00 ; Patch104p @tweak from 5.00 5.00 to spread the ignition sparks further apart
   VolumeType = CYLINDER
   VolCylinderRadius = 1.00
   VolCylinderLength = 0.00
@@ -29564,7 +29564,7 @@ ParticleSystem BuggyNewAirDeathSubExplosionFlameSlave
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AirF_AuroraBombGasSpray
+ParticleSystem AirF_AuroraBombGasSpray ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ALPHA
@@ -29843,7 +29843,7 @@ ParticleSystem airCarrierSparks
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AirF_AuroraBombExplosion
+ParticleSystem AirF_AuroraBombExplosion ; Alias SupW_AuroraBombExplosion
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -29857,9 +29857,9 @@ ParticleSystem AirF_AuroraBombExplosion
   PerParticleAttachedSystem = DaisyExplosionSmoke
   Lifetime = 100.00 100.00
   SystemLifetime = 15
-  Size = 5.00 8.00
+  Size = 7.00 8.00 ; Patch104p @tweak from 5.00 8.00 to reduce the random size variation scale
   StartSizeRate = 0.00 0.00
-  SizeRate = 12.00 25.00
+  SizeRate = 20.00 24.00 ; Patch104p @tweak from 12.00 25.00 to reduce the random size variation scale
   SizeRateDamping = 0.80 0.90
   Alpha1 = 0.25 0.25 0
   Alpha2 = 0.00 0.00 25
@@ -29879,8 +29879,8 @@ ParticleSystem AirF_AuroraBombExplosion
   Color8 = R:0 G:0 B:0 0
   ColorScale = -1.00 -0.10
   BurstDelay = 0.00 0.00
-  BurstCount = 1.00 2.00
-  InitialDelay = 23.00 23.00
+  BurstCount = 1.00 1.00 ; Patch104p @tweak from 1.00 2.00 to spawn consistently less intense explosion particles
+  InitialDelay = 25.00 25.00 ; Patch104p @tweak from 23.00 23.00 to spawn effect 2 frames later
   DriftVelocity = X:0.00 Y:0.00 Z:-0.10
   VelocityType = OUTWARD
   VelOutward = 15.00 20.00
@@ -30526,7 +30526,7 @@ ParticleSystem MammothTankExplosionShockwave
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AirF_AuroraBombGas1
+ParticleSystem AirF_AuroraBombGas1 ; Alias SupW_AuroraBombGas1
   Priority = CRITICAL
   IsOneShot = No
   Shader = ALPHA
@@ -44256,6 +44256,65 @@ ParticleSystem DaisyFlameShockwave
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @feature A copy of DaisyFlameShockwave, but smaller (#1871)
+ParticleSystem AuroraFuelBombShockwave
+  Priority = CRITICAL
+  IsOneShot = No
+  Shader = ADDITIVE
+  Type = PARTICLE
+  ParticleName = EXFire01.tga
+  AngleZ = 0.00 1.00
+  AngularRateZ = -0.05 0.05
+  AngularDamping = 1.00 1.00
+  VelocityDamping = 0.93 0.93
+  Gravity = 0.00
+  PerParticleAttachedSystem = AuroraFuelBombShockwaveSmoke
+  Lifetime = 15.00 15.00
+  SystemLifetime = 1
+  Size = 2.00 2.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 3.00 3.00
+  SizeRateDamping = 0.90 0.90
+  Alpha1 = 0.00 0.00 0
+  Alpha2 = 0.50 5.00 5
+  Alpha3 = 0.00 0.00 15
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:9 G:5 B:4 0
+  Color2 = R:0 G:0 B:0 15
+  Color3 = R:0 G:0 B:0 0
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 2.00
+  BurstDelay = 1.00 1.00
+  BurstCount = 100.00 100.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.10
+  VelocityType = OUTWARD
+  VelOutward = 15.00 15.00
+  VelOutwardOther = 0.00 0.00
+  VolumeType = CYLINDER
+  VolCylinderRadius = 10.00
+  VolCylinderLength = 0.00
+  IsHollow = Yes
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.150000
+  WindAngleChangeMax = 0.450000
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
 ParticleSystem Demo_BombTruckDefaultSmoke
   Priority = WEAPON_EXPLOSION
   IsOneShot = No
@@ -51280,6 +51339,64 @@ ParticleSystem DaisyFlameShockwaveSmoke
   BurstDelay = 3.00 3.00 ; Patch104p @tweak from 3.00 4.00 to avoid non-linear gap sizes in smoke circles
   BurstCount = 1.00 1.00
   InitialDelay = 4.00 4.00
+  DriftVelocity = X:0.10 Y:0.10 Z:0.10
+  VelocityType = OUTWARD
+  VelOutward = 5.00 5.00
+  VelOutwardOther = 0.00 0.00
+  VolumeType = CYLINDER
+  VolCylinderRadius = 1.00
+  VolCylinderLength = 0.00
+  IsHollow = Yes
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.150000
+  WindAngleChangeMax = 0.450000
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
+; Patch104p @feature A copy of DaisyFlameShockwaveSmoke, but smaller (#1871)
+ParticleSystem AuroraFuelBombShockwaveSmoke
+  Priority = CRITICAL
+  IsOneShot = No
+  Shader = ALPHA
+  Type = PARTICLE
+  ParticleName = EXCloud01.tga
+  AngleZ = 0.00 1.00
+  AngularRateZ = -0.03 0.01
+  AngularDamping = 0.96 0.99
+  VelocityDamping = 0.60 0.60
+  Gravity = 0.00
+  Lifetime = 100.00 100.00
+  SystemLifetime = 10
+  Size = 3.00 3.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 6.00 8.00
+  SizeRateDamping = 0.80 0.90
+  Alpha1 = 0.00 0.00 0
+  Alpha2 = 0.40 0.40 2
+  Alpha3 = 0.00 0.00 100
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:219 G:219 B:181 0
+  Color2 = R:0 G:0 B:0 0
+  Color3 = R:0 G:0 B:0 0
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 3.00 3.00
+  BurstCount = 1.00 1.00
+  InitialDelay = 2.00 2.00
   DriftVelocity = X:0.10 Y:0.10 Z:0.10
   VelocityType = OUTWARD
   VelOutward = 5.00 5.00

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -2003,6 +2003,16 @@ AudioEvent ExplosionDaisyCutter
   Type = world shrouded everyone
 End
 
+; Patch104p @feature A copy of DaisyCutterIgnite, but quieter (#1871)
+AudioEvent AuroraFuelBombIgnite
+  Control = interrupt
+  Sounds = sdaiigna
+  Priority = high
+  Limit = 1
+  Volume = 80
+  Type = world shrouded everyone
+End
+
 AudioEvent TechnicalWeaponUpgrade
   Sounds = gsalvage
   Limit = 1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7670,7 +7670,7 @@ End
 
 ; Patch104p @bugfix commy2 11/09/2021 Move logic to create secondary explosion inside the weapon.
 ; This is necessary, because the projectile dies on collisions (although it keeps traveling).
-; With this the Fuel Air Bomb no longer triggers the secondary explision before the bomb hits the ground or target.
+; With this the Fuel Air Bomb no longer triggers the secondary explosion before the bomb hits the ground or target.
 
 ;------------------------------------------------------------------------------
 Weapon SupW_AuroraFuelBombWeapon ; Alias SupW_AuroraBombWeapon
@@ -7683,7 +7683,7 @@ Weapon SupW_AuroraFuelBombWeapon ; Alias SupW_AuroraBombWeapon
   WeaponSpeed             = 99999
   ProjectileObject        = SupW_AuroraFuelAirBomb
   FireFX                  = FX_AuroraBombLaunch
-  ProjectileDetonationFX  = AirF_FX_AuroraBombExplode
+  ProjectileDetonationFX  = SupW_FX_AuroraBombDetonate ; Patch104p @tweak from AirF_FX_AuroraBombExplode
   ProjectileDetonationOCL = SupW_OCL_FuelAirBomb
   RadiusDamageAffects     = ALLIES ENEMIES NEUTRALS NOT_SIMILAR
   ClipSize                = 1                        ; how many shots in a Clip (0 == infinite)
@@ -7865,7 +7865,7 @@ End
 
 
 ;------------------------------------------------------------------------------
-Weapon AirF_AuroraBombWeapon
+Weapon AirF_AuroraBombWeapon ; unused
   ;PrimaryDamage           = 200.0
   ;PrimaryDamageRadius     = 40.0
   PrimaryDamage           = 2.0


### PR DESCRIPTION
* Closes #1751

This is an alternative implementation for fixing and improving Alpha Aurora bomb effects. The main issues were already raised in #1751. This change addresses additional problems and avoids the down sides of #1751.

* The initial Aurora bomb hit now shows the hit particle effects and sound. Is consistent with regular Aurora bomb hit effects.
* The initial Aurora bomb hit no longer draws a scorch, because it is covered by the particles at the time of the impact and would be overdrawn soon after by the bigger scorch for the gas explosion. Total explosion scorch count is 1 (optimal).
* The ignite sound effect is preserved, but is made a bit quieter than the one of the Daisy Cutter ignition, because the sparks are smaller and there is now the other explosion sound triggered at the same time.
* The first ignition sparks are now visible earlier and spread further apart.
* The second ignition sparks are now less in numbers and spread further apart.
* The second ignition sparks now properly fade out.
* The second ignition sparks now have random size.
* The lingering green gas clouds are removed.
* The final gas explosion is now just one explosion instance instead of 2 to 4.
* The final gas explosion is now synced better with the actual damage and sound event.
* The final gas explosion now has much less random size variation, so it never looks too small.
* The original Alpha bomb shock wave effect is now a smaller copy of the Daisy Cutter shock wave.

## Patched (Before)

https://user-images.githubusercontent.com/4720891/233851401-7742e212-5f8c-4e8c-87a5-cea6485700a9.mp4

## Patched (This)

https://user-images.githubusercontent.com/4720891/233851416-60f58c28-89f3-40da-8b48-148e0821dc04.mp4
