### PR TITLE
Change: Add catch fire death effect variant to USA Microwave Tank

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1874_microwave_death_effect.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1874_microwave_death_effect.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-24
+
+title: Adds catch fire and explode death effect variant to USA Microwave Tank
+
+changes:
+  - tweak: The USA Microwave Tank now either explodes straight away on death or first catches fire and then explodes afterwards. This is consistent with several other USA tanks.
+
+labels:
+  - design
+  - enhancement
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1874
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7401,6 +7401,17 @@ Object AirF_AmericaTankMicrowave
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
+  ; Patch104p @tweak xezon 25/04/2023 Adds catch fire, and explode death. (#1874)
+  Behavior = SlowDeathBehavior ModuleTag_11
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 50
+    DestructionDelay = 2000
+    DestructionDelayVariance = 300
+    FX  = INITIAL  FX_CrusaderCatchFire
+    OCL = FINAL    OCL_MicrowaveTankDeath
+    FX  = FINAL    FX_GenericTankDeathExplosion
+  End
+
   Behavior                 = TransitionDamageFX ModuleTag_12
     ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -2785,6 +2785,17 @@ Object AmericaTankMicrowave
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
+  ; Patch104p @tweak xezon 25/04/2023 Adds catch fire, and explode death. (#1874)
+  Behavior = SlowDeathBehavior ModuleTag_11
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 50
+    DestructionDelay = 2000
+    DestructionDelayVariance = 300
+    FX  = INITIAL  FX_CrusaderCatchFire
+    OCL = FINAL    OCL_MicrowaveTankDeath
+    FX  = FINAL    FX_GenericTankDeathExplosion
+  End
+
   Behavior                 = TransitionDamageFX ModuleTag_12
     ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -7095,6 +7095,17 @@ Object Lazr_AmericaTankMicrowave
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
+  ; Patch104p @tweak xezon 25/04/2023 Adds catch fire, and explode death. (#1874)
+  Behavior = SlowDeathBehavior ModuleTag_11
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 50
+    DestructionDelay = 2000
+    DestructionDelayVariance = 300
+    FX  = INITIAL  FX_CrusaderCatchFire
+    OCL = FINAL    OCL_MicrowaveTankDeath
+    FX  = FINAL    FX_GenericTankDeathExplosion
+  End
+
   Behavior                 = TransitionDamageFX ModuleTag_12
     ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -7566,6 +7566,17 @@ Object SupW_AmericaTankMicrowave
     FX  = FINAL    FX_GenericTankDeathExplosion
   End
 
+  ; Patch104p @tweak xezon 25/04/2023 Adds catch fire, and explode death. (#1874)
+  Behavior = SlowDeathBehavior ModuleTag_11
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    ProbabilityModifier = 50
+    DestructionDelay = 2000
+    DestructionDelayVariance = 300
+    FX  = INITIAL  FX_CrusaderCatchFire
+    OCL = FINAL    OCL_MicrowaveTankDeath
+    FX  = FINAL    FX_GenericTankDeathExplosion
+  End
+
   Behavior                 = TransitionDamageFX ModuleTag_12
     ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition


### PR DESCRIPTION
This change adds the catch fire death effect variant to USA Microwave Tank. This chassis looks similar to Crusader, Paladin, so it can also have the catch fire variant.

| Object                                    | FX_CrusaderCatchFire chance |
|-------------------------------------------|-----------------------------|
| **Patched AmericaTankMicrowave (this)**   | 50%
| Original AmericaVehicleDozer              | 100%
| Original AmericaTankCrusader              | 50%
| Original AmericaTankPaladin               | 50%
| Original AmericaTankAvenger               | 50%
| Original ChinaVehicleDozer                | 100%
| Original ChinaVehicleInfernoCannon        | 100%
| Original GLATankScorpion                  | 100%
| Original GLATankMarauder                  | 100%
| Original GLAVehicleScudLauncher           | 100%
