### PR TITLE
Fix: Add smoke particles to wrecks of China Troop Crawler, Listening Outpost

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1875_outpost_crawler_wreck_smoke.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1875_outpost_crawler_wreck_smoke.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-24
+
+title: Adds missing smoke particles to wrecks of China Troop Crawler, Listening Outpost
+
+changes:
+  - tweak: The wrecks of the China Troop Crawler and Listening Outpost now emit faint smoke particles.
+
+labels:
+  - china
+  - design
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1875
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -808,6 +808,10 @@ Object ChinaVehicleTroopCrawlerDeadHull
     DestructionDelay  = 9500
   End
 
+  ; Patch104p @fix xezon 24/04/2023 Adds missing wreck particles. (#1875)
+  Behavior = TransitionDamageFX ModuleTag_06
+    RubbleParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+  End
 
   Geometry = BOX
   GeometryMajorRadius = 9.0
@@ -863,6 +867,10 @@ Object ChinaVehicleAssaultTroopCrawlerDeadHull
     DestructionDelay  = 9500
   End
 
+  ; Patch104p @fix xezon 24/04/2023 Adds missing wreck particles. (#1875)
+  Behavior = TransitionDamageFX ModuleTag_06
+    RubbleParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+  End
 
   Geometry = BOX
   GeometryMajorRadius = 9.0
@@ -2026,6 +2034,10 @@ Object ChinaVehicleListeningOutpostDeadHull
     DestructionDelay  = 9500
   End
 
+  ; Patch104p @fix xezon 24/04/2023 Adds missing wreck particles. (#1875)
+  Behavior = TransitionDamageFX ModuleTag_06
+    RubbleParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+  End
 
   Geometry = BOX
   GeometryMajorRadius = 9.0


### PR DESCRIPTION
This change adds smoke particles to the wrecks of China Troop Crawler, Listening Outpost. Several other china vehicle wrecks already have it as well.

## Patched

![shot_20230426_172907_3](https://user-images.githubusercontent.com/4720891/234625684-7847086a-24db-4eaa-bbfb-1ad27e4b717c.jpg)

![shot_20230426_173006_5](https://user-images.githubusercontent.com/4720891/234625695-6e361f6e-f166-405e-a887-c9a2fa7e6782.jpg)
