### PR TITLE
Change: Move Radar upgrade button of China Command Center in optional bundle only

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1861_china_radar_button_placement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1861_china_radar_button_placement.yaml
@@ -10,10 +10,12 @@ labels:
   - china
   - gui
   - minor
+  - optional
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1861
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1884
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1884_boss_radar_button_placement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1884_boss_radar_button_placement.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-29
+
+title: Moves Radar upgrade button of Boss Command Center to where China Radar upgrade button is positioned
+
+changes:
+  - tweak: Moves the Radar upgrade button of Boss Command Center to where China Radar upgrade button is positioned. It is now consistent with the placement on the China Command Center.
+
+labels:
+  - boss
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1884
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -848,8 +848,13 @@ CommandSet ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -864,8 +869,13 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3165,8 +3175,13 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3183,8 +3198,13 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3893,8 +3913,13 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Early_Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -3924,8 +3949,13 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Early_Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -4699,8 +4729,13 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -4715,8 +4750,13 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage
   7  = Early_Command_EmergencyRepair
   8  = Command_EMPPulse
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar
+;patch104p-core-end
   10 = Command_Frenzy
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar ; Patch104p @tweak from 9 (#1861)
+;patch104p-optional-end
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -5046,7 +5086,12 @@ CommandSet Boss_ChinaCommandCenterCommandSet
   6  = Command_ArtilleryBarrage ; Patch104p @tweak from 5
   7  = Command_SneakAttack ; Patch104p @tweak from 9
   8  = Command_EMPPulse ; Patch104p @tweak from 6
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar ; Patch104p @tweak from 11
+;patch104p-core-end
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar
+;patch104p-optional-end
   12 = Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
@@ -5061,7 +5106,12 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   6  = Command_ArtilleryBarrage ; Patch104p @tweak from 5
   7  = Command_SneakAttack ; Patch104p @tweak from 9
   8  = Command_EMPPulse ; Patch104p @tweak from 6
+;patch104p-core-begin
+  9  = Command_UpgradeChinaRadar ; Patch104p @tweak from 11
+;patch104p-core-end
+;patch104p-optional-begin
   11 = Command_UpgradeChinaRadar
+;patch104p-optional-end
   12 = Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell

--- a/Patch104pZH/ModBundleFullPacks.json
+++ b/Patch104pZH/ModBundleFullPacks.json
@@ -7,6 +7,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioArabic",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -24,6 +25,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioBrazilian",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -41,6 +43,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioChinese",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -58,6 +61,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioEnglish",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -75,6 +79,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioFrench",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -91,6 +96,7 @@
                 "name": "FullGerman",
                 "itemNames": [
                     "AxOptionalAudio",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -108,6 +114,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioItalian",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -125,6 +132,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioKorean",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -142,6 +150,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioPolish",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -158,6 +167,7 @@
                 "name": "FullRussian",
                 "itemNames": [
                     "AxOptionalAudio",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",
@@ -175,6 +185,7 @@
                 "itemNames": [
                     "AxOptionalAudio",
                     "AxOptionalAudioSpanish",
+                    "AxOptionalINI",
                     "AxOptionalTextures",
                     "AxOptionalW3D",
                     "CoreAudio",

--- a/Patch104pZH/ModBundleItems.json
+++ b/Patch104pZH/ModBundleItems.json
@@ -337,7 +337,38 @@
                             "deleteComments": ";",
                             "deleteWhitespace": 1,
                             "sourceEncoding": "ascii",
-                            "targetEncoding": "ascii"
+                            "targetEncoding": "ascii",
+                            "excludeMarkersList": [
+                                [
+                                    ";patch104p-optional-begin",
+                                    ";patch104p-optional-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "AxOptionalINI",
+                "big": true,
+                "files": [
+                    {
+                        "parent": "GameFilesEdited",
+                        "sourceList": [
+                            "Data/INI/CommandSet.ini"
+                        ],
+                        "params": {
+                            "forceEOL": "\r\n",
+                            "deleteComments": ";",
+                            "deleteWhitespace": 1,
+                            "sourceEncoding": "ascii",
+                            "targetEncoding": "ascii",
+                            "excludeMarkersList": [
+                                [
+                                    ";patch104p-core-begin",
+                                    ";patch104p-core-end"
+                                ]
+                            ]
                         }
                     }
                 ]


### PR DESCRIPTION
* Follow up for #1861

This change moves the Radar upgrade button position for optional bundle only. Radar button for both Boss and China will take original China Radar button position. This way legacy players are not confused by new Radar button position.
