### PR TITLE
Change: Optimize Clean Toxins button placement of USA Ambulance

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1885_clean_toxins_button_placement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1885_clean_toxins_button_placement.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-04-30
+
+title: Optimizes Clean Toxins button placement of USA Ambulance, HazMat Infantry
+
+changes:
+  - tweak: The Clean Toxins button of the USA Ambulance is now optionally placed on slot 12.
+  - tweak: The Clean Toxins button of the HazMat Infantry is now optionally placed on slot 12.
+
+labels:
+  - gui
+  - minor
+  - optional
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1885
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -619,14 +619,24 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   6  = Command_TransportExit
   7  = Command_TransportExit
   9  = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
+;patch104p-core-begin
   10 = Command_AmbulanceCleanupArea
+;patch104p-core-end
   11 = Command_AttackMove
+;patch104p-optional-begin
+  12 = Command_AmbulanceCleanupArea ; Patch104p @tweak Moves button to the right side. (#1885)
+;patch104p-optional-end
   13 = Command_Guard
   14 = Command_Stop
 End
 
 CommandSet AmericaInfantryHazMatCommandSet
+;patch104p-core-begin
   1  = Command_AmbulanceCleanupArea
+;patch104p-core-end
+;patch104p-optional-begin
+  12 = Command_AmbulanceCleanupArea ; Patch104p @tweak Moves button to the right side. (#1885)
+;patch104p-optional-end
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -4059,8 +4069,13 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   6  = Command_TransportExit
   7  = Command_TransportExit
   9  = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
+;patch104p-core-begin
   10 = Command_AmbulanceCleanupArea
+;patch104p-core-end
   11 = Command_AttackMove
+;patch104p-optional-begin
+  12 = Command_AmbulanceCleanupArea ; Patch104p @tweak Moves button to the right side. (#1885)
+;patch104p-optional-end
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -4933,8 +4948,13 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   6  = Command_TransportExit
   7  = Command_TransportExit
   9  = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
+;patch104p-core-begin
   10 = Command_AmbulanceCleanupArea
+;patch104p-core-end
   11 = Command_AttackMove
+;patch104p-optional-begin
+  12 = Command_AmbulanceCleanupArea ; Patch104p @tweak Moves button to the right side. (#1885)
+;patch104p-optional-end
   13 = Command_Guard
   14 = Command_Stop
 End


### PR DESCRIPTION
This change optimizes the Clean Toxins button placement of the USA Ambulance (and the unused HazMat infantry). It is moved one position to the right, according to the draft shown in the linked discussion. Optional content only.

* https://github.com/TheSuperHackers/GeneralsGamePatch/discussions/1543#discussioncomment-4685730

## Patched, Optional

![shot_20230430_080514_1](https://user-images.githubusercontent.com/4720891/235338664-62298c76-713f-40bf-94ee-9d9fc7b4bab7.jpg)
