### PR TITLE
Change: Optimize button placements of Boss Dozer

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1886_boss_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1886_boss_dozer_buttons.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-30
+
+title: Optimizes button placements of Boss Dozer
+
+changes:
+  - tweak: Optimizes button placements of Boss Dozer. The buttons are now placed at more familiar China button positions. This makes it easier to locate the buttons when one is familiar with the China button positions.
+
+labels:
+  - boss
+  - gui
+  - minor
+  - optional
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1886
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1888_china_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1888_china_dozer_buttons.yaml
@@ -4,7 +4,7 @@ date: 2023-04-30
 title: Optimizes button placements of China Dozer
 
 changes:
-  - fix: Optimizes button placements of China Dozer. Swaps the positions of Airfield, Propaganda Center and Internet Center to achieve consistency with button placements of USA Dozer and GLA Worker.
+  - tweak: Optimizes button placements of China Dozer. Swaps the positions of Airfield, Propaganda Center and Internet Center to achieve consistency with button placements of USA Dozer and GLA Worker.
 
 labels:
   - china

--- a/Patch104pZH/Design/Changes/v1.0/1889_usa_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1889_usa_dozer_buttons.yaml
@@ -4,7 +4,7 @@ date: 2023-04-30
 title: Optimizes button placements of USA Dozer
 
 changes:
-  - fix: Optimizes button placements of USA Dozer. Swaps the positions of Airfield, Strategy Center, Supply Drop Zone, Particle Cannon, Command Center to achieve consistency with button placements of China Dozer and GLA Worker.
+  - tweak: Optimizes button placements of USA Dozer. Swaps the positions of Airfield, Strategy Center, Supply Drop Zone, Particle Cannon, Command Center to achieve consistency with button placements of China Dozer and GLA Worker.
 
 labels:
   - gui

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5447,21 +5447,40 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
 End
 
 
+; Patch104p @tweak xezon 30/04/2023 Moves buttons into more familiar China button positions. (#1886)
 CommandSet Boss_AmericaDozerCommandSet
+;patch104p-core-begin
   1  = Boss_Command_ConstructAmericaPowerPlant
-  2  = Boss_Command_ConstructChinaBunker
-  3  = Boss_Command_ConstructChinaSupplyCenter
-  4  = Boss_Command_ConstructChinaGattlingCannon
-  5  = Boss_Command_ConstructChinaBarracks
+  2  = Boss_Command_ConstructGLATunnelNetwork
+  3  = Boss_Command_ConstructChinaBarracks
+  4  = Boss_Command_ConstructChinaAirfield
+  5  = Boss_Command_ConstructChinaSupplyCenter
   6  = Boss_Command_ConstructAmericaPatriotBattery
-  7  = Boss_Command_ConstructChinaWarFactory
-  8  = Boss_Command_ConstructGLATunnelNetwork
-  9  = Boss_Command_ConstructChinaAirfield
-  10  = Boss_Command_ConstructChinaSpeakerTower
-  11 = Boss_Command_ConstructChinaNuclearMissileLauncher
+  7  = Boss_Command_ConstructChinaBunker
+  8  = Boss_Command_ConstructChinaSpeakerTower
+  9  = Boss_Command_ConstructChinaGattlingCannon
+  10 = Boss_Command_ConstructChinaNuclearMissileLauncher
+  11 = Boss_Command_ConstructChinaWarFactory
   12 = Boss_Command_ConstructChinaCommandCenter
   13 = Boss_Command_ConstructGLAScudStorm
-  14  = Boss_Command_ConstructAmericaParticleCannonUplink
+  14 = Boss_Command_ConstructAmericaParticleCannonUplink
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Boss_Command_ConstructAmericaPowerPlant
+  2  = Boss_Command_ConstructChinaAirfield
+  3  = Boss_Command_ConstructChinaBarracks
+  4  = Boss_Command_ConstructGLATunnelNetwork
+  5  = Boss_Command_ConstructChinaSupplyCenter
+  6  = Boss_Command_ConstructAmericaPatriotBattery
+  7  = Boss_Command_ConstructChinaBunker
+  8  = Boss_Command_ConstructChinaSpeakerTower
+  9  = Boss_Command_ConstructChinaGattlingCannon
+  11 = Boss_Command_ConstructChinaWarFactory
+  10 = Boss_Command_ConstructChinaNuclearMissileLauncher
+  12 = Boss_Command_ConstructChinaCommandCenter
+  13 = Boss_Command_ConstructGLAScudStorm
+  14 = Boss_Command_ConstructAmericaParticleCannonUplink
+;patch104p-optional-end
 End
 
 ; Patch104p @tweak xezon 19/04/2023 Moves buttons into more familiar China button positions. (#1859)


### PR DESCRIPTION
* Split off of #1579

This change optimizes button placements of Boss Dozer. The buttons are now placed at more familiar China button positions. This makes it easier to locate the buttons when one is familiar with the China button positions.

## Original

![shot_20230430_114417_1](https://user-images.githubusercontent.com/4720891/235346670-d08453a3-85ff-4eea-b107-f62a73a5bfea.jpg)

## Patched, Core

![shot_20230430_114321_2](https://user-images.githubusercontent.com/4720891/235346708-a0a0ecb3-d522-44bc-babb-56ca39d6ae8e.jpg)

## Patched, Optional

![shot_20230430_113605_2](https://user-images.githubusercontent.com/4720891/235346721-39de957a-e06d-4020-b9e9-285c9769819d.jpg)
