### PR TITLE
Fix: Add Stop command button to all worker units

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1887_dozer_worker_stop_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1887_dozer_worker_stop_button.yaml
@@ -1,0 +1,23 @@
+---
+date: 2023-04-30
+
+title: Adds missing Stop command button to all worker units
+
+changes:
+  - fix: Adds the Stop command button to all worker units (except Boss). This way button can be pressed to stop worker units, including in group selection with other units. The Clear Mines, GLA Fake Structures and USA Airfield buttons had to be moved to make room for the Stop button.
+
+labels:
+  - bug
+  - china
+  - gla
+  - gui
+  - minor
+  - optional
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1887
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -40,7 +40,10 @@ CommandSet EmptyCommandSet
 End
 
 ; Dozer Command Sets ----------------------------------------------------------
+
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
 CommandSet AmericaDozerCommandSet
+;patch104p-core-begin
   1  = Command_ConstructAmericaPowerPlant
   2  = Command_ConstructAmericaStrategyCenter
   3  = Command_ConstructAmericaBarracks
@@ -53,9 +56,27 @@ CommandSet AmericaDozerCommandSet
   11 = Command_ConstructAmericaWarFactory
   13 = Command_ConstructAmericaAirfield
   14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Command_ConstructAmericaPowerPlant
+  2  = Command_ConstructAmericaStrategyCenter
+  3  = Command_ConstructAmericaBarracks
+  4  = Command_ConstructAmericaSupplyDropZone
+  5  = Command_ConstructAmericaSupplyCenter
+  6  = Command_ConstructAmericaParticleCannonUplink
+  7  = Command_ConstructAmericaPatriotBattery
+  8  = Command_ConstructAmericaCommandCenter
+  9  = Command_ConstructAmericaFireBase
+  10 = Command_ConstructAmericaAirfield
+  11 = Command_ConstructAmericaWarFactory
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
+;patch104p-optional-end
 End
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet GLAWorkerCommandSet
+;patch104p-core-begin
   1  = Command_ConstructGLASupplyStash
   2  = Command_ConstructGLADemoTrap
   3  = Command_ConstructGLABarracks
@@ -68,10 +89,28 @@ CommandSet GLAWorkerCommandSet
  10  = Command_ConstructGLACommandCenter
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Command_ConstructGLASupplyStash
+  2  = Command_ConstructGLADemoTrap
+  3  = Command_ConstructGLABarracks
+  4  = Command_ConstructGLAPalace
+  5  = Command_ConstructGLAStingerSite
+  6  = Command_ConstructGLABlackMarket
+  7  = Command_ConstructGLATunnelNetwork
+  8  = Command_ConstructGLAScudStorm
+  9  = Command_ConstructGLAArmsDealer
+ 10  = Command_ConstructGLACommandCenter
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet GLAWorkerFakeBuildingsCommandSet
+;patch104p-core-begin
   1 = Command_ConstructFakeGLACommandCenter
   2 = Command_ConstructFakeGLABarracks
   3 = Command_ConstructFakeGLASupplyStash
@@ -79,9 +118,22 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   5 = Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
  14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1 = Command_ConstructFakeGLACommandCenter
+  2 = Command_ConstructFakeGLABarracks
+  3 = Command_ConstructFakeGLASupplyStash
+  4 = Command_ConstructFakeGLAArmsDealer
+  5 = Command_ConstructFakeGLABlackMarket
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
 CommandSet ChinaDozerCommandSet
+;patch104p-core-begin
   1  = Command_ConstructChinaPowerPlant
   2  = Command_ConstructChinaInternetCenter
   3  = Command_ConstructChinaBarracks
@@ -95,6 +147,23 @@ CommandSet ChinaDozerCommandSet
  11  = Command_ConstructChinaWarFactory
  12  = Command_ConstructChinaCommandCenter
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Command_ConstructChinaPowerPlant
+  2  = Command_ConstructChinaInternetCenter
+  3  = Command_ConstructChinaBarracks
+  4  = Command_ConstructChinaAirfield
+  5  = Command_ConstructChinaSupplyCenter
+  6  = Command_ConstructChinaPropagandaCenter
+  7  = Command_ConstructChinaBunker
+  8  = Command_ConstructChinaSpeakerTower
+  9  = Command_ConstructChinaGattlingCannon
+ 10  = Command_ConstructChinaNuclearMissileLauncher
+ 11  = Command_ConstructChinaWarFactory
+ 12  = Command_ConstructChinaCommandCenter
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 ; Unit Command Sets -----------------------------------------------------------
@@ -1508,7 +1577,9 @@ CommandSet GC_Chem_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
 CommandSet GC_Chem_GLAWorkerCommandSet
+;patch104p-core-begin
   1  = GC_Chem_Command_ConstructGLASupplyStash
   2  = GC_Chem_Command_ConstructGLADemoTrap
   3  = GC_Chem_Command_ConstructGLABarracks
@@ -1520,6 +1591,21 @@ CommandSet GC_Chem_GLAWorkerCommandSet
   9  = GC_Chem_Command_ConstructGLAArmsDealer
  10  = GC_Chem_Command_ConstructGLACommandCenter
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = GC_Chem_Command_ConstructGLASupplyStash
+  2  = GC_Chem_Command_ConstructGLADemoTrap
+  3  = GC_Chem_Command_ConstructGLABarracks
+  4  = GC_Chem_Command_ConstructGLAPalace
+  5  = GC_Chem_Command_ConstructGLAStingerSite
+  6  = GC_Chem_Command_ConstructGLABlackMarket
+  7  = GC_Chem_Command_ConstructGLATunnelNetwork
+  8  = GC_Chem_Command_ConstructGLAScudStorm
+  9  = GC_Chem_Command_ConstructGLAArmsDealer
+ 10  = GC_Chem_Command_ConstructGLACommandCenter
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet GC_Chem_GLABarracksCommandSet
@@ -1632,7 +1718,9 @@ CommandSet GC_Slth_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
 CommandSet GC_Slth_GLAWorkerCommandSet
+;patch104p-core-begin
   1  = GC_Slth_Command_ConstructGLASupplyStash
   2  = GC_Slth_Command_ConstructGLADemoTrap
   3  = GC_Slth_Command_ConstructGLABarracks
@@ -1644,6 +1732,21 @@ CommandSet GC_Slth_GLAWorkerCommandSet
   9  = GC_Slth_Command_ConstructGLAArmsDealer
  10  = GC_Slth_Command_ConstructGLACommandCenter
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = GC_Slth_Command_ConstructGLASupplyStash
+  2  = GC_Slth_Command_ConstructGLADemoTrap
+  3  = GC_Slth_Command_ConstructGLABarracks
+  4  = GC_Slth_Command_ConstructGLAPalace
+  5  = GC_Slth_Command_ConstructGLAStingerSite
+  6  = GC_Slth_Command_ConstructGLABlackMarket
+  7  = GC_Slth_Command_ConstructGLATunnelNetwork
+  8  = GC_Slth_Command_ConstructGLAScudStorm
+  9  = GC_Slth_Command_ConstructGLAArmsDealer
+ 10  = GC_Slth_Command_ConstructGLACommandCenter
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet GC_Slth_GLACommandCenterCommandSet
@@ -1815,7 +1918,9 @@ CommandSet AirF_SpecialPowerShortcutUSA
   11 = AirF_Command_CarpetBombFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
 CommandSet AirF_AmericaDozerCommandSet
+;patch104p-core-begin
   1  = AirF_Command_ConstructAmericaPowerPlant
   2  = AirF_Command_ConstructAmericaStrategyCenter
   3  = AirF_Command_ConstructAmericaBarracks
@@ -1828,6 +1933,22 @@ CommandSet AirF_AmericaDozerCommandSet
   11 = AirF_Command_ConstructAmericaWarFactory
   13 = AirF_Command_ConstructAmericaAirfield
   14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = AirF_Command_ConstructAmericaPowerPlant
+  2  = AirF_Command_ConstructAmericaStrategyCenter
+  3  = AirF_Command_ConstructAmericaBarracks
+  4  = AirF_Command_ConstructAmericaSupplyDropZone
+  5  = AirF_Command_ConstructAmericaSupplyCenter
+  6  = AirF_Command_ConstructAmericaParticleCannonUplink
+  7  = AirF_Command_ConstructAmericaPatriotBattery
+  8  = AirF_Command_ConstructAmericaCommandCenter
+  9  = AirF_Command_ConstructAmericaFireBase
+  10 = AirF_Command_ConstructAmericaAirfield
+  11 = AirF_Command_ConstructAmericaWarFactory
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet AirF_AmericaCommandCenterCommandSet
@@ -2052,7 +2173,9 @@ CommandSet Demo_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Demo_GLAWorkerCommandSet
+;patch104p-core-begin
   1  = Demo_Command_ConstructGLASupplyStash
   2  = Demo_Command_ConstructGLADemoTrap
   3  = Demo_Command_ConstructGLABarracks
@@ -2065,10 +2188,28 @@ CommandSet Demo_GLAWorkerCommandSet
  10  = Demo_Command_ConstructGLACommandCenter
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Demo_Command_ConstructGLASupplyStash
+  2  = Demo_Command_ConstructGLADemoTrap
+  3  = Demo_Command_ConstructGLABarracks
+  4  = Demo_Command_ConstructGLAPalace
+  5  = Demo_Command_ConstructGLAStingerSite
+  6  = Demo_Command_ConstructGLABlackMarket
+  7  = Demo_Command_ConstructGLATunnelNetwork
+  8  = Demo_Command_ConstructGLAScudStorm
+  9  = Demo_Command_ConstructGLAArmsDealer
+ 10  = Demo_Command_ConstructGLACommandCenter
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
+;patch104p-core-begin
   1 = Demo_Command_ConstructFakeGLACommandCenter
   2 = Demo_Command_ConstructFakeGLABarracks
   3 = Demo_Command_ConstructFakeGLASupplyStash
@@ -2076,6 +2217,17 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   5 = Demo_Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
  14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1 = Demo_Command_ConstructFakeGLACommandCenter
+  2 = Demo_Command_ConstructFakeGLABarracks
+  3 = Demo_Command_ConstructFakeGLASupplyStash
+  4 = Demo_Command_ConstructFakeGLAArmsDealer
+  5 = Demo_Command_ConstructFakeGLABlackMarket
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -2372,7 +2524,9 @@ CommandSet Demo_GLATankScorpionCommandSetUpgrade
   14 = Command_Stop
 End
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Demo_GLAWorkerCommandSetUpgrade
+;patch104p-core-begin
   1  = Demo_Command_ConstructGLASupplyStash
   2  = Demo_Command_ConstructGLADemoTrap
   3  = Demo_Command_ConstructGLABarracks
@@ -2386,11 +2540,30 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
  12  = Demo_Command_TertiarySuicide
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Demo_Command_ConstructGLASupplyStash
+  2  = Demo_Command_ConstructGLADemoTrap
+  3  = Demo_Command_ConstructGLABarracks
+  4  = Demo_Command_ConstructGLAPalace
+  5  = Demo_Command_ConstructGLAStingerSite
+  6  = Demo_Command_ConstructGLABlackMarket
+  7  = Demo_Command_ConstructGLATunnelNetwork
+  8  = Demo_Command_ConstructGLAScudStorm
+  9  = Demo_Command_ConstructGLAArmsDealer
+ 10  = Demo_Command_ConstructGLACommandCenter
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 12  = Demo_Command_TertiarySuicide
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 ; Patch104p @bugfix commy2 03/09/2021 Used for fake buildings after Demolitions upgrade is researched.
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
+;patch104p-core-begin
   1 = Demo_Command_ConstructFakeGLACommandCenter
   2 = Demo_Command_ConstructFakeGLABarracks
   3 = Demo_Command_ConstructFakeGLASupplyStash
@@ -2399,6 +2572,18 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
  12 = Demo_Command_TertiarySuicide
  13 = Command_UpgradeGLAWorkerRealCommandSet
  14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1 = Demo_Command_ConstructFakeGLACommandCenter
+  2 = Demo_Command_ConstructFakeGLABarracks
+  3 = Demo_Command_ConstructFakeGLASupplyStash
+  4 = Demo_Command_ConstructFakeGLAArmsDealer
+  5 = Demo_Command_ConstructFakeGLABlackMarket
+ 12 = Demo_Command_TertiarySuicide
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -2654,7 +2839,9 @@ CommandSet Slth_SpecialPowerShortcutGLA
   7 = Slth_Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Slth_GLAWorkerCommandSet
+;patch104p-core-begin
   1  = Slth_Command_ConstructGLASupplyStash
   2  = Slth_Command_ConstructGLADemoTrap
   3  = Slth_Command_ConstructGLABarracks
@@ -2667,10 +2854,28 @@ CommandSet Slth_GLAWorkerCommandSet
  10  = Slth_Command_ConstructGLACommandCenter
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Slth_Command_ConstructGLASupplyStash
+  2  = Slth_Command_ConstructGLADemoTrap
+  3  = Slth_Command_ConstructGLABarracks
+  4  = Slth_Command_ConstructGLAPalace
+  5  = Slth_Command_ConstructGLAStingerSite
+  6  = Slth_Command_ConstructGLABlackMarket
+  7  = Slth_Command_ConstructGLATunnelNetwork
+  8  = Slth_Command_ConstructGLAScudStorm
+  9  = Slth_Command_ConstructGLAArmsDealer
+ 10  = Slth_Command_ConstructGLACommandCenter
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
+;patch104p-core-begin
   1 = Slth_Command_ConstructFakeGLACommandCenter
   2 = Slth_Command_ConstructFakeGLABarracks
   3 = Slth_Command_ConstructFakeGLASupplyStash
@@ -2678,6 +2883,17 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   5 = Slth_Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
  14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1 = Slth_Command_ConstructFakeGLACommandCenter
+  2 = Slth_Command_ConstructFakeGLABarracks
+  3 = Slth_Command_ConstructFakeGLASupplyStash
+  4 = Slth_Command_ConstructFakeGLAArmsDealer
+  5 = Slth_Command_ConstructFakeGLABlackMarket
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -2941,7 +3157,9 @@ CommandSet Chem_SpecialPowerShortcutGLA
   ;7 = Command_GPSScramblerFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerFakeCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Chem_GLAWorkerCommandSet
+;patch104p-core-begin
   1  = Chem_Command_ConstructGLASupplyStash
   2  = Chem_Command_ConstructGLADemoTrap
   3  = Chem_Command_ConstructGLABarracks
@@ -2954,10 +3172,28 @@ CommandSet Chem_GLAWorkerCommandSet
  10  = Chem_Command_ConstructGLACommandCenter
  13  = Command_UpgradeGLAWorkerFakeCommandSet
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Chem_Command_ConstructGLASupplyStash
+  2  = Chem_Command_ConstructGLADemoTrap
+  3  = Chem_Command_ConstructGLABarracks
+  4  = Chem_Command_ConstructGLAPalace
+  5  = Chem_Command_ConstructGLAStingerSite
+  6  = Chem_Command_ConstructGLABlackMarket
+  7  = Chem_Command_ConstructGLATunnelNetwork
+  8  = Chem_Command_ConstructGLAScudStorm
+  9  = Chem_Command_ConstructGLAArmsDealer
+ 10  = Chem_Command_ConstructGLACommandCenter
+ 11  = Command_UpgradeGLAWorkerFakeCommandSet
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 ; Patch104p @fix Preserve Command_DisarmMinesAtPosition button in Fake Buildings command set.
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, UpgradeGLAWorkerRealCommandSet from 13 to 11 to make room for it. (#1887)
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
+;patch104p-core-begin
   1 = Chem_Command_ConstructFakeGLACommandCenter
   2 = Chem_Command_ConstructFakeGLABarracks
   3 = Chem_Command_ConstructFakeGLASupplyStash
@@ -2965,6 +3201,17 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   5 = Chem_Command_ConstructFakeGLABlackMarket
  13 = Command_UpgradeGLAWorkerRealCommandSet
  14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1 = Chem_Command_ConstructFakeGLACommandCenter
+  2 = Chem_Command_ConstructFakeGLABarracks
+  3 = Chem_Command_ConstructFakeGLASupplyStash
+  4 = Chem_Command_ConstructFakeGLAArmsDealer
+  5 = Chem_Command_ConstructFakeGLABlackMarket
+ 11 = Command_UpgradeGLAWorkerRealCommandSet
+ 13 = Command_DisarmMinesAtPosition
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Chem_GLABarracksCommandSet
@@ -3144,7 +3391,9 @@ CommandSet Nuke_SpecialPowerShortcutChina
   10 = Command_FrenzyFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
 CommandSet Nuke_ChinaDozerCommandSet
+;patch104p-core-begin
   1  = Nuke_Command_ConstructChinaPowerPlant
   2  = Nuke_Command_ConstructChinaInternetCenter
   3  = Nuke_Command_ConstructChinaBarracks
@@ -3158,6 +3407,23 @@ CommandSet Nuke_ChinaDozerCommandSet
  11  = Nuke_Command_ConstructChinaWarFactory
  12  = Nuke_Command_ConstructChinaCommandCenter
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Nuke_Command_ConstructChinaPowerPlant
+  2  = Nuke_Command_ConstructChinaInternetCenter
+  3  = Nuke_Command_ConstructChinaBarracks
+  4  = Nuke_Command_ConstructChinaAirfield
+  5  = Nuke_Command_ConstructChinaSupplyCenter
+  6  = Nuke_Command_ConstructChinaPropagandaCenter
+  7  = Nuke_Command_ConstructChinaBunker
+  8  = Nuke_Command_ConstructChinaSpeakerTower
+  9  = Nuke_Command_ConstructChinaGattlingCannon
+ 10  = Nuke_Command_ConstructChinaNuclearMissileLauncher
+ 11  = Nuke_Command_ConstructChinaWarFactory
+ 12  = Nuke_Command_ConstructChinaCommandCenter
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 
@@ -3544,7 +3810,9 @@ CommandSet SupW_SpecialPowerShortcutUSA
   10 = Command_CIAIntelligenceFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
 CommandSet SupW_AmericaDozerCommandSet
+;patch104p-core-begin
   1  = SupW_Command_ConstructAmericaPowerPlant
   2  = SupW_Command_ConstructAmericaStrategyCenter
   3  = SupW_Command_ConstructAmericaBarracks
@@ -3557,6 +3825,22 @@ CommandSet SupW_AmericaDozerCommandSet
   11 = SupW_Command_ConstructAmericaWarFactory
   13 = SupW_Command_ConstructAmericaAirfield
   14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = SupW_Command_ConstructAmericaPowerPlant
+  2  = SupW_Command_ConstructAmericaStrategyCenter
+  3  = SupW_Command_ConstructAmericaBarracks
+  4  = SupW_Command_ConstructAmericaSupplyDropZone
+  5  = SupW_Command_ConstructAmericaSupplyCenter
+  6  = SupW_Command_ConstructAmericaParticleCannonUplink
+  7  = SupW_Command_ConstructAmericaPatriotBattery
+  8  = SupW_Command_ConstructAmericaCommandCenter
+  9  = SupW_Command_ConstructAmericaFireBase
+  10 = SupW_Command_ConstructAmericaAirfield
+  11 = SupW_Command_ConstructAmericaWarFactory
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet SupW_AmericaBarracksCommandSet
@@ -3897,7 +4181,9 @@ CommandSet Infa_SpecialPowerShortcutChina
 END
 
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
 CommandSet Infa_ChinaDozerCommandSet
+;patch104p-core-begin
   1  = Infa_Command_ConstructChinaPowerPlant
   2  = Infa_Command_ConstructChinaInternetCenter
   3  = Infa_Command_ConstructChinaBarracks
@@ -3911,6 +4197,23 @@ CommandSet Infa_ChinaDozerCommandSet
  11  = Infa_Command_ConstructChinaWarFactory
  12  = Infa_Command_ConstructChinaCommandCenter
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Infa_Command_ConstructChinaPowerPlant
+  2  = Infa_Command_ConstructChinaInternetCenter
+  3  = Infa_Command_ConstructChinaBarracks
+  4  = Infa_Command_ConstructChinaAirfield
+  5  = Infa_Command_ConstructChinaSupplyCenter
+  6  = Infa_Command_ConstructChinaPropagandaCenter
+  7  = Infa_Command_ConstructChinaBunker
+  8  = Infa_Command_ConstructChinaSpeakerTower
+  9  = Infa_Command_ConstructChinaGattlingCannon
+ 10  = Infa_Command_ConstructChinaNuclearMissileLauncher
+ 11  = Infa_Command_ConstructChinaWarFactory
+ 12  = Infa_Command_ConstructChinaCommandCenter
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Infa_ChinaPowerPlantCommandSet
@@ -4372,7 +4675,9 @@ CommandSet Lazr_SpecialPowerShortcutUSA
   11 = Lazr_Command_FireLaserCannonFromShortcut
 END
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
 CommandSet Lazr_AmericaDozerCommandSet
+;patch104p-core-begin
   1  = Lazr_Command_ConstructAmericaPowerPlant
   2  = Lazr_Command_ConstructAmericaStrategyCenter
   3  = Lazr_Command_ConstructAmericaBarracks
@@ -4386,6 +4691,23 @@ CommandSet Lazr_AmericaDozerCommandSet
   11 = Lazr_Command_ConstructAmericaWarFactory
   13 = Lazr_Command_ConstructAmericaAirfield
   14 = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Lazr_Command_ConstructAmericaPowerPlant
+  2  = Lazr_Command_ConstructAmericaStrategyCenter
+  3  = Lazr_Command_ConstructAmericaBarracks
+  4  = Lazr_Command_ConstructAmericaSupplyDropZone
+  5  = Lazr_Command_ConstructAmericaSupplyCenter
+; 6  = Lazr_Command_ConstructLaserCannon
+  6  = Lazr_Command_ConstructAmericaParticleCannonUplink
+  7  = Lazr_Command_ConstructAmericaPatriotBattery
+  8  = Lazr_Command_ConstructAmericaCommandCenter
+  9  = Lazr_Command_ConstructAmericaFireBase
+  10 = Lazr_Command_ConstructAmericaAirfield
+  11 = Lazr_Command_ConstructAmericaWarFactory
+  13 = Command_DisarmMinesAtPosition
+  14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -4710,7 +5032,9 @@ CommandSet Tank_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut
 End
 
+; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
 CommandSet Tank_ChinaDozerCommandSet
+;patch104p-core-begin
   1  = Tank_Command_ConstructChinaPowerPlant
   2  = Tank_Command_ConstructChinaInternetCenter
   3  = Tank_Command_ConstructChinaBarracks
@@ -4724,6 +5048,23 @@ CommandSet Tank_ChinaDozerCommandSet
  11  = Tank_Command_ConstructChinaWarFactory
  12  = Tank_Command_ConstructChinaCommandCenter
  14  = Command_DisarmMinesAtPosition
+;patch104p-core-end
+;patch104p-optional-begin
+  1  = Tank_Command_ConstructChinaPowerPlant
+  2  = Tank_Command_ConstructChinaInternetCenter
+  3  = Tank_Command_ConstructChinaBarracks
+  4  = Tank_Command_ConstructChinaAirfield
+  5  = Tank_Command_ConstructChinaSupplyCenter
+  6  = Tank_Command_ConstructChinaPropagandaCenter
+  7  = Tank_Command_ConstructChinaBunker
+  8  = Tank_Command_ConstructChinaSpeakerTower
+  9  = Tank_Command_ConstructChinaGattlingCannon
+ 10  = Tank_Command_ConstructChinaNuclearMissileLauncher
+ 11  = Tank_Command_ConstructChinaWarFactory
+ 12  = Tank_Command_ConstructChinaCommandCenter
+ 13  = Command_DisarmMinesAtPosition
+ 14  = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSet


### PR DESCRIPTION
* Split off of #1579

This change adds the Stop command button to all worker units (except Boss). This way button can be pressed to stop worker units, including in group selection with other units.

To put the Stop button at its expected position, the Clear Mines, GLA Fake Structures and USA Airfield buttons had to be moved.

This change applies to the optional Patch bundle only.

### Advantages

* Stop button added
* Clear Mines button now at same Position as Guard Mode button
* USA Airfield button is closer to other structures, and in same row as China Airfield

### Disadvantages

* Clear Mines, GLA Fake Structures, USA Airfield buttons moved
* GLA Fake Structures button is closer to Arms Dealer button

## Patched, Before

![shot_20230121_131853_1](https://user-images.githubusercontent.com/4720891/213867013-6a1f373d-0a7f-47f7-997d-7dcd34b197ab.jpg)

![shot_20230121_131859_3](https://user-images.githubusercontent.com/4720891/213867014-577b515a-abc0-4513-b32f-c63ec95e3803.jpg)

![shot_20230121_131902_4](https://user-images.githubusercontent.com/4720891/213867015-59a71fff-40ac-4189-b6ad-e37fef355c92.jpg)

## Patched, After (This)

![shot_20230121_133026_2](https://user-images.githubusercontent.com/4720891/213867031-711fdab9-2da3-45e1-8640-d314ff892aa1.jpg)

![shot_20230121_133030_3](https://user-images.githubusercontent.com/4720891/213867038-551e8b2a-313f-4833-bce2-e388ff0fe097.jpg)

![shot_20230121_133037_4](https://user-images.githubusercontent.com/4720891/213867042-9a628bd6-0c26-49fe-a8da-38e4bea75c8b.jpg)

All regular worker units selected.

![shot_20230121_132855_1](https://user-images.githubusercontent.com/4720891/213867086-5cbf44fc-ae83-4d3c-b0fd-bfcb2889ec1b.jpg)
