### PR TITLE
Change: Optimize button placements of China Dozer

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1888_china_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1888_china_dozer_buttons.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-30
+
+title: Optimizes button placements of China Dozer
+
+changes:
+  - fix: Optimizes button placements of China Dozer. Swaps the positions of Airfield, Propaganda Center and Internet Center to achieve consistency with button placements of USA Dozer and GLA Worker.
+
+labels:
+  - china
+  - gui
+  - minor
+  - optional
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1888
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -132,6 +132,7 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
 End
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6. (#1888)
 CommandSet ChinaDozerCommandSet
 ;patch104p-core-begin
   1  = Command_ConstructChinaPowerPlant
@@ -150,11 +151,11 @@ CommandSet ChinaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = Command_ConstructChinaPowerPlant
-  2  = Command_ConstructChinaInternetCenter
+  2  = Command_ConstructChinaAirfield
   3  = Command_ConstructChinaBarracks
-  4  = Command_ConstructChinaAirfield
+  4  = Command_ConstructChinaPropagandaCenter
   5  = Command_ConstructChinaSupplyCenter
-  6  = Command_ConstructChinaPropagandaCenter
+  6  = Command_ConstructChinaInternetCenter
   7  = Command_ConstructChinaBunker
   8  = Command_ConstructChinaSpeakerTower
   9  = Command_ConstructChinaGattlingCannon
@@ -3392,6 +3393,7 @@ CommandSet Nuke_SpecialPowerShortcutChina
 END
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6. (#1888)
 CommandSet Nuke_ChinaDozerCommandSet
 ;patch104p-core-begin
   1  = Nuke_Command_ConstructChinaPowerPlant
@@ -3410,11 +3412,11 @@ CommandSet Nuke_ChinaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = Nuke_Command_ConstructChinaPowerPlant
-  2  = Nuke_Command_ConstructChinaInternetCenter
+  2  = Nuke_Command_ConstructChinaAirfield
   3  = Nuke_Command_ConstructChinaBarracks
-  4  = Nuke_Command_ConstructChinaAirfield
+  4  = Nuke_Command_ConstructChinaPropagandaCenter
   5  = Nuke_Command_ConstructChinaSupplyCenter
-  6  = Nuke_Command_ConstructChinaPropagandaCenter
+  6  = Nuke_Command_ConstructChinaInternetCenter
   7  = Nuke_Command_ConstructChinaBunker
   8  = Nuke_Command_ConstructChinaSpeakerTower
   9  = Nuke_Command_ConstructChinaGattlingCannon
@@ -4182,6 +4184,7 @@ END
 
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6. (#1888)
 CommandSet Infa_ChinaDozerCommandSet
 ;patch104p-core-begin
   1  = Infa_Command_ConstructChinaPowerPlant
@@ -4200,11 +4203,11 @@ CommandSet Infa_ChinaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = Infa_Command_ConstructChinaPowerPlant
-  2  = Infa_Command_ConstructChinaInternetCenter
+  2  = Infa_Command_ConstructChinaAirfield
   3  = Infa_Command_ConstructChinaBarracks
-  4  = Infa_Command_ConstructChinaAirfield
+  4  = Infa_Command_ConstructChinaPropagandaCenter
   5  = Infa_Command_ConstructChinaSupplyCenter
-  6  = Infa_Command_ConstructChinaPropagandaCenter
+  6  = Infa_Command_ConstructChinaInternetCenter
   7  = Infa_Command_ConstructChinaBunker
   8  = Infa_Command_ConstructChinaSpeakerTower
   9  = Infa_Command_ConstructChinaGattlingCannon
@@ -5033,6 +5036,7 @@ CommandSet Tank_SpecialPowerShortcutChina
 End
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 4 to 2, PropagandaCenter from 6 to 4, InternetCenter from 2 to 6. (#1888)
 CommandSet Tank_ChinaDozerCommandSet
 ;patch104p-core-begin
   1  = Tank_Command_ConstructChinaPowerPlant
@@ -5051,11 +5055,11 @@ CommandSet Tank_ChinaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = Tank_Command_ConstructChinaPowerPlant
-  2  = Tank_Command_ConstructChinaInternetCenter
+  2  = Tank_Command_ConstructChinaAirfield
   3  = Tank_Command_ConstructChinaBarracks
-  4  = Tank_Command_ConstructChinaAirfield
+  4  = Tank_Command_ConstructChinaPropagandaCenter
   5  = Tank_Command_ConstructChinaSupplyCenter
-  6  = Tank_Command_ConstructChinaPropagandaCenter
+  6  = Tank_Command_ConstructChinaInternetCenter
   7  = Tank_Command_ConstructChinaBunker
   8  = Tank_Command_ConstructChinaSpeakerTower
   9  = Tank_Command_ConstructChinaGattlingCannon


### PR DESCRIPTION
* Split off of #1579
* Follow up for #1887

This change optimizes button placements of China Dozer. Swaps the positions of Airfield, Propaganda Center and Internet Center to achieve consistency with button placements of USA Dozer and GLA Worker. This applies to the optional Patch bundle only.

Advantages:
* Airfields, Tech Centers, Money Centers share same position across all factions

Disadvantages:
* Buttons moved around

## Patched, Before

![shot_20230121_133030_3](https://user-images.githubusercontent.com/4720891/213867038-551e8b2a-313f-4833-bce2-e388ff0fe097.jpg)

## Patched, After (This)

![shot_20230128_095927_2](https://user-images.githubusercontent.com/4720891/215259567-bbad7a39-2289-47e0-8a0d-513e0233a0fd.jpg)