### PR TITLE
Change: Optimize button placements of USA Dozer

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1889_usa_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1889_usa_dozer_buttons.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-30
+
+title: Optimizes button placements of USA Dozer
+
+changes:
+  - fix: Optimizes button placements of USA Dozer. Swaps the positions of Airfield, Strategy Center, Supply Drop Zone, Particle Cannon, Command Center to achieve consistency with button placements of China Dozer and GLA Worker.
+
+labels:
+  - gui
+  - minor
+  - optional
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1889
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -42,6 +42,7 @@ End
 ; Dozer Command Sets ----------------------------------------------------------
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10. (#1889)
 CommandSet AmericaDozerCommandSet
 ;patch104p-core-begin
   1  = Command_ConstructAmericaPowerPlant
@@ -59,15 +60,15 @@ CommandSet AmericaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = Command_ConstructAmericaPowerPlant
-  2  = Command_ConstructAmericaStrategyCenter
+  2  = Command_ConstructAmericaAirfield
   3  = Command_ConstructAmericaBarracks
-  4  = Command_ConstructAmericaSupplyDropZone
+  4  = Command_ConstructAmericaStrategyCenter
   5  = Command_ConstructAmericaSupplyCenter
-  6  = Command_ConstructAmericaParticleCannonUplink
+  6  = Command_ConstructAmericaSupplyDropZone
   7  = Command_ConstructAmericaPatriotBattery
-  8  = Command_ConstructAmericaCommandCenter
+  8  = Command_ConstructAmericaParticleCannonUplink
   9  = Command_ConstructAmericaFireBase
-  10 = Command_ConstructAmericaAirfield
+  10 = Command_ConstructAmericaCommandCenter
   11 = Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop
@@ -1919,6 +1920,7 @@ CommandSet AirF_SpecialPowerShortcutUSA
 END
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10. (#1889)
 CommandSet AirF_AmericaDozerCommandSet
 ;patch104p-core-begin
   1  = AirF_Command_ConstructAmericaPowerPlant
@@ -1936,15 +1938,15 @@ CommandSet AirF_AmericaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = AirF_Command_ConstructAmericaPowerPlant
-  2  = AirF_Command_ConstructAmericaStrategyCenter
+  2  = AirF_Command_ConstructAmericaAirfield
   3  = AirF_Command_ConstructAmericaBarracks
-  4  = AirF_Command_ConstructAmericaSupplyDropZone
+  4  = AirF_Command_ConstructAmericaStrategyCenter
   5  = AirF_Command_ConstructAmericaSupplyCenter
-  6  = AirF_Command_ConstructAmericaParticleCannonUplink
+  6  = AirF_Command_ConstructAmericaSupplyDropZone
   7  = AirF_Command_ConstructAmericaPatriotBattery
-  8  = AirF_Command_ConstructAmericaCommandCenter
+  8  = AirF_Command_ConstructAmericaParticleCannonUplink
   9  = AirF_Command_ConstructAmericaFireBase
-  10 = AirF_Command_ConstructAmericaAirfield
+  10 = AirF_Command_ConstructAmericaCommandCenter
   11 = AirF_Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop
@@ -3811,6 +3813,7 @@ CommandSet SupW_SpecialPowerShortcutUSA
 END
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10. (#1889)
 CommandSet SupW_AmericaDozerCommandSet
 ;patch104p-core-begin
   1  = SupW_Command_ConstructAmericaPowerPlant
@@ -3828,15 +3831,15 @@ CommandSet SupW_AmericaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = SupW_Command_ConstructAmericaPowerPlant
-  2  = SupW_Command_ConstructAmericaStrategyCenter
+  2  = SupW_Command_ConstructAmericaAirfield
   3  = SupW_Command_ConstructAmericaBarracks
-  4  = SupW_Command_ConstructAmericaSupplyDropZone
+  4  = SupW_Command_ConstructAmericaStrategyCenter
   5  = SupW_Command_ConstructAmericaSupplyCenter
-  6  = SupW_Command_ConstructAmericaParticleCannonUplink
+  6  = SupW_Command_ConstructAmericaSupplyDropZone
   7  = SupW_Command_ConstructAmericaPatriotBattery
-  8  = SupW_Command_ConstructAmericaCommandCenter
+  8  = SupW_Command_ConstructAmericaParticleCannonUplink
   9  = SupW_Command_ConstructAmericaFireBase
-  10 = SupW_Command_ConstructAmericaAirfield
+  10 = SupW_Command_ConstructAmericaCommandCenter
   11 = SupW_Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop
@@ -4676,6 +4679,7 @@ CommandSet Lazr_SpecialPowerShortcutUSA
 END
 
 ; Patch104p @fix xezon 30/04/2023 Optionally add Stop button and move DisarmMinesAtPosition from 14 to 13, Airfield from 13 to 10 to make room for it. (#1887)
+; Patch104p @tweak xezon 30/04/2023 Optionally moves Airfield from 10 to 2, StrategyCenter from 2 to 4, SupplyDropZone from 4 to 6, ParticleCannonUplink from 6 to 8, CommandCenter from 8 to 10. (#1889)
 CommandSet Lazr_AmericaDozerCommandSet
 ;patch104p-core-begin
   1  = Lazr_Command_ConstructAmericaPowerPlant
@@ -4683,7 +4687,6 @@ CommandSet Lazr_AmericaDozerCommandSet
   3  = Lazr_Command_ConstructAmericaBarracks
   4  = Lazr_Command_ConstructAmericaSupplyDropZone
   5  = Lazr_Command_ConstructAmericaSupplyCenter
-; 6  = Lazr_Command_ConstructLaserCannon
   6  = Lazr_Command_ConstructAmericaParticleCannonUplink
   7  = Lazr_Command_ConstructAmericaPatriotBattery
   8  = Lazr_Command_ConstructAmericaCommandCenter
@@ -4694,16 +4697,15 @@ CommandSet Lazr_AmericaDozerCommandSet
 ;patch104p-core-end
 ;patch104p-optional-begin
   1  = Lazr_Command_ConstructAmericaPowerPlant
-  2  = Lazr_Command_ConstructAmericaStrategyCenter
+  2  = Lazr_Command_ConstructAmericaAirfield
   3  = Lazr_Command_ConstructAmericaBarracks
-  4  = Lazr_Command_ConstructAmericaSupplyDropZone
+  4  = Lazr_Command_ConstructAmericaStrategyCenter
   5  = Lazr_Command_ConstructAmericaSupplyCenter
-; 6  = Lazr_Command_ConstructLaserCannon
-  6  = Lazr_Command_ConstructAmericaParticleCannonUplink
+  6  = Lazr_Command_ConstructAmericaSupplyDropZone
   7  = Lazr_Command_ConstructAmericaPatriotBattery
-  8  = Lazr_Command_ConstructAmericaCommandCenter
+  8  = Lazr_Command_ConstructAmericaParticleCannonUplink
   9  = Lazr_Command_ConstructAmericaFireBase
-  10 = Lazr_Command_ConstructAmericaAirfield
+  10 = Lazr_Command_ConstructAmericaCommandCenter
   11 = Lazr_Command_ConstructAmericaWarFactory
   13 = Command_DisarmMinesAtPosition
   14 = Command_Stop


### PR DESCRIPTION
* Split off of #1579
* Follow up for #1887

This change optimizes button placements of USA Dozer. Swaps the positions of Airfield, Strategy Center, Supply Drop Zone, Particle Cannon, Command Center to achieve consistency with button placements of China Dozer and GLA Worker. This applies to the optional Patch bundle only.

Advantages:
* Airfields, Tech Centers, Money Centers share same position across all factions

Disadvantages:
* Buttons moved around

## Patched, Before

![shot_20230121_133037_4](https://user-images.githubusercontent.com/4720891/213867042-9a628bd6-0c26-49fe-a8da-38e4bea75c8b.jpg)

## Patched, After (This)

![shot_20230430_111722_1](https://user-images.githubusercontent.com/4720891/235345466-a7db5f47-aef2-42c2-82bb-a2962eb998c9.jpg)
