### PR TITLE
Change: Optimize Combat Drop button placement of USA Chinook

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -194,12 +194,12 @@ CommandSet AmericaVehicleChinookCommandSet
   8 = Command_TransportExit
 ;patch104p-core-begin
   9 = Command_ChinookUnload
+ 10 = Command_CombatDrop
 ;patch104p-core-end
 ;patch104p-optional-begin
   9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+ 12 = Command_CombatDrop ; Patch104p @tweak from 10. (#1890)
 ;patch104p-optional-end
- 10 = Command_CombatDrop
-; 13 = Command_Guard
  14 = Command_Stop
 End
 
@@ -2065,11 +2065,12 @@ CommandSet AirF_AmericaVehicleChinookCommandSet
   8 = Command_TransportExit
 ;patch104p-core-begin
   9 = Command_ChinookUnload
+ 10 = Command_CombatDrop
 ;patch104p-core-end
 ;patch104p-optional-begin
   9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+ 12 = Command_CombatDrop ; Patch104p @tweak from 10. (#1890)
 ;patch104p-optional-end
- 10 = Command_CombatDrop
  11 = Command_AttackMove
 ;12 = Command_GuardFlyingUnitsOnly ; Helix does not have air guard either.
  13 = Command_Guard
@@ -4096,12 +4097,12 @@ CommandSet SupW_AmericaVehicleChinookCommandSet
   8 = Command_TransportExit
 ;patch104p-core-begin
   9 = Command_ChinookUnload
+ 10 = Command_CombatDrop
 ;patch104p-core-end
 ;patch104p-optional-begin
   9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+ 12 = Command_CombatDrop ; Patch104p @tweak from 10. (#1890)
 ;patch104p-optional-end
- 10 = Command_CombatDrop
-; 13 = Command_Guard
  14 = Command_Stop
 End
 
@@ -4869,12 +4870,12 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
   8 = Command_TransportExit
 ;patch104p-core-begin
   9 = Command_ChinookUnload
+ 10 = Command_CombatDrop
 ;patch104p-core-end
 ;patch104p-optional-begin
   9 = Command_EmptyCrawler ; Patch104p @tweak from Command_ChinookUnload, so that all vehicles use same evacuate command button. (#1565)
+ 12 = Command_CombatDrop ; Patch104p @tweak from 10. (#1890)
 ;patch104p-optional-end
- 10 = Command_CombatDrop
-; 13 = Command_Guard
  14 = Command_Stop
 End
 


### PR DESCRIPTION
This change optimizes the Combat Drop  button placement of the USA Chinook. It is moved one position to the right, according to the draft shown in the linked discussion. Optional content only.

* https://github.com/TheSuperHackers/GeneralsGamePatch/discussions/1543#discussioncomment-4685730

## Patched, Optional
![shot_20230430_123718_1](https://user-images.githubusercontent.com/4720891/235348652-21d236d0-74bd-45b5-bc97-e33c25bfdf7a.jpg)
