### PR TITLE
Fix: Keep disabled Overlord attachment upgrade buttons in Command Set

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1891_overlord_attachment_upgrade_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1891_overlord_attachment_upgrade_buttons.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-30
+
+title: Fixes issue where China Overlord attachment upgrade buttons disappear after research
+
+changes:
+  - fix: China Overlord upgrade buttons will no longer disappear after researching the Gattling Cannon or Propaganda Tower upgrades. They will still disappear when researching Bunker upgrade however, because that claims the upgrade button positions with passenger buttons. The upgrade buttons can now be used on multi Overlord selection to build an upgrade any time, as long as one of the selected Overlords does not own the Bunker upgrade.
+
+labels:
+  - bug
+  - china
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1891
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -695,13 +695,13 @@ CommandSet ChinaTankOverlordBattleBunkerCommandSet
   14 = Command_Stop
 End
 
-CommandSet ChinaTankOverlordGattlingCannonCommandSet
+CommandSet ChinaTankOverlordGattlingCannonCommandSet ; Legacy
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
-CommandSet ChinaTankOverlordPropagandaTowerCommandSet
+CommandSet ChinaTankOverlordPropagandaTowerCommandSet ; Legacy
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -5181,13 +5181,13 @@ CommandSet Tank_ChinaVehicleBattleMasterCommandSet
   14 = Command_Stop
 End
 
-CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
+CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet ; Legacy
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
 
-CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
+CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet ; Unused
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -5201,9 +5201,7 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
 End
 
 CommandSet Tank_ChinaTankEmperorDefaultCommandSet
-  ;1  = Command_UpgradeChinaOverlordBattleBunker   ;Does not get this upgrade.
   3  = Tank_Command_UpgradeChinaOverlordGattlingCannon
-  ;5  = Command_UpgradeChinaOverlordPropagandaTower ;Is granted this upgrade innately.
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15809,7 +15809,7 @@ Object Boss_VehicleHelix
 
 
 
-  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
+  ; Patch104p @bugfix xezon 11/01/2023 Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons. (#1542)
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -199,7 +199,7 @@ Object ChinaVehicleHelix
 
 
 
-  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
+  ; Patch104p @bugfix xezon 11/01/2023 Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons. (#1542)
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -396,16 +396,9 @@ Object ChinaTankOverlord
   Behavior = ProductionUpdate ModuleTag_10
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
   End
-  Behavior = CommandSetUpgrade ModuleTag_11
-    CommandSet = ChinaTankOverlordGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordGattlingCannon
-    ConflictsWith = Upgrade_ChinaOverlordPropagandaTower Upgrade_ChinaOverlordBattleBunker
-  End
-  Behavior = CommandSetUpgrade ModuleTag_12
-    CommandSet = ChinaTankOverlordPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordPropagandaTower
-    ConflictsWith = Upgrade_ChinaOverlordGattlingCannon Upgrade_ChinaOverlordBattleBunker
-  End
+
+  ; Patch104p @tweak xezon 30/09/2021 Removes the Gattling Cannon and Propaganda Tower CommandSetUpgrade behaviours to keep disabled upgrade buttons. (#1891)
+
   Behavior = CommandSetUpgrade ModuleTag_13
     CommandSet = ChinaTankOverlordBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaOverlordBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -474,7 +474,7 @@ Object Nuke_ChinaVehicleHelix
 
 
 
-  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
+  ; Patch104p @bugfix xezon 11/01/2023 Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons. (#1542)
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
@@ -17308,16 +17308,9 @@ Object Nuke_ChinaTankOverlord
   Behavior = ProductionUpdate ModuleTag_10
     MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
   End
-  Behavior = CommandSetUpgrade ModuleTag_11
-    CommandSet = ChinaTankOverlordGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordGattlingCannon
-    ConflictsWith = Upgrade_ChinaOverlordPropagandaTower Upgrade_ChinaOverlordBattleBunker
-  End
-  Behavior = CommandSetUpgrade ModuleTag_12
-    CommandSet = ChinaTankOverlordPropagandaTowerCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordPropagandaTower
-    ConflictsWith = Upgrade_ChinaOverlordGattlingCannon Upgrade_ChinaOverlordBattleBunker
-  End
+
+  ; Patch104p @bugfix xezon 30/09/2021 Removes the Gattling Cannon and Propaganda Tower CommandSetUpgrade behaviours to keep disabled upgrade buttons. (#1891)
+
   Behavior = CommandSetUpgrade ModuleTag_13
     CommandSet = ChinaTankOverlordBattleBunkerCommandSet
     TriggeredBy   = Upgrade_ChinaOverlordBattleBunker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -201,7 +201,7 @@ Object Tank_ChinaVehicleHelix
 
 
 
-  ; Patch104p @tweak Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons.
+  ; Patch104p @bugfix xezon 11/01/2023 Removes all CommandSetUpgrade behaviours to keep disabled upgrade buttons. (#1542)
   ;--------------------------
   Behavior = ObjectCreationUpgrade ModuleTag_22
     UpgradeObject = OCL_HelixGattlingCannon
@@ -3078,6 +3078,7 @@ Object Tank_ChinaTankEmperor ; Alias Tank_ChinaTankOverlord
   End
 
   ; Patch104p @bugfix commy2 07/09/2021 Enabled this to highlight the Propaganda Tower upgrade icon on the unit.
+  ; Patch104p @bugfix xezon 30/09/2021 Removes the Gattling Cannon CommandSetUpgrade behaviour to keep disabled upgrade buttons. (#1891)
 
 ; Prop Tower is intrinsic.  Plus, GrantUpgradeCreates on units crash savegames if the unit is Elite.
   Behavior = GrantUpgradeCreate ModuleTag_22
@@ -3095,39 +3096,10 @@ Object Tank_ChinaTankEmperor ; Alias Tank_ChinaTankOverlord
     ;ConflictsWith = Upgrade_ChinaOverlordBattleBunker
   End
 
-  ;Propaganda tower is an innate ability without using art or subobjects.
-  ;Behavior = ObjectCreationUpgrade ModuleTag_08
-  ;  UpgradeObject = OCL_EmperorPropagandaTower
-  ;  TriggeredBy   = Upgrade_ChinaOverlordPropagandaTower
-  ;  ConflictsWith = Upgrade_ChinaOverlordBattleBunker
-  ;End
-
-  ; Doesn't get this upgrade!
-  ; Behavior = ObjectCreationUpgrade ModuleTag_09
-    ; UpgradeObject = OCL_OverlordBattleBunker
-    ; TriggeredBy   = Upgrade_ChinaOverlordBattleBunker
-    ; ConflictsWith = Upgrade_ChinaOverlordGattlingCannon Upgrade_ChinaOverlordPropagandaTower
-  ; End
-
   Behavior = ProductionUpdate ModuleTag_10
     ; MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
      MaxQueueEntries = 2; Propaganda model is hacked to not show up.
   End
-  Behavior = CommandSetUpgrade ModuleTag_11
-    CommandSet = Tank_ChinaTankOverlordGattlingCannonCommandSet
-    TriggeredBy   = Upgrade_ChinaOverlordGattlingCannon
-    ConflictsWith = Upgrade_ChinaOverlordPropagandaTower Upgrade_ChinaOverlordBattleBunker
-  End
-  ;Behavior = CommandSetUpgrade ModuleTag_12
-   ; CommandSet = Tank_ChinaTankOverlordPropagandaTowerCommandSet
-    ;TriggeredBy   = Upgrade_ChinaOverlordPropagandaTower
-    ;ConflictsWith = Upgrade_ChinaOverlordGattlingCannon Upgrade_ChinaOverlordBattleBunker
-  ;End
-  ; Behavior = CommandSetUpgrade ModuleTag_13
-   ;  CommandSet = Tank_ChinaTankOverlordBattleBunkerCommandSet
-   ;  TriggeredBy   = Upgrade_ChinaOverlordBattleBunker
-    ; ConflictsWith = Upgrade_ChinaOverlordGattlingCannon Upgrade_ChinaOverlordPropagandaTower
-  ; End
 
   Behavior = PhysicsBehavior ModuleTag_14
     Mass = 50.0


### PR DESCRIPTION
* Relates to #1542

This change simplifies China Overlord and Emperor attachment Command Set. Buttons will no longer disappear after researching the Gattling Cannon or Propaganda Tower upgrades. They will still disappear when researching Bunker upgrade however, because that claims the upgrade button positions with passenger buttons.

With this change the upgrade buttons can be used on multi Overlord selection to build an upgrade any time, as long as one of the selected Overlords does not own the Bunker upgrade.

This behavior is consistent with USA vehicle drone upgrade buttons and Helix upgrade buttons (as of #1542).

![shot_20230430_163340_1](https://user-images.githubusercontent.com/4720891/235358739-21e43972-10cc-4b63-898c-f54e37b20571.jpg)
