### PR TITLE
Fix: Add missing upgrade buttons to Boss General

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1892_boss_missing_upgrade_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1892_boss_missing_upgrade_buttons.yaml
@@ -1,0 +1,27 @@
+---
+date: 2023-04-30
+
+title: Adds missing upgrade buttons to Boss General
+
+changes:
+  - fix: Adds missing Drone Armor upgrade to Boss General Particle Cannon. It is used by Boss Sentry Drone.
+  - fix: Adds missing Countermeasures upgrade to Boss General Airfield. It is used by Boss Aurora, Raptor, Spectre.
+  - fix: Adds missing Laser Missiles upgrade to Boss General Airfield. It is used by Boss Raptor.
+  - fix: Adds missing AP Bullets upgrade to Boss General Scud Storm. It is used by Boss Jarmen Kell.
+  - fix: Adds missing Junk Repair upgrade to Boss General Scud Storm. It is used by Boss Rocket Buggy, Combat Bike.
+  - fix: Adds missing Anthrax Beta upgrade to Boss General Scud Storm. It is used by Boss Scud Storm.
+  - tweak: Moves Mig Armor upgrade button up by one slot to make room for the added upgrades in Boss Airfield.
+
+labels:
+  - boss
+  - buff
+  - bug
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1892
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1892_boss_scud_storm_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1892_boss_scud_storm_buttons.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-04-30
+
+title: Optimizes button placements of Boss Scud Storm
+
+changes:
+  - tweak: Swaps the Buggy Ammo and AP Rockets upgrade buttons in Boss Scud Storm to take same order as they do in the GLA Black Market.
+
+labels:
+  - boss
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1892
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5505,26 +5505,32 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
 End
 
 ; Patch104p @bugfix xezon 16/04/2023 Adds missing rally point button to Boss Airfield.
+; Patch104p @bugfix xezon 16/04/2023 Moves Mig Armor upgrade button into top row to make room for other upgrades below. (#1892)
+; Patch104p @bugfix xezon 16/04/2023 Adds missing Counter Measures and Laser Missiles upgrade buttons. (#1892)
 CommandSet Boss_ChinaAirfieldCommandSet
  1  = Boss_Command_ConstructChinaJetMIG
  2  = Boss_Command_ConstructAmericaJetRaptor ; AirF version
  3  = Boss_Command_ConstructChinaVehicleHelix
  4  = Boss_Command_ConstructAmericaJetAurora
- 8  = Command_UpgradeChinaAircraftArmor
-; 10 = Command_UpgradeAmericaBunkerBusters
+ 7  = Command_UpgradeChinaAircraftArmor ; Patch @tweak from 8
+ 8  = Command_UpgradeAmericaLaserMissiles
+ 10 = Command_UpgradeAmericaCountermeasures
  12 = Command_UpgradeChinaMines
  13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 ; Patch104p @bugfix xezon 16/04/2023 Adds missing rally point button to Boss Airfield.
+; Patch104p @bugfix xezon 16/04/2023 Moves Mig Armor upgrade button into top row to make room for other upgrades below. (#1892)
+; Patch104p @bugfix xezon 16/04/2023 Adds missing Counter Measures and Laser Missiles upgrade buttons. (#1892)
 CommandSet Boss_ChinaAirfieldCommandSetUpgrade
  1  = Boss_Command_ConstructChinaJetMIG
  2  = Boss_Command_ConstructAmericaJetRaptor ; AirF version
  3  = Boss_Command_ConstructChinaVehicleHelix
  4  = Boss_Command_ConstructAmericaJetAurora
- 8  = Command_UpgradeChinaAircraftArmor
-; 10 = Command_UpgradeAmericaBunkerBusters
+ 7  = Command_UpgradeChinaAircraftArmor ; Patch @tweak from 8
+ 8  = Command_UpgradeAmericaLaserMissiles
+ 10 = Command_UpgradeAmericaCountermeasures
  12 = Command_UpgradeEMPMines
  13 = Command_SetRallyPoint
  14 = Command_Sell
@@ -5618,38 +5624,51 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
 End
 
 
-
+; Patch104p @bugfix xezon 30/04/2023 Adds missing Drone Armor upgrade button. (#1892)
 CommandSet Boss_AmericaParticleUplinkCannonCommandSet
   1 = Command_FireParticleUplinkCannon
   4 = Command_UpgradeAmericaSentryDroneGun
   6 = Command_UpgradeAmericaCompositeArmor
+  7 = Command_UpgradeAmericaDroneArmor
   8 = Command_UpgradeAmericaAdvancedTraining
  12 = Command_UpgradeChinaMines
  14 = Command_Sell
 End
 
+; Patch104p @bugfix xezon 30/04/2023 Adds missing Drone Armor upgrade button. (#1892)
 CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
   1 = Command_FireParticleUplinkCannon
   4 = Command_UpgradeAmericaSentryDroneGun
   6 = Command_UpgradeAmericaCompositeArmor
+  7 = Command_UpgradeAmericaDroneArmor
   8 = Command_UpgradeAmericaAdvancedTraining
  12 = Command_UpgradeEMPMines
  14 = Command_Sell
 End
 
+; Patch104p @tweak xezon 30/04/2023 Sorts Buggy Ammo and AP Rockets upgrade buttons to some order as in GLA Black Market. (#1892)
+; Patch104p @bugfix xezon 30/04/2023 Adds missing AP Bullets, JunkRepair, Anthrax Beta upgrade button. (#1892)
 CommandSet Boss_GLAScudStormCommandSet
   1  = Command_ScudStorm
-  4  = Command_UpgradeGLABuggyAmmo
-  6  = Command_UpgradeGLAAPRockets
+  3  = Command_UpgradeGLAAPBullets
+  4  = Command_UpgradeGLAAPRockets ; Patch104p @tweak from 6
+  5  = Command_UpgradeGLAJunkRepair
+  6  = Command_UpgradeGLABuggyAmmo ; Patch104p @tweak from 4
+  7  = Command_UpgradeGLAAnthraxBeta
   8  = Command_UpgradeGLAArmTheMob
   12 = Command_UpgradeChinaMines
   14 = Command_Sell
 End
 
+; Patch104p @tweak xezon 30/04/2023 Sorts Buggy Ammo and AP Rockets upgrade buttons to some order as in GLA Black Market. (#1892)
+; Patch104p @bugfix xezon 30/04/2023 Adds missing AP Bullets, JunkRepair, Anthrax Beta upgrade button. (#1892)
 CommandSet Boss_GLAScudStormCommandSetUpgrade
   1  = Command_ScudStorm
-  4  = Command_UpgradeGLABuggyAmmo
-  6  = Command_UpgradeGLAAPRockets
+  3  = Command_UpgradeGLAAPBullets
+  4  = Command_UpgradeGLAAPRockets ; Patch104p @tweak from 6
+  5  = Command_UpgradeGLAJunkRepair
+  6  = Command_UpgradeGLABuggyAmmo ; Patch104p @tweak from 4
+  7  = Command_UpgradeGLAAnthraxBeta
   8  = Command_UpgradeGLAArmTheMob
   12 = Command_UpgradeEMPMines
   14 = Command_Sell


### PR DESCRIPTION
This change adds missing upgrade buttons to Boss General.

* Drone Armor upgrade for Boss Sentry Drone
* Countermeasures upgrade for Boss Aurora, Raptor, Spectre
* Laser Missiles upgrade for Boss Raptor
* AP Bullets upgrade for Boss Jarmen Kell
* Junk Repair upgrade for Boss Rocket Buggy and Combat Bike
* Anthrax Beta upgrade for Boss Scud Storm

The Mig Armor upgrade is moved one position up to make room at the bottom for the USA upgrades.

The Rocket Buggy and AP Rockets positions are swapped to take same order as they do in Black Market.

## Patched

### Drone Armor

![shot_20230513_105803_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/73b360af-4f7b-4b92-a328-98d6cd6a16f6)

### Countermeasures & Laser Missiles

![shot_20230430_172822_2](https://user-images.githubusercontent.com/4720891/235362277-e23cf0fa-1f7c-4c11-9599-f6b043b51107.jpg)

### AP Bullets, Junk Repair, Anthrax Beta

![shot_20230430_172815_1](https://user-images.githubusercontent.com/4720891/235362293-b77b908f-9a71-4b9f-afd9-3387c74a435c.jpg)
