### PR TITLE
Change: Add Countermeasures armor upgrade bonus to Boss Raptor

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1893_boss_raptor_countermeasures.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1893_boss_raptor_countermeasures.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-04-30
+
+title: Adds missing Countermeasures upgrade armor bonus to Boss King Raptor
+
+changes:
+  - tweak: The Boss King Raptor now receives the Countermeasures upgrade armor bonus. This is consistent with Boss Aurora and Boss Spectre.
+
+labels:
+  - boss
+  - buff
+  - design
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1893
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -16286,7 +16286,7 @@ Object Boss_JetRaptor
   End
   ArmorSet
     Conditions            = PLAYER_UPGRADE
-    Armor                 = AirplaneArmor ;CountermeasuresAirplaneArmor ; uncomment if we ever feel like fixing the AFG KRaptor ~commy2
+    Armor                 = CountermeasuresAirplaneArmor ; Patch104p @tweak Enables the regular armor bonus. (#1893)
     DamageFX              = None
   End
 


### PR DESCRIPTION
This change adds the Countermeasures armor upgrade bonus to the Boss Raptor. The Boss Aurora and Spectre already have it.