### PR TITLE
Change: Move China Overlord evacuation button to common position

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/165_vehicle_evacuation_button_placement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/165_vehicle_evacuation_button_placement.yaml
@@ -4,10 +4,11 @@ date: 2021-09-03
 title: Fixes issue that prevents evacuating different vehicles in a group selection
 
 changes:
-  - fix: The evacuate buttons of the USA Humvee, Ambulance, China Troopcrawler, Outpost, GLA Technical and Battle Bus are now at the same position. This allows the player to evacuate all vehicles at once when a group of different vehicles is selected.
+  - fix: The evacuate buttons of the USA Humvee, Ambulance, China Troopcrawler, Outpost, Bunker Overlord, GLA Technical and Battle Bus are now at the same position. This allows the player to evacuate all vehicles at once when a group of different vehicles is selected.
 
 labels:
   - bug
+  - controversial
   - design
   - gui
   - minor
@@ -15,6 +16,8 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/165
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1894
 
 authors:
   - commy2
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1894_overlord_evacuation_button_placement.txt
+++ b/Patch104pZH/Design/Changes/v1.0/1894_overlord_evacuation_button_placement.txt
@@ -1,0 +1,1 @@
+165_vehicle_evacuation_button_placement.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -683,13 +683,15 @@ CommandSet ChinaTankOverlordDefaultCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @tweak from Command_Evacuate to Command_EmptyCrawler, so that all vehicles use same evacuate command button.
+; Patch104p @tweak xezon 30/04/2023 Moves Command_EmptyCrawler from 6 to 9, so that it can be evacuated together with other ground vehicles.
 CommandSet ChinaTankOverlordBattleBunkerCommandSet
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
-  6 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
+  9 = Command_EmptyCrawler
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop


### PR DESCRIPTION
* Follow up for #165

This change moves the China Overlord evacuation button to the common evacuation position. This allows to evacuate the Overlord with other transport units in a group selection.

![shot_20230501_115208_2](https://user-images.githubusercontent.com/4720891/235437593-eddfabe7-6180-48bd-bb99-60663c0fccc0.jpg)
