### PR TITLE
Change: Fixes order of China Overlord and Helix attachment cameo icons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaAir.ini
@@ -6,12 +6,13 @@ Object ChinaVehicleHelix
   ButtonImage            = SNHelix
 
   ; Patch104p @bugfix commy2 19/09/2021 Add upgrade icon for Napalm Bomb.
+  ; Patch104p @tweak xezon 30/04/2023 Moves GattlingCannon from 3 to 5, BattleBunker from 5 to 3.
 
   UpgradeCameo1 = Upgrade_HelixNapalmBomb
   UpgradeCameo2 = Upgrade_ChinaBlackNapalm
-  UpgradeCameo3 = Upgrade_ChinaHelixGattlingCannon
+  UpgradeCameo3 = Upgrade_ChinaHelixBattleBunker
   UpgradeCameo4 = Upgrade_ChinaHelixPropagandaTower
-  UpgradeCameo5 = Upgrade_ChinaHelixBattleBunker
+  UpgradeCameo5 = Upgrade_ChinaHelixGattlingCannon
 
     Draw = W3DOverlordAircraftDraw  ModuleTag_01; Works with the dependencyModelDraw of the upgrade portable structures
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -227,11 +227,13 @@ Object ChinaTankOverlord
   SelectPortrait         = SNOverlord_L
   ButtonImage            = SNOverlord
 
+  ; Patch104p @tweak xezon 30/04/2023 Moves GattlingCannon from 4 to 5, PropagandaTower from 5 to 4.
+
   UpgradeCameo1 = Upgrade_ChinaUraniumShells
   UpgradeCameo2 = Upgrade_ChinaNuclearTanks
   UpgradeCameo3 = Upgrade_ChinaOverlordBattleBunker
-  UpgradeCameo4 = Upgrade_ChinaOverlordGattlingCannon
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo4 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -278,12 +278,13 @@ Object Nuke_ChinaVehicleHelix
   ButtonImage            = SNHelix
 
   ; Patch104p @bugfix commy2 19/09/2021 Moved upgrade icon for Nuke Bomb for cross faction consistency.
+  ; Patch104p @tweak xezon 30/04/2023 Moves GattlingCannon from 3 to 5, BattleBunker from 5 to 3.
 
   UpgradeCameo1 = Nuke_Upgrade_HelixNukeBomb
   ;UpgradeCameo2 = Upgrade_ChinaBlackNapalm
-  UpgradeCameo3 = Upgrade_ChinaHelixGattlingCannon
+  UpgradeCameo3 = Upgrade_ChinaHelixBattleBunker
   UpgradeCameo4 = Upgrade_ChinaHelixPropagandaTower
-  UpgradeCameo5 = Upgrade_ChinaHelixBattleBunker
+  UpgradeCameo5 = Upgrade_ChinaHelixGattlingCannon
 
     Draw = W3DOverlordAircraftDraw  ModuleTag_01; Works with the dependencyModelDraw of the upgrade portable structures
 
@@ -17142,12 +17143,14 @@ Object Nuke_ChinaTankOverlord
 
   ; Patch104p @refactor xezon 08/04/2023 Comments the incorrect and unused Nuke upgrades.
   ; Patch104p @bugfix xezon 08/04/2023 Adds missing IsotopeStability icon.
+  ; Patch104p @tweak xezon 30/04/2023 Moves GattlingCannon from 4 to 5, PropagandaTower from 5 to 4.
+
   ;UpgradeCameo1 = Nuke_Upgrade_ChinaWGUraniumShells
   ;UpgradeCameo2 = Nuke_Upgrade_ChinaFusionReactors
   UpgradeCameo2 = Upgrade_ChinaIsotopeStability
   UpgradeCameo3 = Upgrade_ChinaOverlordBattleBunker
-  UpgradeCameo4 = Upgrade_ChinaOverlordGattlingCannon
-  UpgradeCameo5 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo4 = Upgrade_ChinaOverlordPropagandaTower
+  UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
 
   Draw = W3DOverlordTankDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -6,12 +6,13 @@ Object Tank_ChinaVehicleHelix
   ButtonImage            = SNHelix
 
   ; Patch104p @bugfix commy2 19/09/2021 Add upgrade icon for Napalm Bomb.
+  ; Patch104p @tweak xezon 30/04/2023 Moves GattlingCannon from 3 to 5, BattleBunker from 5 to 3.
 
   UpgradeCameo1 = Upgrade_HelixNapalmBomb
   UpgradeCameo2 = Upgrade_ChinaBlackNapalm
-  UpgradeCameo3 = Upgrade_ChinaHelixGattlingCannon
+  UpgradeCameo3 = Upgrade_ChinaHelixBattleBunker
   UpgradeCameo4 = Upgrade_ChinaHelixPropagandaTower
-  UpgradeCameo5 = Upgrade_ChinaHelixBattleBunker
+  UpgradeCameo5 = Upgrade_ChinaHelixGattlingCannon
 
     Draw = W3DOverlordAircraftDraw  ModuleTag_01; Works with the dependencyModelDraw of the upgrade portable structures
 
@@ -2924,12 +2925,13 @@ Object Tank_ChinaTankEmperor ; Alias Tank_ChinaTankOverlord
   ButtonImage            = SNEmpTank
 
   ; Patch104p @bugfix commy2 07/09/2021 Added upgrade icon for Subliminal Messaging.
+  ; Patch104p @tweak xezon 30/04/2023 Moves GattlingCannon from 3 to 5, SubliminalMessaging from 5 to 3.
 
   UpgradeCameo1 = Upgrade_ChinaUraniumShells
   UpgradeCameo2 = Upgrade_ChinaNuclearTanks
-  UpgradeCameo3 = Upgrade_ChinaOverlordGattlingCannon
+  UpgradeCameo3 = Upgrade_ChinaSubliminalMessaging
   UpgradeCameo4 = Upgrade_ChinaOverlordPropagandaTower
-  UpgradeCameo5 = Upgrade_ChinaSubliminalMessaging
+  UpgradeCameo5 = Upgrade_ChinaOverlordGattlingCannon
 
   Draw = W3DOverlordTankDraw ModuleTag_01
     ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.


### PR DESCRIPTION
This change fixes the order of the China Overlord and Helix attachment cameo icons.

| Object                  | Cameo left           | Cameo mid        | Cameo right          |
|-------------------------|----------------------|------------------|----------------------|
| Original Emperor        | Subliminal Messaging | Propaganda Tower | Gattling Cannon      |
| Original Overlord       | Propaganda Tower     | Gattling Cannon  | Battle Bunker        |
| Original Helix          | Battle Bunker        | Propaganda Tower | Gattling Cannon      |
| Original Infantry Helix |                      |                  | Battle Bunker        |
| **Patched Emperor (this)**  | Gattling Cannon      | Propaganda Tower | Subliminal Messaging |
| **Patched Overlord (this)** | Gattling Cannon      | Propaganda Tower | Battle Bunker        |
| **Patched Helix (this)**    | Gattling Cannon      | Propaganda Tower | Battle Bunker        |

## Patched

![shot_20230501_120159_1](https://user-images.githubusercontent.com/4720891/235439647-e76a604d-9189-47b1-80d2-08d4cd1f43e8.jpg)

![shot_20230501_120205_2](https://user-images.githubusercontent.com/4720891/235439652-95158a8e-74ba-44d9-84c0-a1f06e7ccdac.jpg)
