### PR TITLE
Change: Swap Drop Bomb and Evacuate buttons on China Helix command set

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1897_helix_evacuation_button_placement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1897_helix_evacuation_button_placement.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-05-01
+
+title: Swaps Drop Bomb and Evacuate buttons on China Helix command set
+
+changes:
+  - tweak: Swaps Drop Bomb and Evacuate buttons on China Helix command set to allow evacuation in group selections with other kinds of transports.
+
+labels:
+  - china
+  - enhancement
+  - gui
+  - minor
+  - optional
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1897
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -735,6 +735,7 @@ End
 
 ;----------------------------------------
 CommandSet ChinaVehicleHelixCommandSet
+;patch104p-core-begin
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -752,6 +753,27 @@ CommandSet ChinaVehicleHelixCommandSet
  12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
+;patch104p-core-end
+;patch104p-optional-begin
+; Patch104p @tweak xezon 01/05/2023 Optionally swaps evacuation and drop bomb button to put the evacuation button at the common position. (#1897)
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
+  8 = Command_UpgradeChinaHelixPropagandaTower
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
+  7 = Command_UpgradeChinaHelixNapalmBomb
+ 12 = Command_ChinaHelixDropNapalmBomb
+  ;---------
+  9 = Command_EmptyCrawler
+ 11 = Command_AttackMove
+ 13 = Command_Guard
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet ChinaHelixGattlingCannonCommandSet ; Legacy
@@ -3669,6 +3691,7 @@ CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
 End
 
 CommandSet Nuke_ChinaVehicleHelixCommandSet
+;patch104p-core-begin
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -3686,6 +3709,27 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
  12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
+;patch104p-core-end
+;patch104p-optional-begin
+; Patch104p @tweak xezon 01/05/2023 Optionally swaps evacuation and drop bomb button to put the evacuation button at the common position. (#1897)
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  ;---------
+  6 = Command_UpgradeChinaHelixBattleBunker
+  8 = Command_UpgradeChinaHelixPropagandaTower
+ 10 = Command_UpgradeChinaHelixGattlingCannon
+  ;---------
+  7 = Nuke_Command_UpgradeChinaHelixNukeBomb
+ 12 = Nuke_Command_ChinaHelixDropNukeBomb
+  ;---------
+  9 = Command_EmptyCrawler
+ 11 = Command_AttackMove
+ 13 = Command_Guard
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Nuke_ChinaHelixGattlingCannonCommandSet ; Legacy
@@ -4580,6 +4624,7 @@ CommandSet Infa_ChinaListeningOutpostCommandSet
 End
 
 CommandSet Infa_ChinaVehicleHelixCommandSet
+;patch104p-core-begin
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -4590,16 +4635,36 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   8 = Command_TransportExit
   ;---------
   9 = Command_UpgradeChinaHelixNapalmBomb
-; 10 = Command_ChinaHelixDropNapalmBomb
   10 = Infa_Command_UpgradeChinaHelixBattleBunker
   ;---------
  11 = Command_AttackMove
  12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
  13 = Command_Guard
  14 = Command_Stop
+;patch104p-core-end
+;patch104p-optional-begin
+; Patch104p @tweak xezon 01/05/2023 Optionally swaps evacuation and drop bomb button to put the evacuation button at the common position. (#1897)
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  6 = Command_TransportExit
+  7 = Command_TransportExit
+  8 = Command_TransportExit
+  ;---------
+ 10 = Infa_Command_UpgradeChinaHelixBattleBunker
+ 12 = Command_UpgradeChinaHelixNapalmBomb
+  ;---------
+  9 = Command_EmptyCrawler
+ 11 = Command_AttackMove
+ 13 = Command_Guard
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Infa_ChinaHelixBombCommandSet
+;patch104p-core-begin
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
@@ -4611,10 +4676,31 @@ CommandSet Infa_ChinaHelixBombCommandSet
   ;---------
   9 = Command_ChinaHelixDropNapalmBomb
   10 = Infa_Command_UpgradeChinaHelixBattleBunker
+  ;---------
   11 = Command_AttackMove
   12 = Command_EmptyCrawler ; Patch104p @tweak from Command_Evacuate, so that all vehicles use same evacuate command button.
   13 = Command_Guard
   14 = Command_Stop
+;patch104p-core-end
+;patch104p-optional-begin
+; Patch104p @tweak xezon 01/05/2023 Optionally swaps evacuation and drop bomb button to put the evacuation button at the common position. (#1897)
+  1 = Command_TransportExit
+  2 = Command_TransportExit
+  3 = Command_TransportExit
+  4 = Command_TransportExit
+  5 = Command_TransportExit
+  6 = Command_TransportExit
+  7 = Command_TransportExit
+  8 = Command_TransportExit
+  ;---------
+ 10 = Infa_Command_UpgradeChinaHelixBattleBunker
+ 12 = Command_ChinaHelixDropNapalmBomb
+  ;---------
+  9 = Command_EmptyCrawler
+ 11 = Command_AttackMove
+ 13 = Command_Guard
+ 14 = Command_Stop
+;patch104p-optional-end
 End
 
 CommandSet Infa_ChinaInfantryBlackLotusCommandSet


### PR DESCRIPTION
This change swaps the Drop Bomb and Evacuate buttons on China Helix command set. This way the Evacuate button shares the common position and it can be evacuated together with other vehicles. Optional only.

### Advantages

* Helix Evacuation button now works in group selection with all other vehicles, such as the USA Chinook.
* Helix Drop Napalm Bomb button can still be used with Regular, Infantry and Tank Helix in group selection.
* Button layout still looks very close to the original, because just 2 buttons swapped.
* Optional only, core Helix button layout is unchanged

### Disadvantages

* Buttons are moved in optional bundle.
* Napalm bombs are visually further apart which looks odd on first sight. This can be improved by changing the visuals of the buttons.

## Patched Regular Helix

![shot_20230501_172249_2](https://user-images.githubusercontent.com/4720891/235492845-161365be-cc74-403a-b158-ce78fe5e5754.jpg)

## Patched Infantry Helix

![shot_20230501_172245_1](https://user-images.githubusercontent.com/4720891/235492894-042da719-4f37-4e12-a9b9-19c13f9ed8ea.jpg)
