### PR TITLE
Fix: Set audio limit for Vehicle Snipe

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1900_vehicle_snipe_sound_limit.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1900_vehicle_snipe_sound_limit.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-05-03
+
+title: Sets audio limit for Vehicle Snipe
+
+changes:
+  - fix: Sets an audio limit of 2 for Vehicle Snipe. This way it can no longer spam many sounds on Neutron Shell hits.
+
+labels:
+  - audio
+  - bug
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1900
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -6419,11 +6419,13 @@ AudioEvent ParachuteOpen
   Type        = world shrouded everyone
 End
 
+; Patch104p @bugfix xezon 03/05/2023 Adds small limit to not spam as many sounds with Neutron Shell hits.
 AudioEvent VehicleSnipeVictim
   Sounds      = gvehsnia
   Priority    = high
   VolumeShift = -15
   Volume      = 70
+  Limit       = 2
   Type        = world shrouded everyone
 End
 


### PR DESCRIPTION
* Follow up for #1872

This change sets an audio limit of 2 for Vehicle Snipe. This way it can no longer spam many sounds on Neutron Shell hits.