### PR TITLE
Fix: Prevent shells of China Artillery Barrage from killing each other

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -5467,9 +5467,11 @@ Object ChinaArtilleryBarrageShell
 
   ; *** ENGINEERING Parameters ***
   KindOf            = PRELOAD CAN_CAST_REFLECTIONS PROJECTILE ;SMALL_MISSILE
+
+  ; Patch104p @bugfix xezon 04/05/2023 Change health from 100 to prevent shells eventually killing each other on impact at random.
   Body = ActiveBody ModuleTag_02
-    MaxHealth       = 100.0
-    InitialHealth   = 100.0
+    MaxHealth       = 400.0
+    InitialHealth   = 400.0
   End
 
 ; ---- begin Projectile death behaviors


### PR DESCRIPTION
* Relates to TheSuperHackers/GeneralsGameCode#210

This change prevent shells of the China Artillery Barrage from killing each other by increasing their health to 400. This fix potentially avoids scenarios where 1 or 2 Oil Derricks survive a Level 3 Artillery Barrage at random.

400 health was chosen because with that the Artillery deals reliably max damage on a single point attack in a test scenario. See TheSuperHackers/GeneralsGameCode#210 for more details.

(**health** refers to Artillery shell health)

![Untitled-1](https://user-images.githubusercontent.com/4720891/236294993-795ee4aa-b7ea-402c-aa82-ccdb8d886448.png)

400 health is still low enough to be destructible by Super Weapons, such as GLA SCUD Storm with 500 damage per missile or China Nuke Missile with 700 damage per blast.
