### PR TITLE
Remove Tertiary weapon slot from Neutron Shells command button

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1890,9 +1890,10 @@ CommandButton Command_ChinaNukeWarhead
   DescriptLabel           = CONTROLBAR:ToolTipChinaNukeWarhead
 End
 
+; Patch104p @refactor xezon 04/05/2023 Removes obsolete TERTIARY weapon slot.
 CommandButton Command_ChinaNeutronWarhead
   Command                 = SWITCH_WEAPON
-  WeaponSlot              = SECONDARY TERTIARY
+  WeaponSlot              = SECONDARY
   Options                 = CHECK_LIKE OK_FOR_MULTI_SELECT NEED_UPGRADE
   Upgrade                 = Upgrade_ChinaNeutronShells
   TextLabel               = CONTROLBAR:NeutronWarhead


### PR DESCRIPTION
This change removes the TERTIARY Weapon Slot from the Neutron Shells command button. The Nuke Cannon has no Tertiary weapon.

It makes no difference to functionality. Needs no further documentation.