### PR TITLE
Fix: Sets correct name for Demo_Command_ConstructGLATankScorpion

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1904_demo_command_scorpion_spelling.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1904_demo_command_scorpion_spelling.yaml
@@ -1,0 +1,17 @@
+---
+date: 2023-05-05
+
+title: Sets correct name for Demo_Command_ConstructGLATankScorpion
+
+changes:
+  - fix: Sets correct name for Demo_Command_ConstructGLATankScorpion. Originally it is misspelled as Demo_Command_ConsturctGLATankScorpion.
+
+labels:
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1904
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5089,7 +5089,8 @@ CommandButton Demo_Command_ConstructGLAVehicleQuadCannon
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildQuadCannon
 End
 
-CommandButton Demo_Command_ConsturctGLATankScorpion
+; Patch104p @fix xezon 05/05/2023 Renames misspelled button from Demo_Command_ConsturctGLATankScorpion (#1904)
+CommandButton Demo_Command_ConstructGLATankScorpion
   Command       = UNIT_BUILD
   Object        = Demo_GLATankScorpion
   TextLabel     = CONTROLBAR:ConstructGLATankScorpion

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2319,7 +2319,7 @@ CommandSet Demo_GLATunnelNetworkCommandSet
 End
 
 CommandSet Demo_GLAArmsDealerCommandSet
-  1  = Demo_Command_ConsturctGLATankScorpion
+  1  = Demo_Command_ConstructGLATankScorpion
   2  = Demo_Command_ConstructGLAVehicleTechnical
   3  = Demo_Command_ConstructGLAVehicleRadarVan
   4  = Demo_Command_ConstructGLAVehicleQuadCannon
@@ -2680,7 +2680,7 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
 End
 
 CommandSet Demo_GLAArmsDealerCommandSetUpgrade
-  1  = Demo_Command_ConsturctGLATankScorpion
+  1  = Demo_Command_ConstructGLATankScorpion
   2  = Demo_Command_ConstructGLAVehicleTechnical
   3  = Demo_Command_ConstructGLAVehicleRadarVan
   4  = Demo_Command_ConstructGLAVehicleQuadCannon


### PR DESCRIPTION
* Fixes #327

This change fixes misspelled Demo_Command_ConstructGLATankScorpion.

kABUSE
> I am sure you are safe to fix this without further precautions.
