### PR TITLE
Fix: Prevent shells of China Artillery Barrage from killing each other

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1905_artillery_shells_health.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1905_artillery_shells_health.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-05
+
+title: Prevents shells of China Artillery Barrage from killing each other
+
+changes:
+  - fix: The shells of the China Artillery Barrage can no longer kill each other at random. Therefore random damage discrepancies on target structures are reduced.
+
+labels:
+  - buff
+  - bug
+  - china
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1905
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -5256,6 +5256,7 @@ Weapon MilitiaTankGun
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix xezon 05/05/2023 Adds NOT_SIMILAR flag to prevent shells eventually killing each other on impact at random. (#1905)
 Weapon ArtilleryBarrageDamageWeapon
   PrimaryDamage         = 105.0     ;GS changed to what it was secretly doing pending review
   PrimaryDamageRadius   = 50.0
@@ -5264,7 +5265,7 @@ Weapon ArtilleryBarrageDamageWeapon
   DeathType             = EXPLODED
   WeaponSpeed           = 99999.0
   ProjectileDetonationFX = FX_ArtilleryBarrage
-  RadiusDamageAffects   = ENEMIES NEUTRALS ALLIES
+  RadiusDamageAffects   = ENEMIES NEUTRALS ALLIES NOT_SIMILAR
   DelayBetweenShots     = 0    ; time between shots, msec
   ClipSize              = 1    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0    ; how long to reload a Clip, msec


### PR DESCRIPTION
* Relates to TheSuperHackers/GeneralsGameCode#210
* Closes TheSuperHackers/GeneralsGamePatch#1902

This change prevents shells of the China Artillery Barrage from killing each other by excluding damaging others of their kind. Therefore random damage discrepancies on target structures are reduced. This fix potentially avoids scenarios where 1 or 2 Oil Derricks survive a Level 3 Artillery Barrage at random.
