### PR TITLE
Change: Improve voice setup of China Black Lotus

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1908_unused_black_lotus_voices.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1908_unused_black_lotus_voices.yaml
@@ -1,0 +1,29 @@
+---
+date: 2023-05-05
+
+title: Adds unused voice variation(s) to China Black Lotus
+
+changes:
+  - tweak: Adds unused voice "I'm in. We control the building now" to BlackLotusVoiceCaptureComplete.
+  - tweak: Adds unused voice "Building capture complete" to BlackLotusVoiceCaptureComplete.
+  - tweak: Adds unused voice "We have their building. What's next?" to BlackLotusVoiceCaptureComplete.
+  - tweak: Adds unused voice "I'll make this quick" to BlackLotusVoiceHackVehicle.
+  - tweak: Adds unused voice "I got it covered" to BlackLotusVoiceHackVehicle.
+  - tweak: Adds unused voice "That's it. Their vehicle is down" to BlackLotusVoiceDisableComplete.
+  - tweak: Adds unused voice "The vehicle is down. What's next?" to BlackLotusVoiceDisableComplete.
+  - tweak: Adds unused voice "They won't even notice" to BlackLotusVoiceHackCash.
+  - tweak: Adds unused voice "Credit transfer ready" to BlackLotusVoiceCashComplete.
+
+labels:
+  - audio
+  - china
+  - design
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1908
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1908_unused_super_lotus_voices.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1908_unused_super_lotus_voices.yaml
@@ -1,0 +1,23 @@
+---
+date: 2023-05-05
+
+title: Adds unused voice variation(s) to China Super Lotus
+
+changes:
+  - feature: Adds unused voice "Super Lotus here. Give me an update" to SuperBlackLotusVoiceCreate.
+  - feature: Adds unused voice "Super Lotus" to SuperBlackLotusVoiceSelect.
+  - feature: Adds unused voice "I'm quick" to SuperBlackLotusVoiceMove.
+
+labels:
+  - audio
+  - china
+  - design
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1908
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -706,24 +706,25 @@ Object Infa_ChinaInfantryBlackLotus
   CommandSet            = Infa_ChinaInfantryBlackLotusCommandSet
 
   ; *** AUDIO Parameters ***
-  VoiceSelect = BlackLotusVoiceSelect
-  VoiceMove = BlackLotusVoiceMove
+  ; Patch104p @feature xezon 05/05/2023 Uses Super Lotus voices. (#1908)
+  VoiceSelect = SuperBlackLotusVoiceSelect
+  VoiceMove = SuperBlackLotusVoiceMove
   VoiceAttack = NoSound
-  VoiceGuard = BlackLotusVoiceMove
+  VoiceGuard = SuperBlackLotusVoiceMove
   VoiceFear = BlackLotusVoiceFear
   VoiceTaskComplete = BlackLotusVoiceCaptureComplete
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
 
   UnitSpecificSounds
-    VoiceCreate          = BlackLotusVoiceCreate
-    VoiceGarrison = BlackLotusVoiceMove
-    VoiceEnter = BlackLotusVoiceMove
-    VoiceEnterHostile = BlackLotusVoiceMove
+    VoiceCreate = SuperBlackLotusVoiceCreate
+    VoiceGarrison = SuperBlackLotusVoiceMove
+    VoiceEnter = SuperBlackLotusVoiceMove
+    VoiceEnterHostile = SuperBlackLotusVoiceMove
     VoiceStealCashComplete = BlackLotusVoiceCashComplete
     VoiceDisableVehicleComplete = BlackLotusVoiceDisableComplete
     VoiceCaptureBuildingComplete = BlackLotusVoiceCaptureComplete
-    VoiceGetHealed      = BlackLotusVoiceMove
+    VoiceGetHealed = SuperBlackLotusVoiceMove
   End
 
   ; *** ENGINEERING Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -2179,7 +2179,16 @@ End
 
 
 AudioEvent BlackLotusVoiceSelect
-  Sounds = iblasea iblaseb iblasec  iblased iblasee
+  Sounds = iblasea iblaseb iblasec iblased iblasee ; iblaseg
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+; Patch104p @feature xezon 05/05/2023 Adds variant for Super Lotus. (#1908)
+; iblsseb "Super Lotus"
+AudioEvent SuperBlackLotusVoiceSelect
+  Sounds = iblasea iblasec iblased iblasee iblsseb ; iblaseg
   Control = random
   Volume = 90
   Type = ui voice player
@@ -2194,19 +2203,40 @@ AudioEvent BlackLotusVoiceCreate
   Type = world global player
 End
 
+; Patch104p @feature xezon 05/05/2023 Adds variant for Super Lotus. (#1908)
+; iblssea "Super Lotus here. Give me an update"
+AudioEvent SuperBlackLotusVoiceCreate
+  Sounds = iblssea
+  Control = random
+  Volume  = 110
+  MinVolume = 100
+  Priority = high
+  Type = world global player
+End
+
 AudioEvent BlackLotusVoiceMove
-  Sounds = iblamoa iblamob iblamoc iblamod iblamoe iblamof
+  Sounds = iblamoa iblamob iblamoc iblamod iblamoe iblamof ; iblamog
   Control = random
   Volume = 90
   Type = ui voice player
 End
 
-;AudioEvent BlackLotusVoiceAttack
-;  Sounds = iblaata iblaatb iblaatc iblaate iblaatf iblaatg
-;  Control = random
-;  Volume = 90
-;  Type = ui voice player
-;End
+; Patch104p @feature xezon 05/05/2023 Adds variant for Super Lotus. (#1908)
+; iblssec "I'm quick"
+AudioEvent SuperBlackLotusVoiceMove
+  Sounds = iblamoa iblamob iblamoc iblamoe iblamof iblssec
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+; Patch104p @feature xezon 05/05/2023 Enables unused audio event.
+AudioEvent BlackLotusVoiceAttack
+  Sounds = iblaata iblaatb iblaatc iblaatd iblaate
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
 
 AudioEvent BlackLotusVoiceModeBuilding
   Sounds = iblamba iblambb iblambc
@@ -2231,8 +2261,12 @@ AudioEvent BlackLotusVoiceHackBuilding
   Type = ui voice player
 End
 
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) iblacob iblacoc iblacod (#1908)
+; iblacob "I'm in. We control the building now"
+; iblacoc "Building capture complete"
+; iblacod "We have their building. What's next?"
 AudioEvent BlackLotusVoiceCaptureComplete
-  Sounds = iblacoa
+  Sounds = iblacoa iblacob iblacoc iblacod
   Priority = high
   Control = random
   Volume  = 120
@@ -2248,15 +2282,21 @@ AudioEvent BlackLotusVoiceModeVehicle
   Limit = 1
 End
 
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) iblaatc iblaatd (#1908)
+; iblaatc "I'll make this quick"
+; iblaatd "I got it covered"
 AudioEvent BlackLotusVoiceHackVehicle
-  Sounds = iblah2a iblah2b iblah2c iblah2d iblah2e
+  Sounds = iblah2a iblah2b iblah2c iblah2d iblah2e iblaatc iblaatd
   Control = random
   Volume = 90
   Type = ui voice player
 End
 
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) iblac2c iblac2d (#1908)
+; iblac2c "That's it. Their vehicle is down"
+; iblac2d "The vehicle is down. What's next?"
 AudioEvent BlackLotusVoiceDisableComplete
-  Sounds = iblac2a
+  Sounds = iblac2a iblac2c iblac2d ; iblac2b
   Priority = high
   Control = random
   Volume  = 120
@@ -2273,17 +2313,21 @@ AudioEvent BlackLotusVoiceModeCash
   Limit = 1
 End
 
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) iblah3b (#1908)
+; iblah3b "They won't even notice"
 AudioEvent BlackLotusVoiceHackCash
-  Sounds = iblah3a iblah3d ;iblah3e iblah3c iblah3b
+  Sounds = iblah3a iblah3b iblah3d
   Control = random
   Volume = 90
   Type = ui voice player
 End
 
 
-
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) iblah3c (#1908)
+; iblah3c "Credit transfer ready"
 AudioEvent BlackLotusVoiceCashComplete
-  Sounds = iblah3e
+  Sounds = iblah3c iblah3e
+  Control = random
   Volume  = 120
   MinVolume = 110
   Type = world player global


### PR DESCRIPTION
* Relates to #176

This change adds several unused sounds to Lotus and Super Lotus.

## Lotus

### BlackLotusVoiceCaptureComplete

* iblacob "I'm in. We control the building now"
* iblacoc "Building capture complete"
* iblacod "We have their building. What's next?"

### BlackLotusVoiceHackVehicle

* iblaatc "I'll make this quick"
* iblaatd "I got it covered"

### BlackLotusVoiceDisableComplete

* iblac2c "That's it. Their vehicle is down"
* iblac2d "The vehicle is down. What's next?"

### BlackLotusVoiceHackCash

* iblah3b "They won't even notice"

### BlackLotusVoiceCashComplete

* iblah3c "Credit transfer ready"

### BlackLotusVoiceAttack

* Enabled audio event (unused)

## Super Lotus

### SuperBlackLotusVoiceCreate

* iblssea "Super Lotus here. Give me an update"

### SuperBlackLotusVoiceSelect

* iblsseb "Super Lotus"

### SuperBlackLotusVoiceMove

* iblssec "I'm quick"
