### PR TITLE
Change: Improve voice setup of USA Aurora and Alpha Aurora

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1274_unused_aurora_voices.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1274_unused_aurora_voices.yaml
@@ -6,6 +6,9 @@ title: Adds unused voice variation(s) to USA Aurora
 changes:
   - tweak: Adds unused voice "Fuel levels are critical" to AuroraBomberVoiceLowFuel.
   - tweak: Adds unused voice "Fuel gauge is in the red" to AuroraBomberVoiceLowFuel.
+  - tweak: Adds unused voice "Let's make this quick" to AuroraBomberVoiceAttack.
+  - tweak: Adds unused voice "We won't slow down" to AuroraBomberVoiceAttack.
+  - tweak: Adds unused voice "Will be a clean delivery" to AuroraBomberVoiceAttack.
 
 labels:
   - audio
@@ -16,6 +19,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1274
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1910
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1910_unused_alpha_aurora_voices.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1910_unused_alpha_aurora_voices.yaml
@@ -1,0 +1,28 @@
+---
+date: 2023-05-05
+
+title: Adds unused voice variation(s) to USA Alpha Aurora
+
+changes:
+  - feature: Adds unused voice "Fuel air bomb is armed and ready" to FuelAirAuroraVoiceSelect.
+  - feature: Adds unused voice "Fuel weapon ready for deployment" to FuelAirAuroraVoiceSelect.
+  - feature: Adds unused voice "Ready the fuel air bomb" to FuelAirAuroraVoiceAttack.
+  - feature: Adds unused voice "Dropping off the fuel air bomb" to FuelAirAuroraVoiceAttack.
+  - feature: Adds unused voice "The fuel air bomb should be enough" to FuelAirAuroraVoiceAttack.
+  - feature: Adds unused voice "Let's make this quick" to FuelAirAuroraVoiceAttack.
+  - feature: Adds unused voice "We won't slow down" to FuelAirAuroraVoiceAttack.
+  - feature: Adds unused voice "Will be a clean delivery" to FuelAirAuroraVoiceAttack.
+
+labels:
+  - audio
+  - design
+  - enhancement
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1910
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1910_unused_aurora_voices.txt
+++ b/Patch104pZH/Design/Changes/v1.0/1910_unused_aurora_voices.txt
@@ -1,0 +1,1 @@
+1274_unused_aurora_voices.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -1530,10 +1530,11 @@ Object SupW_AmericaJetAurora
   CommandSet        = SupW_AmericaJetAuroraCommandSet
 
   ; *** AUDIO Parameters ***
-  VoiceSelect = AuroraBomberVoiceSelect
+  ; Patch104p @feature xezon 05/05/2023 Uses FuelAirAurora voices. (#1910)
+  VoiceSelect = FuelAirAuroraVoiceSelect
   VoiceMove = AuroraBomberVoiceMove
   VoiceGuard = AuroraBomberVoiceMove
-  VoiceAttack = AuroraBomberVoiceAttack
+  VoiceAttack = FuelAirAuroraVoiceAttack
   SoundAmbient = AuroraBomberAmbientLoop
   SoundAmbientRubble    = NoSound
   UnitSpecificSounds

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -675,8 +675,12 @@ AudioEvent AuroraBomberVoiceMove
   Type = ui voice player
 End
 
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) vauhata vauhatb vauhatc (Hypersonic Aurora) (#1910)
+; vauhata "Let's make this quick"
+; vauhatb "We won't slow down"
+; vauhatc "Will be a clean delivery"
 AudioEvent AuroraBomberVoiceAttack
-  Sounds = vaurata vauratb vauratc vauratd vaurate
+  Sounds = vaurata vauratb vauratc vauratd vaurate vauhata vauhatb vauhatc
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
@@ -5543,8 +5547,12 @@ AudioEvent KingRaptorVoiceCreate
   Type = world global player
 End
 
-AudioEvent FuelAirAuroraVoiceSelect
-  Sounds = vaursea vaurseb vaursec vaursed vaursee vaursef vaufsea vaufseb
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) vaufsec (#1910)
+; vaufseb "Fuel air bomb is armed and ready"
+; vaufsec "Fuel weapon ready for deployment"
+; Patch104p @tweak xezon 05/05/2023 Removes sound(s) vaursea vaursef (#1910)
+AudioEvent FuelAirAuroraVoiceSelect ; Alias FuelAirAuroraBomberVoiceSelect
+  Sounds = vaurseb vaursec vaursed vaursee vaufseb vaufsec ; vaufsea
   Control= random
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
@@ -5552,8 +5560,8 @@ AudioEvent FuelAirAuroraVoiceSelect
   Type = ui voice player
 End
 
-AudioEvent FuelAirAuroraVoiceCreate
-  Sounds = vaufsea
+AudioEvent FuelAirAuroraVoiceCreate ; Alias FuelAirAuroraBomberVoiceCreate
+  Sounds = vaufsea ; "Fuel air aurora"
   Control= random
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
@@ -5563,8 +5571,16 @@ AudioEvent FuelAirAuroraVoiceCreate
   Type = world global player
 End
 
-AudioEvent FuelAirAuroraVoiceAttack
-  Sounds = vaurata vauratb vauratc vauratd vaurate vaufata vaufatb vaufatc
+; Patch104p @tweak xezon 05/05/2023 Adds former unused sound(s) vauhata vauhatb vauhatc (Hypersonic Aurora) (#1910)
+; vaufata "Ready the fuel air bomb"
+; vaufatb "Dropping off the fuel air bomb"
+; vaufatc "The fuel air bomb should be enough"
+; vauhata "Let's make this quick"
+; vauhatb "We won't slow down"
+; vauhatc "Will be a clean delivery"
+; Patch104p @tweak xezon 05/05/2023 Removes sound(s) vauratb vauratc vaurate (#1910)
+AudioEvent FuelAirAuroraVoiceAttack ; Alias FuelAirAuroraBomberVoiceAttack
+  Sounds = vaurata vauratd vaufata vaufatb vaufatc vauhata vauhatb vauhatc
   Control= random
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e


### PR DESCRIPTION
* Relates to #176

This change adds several unused sounds to USA Aurora and Alpha Aurora. It borrows voices of the unused Hypersonic Aurora.

### AuroraBomberVoiceAttack

* vauhata "Let's make this quick"
* vauhatb "We won't slow down"
* vauhatc "Will be a clean delivery"

### FuelAirAuroraVoiceSelect 

* vaufseb "Fuel air bomb is armed and ready"
* vaufsec "Fuel weapon ready for deployment"

### FuelAirAuroraVoiceAttack 

* vaufata "Ready the fuel air bomb"
* vaufatb "Dropping off the fuel air bomb"
* vaufatc "The fuel air bomb should be enough"
* vauhata "Let's make this quick"
* vauhatb "We won't slow down"
* vauhatc "Will be a clean delivery"
