### PR TITLE
Enable Dragon Tank and Toxin Tractor secondary attack button sounds, but do not use them

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1931,7 +1931,7 @@ CommandButton Command_GLAToxinTractorContaminateGround
   ButtonImage             = SSContaminate
   ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLAFireToxinTractorSlime
-  UnitSpecificSound       = ToxinTractorVoiceModeContam
+  ;UnitSpecificSound       = ToxinTractorVoiceModeContam
 End
 
 CommandButton Command_GLAInfantryRebelCaptureBuilding
@@ -2103,7 +2103,7 @@ CommandButton Command_ChinaDragonTankFireWall
   ButtonImage             = SSFireStorm
   ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipFireWall
-  UnitSpecificSound       = DragonTankVoiceModeFireStorm
+  ;UnitSpecificSound       = DragonTankVoiceModeFireStorm
 End
 
 ;-----------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -1812,8 +1812,9 @@ AudioEvent DragonTankVoiceFireStorm
   Type = ui voice player
 End
 
+; Patch104p @tweak xezon 05/05/2023 Enables sounds.
 AudioEvent DragonTankVoiceModeFireStorm
-  Sounds = ;vdramfa vdramfb vdramfc vdramfd
+  Sounds = vdramfa vdramfb vdramfc
   Control = random
   Volume = 90
   Type = ui voice player
@@ -2965,8 +2966,9 @@ AudioEvent ToxinTractorVoiceAttackContam
   Type = ui voice player
 End
 
+; Patch104p @tweak xezon 05/05/2023 Enables sounds.
 AudioEvent ToxinTractorVoiceModeContam
-  Sounds = ;vtoxmca vtoxmcb vtoxmcc
+  Sounds = vtoxmca vtoxmcb vtoxmcc
   Control = random
   Volume = 90
   Type = ui voice player


### PR DESCRIPTION
This change enable the Dragon Tank and Toxin Tractor secondary attack button sounds, but does not use them. User facing this has no effect, but is technically a better setup - consistent with other disabled setups of this kind.