### PR TITLE
Fix: Remove audio events with no valid sounds

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1912_obsolete_audio_events.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1912_obsolete_audio_events.yaml
@@ -1,0 +1,29 @@
+---
+date: 2023-05-05
+
+title: Removes audio events that reference no valid sounds
+
+changes:
+  - fix: Removes invalid audio event GenericMachineGunFire and all references to it.
+  - fix: Removes invalid audio event MedicMoveStart.
+  - fix: Removes invalid audio event CarBomberDie and all references to it.
+  - fix: Removes invalid audio event ExplosionGeneric.
+  - fix: Removes invalid audio event HeroUSAChargePlace.
+  - fix: Removes invalid audio event HeroUSAChargeBeep.
+  - fix: Removes invalid audio event HeroUSATimeBombClick.
+  - fix: Removes invalid audio event ExecuteDemoralize.
+  - fix: Removes invalid audio event CrateCash.
+  - fix: Removes invalid audio event AngryMobVoiceUpgradeArmTheMobCrowd.
+  - fix: Removes invalid audio event ListeningOutpostVoiceAttack and all references to it.
+
+labels:
+  - audio
+  - bug
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1912
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2848,8 +2848,8 @@ Object ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  VoiceAttack = ListeningOutpostVoiceAttack
-  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  ;VoiceAttack = ListeningOutpostVoiceAttack
+  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16150,8 +16150,8 @@ Object Infa_ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  VoiceAttack = ListeningOutpostVoiceAttack
-  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  ;VoiceAttack = ListeningOutpostVoiceAttack
+  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4833,8 +4833,8 @@ Object Nuke_ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  VoiceAttack = ListeningOutpostVoiceAttack
-  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  ;VoiceAttack = ListeningOutpostVoiceAttack
+  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5078,8 +5078,8 @@ Object Tank_ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  VoiceAttack = ListeningOutpostVoiceAttack
-  VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  ;VoiceAttack = ListeningOutpostVoiceAttack
+  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -77,15 +77,16 @@ AudioEvent AirRaidSiren
   Type        = world everyone
 End
 
-AudioEvent GenericMachineGunFire
-  Sounds      =  iseaatta iseaattb
-  Priority    = low
-  Volume      = 60
-;  MinRange = 100
-;  MaxRange       = 500
-  PitchShift  = -10  10
-  Type        = world shrouded everyone
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent GenericMachineGunFire
+;  Sounds      =  iseaatta iseaattb
+;  Priority    = low
+;  Volume      = 60
+;;  MinRange = 100
+;;  MaxRange       = 500
+;  PitchShift  = -10  10
+;  Type        = world shrouded everyone
+;End
 
 
 AudioEvent HeroUSAKnifeAttack
@@ -873,15 +874,16 @@ AudioEvent TomahawkMoveStart
   Type = world shrouded everyone
 End
 
-AudioEvent MedicMoveStart
-  Sounds= vpristaa vpristab vpristac
-  Priority= low
-  Delay=0 800
-  PitchShift= -10 10
-  VolumeShift= -10
-  Volume=50
-  Type = world shrouded everyone
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent MedicMoveStart
+;  Sounds= vpristaa vpristab vpristac
+;  Priority= low
+;  Delay=0 800
+;  PitchShift= -10 10
+;  VolumeShift= -10
+;  Volume=50
+;  Type = world shrouded everyone
+;End
 
 AudioEvent DozerUSAMoveStart
   Sounds= vtrostaa vtrostab vtrostac vtrostad
@@ -1680,14 +1682,15 @@ AudioEvent CrowdPanicLong
   Type = world shrouded everyone
 End
 
-AudioEvent CarBomberDie
-  Sounds =  vcardiea vcardieb vcardiec
-  Control = interrupt random
-  Volume = 60
-  Limit = 1
-  Priority = normal
-  Type = world shrouded everyone
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent CarBomberDie
+;  Sounds =  vcardiea vcardieb vcardiec
+;  Control = interrupt random
+;  Volume = 60
+;  Limit = 1
+;  Priority = normal
+;  Type = world shrouded everyone
+;End
 
 
 AudioEvent DemoTrapExplosion
@@ -1817,18 +1820,18 @@ AudioEvent BuildingDestroyStone
   Type = world shrouded everyone
 End
 
-
-AudioEvent ExplosionGeneric
-  Sounds = gexp14a gexp14b gexp14c gexp14d gexp15a
-  Control = interrupt random
-  Limit = 1
-  PitchShift = -10  10
-  VolumeShift = -20
-  Volume = 90
-  Priority = normal
-  LowPassCutoff = 50
-  Type = world shrouded everyone
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent ExplosionGeneric
+;  Sounds = gexp14a gexp14b gexp14c gexp14d gexp15a
+;  Control = interrupt random
+;  Limit = 1
+;  PitchShift = -10  10
+;  VolumeShift = -20
+;  Volume = 90
+;  Priority = normal
+;  LowPassCutoff = 50
+;  Type = world shrouded everyone
+;End
 
 AudioEvent BuildingCollapse1
   Sounds = bcoll01a bcoll01b bcoll02a bcoll03a
@@ -3077,31 +3080,33 @@ AudioEvent ScudLauncherWeapon
   Type        = world shrouded everyone
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent HeroUSAChargePlace
+;  Sounds      = iheuchar
+;  Priority    = high
+;  Volume      = 100
+;  MinRange    = 250
+;  MaxRange    = 2000
+;  Type        = world shrouded everyone
+;End
 
-AudioEvent HeroUSAChargePlace
-  Sounds      = iheuchar
-  Priority    = high
-  Volume      = 100
-  MinRange    = 250
-  MaxRange    = 2000
-  Type        = world shrouded everyone
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent HeroUSAChargeBeep
+;  Sounds      = iheubeep
+;  Volume      = 100
+;  MinRange    = 250
+;  MaxRange    = 2000
+;  Type        = world shrouded everyone
+;End
 
-AudioEvent HeroUSAChargeBeep
-  Sounds      = iheubeep
-  Volume      = 100
-  MinRange    = 250
-  MaxRange    = 2000
-  Type        = world shrouded everyone
-End
-
-AudioEvent HeroUSATimeBombClick
-  Sounds      = iheutima iheutimb
-  Volume      = 100
-  MinRange    = 250
-  MaxRange    = 2000
-  Type        = world shrouded everyone
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent HeroUSATimeBombClick
+;  Sounds      = iheutima iheutimb
+;  Volume      = 100
+;  MinRange    = 250
+;  MaxRange    = 2000
+;  Type        = world shrouded everyone
+;End
 
 AudioEvent StealthOn
   Sounds      = gstealon
@@ -3272,12 +3277,13 @@ AudioEvent BinkHandle
   Type = ui player
 End
 
-AudioEvent ExecuteDemoralize
-  Sounds      = uconst1a
-  Priority    = high
-  Volume      = 15
-  Type        = ui player
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent ExecuteDemoralize
+;  Sounds      = uconst1a
+;  Priority    = high
+;  Volume      = 15
+;  Type        = ui player
+;End
 
 AudioEvent RangerFlashBangWeapon
   Sounds      = iranflaa iranflab
@@ -4351,13 +4357,13 @@ AudioEvent SpySatellite
   Type        = world player
 End
 
-AudioEvent CrateCash
-  Sounds      = gcracash
-  Volume      = 100
-  Priority    = high
-  Type        = world global player
-End
-
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent CrateCash
+;  Sounds      = gcracash
+;  Volume      = 100
+;  Priority    = high
+;  Type        = world global player
+;End
 
 ; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) gstolo2a gstolo2b gstolo2c (#1913)
 AudioEvent FireStormLoop
@@ -6873,21 +6879,6 @@ AudioEvent HelixAmbientLoop
   Priority = normal
   Type = world shrouded everyone
 End
-
-;AudioEvent AircraftCarrierSelect
-;  Sounds= bairsela bairselb bairselc
-;  Limit= 1
-;  Volume= 40
-;  Type = ui player
-;End
-
-;AudioEvent AircraftCarrierVoiceAttack
-;  Sounds = bairatta bairattb bairattc bairattd bairatte
-;  Control = random
-;  Limit= 1
-;  Volume= 60
-;  Type = ui voice player
-;End
 
 ; Patch104p @bugfix commy2 09/09/2021 Sound used when Sentry Drone leaves factory.
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -3756,12 +3756,13 @@ AudioEvent AngryMobVoiceUpgradeArmTheMob
   Type = ui voice player
 End
 
-AudioEvent AngryMobVoiceUpgradeArmTheMobCrowd
-  Sounds    = iangupg
-  Limit     = 1
-  Volume    = 70
-  Type      = ui voice player
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent AngryMobVoiceUpgradeArmTheMobCrowd
+;  Sounds    = iangupg
+;  Limit     = 1
+;  Volume    = 70
+;  Type      = ui voice player
+;End
 
 AudioEvent AngryMobVoiceSelect
   Sounds = iangsela iangselb iangselc iangseld
@@ -5022,12 +5023,13 @@ AudioEvent ListeningOutpostVoiceMove
   Type = ui voice player
 End
 
-AudioEvent ListeningOutpostVoiceAttack
-  Sounds =  vlisata vlisatb vlisatc vlisatd vlisate
-  Control = random
-  Volume = 90
-  Type = ui voice player
-End
+; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+;AudioEvent ListeningOutpostVoiceAttack
+;  Sounds =  vlisata vlisatb vlisatc vlisatd vlisate
+;  Control = random
+;  Volume = 90
+;  Type = ui voice player
+;End
 
 
 AudioEvent ListeningOutpostVoiceDeploy

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -551,7 +551,7 @@ Weapon CrusaderMachineGun
   WeaponSpeed = 600         ; dist/sec
   ProjectileObject = NONE
   FireFX = WeaponFX_GenericTankGun
-  FireSound = GenericMachineGunFire
+  ;FireSound = GenericMachineGunFire
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 200               ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
@@ -2344,7 +2344,7 @@ Weapon SuicideDynamitePack
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_SuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -2366,7 +2366,7 @@ Weapon CrushedDynamitePack
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_CrushedDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -2387,7 +2387,7 @@ Weapon SuicideBikeBomb
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_SuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -2409,7 +2409,7 @@ Weapon Demo_SuicideBikeBomb
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_SuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -2431,7 +2431,7 @@ Weapon CrushedBikeBomb
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_SuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -2453,7 +2453,7 @@ Weapon SuicideCarBomb
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_SuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -2473,7 +2473,7 @@ Weapon CINEConvoyNuke
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_CINEConvoyNuke
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -5368,7 +5368,7 @@ Weapon GC_Chem_DemoTrapDetonationWeaponBeta
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoTrapDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
   FireOCL = OCL_PoisonFieldUpgradedMedium
 End
 
@@ -5390,7 +5390,7 @@ Weapon GC_Chem_DemoTrapDetonationWeaponGamma
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoTrapDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
   FireOCL = OCL_PoisonFieldGammaMedium
 End
 
@@ -6776,7 +6776,7 @@ Weapon GC_Chem_SuicideDynamitePackBeta
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_SuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
   FireOCL = OCL_PoisonFieldUpgradedMedium
 End
 
@@ -6798,7 +6798,7 @@ Weapon GC_Chem_SuicideDynamitePackGamma
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_SuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
   FireOCL = OCL_PoisonFieldGammaMedium
 End
 
@@ -6990,7 +6990,7 @@ Weapon Demo_SuicideDynamitePack
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoSuicideDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -7012,7 +7012,7 @@ Weapon Demo_CrushedDynamitePack
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoCrushedDynamitePackDetonation
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -7033,7 +7033,7 @@ Weapon Demo_SuicideDynamitePackPlusFire
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoSuicideDynamitePackDetonationPlusFire
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -7054,7 +7054,7 @@ Weapon Demo_DestroyedWeapon
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoDestroyedDynamitePackDetonation ; Patch104p @tweak commy2 02/09/2022 Use different effect for passive destruction.
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 ;------------------------------------------------------------------------------
@@ -7155,7 +7155,7 @@ Weapon Demo_TerroristOnCombatBikeSuicideDynamitePack
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoSuicideDynamitePackDetonation ; Patch104p @bugfix commy2 09/09/2021 Fixed Demo Bike was using regular Terrorist explosion.
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 
@@ -7177,7 +7177,7 @@ Weapon Demo_TerroristOnCombatBikeSuicideDynamitePackPlusFire
   ClipReloadTime = 0
   AutoReloadsClip = No
   FireFX = WeaponFX_DemoSuicideDynamitePackDetonationPlusFire ; Patch104p @bugfix commy2 09/09/2021 Fixed Demo Bike was using regular Terrorist explosion.
-  FireSound = CarBomberDie
+  ;FireSound = CarBomberDie
 End
 
 


### PR DESCRIPTION
* Relates to #176

This change removes audio events that reference no valid sounds.

* GenericMachineGunFire
* MedicMoveStart
* CarBomberDie
* ExplosionGeneric
* HeroUSAChargePlace
* HeroUSAChargeBeep
* HeroUSATimeBombClick
* ExecuteDemoralize
* CrateCash
* AngryMobVoiceUpgradeArmTheMobCrowd
* ListeningOutpostVoiceAttack
