### PR TITLE
Fix: Misspelled sounds in audio events

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1913_misspelled_audio_event_sounds.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1913_misspelled_audio_event_sounds.yaml
@@ -1,0 +1,34 @@
+---
+date: 2023-05-05
+
+title: Fixes misspelled sounds in audio events
+
+changes:
+  - fix: Fixes misspelled sound(s) gcardami in CarDamagedMoveLoop.
+  - fix: Fixes misspelled sound(s) ucheergl in MissionAccomplishedSound.
+  - fix: Fixes misspelled sound(s) ihaclo1a in HackerWeaponLoop. The hack sequence now has an initiation sound like Black Lotus has.
+  - fix: Fixes misspelled sound(s) icifcdif in CivilianArabFemaleDie.
+  - fix: Fixes misspelled sound(s) gstolo2a, gstolo2b, gstolo2c in FireStormLoop. China Fire Storms now loop correctly.
+  - fix: Fixes misspelled sound(s) irancld "Little house party" in RangerVoiceClearBuilding.
+  - fix: Fixes misspelled sound(s) vhumunc "It's been real" in HumveeVoiceUnload.
+  - fix: Fixes misspelled sound(s) vpoupib "Yeah there should be enough room for him" in POWTruckUSAVoicePickup.
+  - fix: Fixes misspelled sound(s) iredlaa "Ahh hahaha" in RedGuardVoiceLaugh.
+  - fix: Removes misspelled sound(s) vdocclc "Our people will be safer" in DozerChinaVoiceClearMine.
+  - fix: Fixes misspelled sound(s) vnukd2c "Folding up" in NukeCannonVoiceUnDeploy.
+  - fix: Fixes misspelled sound(s) vscoa2b "Sending the missile" in ScorpionTankVoiceAttackRocket.
+  - fix: Fixes misspelled sound(s) vquacra "The worms should like the dirt" in QuadCannonVoiceCrush.
+  - fix: Fixes misspelled sound(s) iworgaa "I will go in that building" in WorkerVoiceGarrison.
+  - fix: Fixes misspelled sound(s) iworrea "I should repair that" in WorkerVoiceRepair.
+  - fix: Fixes misspelled sound(s) ihijatc "It will be mine" in HijackerVoiceAttack.
+
+labels:
+  - audio
+  - bug
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1913
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -1862,8 +1862,9 @@ AudioEvent BuildingCollapse3
   Type = world shrouded everyone
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) gcardami (#1913)
 AudioEvent CarDamagedMoveLoop
-  Sounds = gcardama gcardamb gcardamc gcardamd gcardame gcardamf gcardamg gcardamh gcardamai gcardamj
+  Sounds = gcardama gcardamb gcardamc gcardamd gcardame gcardamf gcardamg gcardamh gcardami gcardamj
   Control = random loop
   Limit = 2
   Delay = 4000 10000
@@ -2316,8 +2317,9 @@ AudioEvent BattleCrySound
   Type = ui player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) ucheer (#1913)
 AudioEvent MissionAccomplishedSound
-  Sounds = ucheer
+  Sounds = ucheergl
   Volume = 75
   Type = ui player
 End
@@ -3114,10 +3116,11 @@ AudioEvent StealthOff
   Type        = world shrouded everyone
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled attack ihaclo1a (#1913)
 AudioEvent HackerWeaponLoop
   Control = loop all random
   Sounds =  ihaclo2a ihaclo2b ihaclo2c
-  Attack =  ihaco1a
+  Attack =  ihaclo1a
   Decay =  ihaclo3a
   PitchShift = -10 10
   VolumeShift= -15
@@ -4118,8 +4121,9 @@ AudioEvent CivilianArabMaleDie
   Type = world shrouded everyone
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) icifcdif (#1913)
 AudioEvent CivilianArabFemaleDie
-  Sounds =  icifcdia icifcdib icifcdic icifcdid icifcdie icifdif icifcdig icifcdih icifcdii icifcdij
+  Sounds =  icifcdia icifcdib icifcdic icifcdid icifcdie icifcdif icifcdig icifcdih icifcdii icifcdij
   Volume = 100
   Limit = 3
   Priority    = normal
@@ -4354,8 +4358,9 @@ AudioEvent CrateCash
 End
 
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) gstolo2a gstolo2b gstolo2c (#1913)
 AudioEvent FireStormLoop
-  Sounds     = gstolo1a gstolo1b gstolo1c
+  Sounds     = gstolo2a gstolo2b gstolo2c
   Attack     = gstolo1a
   Decay      = gstolo3a
   Control    = random loop all

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -57,8 +57,10 @@ AudioEvent RangerVoiceCaptureComplete
   Type = world player global
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) irancld (#1913)
+; irancld "Little house party"
 AudioEvent RangerVoiceClearBuilding
-  Sounds = irancla iranclb iranclc irancl
+  Sounds = irancla iranclb iranclc irancld
   Control = random
   Limit = 1
   Volume = 90
@@ -848,8 +850,10 @@ AudioEvent HumveeVoiceUpgradeTowMissiles
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) vhumunc (#1913)
+; vhumunc "It's been real"
 AudioEvent HumveeVoiceUnload
-  Sounds = vhumuna vhumunb vhumhunc vhumund
+  Sounds = vhumuna vhumunb vhumunc vhumund
   Control = random
   Volume = 90
   Type = ui voice player
@@ -1327,8 +1331,10 @@ AudioEvent POWTruckUSAVoiceMove
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) vpoupib (#1913)
+; vpoupib "Yeah there should be enough room for him"
 AudioEvent POWTruckUSAVoicePickup
-  Sounds =  vpoupia vvpoupib vpoupic vpoupid vpoupie
+  Sounds =  vpoupia vpoupib vpoupic vpoupid vpoupie
   Control = random
   Volume = 90
   Type = ui voice player
@@ -1453,8 +1459,10 @@ AudioEvent RedGuardVoiceBaseAttack
   Type = world global player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) iredlaa (#1913)
+; iredlaa "Ahh hahaha"
 AudioEvent RedGuardVoiceLaugh
-  Sounds = iredla iredlab iredlac
+  Sounds = iredlaa iredlab iredlac
   Control = random
   Priority = high
   Volume  = 120
@@ -2383,8 +2391,10 @@ AudioEvent DozerChinaVoiceCrush
   Type = ui voice player
 End
 
+; Patch104p @tweak xezon 05/05/2023 Removes misspelled sound vdocclc (#1913)
+; vdocclc "Our people will be safer"
 AudioEvent DozerChinaVoiceClearMine
-  Sounds = vdoccla vdocclb vdocdlc vdoccld
+  Sounds = vdoccla vdocclb vdoccld ; vdocclc
   Control = random
   Volume = 90
   Type = ui voice player
@@ -2429,8 +2439,10 @@ AudioEvent NukeCannonVoiceDeploy
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) vnukd2c (#1913)
+; vnukd2c "Folding up"
 AudioEvent NukeCannonVoiceUnDeploy
-  Sounds = vnukd2a vnukd2b vnuk2c
+  Sounds = vnukd2a vnukd2b vnukd2c
   Control = random
   Volume = 90
   Type = ui voice player
@@ -2787,8 +2799,10 @@ AudioEvent ScorpionTankVoiceAttack
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) vscoa2b (#1913)
+; vscoa2b "Sending the missile"
 AudioEvent ScorpionTankVoiceAttackRocket
-  Sounds = vscoa2a vsco2b vscoa2c vscoa2d vscoa2e
+  Sounds = vscoa2a vscoa2b vscoa2c vscoa2d vscoa2e
   Control = random
   Volume = 90
   Type = ui voice player
@@ -3182,8 +3196,10 @@ AudioEvent QuadCannonVoiceSalvage
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) vquacra (#1913)
+; vquacra "The worms should like the dirt"
 AudioEvent QuadCannonVoiceCrush
-  Sounds = vquaacra vquacrb vquacrc vquacrd
+  Sounds = vquacra vquacrb vquacrc vquacrd
   Control = random
   Volume = 90
   Type = ui voice player
@@ -3224,8 +3240,10 @@ AudioEvent WorkerVoiceMoveUpgraded
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) iworgaa (#1913)
+; iworgaa "I will go in that building"
 AudioEvent WorkerVoiceGarrison
-  Sounds = iworga iworgab iworgac
+  Sounds = iworgaa iworgab iworgac
   Control = random
   Volume = 90
   Type = ui voice player
@@ -3263,8 +3281,10 @@ AudioEvent WorkerVoiceSuppliesDepleted
   Type = world player global
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) iworrea (#1913)
+; iworrea "I should repair that"
 AudioEvent WorkerVoiceRepair
-  Sounds = iworre iworreb iworrec iworred iworree iworref
+  Sounds = iworrea iworreb iworrec iworred iworree iworref
   Control = random
   Volume = 90
   Type = ui voice player
@@ -3365,8 +3385,10 @@ AudioEvent HijackerVoiceGarrison
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Fixes misspelled sound(s) ihijatc (#1913)
+; ihijatc "It will be mine"
 AudioEvent HijackerVoiceAttack
-  Sounds = ihijata ihijatb ihijtc ihijatd ihijate
+  Sounds = ihijata ihijatb ihijatc ihijatd ihijate
   Control = random
   Volume = 90
   Type = ui voice player


### PR DESCRIPTION
* Relates to #176

This change fixes misspelled sounds in audio events. Some of these audio events are unused in the game.

### CarDamagedMoveLoop

* gcardami

### MissionAccomplishedSound

* ucheergl

### HackerWeaponLoop

* ihaclo1a, Hack sequence now has initiation sound like Black Lotus has.

### CivilianArabFemaleDie

* icifcdif, Scream

### FireStormLoop

* gstolo2a gstolo2b gstolo2c, China Fire Storms now loop correctly

### RangerVoiceClearBuilding

* irancld "Little house party"

### HumveeVoiceUnload

* vhumunc "It's been real"

### POWTruckUSAVoicePickup

* vpoupib "Yeah there should be enough room for him"

### RedGuardVoiceLaugh

* iredlaa "Ahh hahaha"

### DozerChinaVoiceClearMine

* vdocclc "Our people will be safer", Removed

### NukeCannonVoiceUnDeploy

* vnukd2c "Folding up"

### ScorpionTankVoiceAttackRocket

* vscoa2b "Sending the missile"

### QuadCannonVoiceCrush

* vquacra "The worms should like the dirt"

### WorkerVoiceGarrison

* iworgaa "I will go in that building"

### WorkerVoiceRepair

* iworrea "I should repair that"

### HijackerVoiceAttack

* ihijatc "It will be mine"