### PR TITLE
Add new audio events for unreferenced sounds

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1916_new_audio_events.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1916_new_audio_events.yaml
@@ -1,0 +1,24 @@
+---
+date: 2023-05-05
+
+title: Adds new audio events for originally unreferenced sounds
+
+changes:
+  - feature: |
+      Adds new audio events for originally unreferenced sounds.
+        - GenericDamaged
+        - CivGrappleAmbientLoop
+        - Cin_ParadeMusicLoop
+        - CivilianPanicFemale2
+
+labels:
+  - audio
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1916
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -3500,6 +3500,16 @@ AudioEvent BridgeDamaged
   Type = world shrouded everyone
 End
 
+; Patch104p @feature xezon 05/05/2023 Adds former unused sound(s) in new audio event. (#1916)
+AudioEvent GenericDamaged
+  Sounds =  bgendama bgendamb bgendamc
+  Control = random
+  Volume = 90
+  Limit = 2
+  Priority = normal
+  Type = world shrouded everyone
+End
+
 ;The regular un-upgraded bomb truck bomb when it blows.
 AudioEvent BombTruckDefaultBombDetonation
   Sounds      = bgendiea bgendieb bgendiec bgendied bgendiee bgendief
@@ -4514,6 +4524,17 @@ AudioEvent CivAirportAmbience
   Type = world everyone
 End
 
+; Patch104p @feature xezon 05/05/2023 Adds former unused sound(s) in new audio event. (#1916)
+AudioEvent CivGrappleAmbientLoop
+  Sounds = bgralo2a bgralo2b
+  Attack = bgralo1
+  Decay = bgralo3
+  Control = loop all random
+  Priority = lowest
+  Volume = 70
+  VolumeShift = -10
+  Type = world everyone
+End
 
 AudioEvent CivIndustrialPlantAmbientLoop
   Sounds = bindlo1a bindlo1b bindlo1c bindlo1d
@@ -6332,6 +6353,16 @@ AudioEvent Cin_ParadeTank3
   Type       = world everyone
 End
 
+; Patch104p @feature xezon 05/05/2023 Adds former unused sound(s) in new audio event. (#1916)
+AudioEvent Cin_ParadeMusicLoop
+  Sounds = cparmusa
+  Control = loop
+  Priority = low
+  Limit = 2
+  Volume = 100
+  Type = world everyone
+End
+
 AudioEvent Cin_ParadePanicFemaleLoop
   Sounds =  cparpa1a cparpa1b cparpa1c cparpa1d cparpa1e
   Control = random loop all
@@ -6389,6 +6420,15 @@ End
 
 AudioEvent CivilianPanicFemale
   Sounds =  gpanfema gpanfemb gpanfemc
+  Volume = 65
+  VolumeShift = -20
+  Limit = 2
+  Type = world shrouded everyone
+End
+
+; Patch104p @feature xezon 05/05/2023 Adds former unused sound(s) in new audio event. (#1916)
+AudioEvent CivilianPanicFemale2
+  Sounds =  gpanfe2a gpanfe2b gpanfe2c gpanfe2d gpanfe2e
   Volume = 65
   VolumeShift = -20
   Limit = 2


### PR DESCRIPTION
* Relates to #176

This change adds new audio events for previously unreferenced sounds. The settings of the events have been copied from similar audio events.

* GenericDamaged
* CivGrappleAmbientLoop
* Cin_ParadeMusicLoop
* CivilianPanicFemale2
