### PR TITLE
Move new upgrade audio event INI definitions near the original ones

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1026_fortified_structure_upgrade_voice.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1026_fortified_structure_upgrade_voice.yaml
@@ -14,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1026
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1917
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/1026_moab_upgrade_voice.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1026_moab_upgrade_voice.yaml
@@ -14,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1026
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1917
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/1026_neutron_shells_upgrade_voice.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1026_neutron_shells_upgrade_voice.yaml
@@ -14,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1026
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1917
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/1026_sentry_gun_upgrade_voice.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1026_sentry_gun_upgrade_voice.yaml
@@ -14,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1026
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1917
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -5314,6 +5314,38 @@ AudioEvent HelixVoiceUpgradeNuclearBomb
   Type = ui voice player
 End
 
+; Patch104p @feature commy2 20/08/2022 Adds upgrade voice for MOAB. (#1026)
+AudioEvent EvaVoiceUpgradeMOAB
+  Sounds = eumoaup
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+; Patch104p @feature commy2 20/08/2022 Adds upgrade voice for Sentry Drone Gun. (#1026)
+AudioEvent EvaVoiceUpgradeSentryDrone
+  Sounds = eusdrnup
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+; Patch104p @feature commy2 20/08/2022 Adds upgrade voice for Neutron Shells. (#1026)
+AudioEvent EvaVoiceUpgradeNeutronShell
+  Sounds = ecneutup
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+; Patch104p @feature commy2 20/08/2022 Adds upgrade voice for Fortified Structure. (#1026)
+AudioEvent EvaVoiceUpgradeFortifiedStructure
+  Sounds = eggardup
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
 ; Patch104p @feature Stubbjax 23/09/2022 Adds upgrade voice for Satellite Hack One. (#1262)
 AudioEvent EvaVoiceUpgradeSatelliteHackOne
   Sounds = ecsat1up
@@ -5681,32 +5713,3 @@ End
 
 
 
-
-; Patch104p @tweak commy2 20/08/2022 Add some upgrade voice lines.
-AudioEvent EvaVoiceUpgradeMOAB
-  Sounds = eumoaup
-  Control = random
-  Volume = 90
-  Type = ui voice player
-End
-
-AudioEvent EvaVoiceUpgradeSentryDrone
-  Sounds = eusdrnup
-  Control = random
-  Volume = 90
-  Type = ui voice player
-End
-
-AudioEvent EvaVoiceUpgradeNeutronShell
-  Sounds = ecneutup
-  Control = random
-  Volume = 90
-  Type = ui voice player
-End
-
-AudioEvent EvaVoiceUpgradeFortifiedStructure
-  Sounds = eggardup
-  Control = random
-  Volume = 90
-  Type = ui voice player
-End


### PR DESCRIPTION
* Follow up for #1026

This change moves the new upgrade audio event INI definitions near the original ones. No change in functionality.