### PR TITLE
Remove duplicate and obsolete AuroraBomberVoiceUpgradeBuster definition

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -712,15 +712,16 @@ AudioEvent AuroraBomberVoiceFalling
   Type = world shrouded player
 End
 
-AudioEvent AuroraBomberVoiceUpgradeBuster
-  Sounds =  vauru1a ;vauru1a vauru1b
-  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
-  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
-  Control = random
-  Volume  = 120
-  MinVolume = 110
-  Type = world player global
-End
+; Patch104p @refactor xezon 05/05/2023 Removes duplicate of AuroraVoiceUpgradeBunkerBuster.
+;AudioEvent AuroraBomberVoiceUpgradeBuster
+;  Sounds =  vauru1a ;vauru1a vauru1b
+;  Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
+;  Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
+;  Control = random
+;  Volume  = 120
+;  MinVolume = 110
+;  Type = world player global
+;End
 
 
 


### PR DESCRIPTION
This change removes `AuroraBomberVoiceUpgradeBuster`. It is a duplicate of `AuroraVoiceUpgradeBunkerBuster`.