### PR TITLE
Change: Adds sound variation for selecting the GLA Barracks

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -1341,8 +1341,14 @@ AudioEvent BarracksChinaSelect
   Type = ui player
 End
 
+; Patch104p @tweak xezon 05/05/2023 Optionally adds former unused sound(s) bbargsel
 AudioEvent BarracksGLASelect
-  Sounds= bbagsela
+;patch104p-core-begin
+  Sounds = bbagsela
+;patch104p-core-end
+;patch104p-optional-begin
+  Sounds = bbagsela bbargsel
+;patch104p-optional-end
   Limit= 1
   Volume= 50
   Type = ui player

--- a/Patch104pZH/ModBundleItems.json
+++ b/Patch104pZH/ModBundleItems.json
@@ -364,6 +364,7 @@
                         "parent": "GameFilesEdited",
                         "sourceList": [
                             "Data/INI/CommandSet.ini",
+                            "Data/INI/SoundEffects.ini",
                             "Data/INI/Voice.ini"
                         ],
                         "params": {


### PR DESCRIPTION
* Relates to #176

This change adds a sound variation for selecting the GLA Barracks. The sound is similar to the original one. For optional bundle.