### PR TITLE
Fix: Remove duplicate sounds in audio events

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1926_duplicate_audio_event_sounds.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1926_duplicate_audio_event_sounds.yaml
@@ -1,0 +1,24 @@
+---
+date: 2023-05-05
+
+title: Removes duplicate sounds in audio events
+
+changes:
+  - fix: Removes duplicate sounds in CrowdPanic.
+  - fix: Removes duplicate sounds in CrowdPanicLong.
+  - fix: Removes duplicate sounds in HumveeMoveStart.
+  - fix: Removes duplicate sounds in Amb_UrbanChinaCourtyardBirds.
+  - fix: Removes duplicate sounds in ComancheVoiceAttackRocket.
+  - fix: Removes duplicate sounds in MigVoiceFalling.
+  - fix: Removes duplicate sounds in JarmenKellVoiceFear.
+
+labels:
+  - audio
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1926
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -1669,16 +1669,17 @@ AudioEvent ComancheDamagedLoopGlobal
   Priority= low
 End
 
-
+; Patch104p @fix xezon 05/05/2023 Removes duplicate sound(s) gpanic1d (#1926)
 AudioEvent CrowdPanic
-  Sounds =  gpanic1a gpanic1b gpanic1c gpanic1d gpanic1d gpanic1f gpanic1g
+  Sounds =  gpanic1a gpanic1b gpanic1c gpanic1d gpanic1f gpanic1g ; gpanic1e
   Volume = 65
   Limit = 2
   Type = world shrouded everyone
 End
 
+; Patch104p @fix xezon 05/05/2023 Removes duplicate sound(s) gpanic1d (#1926)
 AudioEvent CrowdPanicLong
-  Sounds =  gpanic1a gpanic1b gpanic1c gpanic1d gpanic1d gpanic1f gpanic1g
+  Sounds =  gpanic1a gpanic1b gpanic1c gpanic1d gpanic1f gpanic1g ; gpanic1e
   Volume = 65
   Limit = 2
   Type = world shrouded everyone
@@ -2627,8 +2628,9 @@ AudioEvent FerryMoveLoop
   Type        = world shrouded everyone
 End
 
+; Patch104p @fix xezon 05/05/2023 Removes duplicate sound(s) vhumstaa vhumstab vhumstac vhumstad (#1926)
 AudioEvent HumveeMoveStart
-  Sounds      = vhumstaa vhumstab vhumstac vhumstad vhumstaa vhumstab vhumstac vhumstad vhumstae
+  Sounds      = vhumstaa vhumstab vhumstac vhumstad vhumstae
   Volume      = 60
   PitchShift  = -5 5
   Delay       = 0 500
@@ -5918,9 +5920,9 @@ AudioEvent Amb_UrbanChinaCourtyardLoop
   Type = world everyone
 End
 
-
+; Patch104p @fix xezon 05/05/2023 Removes duplicate sound(s) auccbi1g (#1926)
 AudioEvent Amb_UrbanChinaCourtyardBirds
-  Sounds = auccbi1a auccbi1c auccbi1d auccbi1e auccbi1f auccbi1g auccbi1g auccbi1h auccbi1i ;auccbi1b missing
+  Sounds = auccbi1a auccbi1c auccbi1d auccbi1e auccbi1f auccbi1g auccbi1h auccbi1i ;auccbi1b missing
   Delay = 6000  12000
   Control = loop all random
   Priority = LOWEST

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -496,8 +496,9 @@ AudioEvent ComancheVoiceAttack
   Type = ui voice player
 End
 
+; Patch104p @fix xezon 05/05/2023 Removes duplicate sound(s) vcoma2b (#1926)
 AudioEvent ComancheVoiceAttackRocket
-  Sounds = vcoma2a vcoma2b vcoma2b vcoma2c vcoma2d
+  Sounds = vcoma2a vcoma2b vcoma2c vcoma2d
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
@@ -1763,8 +1764,9 @@ AudioEvent MigVoiceAirPatrol
   Type = ui voice player
 End
 
+; Patch104p @fix xezon 05/05/2023 Removes duplicate sound(s) vmigfac (#1926)
 AudioEvent MigVoiceFalling
-  Sounds = vmigfaa vmigfab vmigfac vmigfac vmigfad vmigfae
+  Sounds = vmigfaa vmigfab vmigfac vmigfad vmigfae
   Control = random
   Priority = LOW ; Patch104p @bugfix to be consistent with Voice Die limits
   Limit = 3 ; Patch104p @bugfix to be consistent with Voice Die limits
@@ -3498,8 +3500,9 @@ AudioEvent JarmenKellVoiceModeSnipe
   Limit = 1
 End
 
+; Patch104p @fix xezon 05/05/2023 Removes duplicate sound(s) ijarfec (#1926)
 AudioEvent JarmenKellVoiceFear
-  Sounds = ijarfea ijarfeb ijarfec ijarfec ijarfed ijarfee
+  Sounds = ijarfea ijarfeb ijarfec ijarfed ijarfee
   Control = random
   Volume = 100
   MinVolume = 80


### PR DESCRIPTION
* Relates to #176

This change removes duplicate sounds in audio events:

* CrowdPanic
* CrowdPanicLong
* HumveeMoveStart
* Amb_UrbanChinaCourtyardBirds
* ComancheVoiceAttackRocket
* MigVoiceFalling
* JarmenKellVoiceFear