### PR TITLE
Fix: Sets correct decay and attack sounds for AmbientCrowdAngryArabs1, AvalancheTextureLoop

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1927_incorrect_audio_event_sounds.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1927_incorrect_audio_event_sounds.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-05
+
+title: Sets correct attack and decay sounds in audio events
+
+changes:
+  - fix: Sets correct decay sound in AmbientCrowdAngryArabs1.
+  - fix: Sets correct attack and decay sounds in AvalancheTextureLoop.
+
+labels:
+  - audio
+  - bug
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1927
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -2756,10 +2756,11 @@ AudioEvent AmbientInfantryCharge1
   Type       = world shrouded everyone
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Sets correct decay sound. (#1927)
 AudioEvent AmbientCrowdAngryArabs1
   Control = loop all random
   Sounds =  aangr01a aangr01b aangr01c aangr01d
-  Decay = ainfa01e
+  Decay = aangr01e
   Limit = 2
   PitchShift = -5  5
 ;  MinRange = 200
@@ -6927,11 +6928,12 @@ AudioEvent AvalancheRumbleLoop
   Type = world shrouded everyone
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Sets correct attack and decay sounds. (#1927)
 AudioEvent AvalancheTextureLoop
   Control = loop all random
   Sounds =  cavtlo2a cavtlo2b cavtlo2c cavtlo2d cavtlo2e cavtlo2a cavtlo2b cavtlo2d cavtlo2e
-  Attack = cavtlo2a
-  Decay = cavtlo3a
+  Attack = cavtlo1a
+  Decay = cavtlo2f
   Limit = 1
   Volume = 130
   MinRange = 600


### PR DESCRIPTION
* Relates to #176

This change sets the correct decay and attack sounds for AmbientCrowdAngryArabs1 and AvalancheTextureLoop.