### PR TITLE
Fix: Set unique set of insect sounds for Amb_DesertVillageNightInsect2

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1929_night_insect_sounds.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1929_night_insect_sounds.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-05-05
+
+title: Sets unique set of insect sounds for Amb_DesertVillageNightInsect2
+
+changes:
+  - fix: Sets unique set of insect sounds for Amb_DesertVillageNightInsect2. Originally it uses the same sounds as Amb_DesertVillageNightInsect does.
+
+labels:
+  - audio
+  - enhancement
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1929
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -5174,8 +5174,9 @@ AudioEvent Amb_DesertVillageNightInsect
   Type = world everyone
 End
 
+; Patch104p @fix xezon 05/05/2023 Sounds from adnvin1a adnvin1b adnvin1c. (#1929)
 AudioEvent Amb_DesertVillageNightInsect2
-  Sounds = adnvin1a adnvin1b adnvin1c
+  Sounds = adnvin2a adnvin2b adnvin2c adnvin2d
   Control = loop random
   Priority = lowest
   Volume = 90


### PR DESCRIPTION
* Relates to #176

This change adds the unused night insect sounds to Amb_DesertVillageNightInsect2.

Originally Amb_DesertVillageNightInsect and Amb_DesertVillageNightInsect2 use the same set of sounds, while there is a second set of night insect sounds.