### PR TITLE
Fix: Achieve homogeneous firing sound for machine guns of USA Comanche and China Helix

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1930_comanche_gun_firing_sequence.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1930_comanche_gun_firing_sequence.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-05-05
+
+title: Achieves homogeneous firing sound for machine gun of USA Comanche
+
+changes:
+  - tweak: Achieves homogeneous firing sound for machine gun of USA Comanche by removing the audio file with the single shot.
+
+labels:
+  - audio
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1930
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1930_helix_gun_firing_sequence.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1930_helix_gun_firing_sequence.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-05-05
+
+title: Achieves homogeneous firing sound for machine gun of China Helix
+
+changes:
+  - tweak: Achieves homogeneous firing sound for machine gun of China Helix by removing the audio file with the single shot.
+
+labels:
+  - audio
+  - china
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1930
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -3980,9 +3980,11 @@ AudioEvent RailroadBridgeMetalFatigue
   Type = world shrouded everyone
 End
 
+
 ; Patch104p @tweak xezon 09/05/2023 Increases volume from 70 so it is not much quieter than Ranger and Humvee. (#1939)
+; Patch104p @fix xezon 05/05/2023 Removes vcomwe2c to achieve homogeneous firing sequence. (#1930)
 AudioEvent ComancheWeaponMachineGun
-  Sounds = vcomwe2a vcomwe2b vcomwe2c vcomwe2d
+  Sounds = vcomwe2a vcomwe2b vcomwe2d ; (double shot) ; vcomwe2c (single shot)
   Control= random interrupt
   Priority = normal
   VolumeShift= -15
@@ -7661,8 +7663,9 @@ AudioEvent CombatCycleRebelWeapon
 End
 
 ; Patch104p @tweak xezon 09/05/2023 Increases volume from 80 so it is not much quieter than Ranger and Humvee. (#1939)
+; Patch104p @fix xezon 05/05/2023 Removes vcomwe2c to achieve homogeneous firing sequence. (#1930)
 AudioEvent HelixWeaponMachineGun
-  Sounds = vcomwe2a vcomwe2b vcomwe2c vcomwe2d
+  Sounds = vcomwe2a vcomwe2b vcomwe2d ; (double shot) ; vcomwe2c (single shot)
   Control= random interrupt
   Priority = normal
   VolumeShift= -15


### PR DESCRIPTION
This change achieves homogeneous firing sound for the machine guns of USA Comanche and China Helix.

Originally it plays sounds from a pool of 4 files, where 3 have a double shot and 1 has a single shot. The single shot sound interrupts the homogeneous firing.

## Original

https://user-images.githubusercontent.com/4720891/236868176-5d27ed2c-69ab-4f0a-bafc-04d200482866.mp4

## Patched

https://user-images.githubusercontent.com/4720891/236868234-b62ee27c-808e-4c0b-95c7-ecc9219404e1.mp4
