### PR TITLE
Change: Add unique machine gun firing sounds to USA Battle Drone

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1931_battle_drone_gun_audio.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1931_battle_drone_gun_audio.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-05
+
+title: Adds unique machine gun firing sounds to USA Battle Drone
+
+changes:
+  - feature: Adds unique machine gun firing sounds to the USA Battle Drone. Originally it uses the machine gun sounds of the Comanche helicopter.
+
+labels:
+  - audio
+  - enhancement
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1931
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -3139,16 +3139,15 @@ AudioEvent HackerWeaponLoop
 End
 
 
-
+; Patch104p @feature xezon 05/05/2023 Replaces comanche gun sounds with drone gun sounds. (#1931)
 AudioEvent BattleDroneWeapon
-  Sounds = vcomwe2a vcomwe2b vcomwe2c vcomwe2d
-;  Sounds = vdroweaa vdroweab vdroweac vdrowead vdroweae
+  Sounds = vdrowead vdroweae ; (single shot) ; vdroweaa vdroweab vdroweac (multi shot)
   Control= random interrupt
   Priority    = normal
-;  PitchShift = -5 5
+  PitchShift = -5 5
   VolumeShift= -15
   Limit = 3
-  Volume = 70
+  Volume = 60
 ;  MinRange = 200
 ;  MaxRange = 600
   Type = world shrouded everyone


### PR DESCRIPTION
* Relates to #176

This change enables the unique gun firing sounds for the USA Battle Drone. This way the Battle Drone gun no longer sounds like the guns of the Helix and Comanche. The sounds already exist in the game but were unused.

### Original

https://user-images.githubusercontent.com/4720891/236870858-137787e2-cec6-4ab5-9638-12fd6288663e.mp4

### Patched

https://user-images.githubusercontent.com/4720891/236870930-f830f1dc-a1da-4d8e-b5ad-fbd0a05cb65e.mp4
