### PR TITLE
Fix: Remove invalid sound from SupplyTruckVoiceSupply

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1933_supply_truck_invalid_sound.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1933_supply_truck_invalid_sound.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-05
+
+title: Removes invalid sound from SupplyTruckVoiceSupply
+
+changes:
+  - fix: Removes invalid sound vsupspe from SupplyTruckVoiceSupply.
+
+labels:
+  - audio
+  - bug
+  - china
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1933
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -2304,8 +2304,9 @@ AudioEvent SupplyTruckVoiceMove
   Type = ui voice player
 End
 
+; Patch104p @bugfix xezon 05/05/2023 Removes missing sound(s) vsupspe (#1933)
 AudioEvent SupplyTruckVoiceSupply
-  Sounds = vsupspa vsupspb vsupspc vsupspd vsupspe
+  Sounds = vsupspa vsupspb vsupspc vsupspd
   Control = random
   Volume = 90
   Type = ui voice player


### PR DESCRIPTION
* Relates to #176

This change removes an invalid sound from the SupplyTruckVoiceSupply.