### PR TITLE
Change: Increase volume of ComancheWeaponMachineGun, HelixWeaponMachineGun

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1939_comanche_gun_volume.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1939_comanche_gun_volume.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-09
+
+title: Increases volume of USA Comanche machine gun
+
+changes:
+  - tweak: Increases the volume of the USA Comanche machine gun from 70 to 90. It is no longer much quieter than machine guns of Humvee and Ranger.
+
+labels:
+  - audio
+  - design
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1939
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1939_helix_gun_volume.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1939_helix_gun_volume.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-09
+
+title: Increases volume of China Helix machine gun
+
+changes:
+  - tweak: Increases the volume of the China Helix machine gun from 80 to 90. It is no longer much quieter than machine guns of Humvee and Ranger.
+
+labels:
+  - audio
+  - china
+  - design
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1939
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -3980,14 +3980,14 @@ AudioEvent RailroadBridgeMetalFatigue
   Type = world shrouded everyone
 End
 
-
+; Patch104p @tweak xezon 09/05/2023 Increases volume from 70 so it is not much quieter than Ranger and Humvee. (#1939)
 AudioEvent ComancheWeaponMachineGun
   Sounds = vcomwe2a vcomwe2b vcomwe2c vcomwe2d
   Control= random interrupt
   Priority = normal
   VolumeShift= -15
   Limit = 3
-  Volume = 70
+  Volume = 90
 ;  MinRange = 400
 ;  MaxRange = 800
   Type = world shrouded everyone

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -7660,13 +7660,14 @@ AudioEvent CombatCycleRebelWeapon
   Type = world shrouded everyone
 End
 
+; Patch104p @tweak xezon 09/05/2023 Increases volume from 80 so it is not much quieter than Ranger and Humvee. (#1939)
 AudioEvent HelixWeaponMachineGun
   Sounds = vcomwe2a vcomwe2b vcomwe2c vcomwe2d
   Control= random interrupt
   Priority = normal
   VolumeShift= -15
   Limit = 3
-  Volume = 80
+  Volume = 90
 ;  MinRange = 400
 ;  MaxRange = 800
   Type = world shrouded everyone


### PR DESCRIPTION
This change increases the volume of the ComancheWeaponMachineGun from 70 to 90, HelixWeaponMachineGun from 80 to 90. This way it is no longer much quieter than guns of Ranger, Humvee and Co.

## Original

Humvee Gun: ~ -8 db
Ranger Gun: ~ -10 db
Comanche Gun: ~ -15 db
Helix Gun: ~ -12 db

## Patched

Comanche Gun: ~ -10 db
Helix Gun: ~ -10 db