### PR TITLE
Fix: Misspelled speech in dialog events

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1940_misspelled_dialog_event_sounds.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1940_misspelled_dialog_event_sounds.yaml
@@ -1,0 +1,26 @@
+---
+date: 2023-05-09
+
+title: Fixes misspelled speech in dialog events
+
+changes:
+  - fix: Fixes misspelled filename in EvaGLA_CashStolen.
+  - fix: Fixes misspelled filename in EvaGLA_VehicleStolen.
+  - fix: Fixes misspelled filename in EvaChina_CashStolen.
+  - fix: Fixes misspelled filename in EvaUSA_BaseDefensesOffLine.
+  - fix: Fixes misspelled filename in EvaUSA_CashStolen.
+  - fix: Fixes misspelled filename in Cin_SquadronFlyBy02.
+  - fix: Fixes misspelled filename in Taunts_Turtle087.
+  - fix: Fixes misspelled filename in EvaGLA_FundsTransferred.
+
+labels:
+  - audio
+  - bug
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1940
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Speech.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Speech.ini
@@ -65,8 +65,9 @@ DialogEvent EvaGLA_BuildingStolen
   Volume= 90
 End
 
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent EvaGLA_CashStolen
-  Filename = eglcashs.wav
+  Filename = egcashs.wav
   Volume= 90
 End
 
@@ -147,9 +148,9 @@ DialogEvent EvaGLA_UnitLost
   Filename =  egunitl.wav
 End
 
-
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent EvaGLA_VehicleStolen
-  Filename =  eglvehst.wav
+  Filename =  egvehst.wav
 End
 
 DialogEvent EvaGLA_UpgradeComplete
@@ -199,8 +200,9 @@ DialogEvent EvaChina_BuildingStolen
   Filename =  ecbuist.wav
 End
 
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent EvaChina_CashStolen
-  Filename =  echcashs.wav
+  Filename =  eccashs.wav
 End
 
 DialogEvent EvaChina_GeneralLevelUp
@@ -308,8 +310,9 @@ DialogEvent EvaUSA_AllyUnderAttack
   Filename = euallyu.wav
 End
 
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent EvaUSA_BaseDefensesOffLine
-  Filename = eusasoff.wav
+  Filename = eubasof.wav
 End
 
 DialogEvent EvaUSA_BeaconDetected
@@ -329,8 +332,9 @@ DialogEvent EvaUSA_BuildingStolen
   Filename =  eubuist.wav
 End
 
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent EvaUSA_CashStolen
-  Filename =  euscashs.wav
+  Filename =  eucashs.wav
 End
 
 DialogEvent EvaUSA_GeneralLevelUp
@@ -837,8 +841,9 @@ DialogEvent Cin_SquadronFlyBy01
   Volume = 90
 End
 
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent Cin_SquadronFlyBy02
-  Filename = csquflya.wav
+  Filename = csquflyb.wav
   Priority = high
   Volume = 90
 End
@@ -2056,8 +2061,9 @@ DialogEvent     Taunts_Turtle086
    Filename =   tturt086.wav
 End
 
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent     Taunts_Turtle087
-   Filename =   tturt088.wav
+   Filename =   tturt087.wav
 End
 
 DialogEvent     Taunts_Turtle088
@@ -10202,8 +10208,9 @@ DialogEvent     EvaGLA_FundsReceived
    Filename =   egrecfnd.wav
 End
 
+; Patch104p @bugfix xezon 09/05/2023 Fixes misspelled filename. (#1940)
 DialogEvent     EvaGLA_FundsTransferred
-   Filename =   egtrnfnd
+   Filename =   egtrnfnd.wav
 End
 
 DialogEvent     EvaGLA_FundsRequestedAlly


### PR DESCRIPTION
* Relates to #176

This change fixes misspelled speech in dialog events. Some or all of these events may be unused in the game.

Affects

* EvaGLA_CashStolen
* EvaGLA_VehicleStolen
* EvaChina_CashStolen
* EvaUSA_BaseDefensesOffLine
* EvaUSA_CashStolen
* Cin_SquadronFlyBy02
* Taunts_Turtle087
* EvaGLA_FundsTransferred
