### PR TITLE
Fix: Add missing object text variant for Super Lotus and Super Hacker

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1954_super_lotus_hacker_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1954_super_lotus_hacker_text.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-15
+
+title: Adds missing object text variant for Super Lotus and Super Hacker
+
+changes:
+  - fix: Super Lotus and Super Hacker from the China Infantry General now display their proper names on mouse over.
+
+labels:
+  - bug
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1954
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -667,7 +667,7 @@ Object Infa_ChinaInfantryBlackLotus
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:BlackLotus
+  DisplayName         = OBJECT:SuperLotus ; Patch104p @bugfix from OBJECT:BlackLotus (#1954)
   Side                = ChinaInfantryGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -1340,7 +1340,7 @@ Object Infa_ChinaInfantryHacker
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Hacker
+  DisplayName      = OBJECT:SuperHacker ; Patch104p @bugfix from OBJECT:Hacker (#1954)
   Side = ChinaInfantryGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
Add dedicated object text for Super Lotus and Super Hacker. Construction texts already say "Super Lotus" and "Super Hacker".