### PR TITLE
Fix: Add missing text variants for Nuclear Battlemaster and Nuclear Overlord

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1956_nuclear_battlemaster_overlord_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1956_nuclear_battlemaster_overlord_text.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-05-16
+
+title: Adds missing text variants for Nuclear Battlemaster and Nuclear Overlord
+
+changes:
+  - fix: The Nuclear Battlemaster and Nuclear Overlord from the China Nuke General now display their proper names on mouse over and on the construction tooltip.
+
+labels:
+  - bug
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1956
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -6298,19 +6298,22 @@ CommandButton Nuke_Command_ConstructChinaDozer
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildDozer
 End
 
+; Patch104p @tweak commy2 20/08/2022 Use art that resembles unit.
+; Patch104p @bugfix xezon 16/05/2023 TextLabel from CONTROLBAR:ConstructGLATankBattleMaster (#1956)
 CommandButton Nuke_Command_ConstructChinaTankBattleMaster
   Command       = UNIT_BUILD
   Object        = Nuke_ChinaTankBattleMaster
-  TextLabel     = CONTROLBAR:ConstructGLATankBattleMaster
-  ButtonImage   = SNNukeBattlemaster ; Patch104p @tweak commy2 20/08/2022 Use art that resembles unit.
+  TextLabel     = CONTROLBAR:Nuke_ConstructChinaTankBattleMaster
+  ButtonImage   = SNNukeBattlemaster
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildBattlemaster
 End
 
+; Patch104p @bugfix xezon 16/05/2023 TextLabel from CONTROLBAR:ConstructChinaTankOverlord (#1956)
 CommandButton Nuke_Command_ConstructChinaTankOverlord
   Command       = UNIT_BUILD
   Object        = Nuke_ChinaTankOverlord
-  TextLabel     = CONTROLBAR:ConstructChinaTankOverlord
+  TextLabel     = CONTROLBAR:Nuke_ConstructChinaTankOverlord
   ButtonImage   = SNOverlord
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildOverlord

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -16965,7 +16965,7 @@ Object Nuke_ChinaTankBattleMaster
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:BattleMaster
+  DisplayName      = OBJECT:Nuke_BattleMaster ; Patch104p @bugfix from OBJECT:BattleMaster (#1956)
   Side = ChinaNukeGeneral
   EditorSorting   = VEHICLE
   TransportSlotCount = 3                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -17192,7 +17192,7 @@ Object Nuke_ChinaTankOverlord
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Overlord
+  DisplayName         = OBJECT:Nuke_Overlord ; Patch104p @bugfix from OBJECT:Overlord (#1956)
   Side                = ChinaNukeGeneral
   EditorSorting       = VEHICLE
   TransportSlotCount  = 3                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
This change adds dedicated text for Nuclear Battlemaster and Nuclear Overlord. This is consistent with other specialized units, such as Attack Outpost and Assault Troop Crawler.

![shot_20230516_163240_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/5819e7d6-576f-4ef5-bace-b80d67fc604a)
