### PR TITLE
Change: Improve latin text of volume options

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1958_audio_volume_options_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1958_audio_volume_options_text.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-05-17
+
+title: Improves latin text of volume options
+
+changes:
+  - tweak: Improves latin text of sound fx volume option to help clarify that it also affects unit voices.
+  - tweak: Improves latin text of speech volume option to help clarify that it only effects speech dialog.
+
+labels:
+  - enhancement
+  - gui
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1958
+
+authors:
+  - xezon


### PR DESCRIPTION
This change improves latin text of volume options. The motivation is to help clarify that the Sound FX Volume also affects unit voices. There is limited space for the text in English, so we cannot put all that much text. Non-English languages have a bit more room, because they use different Font.

![shot_20230517_175354_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/5b53d6da-46f0-4f7c-9efb-d2e06a69fade)

![shot_20230517_203133_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/3c9f06aa-c26b-4924-854a-b11bd66ecfc0)
