### PR TITLE
Change: Remove obsolete voice line from USA King Raptor

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1962_obsolete_king_raptor_voice.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1962_obsolete_king_raptor_voice.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-05-18
+
+title: Removes obsolete voice line "Raptor here" from USA King Raptor
+
+changes:
+  - tweak: Removes the obsolete voice line "Raptor here" from USA King Raptor. There already is another voice line which says "King Raptor here".
+
+labels:
+  - audio
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1962
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -5392,8 +5392,9 @@ End
 
 ;========= MOD UNITS ===============
 
+; Patch104p @tweak xezon 18/05/2023 Removes vrapsea "Raptor here", because vraksed says "King Raptor here". (#1962)
 AudioEvent KingRaptorVoiceSelect
-  Sounds = vrapsea vrapseb vrapsec vrapsed vrapsee vrapsef vrakseb vraksec vraksed
+  Sounds = vrapseb vrapsec vrapsed vrapsee vrapsef vrakseb vraksec vraksed ; vrapsea
   Control= random
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e


### PR DESCRIPTION
This change removes an obsolete voice line from King Raptor.

### KingRaptorVoiceSelect

* Removes vrapsea "Raptor here", because vraksed says "King Raptor here"
