### PR TITLE
Fix: Remove audio events with no valid sounds (2)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1912_invalid_audio_events.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1912_invalid_audio_events.yaml
@@ -4,26 +4,41 @@ date: 2023-05-05
 title: Removes audio events that reference no valid sounds
 
 changes:
-  - fix: Removes invalid audio event GenericMachineGunFire and all references to it.
-  - fix: Removes invalid audio event MedicMoveStart.
-  - fix: Removes invalid audio event CarBomberDie and all references to it.
-  - fix: Removes invalid audio event ExplosionGeneric.
-  - fix: Removes invalid audio event HeroUSAChargePlace.
-  - fix: Removes invalid audio event HeroUSAChargeBeep.
-  - fix: Removes invalid audio event HeroUSATimeBombClick.
-  - fix: Removes invalid audio event ExecuteDemoralize.
-  - fix: Removes invalid audio event CrateCash.
-  - fix: Removes invalid audio event AngryMobVoiceUpgradeArmTheMobCrowd.
-  - fix: Removes invalid audio event ListeningOutpostVoiceAttack and all references to it.
+  - refactor: Removes invalid audio event GenericMachineGunFire and all references to it.
+  - refactor: Removes invalid audio event MedicMoveStart.
+  - refactor: Removes invalid audio event CarBomberDie and all references to it.
+  - refactor: Removes invalid audio event ExplosionGeneric.
+  - refactor: Removes invalid audio event HeroUSAChargePlace.
+  - refactor: Removes invalid audio event HeroUSAChargeBeep.
+  - refactor: Removes invalid audio event HeroUSATimeBombClick.
+  - refactor: Removes invalid audio event ExecuteDemoralize.
+  - refactor: Removes invalid audio event CrateCash.
+  - refactor: Removes invalid audio event AngryMobVoiceUpgradeArmTheMobCrowd.
+  - refactor: Removes invalid audio event ListeningOutpostVoiceAttack and all references to it.
+  - refactor: Removes invalid audio event RadarNotifyInfiltration.
+  - refactor: Removes invalid audio event BombTruckDisguiseRevealedSuccess and all references to it.
+  - refactor: Removes invalid audio event BombTruckDisguiseRevealedFailure and all references to it.
+  - refactor: Removes invalid audio event ColonelBurtonPlantCharge and all references to it.
+  - refactor: Removes invalid audio event IRPing and all references to it.
+  - refactor: Removes invalid audio event IRPingLoud and all references to it.
+  - refactor: Removes invalid audio event Cin_JetDiveBombsStereo.
+  - refactor: Removes invalid audio event Cin_JetTakeOffStereo.
+  - refactor: Removes invalid audio event Cin_PlaneTakeOffStereo.
+  - refactor: Removes invalid audio event Cin_PlaneTakeOff2Stereo.
+  - refactor: Removes invalid audio event Cin_PlaneLandStereo.
+  - refactor: Removes invalid audio event Cin_CruiseRightLeftStereo.
+  - refactor: Removes invalid audio event Cin_CruiseTopDownStereo.
+  - refactor: Removes invalid audio event Cin_CruiseOverheadStereo.
+  - refactor: Removes invalid audio event Cin_CruiseFinalKillStereo.
 
 labels:
   - audio
-  - bug
   - minor
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1912
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1969
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1969_invalid_audio_events.txt
+++ b/Patch104pZH/Design/Changes/v1.0/1969_invalid_audio_events.txt
@@ -1,0 +1,1 @@
+1912_invalid_audio_events.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -3168,7 +3168,7 @@ Object AirF_AmericaInfantryColonelBurton
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -3190,7 +3190,7 @@ Object AirF_AmericaInfantryColonelBurton
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaCINEUnit.ini
@@ -3720,7 +3720,7 @@ Object CINE_AmericaInfantryColonelBurton
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
   End
 
@@ -3741,7 +3741,7 @@ Object CINE_AmericaInfantryColonelBurton
     UnpackTime              = 5500
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -409,7 +409,7 @@ Object AmericaInfantryColonelBurton
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -431,7 +431,7 @@ Object AmericaInfantryColonelBurton
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -2097,7 +2097,7 @@ Object AmericaInfantryCIAOfficer
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -2119,7 +2119,7 @@ Object AmericaInfantryCIAOfficer
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -16857,7 +16857,7 @@ Object Boss_InfantryColonelBurton
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -16879,7 +16879,7 @@ Object Boss_InfantryColonelBurton
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18631,8 +18631,8 @@ Object Chem_GLAVehicleBombTruck
     TruckLandingSound             = RocketBuggyLand
     TruckPowerslideSound          = NoSound
     DisguiseStarted               = BombTruckDisguiseStarted
-    DisguiseRevealedSuccess       = BombTruckDisguiseRevealedSuccess
-    DisguiseRevealedFailure       = BombTruckDisguiseRevealedFailure
+    DisguiseRevealedSuccess       = NoSound ;BombTruckDisguiseRevealedSuccess
+    DisguiseRevealedFailure       = NoSound ;BombTruckDisguiseRevealedFailure
     VoiceEnter = BombTruckVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -284,8 +284,8 @@ Object ChinaVehicleTroopCrawlerEmpty
     ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
     IRParticleSysName         = IRDetectSonar
     IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1282,8 +1282,8 @@ Object ChinaVehicleTroopCrawler
     ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
     IRParticleSysName         = IRDetectSonar
     IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid
@@ -2848,8 +2848,8 @@ Object ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  ;VoiceAttack = ListeningOutpostVoiceAttack
-  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  VoiceAttack = NoSound ;ListeningOutpostVoiceAttack
+  VoiceAttackAir = NoSound ;ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter
@@ -2889,8 +2889,8 @@ Object ChinaVehicleListeningOutpost
     DetectionRange            = 300 ;John, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
 ;    IRParticleSysName         = IRDetectSonar
 ;    IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13569,7 +13569,7 @@ Object Demo_GLAInfantryJarmenKell
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -13592,7 +13592,7 @@ Object Demo_GLAInfantryJarmenKell
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge  ; Patch104p @bugfix commy2 28/08/2021 Play expected sound effect instead of repeating the voice line.
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge  ; Patch104p @bugfix commy2 28/08/2021 Play expected sound effect instead of repeating the voice line.
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -20033,8 +20033,8 @@ Object Demo_GLAVehicleBombTruck
     TruckLandingSound             = RocketBuggyLand
     TruckPowerslideSound          = NoSound
     DisguiseStarted               = BombTruckDisguiseStarted
-    DisguiseRevealedSuccess       = BombTruckDisguiseRevealedSuccess
-    DisguiseRevealedFailure       = BombTruckDisguiseRevealedFailure
+    DisguiseRevealedSuccess       = NoSound ;BombTruckDisguiseRevealedSuccess
+    DisguiseRevealedFailure       = NoSound ;BombTruckDisguiseRevealedFailure
     VoiceEnter = BombTruckVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2022,8 +2022,8 @@ Object GC_Chem_GLAVehicleBombTruck
     TruckLandingSound             = RocketBuggyLand
     TruckPowerslideSound          = NoSound
     DisguiseStarted               = BombTruckDisguiseStarted
-    DisguiseRevealedSuccess       = BombTruckDisguiseRevealedSuccess
-    DisguiseRevealedFailure       = BombTruckDisguiseRevealedFailure
+    DisguiseRevealedSuccess       = NoSound ;BombTruckDisguiseRevealedSuccess
+    DisguiseRevealedFailure       = NoSound ;BombTruckDisguiseRevealedFailure
     VoiceEnter = BombTruckVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -4067,8 +4067,8 @@ Object GC_Slth_GLAVehicleBattleBus
     TruckPowerslideSound          = RocketBuggyPowerslide
     VoiceUnload                   = BattleBusVoiceUnload
     DisguiseStarted               = BombTruckDisguiseStarted
-    DisguiseRevealedSuccess       = BombTruckDisguiseRevealedSuccess
-    DisguiseRevealedFailure       = BombTruckDisguiseRevealedFailure
+    DisguiseRevealedSuccess       = NoSound ;BombTruckDisguiseRevealedSuccess
+    DisguiseRevealedFailure       = NoSound ;BombTruckDisguiseRevealedFailure
    End
 
   ; *** ENGINEERING Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -5212,8 +5212,8 @@ Object CINE_GLAVehicleBombTruck
     TruckLandingSound             = RocketBuggyLand
     TruckPowerslideSound          = RocketBuggyPowerslide
     DisguiseStarted               = BombTruckDisguiseStarted
-    DisguiseRevealedSuccess       = BombTruckDisguiseRevealedSuccess
-    DisguiseRevealedFailure       = BombTruckDisguiseRevealedFailure
+    DisguiseRevealedSuccess       = NoSound ;BombTruckDisguiseRevealedSuccess
+    DisguiseRevealedFailure       = NoSound ;BombTruckDisguiseRevealedFailure
     VoiceEnter = BombTruckVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4299,8 +4299,8 @@ Object GLAVehicleBombTruck
     TruckLandingSound             = RocketBuggyLand
     TruckPowerslideSound          = NoSound
     DisguiseStarted               = BombTruckDisguiseStarted
-    DisguiseRevealedSuccess       = BombTruckDisguiseRevealedSuccess
-    DisguiseRevealedFailure       = BombTruckDisguiseRevealedFailure
+    DisguiseRevealedSuccess       = NoSound ;BombTruckDisguiseRevealedSuccess
+    DisguiseRevealedFailure       = NoSound ;BombTruckDisguiseRevealedFailure
     VoiceEnter = BombTruckVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -15890,8 +15890,8 @@ Object Infa_ChinaVehicleTroopCrawler
     ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
     IRParticleSysName         = IRDetectSonar
     IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid
@@ -16150,8 +16150,8 @@ Object Infa_ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  ;VoiceAttack = ListeningOutpostVoiceAttack
-  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  VoiceAttack = NoSound ;ListeningOutpostVoiceAttack
+  VoiceAttackAir = NoSound ;ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter
@@ -16191,8 +16191,8 @@ Object Infa_ChinaVehicleListeningOutpost
     DetectionRange            = 300 ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
 ;    IRParticleSysName         = IRDetectSonar
 ;    IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -2715,7 +2715,7 @@ Object Lazr_AmericaInfantryColonelBurton
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -2737,7 +2737,7 @@ Object Lazr_AmericaInfantryColonelBurton
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3274,8 +3274,8 @@ Object Nuke_ChinaVehicleTroopCrawler
     ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
     IRParticleSysName         = IRDetectSonar
     IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid
@@ -4833,8 +4833,8 @@ Object Nuke_ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  ;VoiceAttack = ListeningOutpostVoiceAttack
-  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  VoiceAttack = NoSound ;ListeningOutpostVoiceAttack
+  VoiceAttackAir = NoSound ;ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter
@@ -4874,8 +4874,8 @@ Object Nuke_ChinaVehicleListeningOutpost
     DetectionRange            = 300 ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
 ;    IRParticleSysName         = IRDetectSonar
 ;    IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20062,8 +20062,8 @@ Object Slth_GLAVehicleBombTruck
     TruckLandingSound             = RocketBuggyLand
     TruckPowerslideSound          = NoSound
     DisguiseStarted               = BombTruckDisguiseStarted
-    DisguiseRevealedSuccess       = BombTruckDisguiseRevealedSuccess
-    DisguiseRevealedFailure       = BombTruckDisguiseRevealedFailure
+    DisguiseRevealedSuccess       = NoSound ;BombTruckDisguiseRevealedSuccess
+    DisguiseRevealedFailure       = NoSound ;BombTruckDisguiseRevealedFailure
     VoiceEnter = BombTruckVoiceMove
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -3193,7 +3193,7 @@ Object SupW_AmericaInfantryColonelBurton
     SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
@@ -3215,7 +3215,7 @@ Object SupW_AmericaInfantryColonelBurton
     UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
     FlipOwnerAfterUnpacking = Yes
     FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
-    UnpackSound               = ColonelBurtonPlantCharge
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
     LoseStealthOnTrigger      = Yes
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4007,8 +4007,8 @@ Object Tank_ChinaVehicleTroopCrawler
     ;DetectionRange           = ??? ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
     IRParticleSysName         = IRDetectSonar
     IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid
@@ -5078,8 +5078,8 @@ Object Tank_ChinaVehicleListeningOutpost
   VoiceSelect = ListeningOutpostVoiceSelect
   VoiceMove = ListeningOutpostVoiceMove
   VoiceGuard = ListeningOutpostVoiceMove
-  ;VoiceAttack = ListeningOutpostVoiceAttack
-  ;VoiceAttackAir = ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
+  VoiceAttack = NoSound ;ListeningOutpostVoiceAttack
+  VoiceAttackAir = NoSound ;ListeningOutpostVoiceAttack ; Patch104p @bugfix commy2 11/09/2021 Fix unit staying quiet when ordered to attack airborne target.
   SoundMoveStart = RadarVanMoveStart
   SoundMoveStartDamaged = RadarVanMoveStart
   SoundEnter = HumveeEnter
@@ -5118,8 +5118,8 @@ Object Tank_ChinaVehicleListeningOutpost
     DetectionRange            = 300 ;Dustin, enable this for independant balancing!
     CanDetectWhileGarrisoned  = No ;Garrisoned means being in a structure that you units can shoot out of.
     CanDetectWhileContained   = No ;Contained means being in a transport or tunnel network.
-    PingSound                 = IRPing
-    LoudPingSound             = IRPingLoud
+    PingSound                 = NoSound ;IRPing
+    LoudPingSound             = NoSound ;IRPingLoud
 ;    IRParticleSysName         = IRDetectSonar
 ;    IRBrightParticleSysName   = IRDetectSonarBright
     IRGridParticleSysName     = IRDetectGrid

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -78,7 +78,7 @@ AudioEvent AirRaidSiren
   Type        = world everyone
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent GenericMachineGunFire
 ;  Sounds      =  iseaatta iseaattb
 ;  Priority    = low
@@ -877,7 +877,7 @@ AudioEvent TomahawkMoveStart
   Type = world shrouded everyone
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent MedicMoveStart
 ;  Sounds= vpristaa vpristab vpristac
 ;  Priority= low
@@ -1107,7 +1107,6 @@ End
 
 AudioEvent StingerMissileWeapon
   Sounds = bstiweaa bstiweab bstiweac
-;  Sounds = irpgweaa irpgweab irpgweac irpgwead irpgweae
   Control = interrupt random
   Priority = normal
   Limit= 3
@@ -1687,7 +1686,7 @@ AudioEvent CrowdPanicLong
   Type = world shrouded everyone
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent CarBomberDie
 ;  Sounds =  vcardiea vcardieb vcardiec
 ;  Control = interrupt random
@@ -1825,7 +1824,7 @@ AudioEvent BuildingDestroyStone
   Type = world shrouded everyone
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent ExplosionGeneric
 ;  Sounds = gexp14a gexp14b gexp14c gexp14d gexp15a
 ;  Control = interrupt random
@@ -2728,12 +2727,13 @@ AudioEvent RadarNotifyUnderAttack
   Type       = ui player
 End
 
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
 ;Radar event occurred showing one of our objects (not unit/structure) under attack
-AudioEvent RadarNotifyInfiltration
-  Sounds = ;aangr01b
-  MinVolume = 55
-  Type       = ui player
-End
+;AudioEvent RadarNotifyInfiltration
+;  Sounds = ;aangr01b
+;  MinVolume = 55
+;  Type       = ui player
+;End
 
 AudioEvent HeroGLAWeapon
   Sounds      = ihegweaa
@@ -3090,7 +3090,7 @@ AudioEvent ScudLauncherWeapon
   Type        = world shrouded everyone
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent HeroUSAChargePlace
 ;  Sounds      = iheuchar
 ;  Priority    = high
@@ -3100,7 +3100,7 @@ End
 ;  Type        = world shrouded everyone
 ;End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent HeroUSAChargeBeep
 ;  Sounds      = iheubeep
 ;  Volume      = 100
@@ -3109,7 +3109,7 @@ End
 ;  Type        = world shrouded everyone
 ;End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent HeroUSATimeBombClick
 ;  Sounds      = iheutima iheutimb
 ;  Volume      = 100
@@ -3286,7 +3286,7 @@ AudioEvent BinkHandle
   Type = ui player
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent ExecuteDemoralize
 ;  Sounds      = uconst1a
 ;  Priority    = high
@@ -3386,23 +3386,25 @@ AudioEvent BombTruckDisguiseStarted
   Type        = world shrouded everyone
 End
 
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
 ;Played when bomb truck is revealed but attacking
-AudioEvent BombTruckDisguiseRevealedSuccess
-  Sounds = ;iredchea iredcheb iredchec
-  Control = random
-  Limit = 2
-  PitchShift  = -5  5
-  Volume = 55
-  Priority    = normal
-  Type = ui
-End
+;AudioEvent BombTruckDisguiseRevealedSuccess
+;  Sounds = ;iredchea iredcheb iredchec
+;  Control = random
+;  Limit = 2
+;  PitchShift  = -5  5
+;  Volume = 55
+;  Priority    = normal
+;  Type = ui
+;End
 
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
 ;Played when bomb truck disguised but revealed and not trying to attack
 ;Basically caught with his pants down.
-AudioEvent BombTruckDisguiseRevealedFailure
-  Sounds      = ;gejecta
-  Type        = world global everyone
-End
+;AudioEvent BombTruckDisguiseRevealedFailure
+;  Sounds      = ;gejecta
+;  Type        = world global everyone
+;End
 
 AudioEvent PaladinPointDefenseLaserPulse
   Sounds      = vpalwe2a vpalwe2b vpalwe2c vpalwe2d
@@ -3736,16 +3738,16 @@ AudioEvent ExplosionClusterMine
   Type = world shrouded everyone
 End
 
-
-AudioEvent ColonelBurtonPlantCharge ;this one is triggered in some weird hack way.
-  Sounds = ; icolseta
-  Control = interrupt random
-  Volume = 80
-  Limit = 1
-  Delay = 5500 5500
-  Priority = high
-  Type = world shrouded everyone
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent ColonelBurtonPlantCharge ;this one is triggered in some weird hack way.
+;  Sounds = ; icolseta
+;  Control = interrupt random
+;  Volume = 80
+;  Limit = 1
+;  Delay = 5500 5500
+;  Priority = high
+;  Type = world shrouded everyone
+;End
 
 AudioEvent ColonelBurtonSetDemoCharge
   Sounds = icolseta
@@ -3884,23 +3886,25 @@ AudioEvent AvalancheCrack
   Type = world shrouded everyone
 End
 
-AudioEvent IRPing
-  Sounds      =  ; icolbeep -Dustin says "no beep"
-  Control     = interrupt
-  PitchShift  = 100 100
-  Limit       = 3
-  Volume   = 25
-  Type        = world shrouded everyone
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent IRPing
+;  Sounds      =  ; icolbeep -Dustin says "no beep"
+;  Control     = interrupt
+;  PitchShift  = 100 100
+;  Limit       = 3
+;  Volume   = 25
+;  Type        = world shrouded everyone
+;End
 
-AudioEvent IRPingLoud
-  Sounds      = ; icolbeep -Dustin says "no beep"
-  Control     = interrupt
-  PitchShift  = 120 120
-  Limit       = 3
-  Volume   = 35
-  Type        = world shrouded everyone
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent IRPingLoud
+;  Sounds      = ; icolbeep -Dustin says "no beep"
+;  Control     = interrupt
+;  PitchShift  = 120 120
+;  Limit       = 3
+;  Volume   = 35
+;  Type        = world shrouded everyone
+;End
 
 
 AudioEvent AngryMobWeaponAK47
@@ -4369,7 +4373,7 @@ AudioEvent SpySatellite
   Type        = world player
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent CrateCash
 ;  Sounds      = gcracash
 ;  Volume      = 100
@@ -6528,9 +6532,6 @@ End
 
 AudioEvent NukeTruckMoveLoop
   Control     = loop all random
-;  Sounds      = ctrulo2a ctrulo2b ctrulo2c ctrulo2d
-;  Attack      = ctrulo1a
-;  Decay       = ctrulo3a
   Sounds      = ctr2lo2a ctr2lo2b
   Attack      = ctr2lo1a
   Decay       = ctr2lo3a
@@ -7183,21 +7184,23 @@ AudioEvent Cin_JetBank_D
   Type = world shrouded everyone
 End
 
-AudioEvent Cin_JetDiveBombsStereo
-  Sounds    = ;cjetdiva
-  Limit     = 2
-  Volume = 100
-  Priority = normal
-  Type = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_JetDiveBombsStereo
+;  Sounds    = ;cjetdiva
+;  Limit     = 2
+;  Volume = 100
+;  Priority = normal
+;  Type = ui
+;End
 
-AudioEvent Cin_JetTakeOffStereo
-  Sounds    = ;cjettaka
-  Limit     = 1
-  Volume = 100
-  Priority = normal
-  Type = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_JetTakeOffStereo
+;  Sounds    = ;cjettaka
+;  Limit     = 1
+;  Volume = 100
+;  Priority = normal
+;  Type = ui
+;End
 
 
 AudioEvent FakeBuildingSelect
@@ -7402,26 +7405,29 @@ AudioEvent Cin_TechnicalLeftRight04
   Type        = world everyone
 End
 
-AudioEvent Cin_PlaneTakeOffStereo
-  Sounds      = ;cplane01
-  Volume      = 90
-  MinVolume   = 50
-  Type        = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_PlaneTakeOffStereo
+;  Sounds      = ;cplane01
+;  Volume      = 90
+;  MinVolume   = 50
+;  Type        = ui
+;End
 
-AudioEvent Cin_PlaneTakeOff2Stereo
-  Sounds      = ;cplane02
-  Volume      = 90
-  MinVolume   = 50
-  Type        = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_PlaneTakeOff2Stereo
+;  Sounds      = ;cplane02
+;  Volume      = 90
+;  MinVolume   = 50
+;  Type        = ui
+;End
 
-AudioEvent Cin_PlaneLandStereo
-  Sounds      = ;cplane03
-  Volume      = 90
-  MinVolume   = 50
-  Type        = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_PlaneLandStereo
+;  Sounds      = ;cplane03
+;  Volume      = 90
+;  MinVolume   = 50
+;  Type        = ui
+;End
 
 AudioEvent JetSkid2
   Sounds      = gjetskic
@@ -7493,42 +7499,45 @@ AudioEvent Cin_BusRollStereo
 End
 
 
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_CruiseRightLeftStereo
+;  Control = random
+;  Sounds =  ;ccruise01
+;  Priority = high
+;  Limit = 1
+;  Volume = 90
+;  Type = ui
+;End
 
-AudioEvent Cin_CruiseRightLeftStereo
-  Control = random
-  Sounds =  ;ccruise01
-  Priority = high
-  Limit = 1
-  Volume = 90
-  Type = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_CruiseTopDownStereo
+;  Control = random
+;  Sounds =  ;ccruise02
+;  Priority = high
+;  Limit = 1
+;  Volume = 90
+;  Type = ui
+;End
 
-AudioEvent Cin_CruiseTopDownStereo
-  Control = random
-  Sounds =  ;ccruise02
-  Priority = high
-  Limit = 1
-  Volume = 90
-  Type = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_CruiseOverheadStereo
+;  Control = random
+;  Sounds =  ;ccruise03
+;  Priority = high
+;  Limit = 1
+;  Volume = 90
+;  Type = ui
+;End
 
-AudioEvent Cin_CruiseOverheadStereo
-  Control = random
-  Sounds =  ;ccruise03
-  Priority = high
-  Limit = 1
-  Volume = 90
-  Type = ui
-End
-
-AudioEvent Cin_CruiseFinalKillStereo
-  Control = random
-  Sounds =  ;ccruise04
-  Priority = high
-  Limit = 1
-  Volume = 90
-  Type = ui
-End
+; Patch104p @refactor xezon 20/05/2023 Removes audio event with no valid sounds. (#1969)
+;AudioEvent Cin_CruiseFinalKillStereo
+;  Control = random
+;  Sounds =  ;ccruise04
+;  Priority = high
+;  Limit = 1
+;  Volume = 90
+;  Type = ui
+;End
 
 AudioEvent Cin_C130AmbientLoop
   Sounds      = v130lo2a v130lo2b

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -3815,7 +3815,7 @@ AudioEvent AngryMobVoiceUpgradeArmTheMob
   Type = ui voice player
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent AngryMobVoiceUpgradeArmTheMobCrowd
 ;  Sounds    = iangupg
 ;  Limit     = 1
@@ -5086,7 +5086,7 @@ AudioEvent ListeningOutpostVoiceMove
   Type = ui voice player
 End
 
-; Patch104p @bugfix xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
+; Patch104p @refactor xezon 05/05/2023 Removes audio event with no valid sounds. (#1912)
 ;AudioEvent ListeningOutpostVoiceAttack
 ;  Sounds =  vlisata vlisatb vlisatc vlisatd vlisate
 ;  Control = random


### PR DESCRIPTION
* Follow up for #1912

This change removes more audio events that reference no valid sounds.

* RadarNotifyInfiltration
* BombTruckDisguiseRevealedSuccess
* BombTruckDisguiseRevealedFailure
* ColonelBurtonPlantCharge
* IRPing
* IRPingLoud
* Cin_JetDiveBombsStereo
* Cin_JetTakeOffStereo
* Cin_PlaneTakeOffStereo
* Cin_PlaneTakeOff2Stereo
* Cin_PlaneLandStereo
* Cin_CruiseRightLeftStereo
* Cin_CruiseTopDownStereo
* Cin_CruiseOverheadStereo
* Cin_CruiseFinalKillStereo
