### PR TITLE
Restore original fire sound on tree objects

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1928_medium_fire_sounds.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1928_medium_fire_sounds.yaml
@@ -5,6 +5,7 @@ title: Sets less intense unique set of fire sounds for GenericFireMediumLoop
 
 changes:
   - fix: Sets less intense unique set of fire sounds for GenericFireMediumLoop. Originally it uses the same sounds as GenericFireLargeLoop does.
+  - fix: Sets burning trees to use GenericFireLargeLoop to preserve original audio.
 
 labels:
   - audio
@@ -14,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1928
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1971
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1971_tree_fires.txt
+++ b/Patch104pZH/Design/Changes/v1.0/1971_tree_fires.txt
@@ -1,0 +1,1 @@
+1928_medium_fire_sounds.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NatureProp.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NatureProp.ini
@@ -59,7 +59,7 @@ Object GenericTree ; Logic side computationally expensive tree.
     FlameDamageExpiration = 0
     BurnedDelay      = 2500
     AflameDuration   = 3500
-    BurningSoundName = GenericFireMediumLoop
+    BurningSoundName = GenericFireLargeLoop ; Patch104p @tweak from GenericFireMediumLoop (#1971)
   End
   Behavior = FireSpreadUpdate ModuleTag_06
     OCLEmbers        = OCL_BurningEmbers
@@ -374,7 +374,7 @@ Object TreeFir01B
     FlameDamageExpiration = 0
     BurnedDelay      = 2500
     AflameDuration   = 3500
-    BurningSoundName = GenericFireMediumLoop
+    BurningSoundName = GenericFireLargeLoop ; Patch104p @tweak from GenericFireMediumLoop (#1971)
   End
   Behavior = FireSpreadUpdate ModuleTag_06
     OCLEmbers        = OCL_BurningEmbers
@@ -450,7 +450,7 @@ Object TreeCherryBlossom01
     FlameDamageExpiration = 0
     BurnedDelay      = 2500
     AflameDuration   = 3500
-    BurningSoundName = GenericFireMediumLoop
+    BurningSoundName = GenericFireLargeLoop ; Patch104p @tweak from GenericFireMediumLoop (#1971)
   End
   Behavior = FireSpreadUpdate ModuleTag_06
     OCLEmbers        = OCL_BurningEmbers
@@ -526,7 +526,7 @@ Object TreeCherryBlossom02
     FlameDamageExpiration = 0
     BurnedDelay      = 2500
     AflameDuration   = 3500
-    BurningSoundName = GenericFireMediumLoop
+    BurningSoundName = GenericFireLargeLoop ; Patch104p @tweak from GenericFireMediumLoop (#1971)
   End
   Behavior = FireSpreadUpdate ModuleTag_06
     OCLEmbers        = OCL_BurningEmbers


### PR DESCRIPTION
* Follow up for #1928

This change restores original fire sound on tree objects, because the previously referenced medium fire sounds were changed.