### PR TITLE
Change: Optimize button placements of Boss Dozer (2)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1888_china_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1888_china_dozer_buttons.yaml
@@ -4,7 +4,7 @@ date: 2023-04-30
 title: Optimizes button placements of China Dozer
 
 changes:
-  - fix: Optimizes button placements of China Dozer. Swaps the positions of Airfield, Propaganda Center and Internet Center to achieve consistency with button placements of USA Dozer and GLA Worker.
+  - tweak: Optimizes button placements of China Dozer. Swaps the positions of Airfield, Propaganda Center and Internet Center to achieve consistency with button placements of USA Dozer and GLA Worker.
 
 labels:
   - china

--- a/Patch104pZH/Design/Changes/v1.0/1889_usa_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1889_usa_dozer_buttons.yaml
@@ -4,7 +4,7 @@ date: 2023-04-30
 title: Optimizes button placements of USA Dozer
 
 changes:
-  - fix: Optimizes button placements of USA Dozer. Swaps the positions of Airfield, Strategy Center, Supply Drop Zone, Particle Cannon, Command Center to achieve consistency with button placements of China Dozer and GLA Worker.
+  - tweak: Optimizes button placements of USA Dozer. Swaps the positions of Airfield, Strategy Center, Supply Drop Zone, Particle Cannon, Command Center to achieve consistency with button placements of China Dozer and GLA Worker.
 
 labels:
   - gui

--- a/Patch104pZH/Design/Changes/v1.0/1982_boss_dozer_buttons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1982_boss_dozer_buttons.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-05-28
+
+title: Optimizes button placements of Boss Dozer
+
+changes:
+  - tweak: Optimizes button placements of Boss Dozer. The Barracks and Supply Center buttons are now placed at familiar positions.
+
+labels:
+  - boss
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1982
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5544,13 +5544,13 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
   14 = Command_Sell
 End
 
-
+; Patch104p @tweak xezon 28/05/2023 Swaps positions of Barracks and Supply Center buttons. (#1982)
 CommandSet Boss_AmericaDozerCommandSet
   1  = Boss_Command_ConstructAmericaPowerPlant
   2  = Boss_Command_ConstructChinaBunker
-  3  = Boss_Command_ConstructChinaSupplyCenter
+  3  = Boss_Command_ConstructChinaBarracks
   4  = Boss_Command_ConstructChinaGattlingCannon
-  5  = Boss_Command_ConstructChinaBarracks
+  5  = Boss_Command_ConstructChinaSupplyCenter
   6  = Boss_Command_ConstructAmericaPatriotBattery
   7  = Boss_Command_ConstructChinaWarFactory
   8  = Boss_Command_ConstructGLATunnelNetwork


### PR DESCRIPTION
* Split off of #1886

This change optimizes button placements of Boss Dozer. The Barracks and Supply Center buttons now take familiar positions.

## Original

![shot_20230528_101950_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/9a01c7dc-fad6-480f-9c63-438aa2084c3c)
