### PR TITLE
Fix: Gattlings start spinning pre attack (1)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -1888,6 +1888,7 @@ Object ChinaTankGattling
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
+  ; Patch104p @bugfix xezon 05/06/2023 Adds AliasConditionStates for MOVING to prevent the turret from spinning when attacking and moving without firing.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -1902,8 +1903,16 @@ Object ChinaTankGattling
       WeaponFireFXBone    = PRIMARY   Muzzle
       HideSubObject       = UnusedBoneL UnusedBoneR ; Patch104p @bugfix commy2 08/10/2022 Remove floating cube on night maps.
     End
+    AliasConditionState = ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B ATTACKING MOVING
 
-    ConditionState        = REALLYDAMAGED RUBBLE
+    ConditionState        = REALLYDAMAGED
+      Model               = NVGattTank_D
+    End
+    AliasConditionState = REALLYDAMAGED ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B REALLYDAMAGED ATTACKING MOVING
+
+    ConditionState        = RUBBLE
       Model               = NVGattTank_D
     End
 
@@ -1931,6 +1940,7 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
@@ -1940,6 +1950,7 @@ Object ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -1947,6 +1958,7 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -1956,6 +1968,7 @@ Object ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -1964,6 +1977,7 @@ Object ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -1974,6 +1988,7 @@ Object ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ;-----damaged attacking----------------------
     ConditionState        = REALLYDAMAGED ATTACKING
@@ -1998,6 +2013,7 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2007,6 +2023,7 @@ Object ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2014,6 +2031,7 @@ Object ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2023,6 +2041,7 @@ Object ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2031,6 +2050,7 @@ Object ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2041,6 +2061,7 @@ Object ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2362,6 +2362,7 @@ Object Infa_ChinaTankGattling
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
+  ; Patch104p @bugfix xezon 05/06/2023 Adds AliasConditionStates for MOVING to prevent the turret from spinning when attacking and moving without firing.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -2376,8 +2377,16 @@ Object Infa_ChinaTankGattling
       WeaponFireFXBone    = PRIMARY   Muzzle
       HideSubObject       = UnusedBoneL UnusedBoneR ; Patch104p @bugfix commy2 08/10/2022 Remove floating cube on night maps.
     End
+    AliasConditionState = ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B ATTACKING MOVING
 
-    ConditionState        = REALLYDAMAGED RUBBLE
+    ConditionState        = REALLYDAMAGED
+      Model               = NVGattTank_D
+    End
+    AliasConditionState = REALLYDAMAGED ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B REALLYDAMAGED ATTACKING MOVING
+
+    ConditionState        = RUBBLE
       Model               = NVGattTank_D
     End
 
@@ -2405,6 +2414,7 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
@@ -2414,6 +2424,7 @@ Object Infa_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -2421,6 +2432,7 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -2430,6 +2442,7 @@ Object Infa_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -2438,6 +2451,7 @@ Object Infa_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -2448,6 +2462,7 @@ Object Infa_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ;-----damaged attacking----------------------
     ConditionState        = REALLYDAMAGED ATTACKING
@@ -2472,6 +2487,7 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2481,6 +2497,7 @@ Object Infa_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2488,6 +2505,7 @@ Object Infa_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2497,6 +2515,7 @@ Object Infa_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2505,6 +2524,7 @@ Object Infa_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -2515,6 +2535,7 @@ Object Infa_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -3877,6 +3877,7 @@ Object Nuke_ChinaTankGattling
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
+  ; Patch104p @bugfix xezon 05/06/2023 Adds AliasConditionStates for MOVING to prevent the turret from spinning when attacking and moving without firing.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -3891,8 +3892,16 @@ Object Nuke_ChinaTankGattling
       WeaponFireFXBone    = PRIMARY   Muzzle
       HideSubObject       = UnusedBoneL UnusedBoneR ; Patch104p @bugfix commy2 08/10/2022 Remove floating cube on night maps.
     End
+    AliasConditionState = ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B ATTACKING MOVING
 
-    ConditionState        = REALLYDAMAGED RUBBLE
+    ConditionState        = REALLYDAMAGED
+      Model               = NVGattTank_D
+    End
+    AliasConditionState = REALLYDAMAGED ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B REALLYDAMAGED ATTACKING MOVING
+
+    ConditionState        = RUBBLE
       Model               = NVGattTank_D
     End
 
@@ -3920,6 +3929,7 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
@@ -3929,6 +3939,7 @@ Object Nuke_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -3936,6 +3947,7 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -3945,6 +3957,7 @@ Object Nuke_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -3953,6 +3966,7 @@ Object Nuke_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -3963,6 +3977,7 @@ Object Nuke_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ;-----damaged attacking----------------------
     ConditionState        = REALLYDAMAGED ATTACKING
@@ -3987,6 +4002,7 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -3996,6 +4012,7 @@ Object Nuke_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4003,6 +4020,7 @@ Object Nuke_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4012,6 +4030,7 @@ Object Nuke_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4020,6 +4039,7 @@ Object Nuke_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4030,6 +4050,7 @@ Object Nuke_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4112,6 +4112,7 @@ Object Tank_ChinaTankGattling
 
   ; Patch104p @bugfix commy2 08/10/2022 Fix muzzle flash when aiming at grounded targets.
   ; Patch104p @tweak xezon 09/10/2022 Rescale Gattling AnimationSpeedFactorRange's from 0.5, 0.8, 1.5, 3.0 to 0.60, 0.60, 1.20, 1.80 to match firing rate properly.
+  ; Patch104p @bugfix xezon 05/06/2023 Adds AliasConditionStates for MOVING to prevent the turret from spinning when attacking and moving without firing.
 
   Draw                      = W3DTankDraw ModuleTag_01
     OkToChangeModelColor    = Yes
@@ -4126,8 +4127,16 @@ Object Tank_ChinaTankGattling
       WeaponFireFXBone    = PRIMARY   Muzzle
       HideSubObject       = UnusedBoneL UnusedBoneR ; Patch104p @bugfix commy2 08/10/2022 Remove floating cube on night maps.
     End
+    AliasConditionState = ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B ATTACKING MOVING
 
-    ConditionState        = REALLYDAMAGED RUBBLE
+    ConditionState        = REALLYDAMAGED
+      Model               = NVGattTank_D
+    End
+    AliasConditionState = REALLYDAMAGED ATTACKING MOVING
+    AliasConditionState = USING_WEAPON_B REALLYDAMAGED ATTACKING MOVING
+
+    ConditionState        = RUBBLE
       Model               = NVGattTank_D
     End
 
@@ -4155,6 +4164,7 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
       Model               = NVGattTank
@@ -4164,6 +4174,7 @@ Object Tank_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -4171,6 +4182,7 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
       Model               = NVGattTank
@@ -4180,6 +4192,7 @@ Object Tank_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -4188,6 +4201,7 @@ Object Tank_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
       Model               = NVGattTank
@@ -4198,6 +4212,7 @@ Object Tank_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING MOVING
 
     ;-----damaged attacking----------------------
     ConditionState        = REALLYDAMAGED ATTACKING
@@ -4222,6 +4237,7 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4231,6 +4247,7 @@ Object Tank_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 0.60 0.60 ;set this state to animate  s l o w l y
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_SLOW REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4238,6 +4255,7 @@ Object Tank_ChinaTankGattling
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4247,6 +4265,7 @@ Object Tank_ChinaTankGattling
       WeaponFireFXBone    = SECONDARY Muzzle
       AnimationSpeedFactorRange = 1.20 1.20 ;set this state to animate  medium-fast
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_MEAN REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4255,6 +4274,7 @@ Object Tank_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
     ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING
       Model               = NVGattTank_D
@@ -4265,6 +4285,7 @@ Object Tank_ChinaTankGattling
       ParticleSysBone     = Muzzle01 GattlingMuzzleSmoke
       AnimationSpeedFactorRange = 1.80 1.80 ;set this state to animate  vryfst
     End
+    AliasConditionState = USING_WEAPON_B CONTINUOUS_FIRE_FAST REALLYDAMAGED ATTACKING MOVING
 
 
 


### PR DESCRIPTION
* Fixes #1991

This change fixes the Gattling spin issue on China Gattling Tank. It works, but the implementation is complicated. The fix cannot be applied as is to Overlord Gattling Cannons, because they do not move.