### PR TITLE
Fix: Gattlings start spinning pre attack (2)

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -517,13 +517,13 @@ Object ChinaTankOverlordGattlingCannon
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
     End
-    ConditionState        = ATTACKING
+    ConditionState        = FIRING_A
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
-    ConditionState        = USING_WEAPON_B ATTACKING
+    ConditionState        = FIRING_B
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -531,13 +531,13 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_SLOW FIRING_A
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_SLOW FIRING_B
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -545,13 +545,13 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING
+     ConditionState       = CONTINUOUS_FIRE_MEAN FIRING_A
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING
+     ConditionState       = CONTINUOUS_FIRE_MEAN FIRING_B
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -559,7 +559,7 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_FAST FIRING_A
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -567,7 +567,7 @@ Object ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING
+    ConditionState        = CONTINUOUS_FIRE_FAST FIRING_B
       Model               = NVOvrlrd_G
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -592,13 +592,13 @@ Object ChinaTankOverlordGattlingCannon
       ParticleSysBone     = SparkM01 SparksMedium
       ParticleSysBone     = SparkM02 SparksMedium
     End
-    ConditionState        = ATTACKING REALLYDAMAGED
+    ConditionState        = FIRING_A REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
-    ConditionState        = USING_WEAPON_B ATTACKING REALLYDAMAGED
+    ConditionState        = FIRING_B REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -606,13 +606,13 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  extemely sloowly
     End
-    ConditionState        = CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_SLOW FIRING_A REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_SLOW ATTACKING REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_SLOW FIRING_B REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -620,13 +620,13 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.38 0.38 ;set this state to animate  s l o w l y
     End
-     ConditionState       = CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN FIRING_A REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
       AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
-     ConditionState       = USING_WEAPON_B CONTINUOUS_FIRE_MEAN ATTACKING REALLYDAMAGED
+     ConditionState       = CONTINUOUS_FIRE_MEAN FIRING_B REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -634,7 +634,7 @@ Object ChinaTankOverlordGattlingCannon
       WeaponMuzzleFlash   = SECONDARY MuzzleFX
       AnimationSpeedFactorRange = 0.76 0.76 ;set this state to animate  medium-fast
     End
-    ConditionState        = CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST FIRING_A REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP
@@ -642,7 +642,7 @@ Object ChinaTankOverlordGattlingCannon
       ParticleSysBone    = Muzzle01 GattlingMuzzleSmoke
       ParticleSysBone    = Muzzle02 GattlingMuzzleSmoke
     End
-    ConditionState        = USING_WEAPON_B CONTINUOUS_FIRE_FAST ATTACKING REALLYDAMAGED
+    ConditionState        = CONTINUOUS_FIRE_FAST FIRING_B REALLYDAMAGED
       Model               = NVOvrlrd_GD
       Animation           = NVOvrlrd_G.NVOvrlrd_G
       AnimationMode       = LOOP


### PR DESCRIPTION
* Fixes #1991

This change fixes the Gattling spin issue on Overlord Gattling Cannon, but brings back this issue:

```
; Patch104p @bugfix commy2 08/10/2022 Fix cannon keeps spinning after firing once.
```

Is not clear to me how to fix this properly.