### PR TITLE
Revert: Remove SELECTABLE flag from SalvageCrate (#1836)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1675_salvage_crate_crate_flag.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1675_salvage_crate_crate_flag.yaml
@@ -1,21 +1,18 @@
 ---
 date: 2023-02-11
 
-title: Fixes object flags of SalvageCrate
+title: Adds missing CRATE flag to SalvageCrate
 
 changes:
   - fix: Adds missing CRATE flag to SalvageCrate.
-  - fix: Removes obsolete SELECTABLE flag from SalvageCrate.
 
 labels:
-  - design
   - gla
   - minor
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1675
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1836
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -193,9 +193,8 @@ Object SalvageCrate
 
   ; *** ENGINEERING Parameters ***
   ; Patch104p @fix xezon 11/02/2023 Adds missing crate flag.
-  ; Patch104p @fix xezon 11/02/2023 Removes selectable flag to avoid crate eventually being selectable over terrain with non GLA faction.
   ; Patch104p @bugfix xezon 11/02/2023 Adds inert flag to avoid removal by scaffolds.
-  KindOf = PARACHUTABLE CRATE INERT
+  KindOf = PARACHUTABLE SELECTABLE CRATE INERT ;Only Salvage crates are marked Selectable so the Mouse can interact with them and give Salvage voices.  Being dead makes them not actually selectable
 
   Behavior = SalvageCrateCollide ModuleTag_02
     ForbiddenKindOf = PROJECTILE


### PR DESCRIPTION
* Related to #1836

This change reverts #1836, because it breaks salvage crate pickup voices.