### PR TITLE
Change: Shorten English Particle Cannon timer text

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1999_particle_cannon_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1999_particle_cannon_text.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-09
+
+title: Shortens English Particle Cannon timer text
+
+changes:
+  - tweak: "Particle Uplink Cannon" now reads "Particle Cannon" on the English Superweapon timer.
+
+labels:
+  - gui
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1999
+
+authors:
+  - xezon


### PR DESCRIPTION
This change shortens "Particle Uplink Cannon" to "Particle Cannon" for the English Superweapon timer text.

There are 2 reasons for this:
1. The Particle Cannon is referred to as "Particle Cannon" is every other text
2. "Particle Cannon" is shorter than "Particle Uplink Cannon" and therefore takes less precious space on the screen

## Original

![shot_20230609_194212_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/7da89759-f039-4a2f-bda7-82d8becbea9e)
