### PR TITLE
Fix: Add missing Attack Move button to China ECM Tank

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2000_ecm_attackmove_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2000_ecm_attackmove_button.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-10
+
+title: Adds missing Attack Move button to China ECM Tank
+
+changes:
+  - tweak: Adds the missing Attack Move button to the China ECM Tank. It can now move to attack units on its own.
+
+labels:
+  - bug
+  - china
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2000
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -500,8 +500,10 @@ CommandSet ChinaInfantryHackerCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @bugfix xezon 10/06/2023 Adds missing AttackMove button. (#2000)
 CommandSet ChinaVehicleECMTankCommandSet
   1 = Command_ChinaTankECMDisableVehicle
+  11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End
@@ -5345,8 +5347,10 @@ CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
  14 = Command_Sell
 End
 
+; Patch104p @bugfix xezon 10/06/2023 Adds missing AttackMove button. (#2000)
 CommandSet Tank_ChinaVehicleECMTankCommandSet
   1 = Command_ChinaTankECMDisableVehicle
+  11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
 End


### PR DESCRIPTION
This change adds the AttackMove button to the China ECM Tank. Attack Move works as expected.

## Patched

ECM Tank is attack moving on its own.

![shot_20230610_072020_3](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/075b2952-f11e-4b3c-a86a-77de67bd625b)
