### PR TITLE
Change: Add Guard button to GLA Radar Van

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2000_ecm_attackmove_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2000_ecm_attackmove_button.yaml
@@ -4,7 +4,7 @@ date: 2023-06-10
 title: Adds missing Attack Move button to China ECM Tank
 
 changes:
-  - tweak: Adds the missing Attack Move button to the China ECM Tank. It can now move to attack units on its own.
+  - fix: Adds the missing Attack Move button to the China ECM Tank. It can now move to attack units on its own.
 
 labels:
   - bug

--- a/Patch104pZH/Design/Changes/v1.0/2001_radar_van_guard_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2001_radar_van_guard_button.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-10
+
+title: Adds Guard button to GLA Radar Van
+
+changes:
+  - tweak: Adds the Guard button to the GLA Radar Van. Guard does not do anything special for the Radar Van other than moving to the guard destination, but it allows to use Guard in a group selection with other types of units.
+
+labels:
+  - enhancement
+  - gla
+  - gui
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2001
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -452,9 +452,10 @@ CommandSet GLAVehicleBattleBusCommandSet
   14 = Command_Stop
 End
 
-
+; Patch104p @tweak xezon 10/06/2023 Adds missing Guard button. (#2001)
 CommandSet GLAVehicleRadarVanCommandSet
   1 = Command_RadarVanScan
+  13 = Command_Guard
   14 = Command_Stop
 End
 
@@ -2423,8 +2424,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @tweak xezon 10/06/2023 Adds missing Guard button. (#2001)
 CommandSet Demo_GLAVehicleRadarVanCommandSet
   1 = Command_RadarVanScan
+  13 = Command_Guard
   14 = Command_Stop
 End
 
@@ -2775,9 +2778,11 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   14 = Command_Stop
 End
 
+; Patch104p @tweak xezon 10/06/2023 Adds missing Guard button. (#2001)
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   1 = Command_RadarVanScan
   12 = Demo_Command_TertiarySuicide
+  13 = Command_Guard
   14 = Command_Stop
 End
 
@@ -3089,8 +3094,10 @@ CommandSet Slth_GLAInfantryJarmenKellCommandSet
   14 = Command_Stop
 End
 
+; Patch104p @tweak xezon 10/06/2023 Adds missing Guard button. (#2001)
 CommandSet Slth_GLAVehicleRadarVanCommandSet
   1 = Command_RadarVanScan
+  13 = Command_Guard
   14 = Command_Stop
 End
 


### PR DESCRIPTION
This change adds the Guard button to the GLA Radar Van.

Guard does not do anything special for the Radar Van. It just moves to the target location and idles there. However, adding the Guard button allows it to be used in group selections, which can be useful if the player wants to send a group of units together with a Radar Van somewhere to guard.

The Attack Move button is not required to be added to the Radar Van, because Attack Move already works in group selections regardless of the absence of the button.

## Original

GLA units group selection. Guard button is missing.

![shot_20230610_070759_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/22f9095a-3b42-41ff-9218-0da5f556f522)

## Patched

GLA units group selection. Guard button is present.

![shot_20230610_073631_3](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/9467fb9b-a686-4daf-be4f-7f0afdb31ad1)
