### PR TITLE
Change: Decrease primary damage of Anthrax Gamma Scud Storm from 550 to 500, secondary damage of Anthrax Beta Scud Storm from 200 to 175

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2002_anthrax_beta_scud_storm_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2002_anthrax_beta_scud_storm_damage.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-10
+
+title: Decreases secondary damage of Anthrax Beta Scud Storm missiles from 200 to 175
+
+changes:
+  - tweak: Decreases the secondary damage of the Anthrax Beta Scud Storm missiles from 200 to 175. This way it can no longer take out as many structures in a large area, but is still stronger than the regular Scud Storm.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - major
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2002
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2002_anthrax_gamma_scud_storm_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2002_anthrax_gamma_scud_storm_damage.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-10
+
+title: Decreases primary damage of Anthrax Gamma Scud Storm missiles from 550 to 500
+
+changes:
+  - tweak: Decreases the primary damage of the Anthrax Gamma Scud Storm missiles from 550 to 500. This way it can no longer take out pristine Superweapons in a single strike, but is still better than the Anthrax Beta Scud Storm.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - major
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2002
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6855,7 +6855,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon Chem_ScudStormDamageWeaponGamma
-  PrimaryDamage = 550.0
+  PrimaryDamage = 500.0 ; Patch104p @tweak xezon 10/06/2023 From 550 (#2002)
   PrimaryDamageRadius = 50.0
   SecondaryDamage = 200.0
   SecondaryDamageRadius = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1687,7 +1687,7 @@ End
 Weapon ScudStormDamageWeaponUpgraded
   PrimaryDamage = 500.0
   PrimaryDamageRadius = 50.0
-  SecondaryDamage = 200.0
+  SecondaryDamage = 175.0 ; Patch104p @tweak xezon 10/06/2023 From 200 (#2002)
   SecondaryDamageRadius = 200.0
   AttackRange = 200.0
   DamageType = EXPLOSION

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -1669,7 +1669,7 @@ End
 Weapon ScudStormDamageWeapon
   PrimaryDamage = 500.0
   PrimaryDamageRadius = 50.0
-  SecondaryDamage = 150.0 ;50.0
+  SecondaryDamage = 150.0
   SecondaryDamageRadius = 200.0
   AttackRange = 200.0
   DamageType = EXPLOSION
@@ -1686,9 +1686,9 @@ End
 ;------------------------------------------------------------------------------
 Weapon ScudStormDamageWeaponUpgraded
   PrimaryDamage = 500.0
-  PrimaryDamageRadius = 50.0 ;25.0
-  SecondaryDamage = 200.0 ;100.0
-  SecondaryDamageRadius = 200.0 ;50.0
+  PrimaryDamageRadius = 50.0
+  SecondaryDamage = 200.0
+  SecondaryDamageRadius = 200.0
   AttackRange = 200.0
   DamageType = EXPLOSION
   DeathType = EXPLODED
@@ -6856,9 +6856,9 @@ End
 ;------------------------------------------------------------------------------
 Weapon Chem_ScudStormDamageWeaponGamma
   PrimaryDamage = 550.0
-  PrimaryDamageRadius = 50.0 ;25.0
-  SecondaryDamage = 200.0 ;100.0
-  SecondaryDamageRadius = 200.0 ;50.0
+  PrimaryDamageRadius = 50.0
+  SecondaryDamage = 200.0
+  SecondaryDamageRadius = 200.0
   AttackRange = 200.0
   DamageType = EXPLOSION
   DeathType = EXPLODED


### PR DESCRIPTION
**Merge with Rebase**

* Relates to #1992

This change

* decreases the primary damage of the  Anthrax Gamma Scud Storm from 550 to 500 (-9%)
* decreases the secondary damage of the Anthrax Beta Scud Storm from 200 to 175 (-12.5%)

## Original GLA Scud Storm weapon bonus

| Upgrade         | Primary damage bonus | Secondary damage bonus |
|-----------------|----------------------|------------------------|
| Anthrax Beta    |                      | +33.33%                |
| Anthrax Gamma   | +10.00%              | +33.33%                |

## Patched GLA Scud Storm weapon bonus

| Upgrade         | Primary damage bonus | Secondary damage bonus |
|-----------------|----------------------|------------------------|
| Anthrax Beta    |                      | +16.66%                |
| Anthrax Gamma   |                      | +33.33%                |

## New setup

| Weapon                           | Primary Damage | Primary Radius | Sec. Damage | Sec. Radius |
|----------------------------------|----------------|----------------|-------------|-------------|
| Original Regular Scud Storm      | 500            | 50             | 150         | 200         |
| Patched Anthrax Beta Scud Storm  | 500            | 50             | 175 (-25)   | 200         |
| Patched Anthrax Gamma Scud Storm | 500 (-50)      | 50             | 200         | 200         |
| Original Demo Scud Storm         | 600            | 75             | 150         | 200         |

The Anthrax Gamma Scud Storm now applies less point damage and can no longer take out a Superweapon. And the Anthrax Beta Scud Storm applies less area damage.


# Damages Overview

Scud Storms vs 9 Scud Storms.

![shot_20230609_170227_25](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/a3c831d5-2d1d-4f6c-99fa-3f4ac0529544)

![shot_20230609_170235_26](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/2b525bad-cb1e-4163-abe4-2b179fc5f6c9)


## Original regular GLA Scud Storm vs 9 Scud Storms

| Target                | Structure Damage | Hole Damage |
|-----------------------|------------------|-------------|
| Scud Storm 1          | 42%              |             |
| Scud Storm 2          | 56%              |             |
| Scud Storm 3          | 49%              |             |
| Scud Storm 4          | 70%              |             |
| Scud Storm 5 (Center) | 92%              |             |
| Scud Storm 6          | 63%              |             |
| Scud Storm 7          | 42%              |             |
| Scud Storm 8          | 50%              |             |
| Scud Storm 9          | 36%              |             |
| Combined              | 500%             |             |


## Original GLA Anthrax Beta Scud Storm vs 9 Scud Storms

| Target                | Structure Damage | Hole Damage |
|-----------------------|------------------|-------------|
| Scud Storm 1          | 49%              |             |
| Scud Storm 2          | 62%              |             |
| Scud Storm 3          | 56%              |             |
| Scud Storm 4          | 74%              |             |
| Scud Storm 5 (Center) | 92%              |             |
| Scud Storm 6          | 68%              |             |
| Scud Storm 7          | 49%              |             |
| Scud Storm 8          | 56%              |             |
| Scud Storm 9          | 44%              |             |
| Combined              | 550%             |             |


## Original GLA Anthrax Gamma Scud Storm vs 9 Scud Storms

| Target                | Structure Damage | Hole Damage |
|-----------------------|------------------|-------------|
| Scud Storm 1          | 51%              |             |
| Scud Storm 2          | 66%              |             |
| Scud Storm 3          | 58%              |             |
| Scud Storm 4          | 80%              |             |
| Scud Storm 5 (Center) | 100%             | 0%          |
| Scud Storm 6          | 73%              |             |
| Scud Storm 7          | 52%              |             |
| Scud Storm 8          | 59%              |             |
| Scud Storm 9          | 44%              |             |
| Combined              | 583%             |             |


## Original GLA Demo Scud Storm vs 9 Scud Storms

| Target                | Structure Damage | Hole Damage |
|-----------------------|------------------|-------------|
| Scud Storm 1          | 63%              |             |
| Scud Storm 2          | 90%              |             |
| Scud Storm 3          | 63%              |             |
| Scud Storm 4          | 90%              |             |
| Scud Storm 5 (Center) | 100%             | 0%          |
| Scud Storm 6          | 81%              |             |
| Scud Storm 7          | 46%              |             |
| Scud Storm 8          | 81%              |             |
| Scud Storm 9          | 63%              |             |
| Combined              | 677%             |             |


## Area Damage VS 64 GLA Black Markets

| Weapon                                  | Num Destroyed | Num Damaged | Num Undamaged |
|-----------------------------------------|---------------|-------------|---------------|
| Original GLA Scud Storm                 | 17            | 40          | 7             |
| Original GLA Anthrax Beta Scud Storm    | 23            | 34          | 7             |
| Original GLA Anthrax Gamma Scud Storm   | 23            | 34          | 7             |
| Original GLA Demo Scud Storm            | 20            | 37          | 7             |
| Patched GLA Anthrax Beta Scud Storm     | 21            | 36          | 7             |
| Patched GLA Anthrax Gamma Scud Storm    | 23            | 34          | 7             |


## Area Damage VS 144 USA Supply Drop Zones

| Object                                  | Num Destroyed | Num Damaged | Num Undamaged |
|-----------------------------------------|---------------|-------------|---------------|
| Original GLA Scud Storm                 | 32            | 30          | 82            |
| Original GLA Anthrax Beta Scud Storm    | 48            | 30          | 66            |
| Original GLA Anthrax Gamma Scud Storm   | 48            | 30          | 66            |
| Original GLA Demo Scud Storm            | 33            | 26          | 85            |
| Patched GLA Anthrax Beta Scud Storm     | 43            | 35          | 66            |
| Patched GLA Anthrax Gamma Scud Storm    | 48            | 30          | 66            |


# Rationale

The GLA Anthrax Gamma Scud Storm is arguably the best Superweapon in the game, maybe even better than the Demo Scud Storm. It applies enough center damage to take out a Superweapon and at the same time applies superior area damage. It also leaves Anthrax puddles for a while.

The new weapon damage model decreases the Anthrax Beta and Anthrax Gamma bonus for the Scud Storm.  In practice the Anthrax Beta and Anthrax Gamma Scud Storms are still more likely to take out more buildings in a larger area, which can be significant, especially when targeting secondary economy structure like the USA Supply Drop Zone and GLA Black Market.

This change is also favorable with the China Internet Center buff of #1989. The Anthrax Gamma Scud Storm will no longer be able to take out the pristine Internet Center and all its hackers with one simple strike.