### PR TITLE
Revert: TechRepairPad is deleted when destroyed (#568)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/568_reinforcement_pad_ruin_model.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/568_reinforcement_pad_ruin_model.yaml
@@ -1,10 +1,11 @@
 ---
 date: 2021-10-16
 
-title: Adds ruin model for destroyed Reinforcement Pad Tech building
+title: Adds ruin model to destroyed Reinforcement Pad Tech building
 
 changes:
-  - fix: Adds ruin model for destroyed Reinforcement Pad Tech building.
+  - fix: Adds ruin model to destroyed Tech Reinforcement Pad building.
+  - fix: Adds ruin model to destroyed Tech Repair Bay building.
 
 labels:
   - art
@@ -14,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/568
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2005
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TechBuildings.ini
@@ -275,7 +275,7 @@ Object TechReinforcementPad
   SelectPortrait         = LandingPad_L
   ButtonImage            = LandingPad
 
-  ; Patch104p @bugfix commy2 16/10/2021 Fix building does not use rubble model.
+  ; Patch104p @bugfix commy2 16/10/2021 Fix building does not use rubble model. (#568)
 
   Draw                 = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -478,7 +478,7 @@ Object TechReinforcementPad
     FactionOCL   = Faction:FactionBossGeneral        OCL:OCL_BossGen_ReinforcementPadCHIVehicle
   End
 
-  ; Patch104p @bugfix commy2 16/10/2021 Fix building disappears when destroyed instead of leaving ruin.
+  ; Patch104p @bugfix commy2 16/10/2021 Fix building disappears when destroyed instead of leaving ruin. (#568)
 
   ;Behavior = DestroyDie ModuleTag_06
   ;End
@@ -688,10 +688,8 @@ Object TechRepairPad
     NumberApproachPositions = 5
   End
 
-  ; Patch104p @bugfix commy2 16/10/2021 Fix building disappears when destroyed instead of leaving ruin.
-
-  ;Behavior  = DestroyDie ModuleTag_06
-  ;End
+  Behavior  = DestroyDie ModuleTag_06
+  End
 
   Behavior                  = CreateObjectDie ModuleTag_08
     CreationList       = OCL_LargeStructureDebris
@@ -707,8 +705,8 @@ Object TechRepairPad
   End
   Behavior = TechBuildingBehavior ModuleTag_12
   End
-  Behavior = KeepObjectDie ModuleTag_IWantRubble
-  End
+  ;Behavior = KeepObjectDie ModuleTag_IWantRubble
+  ;End
   Behavior = BaseRegenerateUpdate ModuleTag_11
   End
   Behavior = TransitionDamageFX ModuleTag_31
@@ -734,7 +732,7 @@ Object TechRepairbay
   SelectPortrait         = RepairBay_L
   ButtonImage            = RepairBay
 
-  ; Patch104p @bugfix commy2 16/10/2021 Fix building does not use rubble model.
+  ; Patch104p @bugfix commy2 16/10/2021 Fix building does not use rubble model. (#568)
 
   Draw                 = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes


### PR DESCRIPTION
This change partially reverts #568.

After #568, the destroyed Repair Pad looked almost identical to the really damaged Repair Pad, because the Drop Zone object does not have a dedicated rubble object.

The original setup is now reinstated to provide a notable visual difference between the really damaged and destroyed Repair Pad.

## Repair Pad after 568

Really damaged vs Destroyed Repair Pad.

![shot_20230610_151218_2](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/faa96aa4-609c-47fc-83aa-904bd6b63526)

## Original Repair Pad, after this change

Really damaged vs Destroyed Repair Pad.

![shot_20230610_151549_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/e49445e3-b748-40cc-a6b0-ce5dcc8ffe63)
