### PR TITLE
Fix: Remove obsolete structure damage particle effects

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2011_structure_damage_effects.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2011_structure_damage_effects.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-14
+
+title: Removes obsolete structure damage particle effects
+
+changes:
+  - fix: Removes obsolete structure damage particle effects that would spawn at the center of a building and are not or barely visible.
+
+labels:
+  - art
+  - bug
+  - minor
+  - performance
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2011
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -3737,6 +3737,7 @@ FXList FX_HumveeMissileIgnition
   End
 End
 
+; Patch104p @bugfix xezon 14/06/2023 Removes structure damage particle effects that would spawn at the center of a building and are not or barely visible. (#2011)
 ; ----------------------------------------------
 FXList FX_StructureDamaged
   Sound
@@ -3745,47 +3746,49 @@ FXList FX_StructureDamaged
   ViewShake
     Type = NORMAL
   End
-  ParticleSystem
-    Name = StructureDamagedFlash
-  End
-  ParticleSystem
-    Name = StructureDamagedSmoke
-  End
-  ParticleSystem
-    Name = StructureDamagedDebris
-  End
+  ;ParticleSystem
+  ;  Name = StructureDamagedFlash
+  ;End
+  ;ParticleSystem
+  ;  Name = StructureDamagedSmoke
+  ;End
+  ;ParticleSystem
+  ;  Name = StructureDamagedDebris
+  ;End
 End
 
+; Patch104p @bugfix xezon 14/06/2023 Removes structure damage particle effects that would spawn at the center of a building and are not or barely visible. (#2011)
 ; ----------------------------------------------
 FXList FX_StructureDamagedNoShake
   Sound
     Name = BuildingDamage
   End
-  ParticleSystem
-    Name = StructureDamagedFlash
-  End
-  ParticleSystem
-    Name = StructureDamagedSmoke
-  End
-  ParticleSystem
-    Name = StructureDamagedDebris
-  End
+  ;ParticleSystem
+  ;  Name = StructureDamagedFlash
+  ;End
+  ;ParticleSystem
+  ;  Name = StructureDamagedSmoke
+  ;End
+  ;ParticleSystem
+  ;  Name = StructureDamagedDebris
+  ;End
 End
 
+; Patch104p @bugfix xezon 14/06/2023 Removes structure damage particle effects that would spawn at the center of a building and are not or barely visible. (#2011)
 ; ----------------------------------------------
 FXList FX_StructureDamagedFlameNoShake
   Sound
     Name = NoSound
   End
-  ParticleSystem
-    Name = StructureDamagedFlash
-  End
-  ParticleSystem
-    Name = StructureDamagedSmoke
-  End
-  ParticleSystem
-    Name = StructureDamagedDebris
-  End
+  ;ParticleSystem
+  ;  Name = StructureDamagedFlash
+  ;End
+  ;ParticleSystem
+  ;  Name = StructureDamagedSmoke
+  ;End
+  ;ParticleSystem
+  ;  Name = StructureDamagedDebris
+  ;End
 End
 
 ; ----------------------------------------------


### PR DESCRIPTION
This change removes the obsolete structure damage particle effects. Some effects are never visible and others rarely, depending on the geometry of the structure. Despite, the damage particles always spawn at the very center of a structure, which makes no sense when the damage impact is somewhere else.

## Original

![shot_20230614_174508_4](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/132b3e04-9031-426c-ad13-0643788fb320)

![shot_20230614_174722_6](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/cf5380b4-a3ab-4b0b-9b09-41efceaecbbf)
