### PR TITLE
Change: Increase Anthrax Gamma poison field damage bonus by 20%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2012_anthrax_gamma_field_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2012_anthrax_gamma_field_damage.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-17
+
+title: Increases Anthrax Gamma poison field damage bonus by 20%
+
+changes:
+  - tweak: Increases the Anthrax Gamma poison field damage bonus by 20%, except Anthrax Bomb.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2012
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -21562,7 +21562,7 @@ End
 ;------------------------------------------------------------------------------
 ; CHEMICAL GENERAL SYSTEMS
 ;------------------------------------------------------------------------------
-Object Chem_PoisonFieldGammaLarge
+Object Chem_PoisonFieldGammaLarge ; unused
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -21615,7 +21615,7 @@ Object Chem_PoisonFieldGammaLarge
 End
 
 ;------------------------------------------------------------------------------
-Object Chem_PoisonFieldGammaMedium
+Object Chem_PoisonFieldGammaMedium ; unused
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -21669,7 +21669,7 @@ Object Chem_PoisonFieldGammaMedium
 End
 
 ;------------------------------------------------------------------------------
-Object Chem_PoisonFieldGammaSmall
+Object Chem_PoisonFieldGammaSmall ; unused
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -21724,7 +21724,7 @@ End
 
 
 ;------------------------------------------------------------------------------
-Object Chem_ToxicInfantryGamma
+Object Chem_ToxicInfantryGamma ; unused
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -5717,8 +5717,10 @@ Weapon Chem_TunnelNetworkGunGamma
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 17/06/2023 Changes primary damage from 25.0 (#2012)
+;------------------------------------------------------------------------------
 Weapon Chem_LargePoisonFieldWeaponGamma
-  PrimaryDamage = 25.0
+  PrimaryDamage = 30.0
   PrimaryDamageRadius = 140.0
   AttackRange = 15.0
   MinimumAttackRange = 10.0
@@ -5734,8 +5736,10 @@ Weapon Chem_LargePoisonFieldWeaponGamma
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 17/06/2023 Changes primary damage from 2.5 (#2012)
+;------------------------------------------------------------------------------
 Weapon Chem_MediumPoisonFieldWeaponGamma
-  PrimaryDamage = 2.5
+  PrimaryDamage = 3.0
   PrimaryDamageRadius = 80.0
   AttackRange = 15.0
   MinimumAttackRange = 10.0
@@ -5751,8 +5755,10 @@ Weapon Chem_MediumPoisonFieldWeaponGamma
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 17/06/2023 Changes primary damage from 2.5 (#2012)
+;------------------------------------------------------------------------------
 Weapon Chem_SmallPoisonFieldWeaponGamma
-  PrimaryDamage = 2.5
+  PrimaryDamage = 3.0
   PrimaryDamageRadius = 7.5
   AttackRange = 15.0
   MinimumAttackRange = 10.0


### PR DESCRIPTION
* Resolves #799

This change increases the Anthrax Gamma poison field damage bonus by 20%, except Anthrax Bomb.

All poison field weapons deal their damage every 500 ms (533 ms).

| Weapon                            | Original Damage (DPS) | Patched Damage (DPS) |
|-----------------------------------|:----------------------|:---------------------|
| SmallPoisonFieldWeapon            | 2.0 (3.75)            |                      |
| SmallPoisonFieldWeaponUpgraded    | 2.5 (4.69)            |                      |
| Chem_SmallPoisonFieldWeaponGamma  | 2.5 (4.69)            | 3.0 (5.63)           |
| MediumPoisonFieldWeapon           | 2.0 (3.75)            |                      |
| MediumPoisonFieldWeaponUpgraded   | 2.5 (4.69)            |                      |
| Chem_MediumPoisonFieldWeaponGamma | 2.5 (4.69)            | 3.0 (5.63)           |
| LargePoisonFieldWeapon            | 15 (28.1)             |                      |
| LargePoisonFieldWeaponUpgraded    | 25 (46.9)             |                      |
| Chem_LargePoisonFieldWeaponGamma  | 25 (46.9)             | 30 (56.3)            |
| AnthraxBombPoisonFieldWeapon      | 40 (75.0)             |                      |
| AnthraxBetaBombPoisonFieldWeapon  | 40 (75.0)             |                      |
| AnthraxGammaBombPoisonFieldWeapon | 40 (75.0)             |                      |

# Gamma weapons are used by the following things

### Chem_SmallPoisonFieldWeaponGamma (OCL_PoisonFieldGammaSmall)

* Chem_ToxinShellWeaponGamma


### Chem_MediumPoisonFieldWeaponGamma (OCL_PoisonFieldGammaMedium, OCL_PoisonFieldGammaMedium_ScudStorm)

* BombTruckAnthraxGammaBombEffect
* BombTruckHighExplosiveAnthraxGammaBombEffect (available in Generals Challenge only)
* Chem_SCUDLauncherGunAnthraxGamma
* Chem_SCUDLauncherGunAnthraxGammaPlusOne
* Chem_SCUDLauncherGunAnthraxGammaPlusTwo
* Chem_SuicideWeaponGamma
* Chem_DemoTrapDetonationWeaponGamma
* Chem_GLAVehicleToxinTruck (FireOCLAfterWeaponCooldownUpdate)
* Chem_ScudStormDeathWeaponGamma


### Chem_LargePoisonFieldWeaponGamma (OCL_PoisonFieldGammaLarge)

* Chem_ScudStormDamageWeaponGamma


# Rationale

With this change there is a proper poison field damage bonus continuation from Toxin over Anthrax Beta to Anthrax Gamma, except Anthrax Bomb. The promise of Anthrax Gamma is that Anthrax weapons deal more damage, so design wise it makes most sense that the purple puddles deal more damage than the blue and green ones.

In other changes a few weapon damages of Toxin General have been reduced:

* #699
* #882
* #2002

This change gives back some of the lost damages in Gamma weapons.

1. The nerfed Anthrax Gamma Scud Storm benefits, which is good and logical.
2. The nerfed Toxin Terrorist benefits, which is good, because now it actually becomes better after the Anthrax Gamma upgrade.
3. The Anthrax Gamma Scud Launcher benefits, which is good because it does not have the Explosive warhead and is rarely used as highlighted in #784.
4. The Anthrax Gamma Demo Trap benefits, which is good because the Toxin Demo Trap is not attractive to use as highlighted in #802.
5. The Anthrax Gamma Bomb Truck benefits, which is good because Toxin General does not have the High Explosive upgrade, so a bit more damage for the Anthrax is a nice bonus here.
6. The Anthrax Gamma Toxin Truck benefits. Affects the idle puddle only, not the Nozzle or Sprayer. Is consistent with concept of increased damages on Toxin Tractor guns with upgrades. Is ok and logical.
7. The Anthrax Gamma Scorpion Tank benefits. It would not necessarily need more damage, however, it is for late game and the Toxin Scorpion tanks are more expensive, so this is ok and logical.