### PR TITLE
Fix: Decrease small poison field radius from 12 to 7.5

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2014_small_poison_field_radius.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2014_small_poison_field_radius.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-17
+
+title: Decreases small poison field radius from 12 to 7.5
+
+changes:
+  - fix: Decreases small poison field radius from 12 to 7.5 to match small Anthrax Beta and Anthrax Gamma fields radius.
+
+labels:
+  - bug
+  - controversial
+  - gla
+  - minor
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2014
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/851_toxin_puddle_size.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/851_toxin_puddle_size.yaml
@@ -15,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/851
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2014
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -12149,7 +12149,7 @@ ParticleSystem GC_Chem_AnthraxGammaFieldSmall ; Alias AnthraxGammaFieldSmall
   Gravity = 0.00
   Lifetime = 30.00 30.00 ; Patch104p @tweak from 90.0 90.0 decrease small puddle life time to match ToxinFieldSmall
   SystemLifetime = 3 ; Patch104p @tweak from 5 to be consistent with ToxinFieldSmall
-  Size = 8.00 8.00 ; Patch104p @tweak from 10.00 10.00 to better match damage radius of Toxin Shells
+  Size = 7.00 7.00 ; Patch104p @tweak from 10.00 10.00 to better match damage radius of Toxin Shells (#851)
   StartSizeRate = 0.00 0.00
   SizeRate = 0.75 0.75 ; Patch104p @tweak from 1.00 1.00 to better match damage radius of Toxin Shells
   SizeRateDamping = 0.90 0.95
@@ -64061,7 +64061,7 @@ ParticleSystem AnthraxFieldSmall
   Gravity = 0.00
   Lifetime = 30.00 30.00
   SystemLifetime = 3 ; Patch104p @tweak from 1 to spawn more instances and look more impressive
-  Size = 8.00 8.00 ; Patch104p @tweak from 10.00 10.00 to better match damage radius of Toxin Shells
+  Size = 7.00 7.00 ; Patch104p @tweak from 10.00 10.00 to better match damage radius of Toxin Shells (#851)
   StartSizeRate = 0.00 0.00
   SizeRate = 0.75 0.75 ; Patch104p @tweak from 1.00 1.00 to better match damage radius of Toxin Shells
   SizeRateDamping = 0.90 0.95
@@ -64460,7 +64460,7 @@ ParticleSystem PoisonFieldSmall ; Alias ToxinFieldSmall
   Gravity = 0.00
   Lifetime = 30.00 30.00
   SystemLifetime = 3 ; Patch104p @tweak from 1 to spawn more instances and look more impressive
-  Size = 8.00 8.00 ; Patch104p @tweak from 10.00 10.00 to better match damage radius of Toxin Shells
+  Size = 7.00 7.00 ; Patch104p @tweak from 10.00 10.00 to better match damage radius of Toxin Shells (#851)
   StartSizeRate = 0.00 0.00
   SizeRate = 0.75 0.75 ; Patch104p @tweak from 1.00 1.00 to better match damage radius of Toxin Shells
   SizeRateDamping = 0.90 0.95

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3609,7 +3609,7 @@ End
 ;------------------------------------------------------------------------------
 Weapon SmallPoisonFieldWeapon
   PrimaryDamage = 2.0
-  PrimaryDamageRadius = 12.0 ;7.5
+  PrimaryDamageRadius = 7.5 ; Patch104p @bugfix from 12.0 to be consistent with the upgraded poison fields. (#2014)
   AttackRange = 15.0
   MinimumAttackRange = 10.0
   DamageType = POISON


### PR DESCRIPTION
* Fixes #794

This change decreases small poison field radius from 12 to 7.5 to match small Anthrax Beta and Anthrax Gamma fields radius. The small poison field is used by Scorpion Tank toxin shells.

The particle effect size was adjusted to closer match the damage radius.

| Weapon                           | Original Damage Radius | Patched Damage Radius |
|----------------------------------|------------------------|-----------------------|
| SmallPoisonFieldWeapon           | 12                     | 7.5                   |
| SmallPoisonFieldWeaponUpgraded   | 7.5                    |                       |
| Chem_SmallPoisonFieldWeaponGamma | 7.5                    |                       |
| GC_Chem_GLARebelGunGamma         | 10                     |                       |
| Chem_ToxinTruckGunGamma          | 10                     |                       |
| SmallRadiationFieldWeapon        | 15                     |                       |
| Nuke_SmallRadiationFieldWeapon   | 12                     |                       |

# Rationale

The damage radius of Toxin Shells no longer becomes worse after acquiring the Anthrax Beta upgrade.