### PR TITLE
Change: Decrease build time of GLA Toxin Demo Trap from 16 to 8 seconds

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2015_toxin_trap_build_time.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2015_toxin_trap_build_time.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-18
+
+title: Decreases build time of GLA Toxin Demo Trap from 16 to 8 seconds
+
+changes:
+  - fix: Decreases build time of GLA Toxin Demo Trap from 16 to 8 seconds. This makes it more practical to build before the enemy approaches it.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2015
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5794,7 +5794,7 @@ Object Chem_GLADemoTrap
     Object = Chem_GLAArmsDealer
   End
   BuildCost        = 600
-  BuildTime        = 8.0           ; in seconds
+  BuildTime        = 4.0 ; Patch104p @tweak from 8.0 (#2015)
   EnergyProduction = 0
   VisionRange     = 150.0           ; Shroud clearing distance
   ShroudClearingRange     = 150.0           ; Shroud clearing distance


### PR DESCRIPTION
* Relates to #802

This change decreases the build time of the GLA Toxin Demo Trap from 16 to 8 seconds. 

| Object                        | Build Cost | Build Time | Explosion Damage | 30s Poison Damage |
|-------------------------------|------------|------------|------------------|-------------------|
| Original GLA Trap             | 400        | 10         | 600              |                   |
| Original GLA Demo Trap        | 200        | 6          | 700              |                   |
| Original GLA Stealth Trap     | 400        | 10         | 600              |                   |
| Original GLA Toxin Trap       | 600        | 16         | 250              | 140               |
| Patched GLA Toxin Trap (this) | 600        | 8          | 250              | 140               |

# Rationale

The original GLA Toxin Trap provides poor value. Its damage output is vastly inferior to that of other GLA Traps. It is more expensive. And ultimately the long build time of 16 seconds (without power) makes it unattainable for practical applications. If the opposition can see a GLA Worker swinging his hammer in the air for 16 seconds, then it is much less likely for the Toxin Trap to succeed in a surprise.

8 seconds over 10 seconds build time compensates a bit for the fact that the Toxin Trap costs more and deals less damage than the other Traps.