### PR TITLE
Fix: Decrease small poison field object radius from 6 to 4

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2014_small_poison_field_radius.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2014_small_poison_field_radius.yaml
@@ -4,7 +4,8 @@ date: 2023-06-17
 title: Decreases green Toxin Shells field radius from 12 to 7.5
 
 changes:
-  - fix: Decreases the green Toxin Shells field radius from 12 to 7.5 to match the Anthrax Beta and Anthrax Gamma Toxin Shells field radius.
+  - fix: Decreases the green Toxin Shells poison field radius from 12 to 7.5 to match the Anthrax Beta and Anthrax Gamma Toxin Shells poison field radius.
+  - fix: Decreases the green Toxin Shells object radius from 6 to 4 to match the Anthrax Beta and Anthrax Gamma Toxin Shells object radius.
 
 labels:
   - bug
@@ -16,6 +17,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2014
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2022
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -1982,8 +1982,9 @@ Object PoisonFieldSmall
     DeathFX = FX_ToxicPoolDie
   End
 
+  ; Patch104p @fix xezon 20/06/2023 Changes radius from 6 to be consistent with other small poison puddles. (#2022)
   Geometry            = CYLINDER
-  GeometryMajorRadius = 6.0
+  GeometryMajorRadius = 4.0
   GeometryHeight      = 1.0
   GeometryIsSmall     = No
 


### PR DESCRIPTION
* Follow up for #2014

This change decrease the small poison field object radius from 6 to 4. This is consistent with the other small poison puddle objects. It only affects the size of the area it can be deleted from by other puddles.