### PR TITLE
Change: Prioritize larger Toxin and Radiation hazard fields over smaller ones

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2023_hazard_field_cleanup_health_and_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2023_hazard_field_cleanup_health_and_damage.yaml
@@ -1,0 +1,23 @@
+---
+date: 2023-06-20
+
+title: Prioritizes larger Toxin and Radiation fields over smaller ones
+
+changes:
+  - tweak: Prioritizes larger Toxin and Radiation fields over smaller ones by assigning different amounts of hazard cleanup health and damage to different hazard field sizes. The huge fields of the Anthrax Bomb and Nuke Missile are 2 times stronger than large fields. Large fields of Scud Storm missiles are 5 times stronger than medium fields. And medium fields of Scud Launcher, Toxin Truck, Bomb Truck and Nuclear Reactor are 10 times stronger than small fields. With this progression it is no longer possible to cleanup large hazard fields with just one small hazard field put on top. Overall many hazard cleanups will take more effort and time than originally, unless the created hazard field is equal or larger than the overlapped hazard field.
+
+labels:
+  - buff
+  - bug
+  - china
+  - controversial
+  - design
+  - gla
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2023
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -21583,9 +21583,10 @@ Object Chem_PoisonFieldGammaLarge ; unused
   SoundAmbient      = AnthraxPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 5000
+    InitialHealth    = 5000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = Chem_LargePoisonFieldWeaponGamma
@@ -21596,8 +21597,10 @@ Object Chem_PoisonFieldGammaLarge ; unused
     MaxLifetime = 45000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = LargePoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -21637,9 +21640,10 @@ Object Chem_PoisonFieldGammaMedium ; unused
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = Chem_MediumPoisonFieldWeaponGamma
@@ -21650,8 +21654,10 @@ Object Chem_PoisonFieldGammaMedium ; unused
     MaxLifetime = 30000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -21691,9 +21697,10 @@ Object Chem_PoisonFieldGammaSmall ; unused
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 100
+    InitialHealth    = 100
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = Chem_SmallPoisonFieldWeaponGamma
@@ -21704,8 +21711,10 @@ Object Chem_PoisonFieldGammaSmall ; unused
     MaxLifetime = 10000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = SmallPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLASystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLASystem.ini
@@ -22,9 +22,10 @@ Object GC_Chem_PoisonFieldGammaLarge
   SoundAmbient      = AnthraxPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 5000
+    InitialHealth    = 5000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = Chem_LargePoisonFieldWeaponGamma
@@ -35,8 +36,10 @@ Object GC_Chem_PoisonFieldGammaLarge
     MaxLifetime = 45000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = LargePoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -76,9 +79,10 @@ Object GC_Chem_PoisonFieldGammaMedium
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = Chem_MediumPoisonFieldWeaponGamma
@@ -89,8 +93,10 @@ Object GC_Chem_PoisonFieldGammaMedium
     MaxLifetime = 30000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -131,9 +137,10 @@ Object GC_Chem_PoisonFieldGammaMedium_ScudStorm
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = Chem_MediumPoisonFieldWeaponGamma
@@ -144,8 +151,10 @@ Object GC_Chem_PoisonFieldGammaMedium_ScudStorm
     MaxLifetime = 26000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -185,9 +194,10 @@ Object GC_Chem_PoisonFieldGammaSmall
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 100
+    InitialHealth    = 100
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = Chem_SmallPoisonFieldWeaponGamma
@@ -198,8 +208,10 @@ Object GC_Chem_PoisonFieldGammaSmall
     MaxLifetime = 10000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = SmallPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -37,8 +37,10 @@ Object Nuke_RadiationFieldSmall
     MaxLifetime = 2500
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = SmallRadiationHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -1790,9 +1790,10 @@ Object PoisonFieldLarge
   SoundAmbient      = ToxicPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 100 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 100.0
-    InitialHealth    = 100.0
+    MaxHealth        = 5000
+    InitialHealth    = 5000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = LargePoisonFieldWeapon
@@ -1803,8 +1804,10 @@ Object PoisonFieldLarge
     MaxLifetime = 45000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = LargePoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -1845,9 +1848,10 @@ Object PoisonFieldMedium
   End
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 100 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 100.0
-    InitialHealth    = 100.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
 
   Behavior = FireWeaponUpdate ModuleTag_03
@@ -1859,8 +1863,10 @@ Object PoisonFieldMedium
     MaxLifetime = 30000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -1902,9 +1908,10 @@ Object PoisonFieldMedium_ScudStorm
   End
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 100 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 100.0
-    InitialHealth    = 100.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
 
   Behavior = FireWeaponUpdate ModuleTag_03
@@ -1916,8 +1923,10 @@ Object PoisonFieldMedium_ScudStorm
     MaxLifetime = 26000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -1958,9 +1967,10 @@ Object PoisonFieldSmall
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 100 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 100.0
-    InitialHealth    = 100.0
+    MaxHealth        = 100
+    InitialHealth    = 100
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = SmallPoisonFieldWeapon
@@ -1971,8 +1981,10 @@ Object PoisonFieldSmall
     MaxLifetime = 10000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = SmallPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2012,9 +2024,10 @@ Object PoisonFieldUpgradedLarge
   SoundAmbient      = AnthraxPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 5000
+    InitialHealth    = 5000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = LargePoisonFieldWeaponUpgraded
@@ -2025,8 +2038,10 @@ Object PoisonFieldUpgradedLarge
     MaxLifetime = 45000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = LargePoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2066,9 +2081,10 @@ Object PoisonFieldUpgradedMedium
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = MediumPoisonFieldWeaponUpgraded
@@ -2079,8 +2095,10 @@ Object PoisonFieldUpgradedMedium
     MaxLifetime = 30000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2121,9 +2139,10 @@ Object PoisonFieldUpgradedMedium_ScudStorm
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = MediumPoisonFieldWeaponUpgraded
@@ -2134,8 +2153,10 @@ Object PoisonFieldUpgradedMedium_ScudStorm
     MaxLifetime = 26000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2175,9 +2196,10 @@ Object PoisonFieldUpgradedSmall
 
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 100
+    InitialHealth    = 100
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = SmallPoisonFieldWeaponUpgraded
@@ -2188,8 +2210,10 @@ Object PoisonFieldUpgradedSmall
     MaxLifetime = 10000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = SmallPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2229,9 +2253,10 @@ Object PoisonFieldAnthraxBomb
   SoundAmbient      = AnthraxPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 100 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 100.0
-    InitialHealth    = 100.0
+    MaxHealth        = 10000
+    InitialHealth    = 10000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = AnthraxBombPoisonFieldWeapon
@@ -2242,8 +2267,10 @@ Object PoisonFieldAnthraxBomb
     MaxLifetime = 60000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = AnthraxBombPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2282,9 +2309,10 @@ Object PoisonFieldAnthraxBetaBomb
   SoundAmbient      = AnthraxPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 10000
+    InitialHealth    = 10000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = AnthraxBetaBombPoisonFieldWeapon
@@ -2295,8 +2323,10 @@ Object PoisonFieldAnthraxBetaBomb
     MaxLifetime = 60000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = AnthraxBombPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2335,9 +2365,10 @@ Object PoisonFieldAnthraxGammaBomb
   SoundAmbient      = AnthraxPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 10000
+    InitialHealth    = 10000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = AnthraxGammaBombPoisonFieldWeapon
@@ -2348,8 +2379,10 @@ Object PoisonFieldAnthraxGammaBomb
     MaxLifetime = 60000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = AnthraxBombPoisonHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2389,9 +2422,10 @@ Object RadiationFieldLarge
   SoundAmbient      = RadiationPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 150 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 150.0
-    InitialHealth    = 150.0
+    MaxHealth        = 5000
+    InitialHealth    = 5000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = LargeRadiationFieldWeapon
@@ -2402,8 +2436,10 @@ Object RadiationFieldLarge
     MaxLifetime = 30000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = LargeRadiationHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2443,9 +2479,10 @@ Object RadiationFieldMedium
   SoundAmbient      = RadiationPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 1000
+    InitialHealth    = 1000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = MediumRadiationFieldWeapon
@@ -2456,8 +2493,10 @@ Object RadiationFieldMedium
     MaxLifetime = 30000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = MediumRadiationHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2497,9 +2536,10 @@ Object RadiationFieldSmall
   SoundAmbient      = RadiationPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 120 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 120.0
-    InitialHealth    = 120.0
+    MaxHealth        = 100
+    InitialHealth    = 100
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = SmallRadiationFieldWeapon
@@ -2510,8 +2550,10 @@ Object RadiationFieldSmall
     MaxLifetime = 2500
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = SmallRadiationHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06
@@ -2551,9 +2593,10 @@ Object NukeRadiationFieldWeapon
   SoundAmbient      = RadiationPoolAmbientLoop
 
   ; *** ENGINEERING Parameters ***
+  ; Patch104p @tweak xezon 20/06/2023 Changes health from 150 to scale the field priority. (#2023)
   Body = ActiveBody ModuleTag_02
-    MaxHealth        = 150.0
-    InitialHealth    = 150.0
+    MaxHealth        = 10000
+    InitialHealth    = 10000
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = NukeRadiationFieldWeapon
@@ -2564,8 +2607,10 @@ Object NukeRadiationFieldWeapon
     MaxLifetime = 30000
   End
 
+  ; Patch104p @tweak xezon 20/06/2023 Uses new hazard field weapon to scale the field priority. (#2023)
   Behavior = FireWeaponUpdate ModuleTag_05
-    Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
+    Weapon = NukeMissileRadiationHazardFieldWeapon
+    ;Weapon = HazardFieldCoreWeapon ; Prevents stacking of fields with a small blast of cleaning at the core at startup
   End
 
   Behavior = DestroyDie ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3572,6 +3572,89 @@ Weapon HazardFieldCoreWeapon
   ClipReloadTime = 100000
 End
 
+; Patch104p @feature xezon 20/06/2023 Adds new hazard field weapons for different sizes of puddles. (#2023)
+; The damage radius of the hazard cleanup weapon should not exceed the field damage radius and object radius.
+
+Weapon SmallPoisonHazardFieldWeapon
+  PrimaryDamage = 100
+  PrimaryDamageRadius = 10 ;4
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
+Weapon MediumPoisonHazardFieldWeapon
+  PrimaryDamage = 1000
+  PrimaryDamageRadius = 10 ;40
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
+Weapon LargePoisonHazardFieldWeapon
+  PrimaryDamage = 5000
+  PrimaryDamageRadius = 10 ;70
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
+Weapon AnthraxBombPoisonHazardFieldWeapon
+  PrimaryDamage = 10000
+  PrimaryDamageRadius = 10 ;150
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
+Weapon SmallRadiationHazardFieldWeapon
+  PrimaryDamage = 100
+  PrimaryDamageRadius = 10
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
+Weapon MediumRadiationHazardFieldWeapon
+  PrimaryDamage = 1000
+  PrimaryDamageRadius = 10 ;25
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
+Weapon LargeRadiationHazardFieldWeapon
+  PrimaryDamage = 5000
+  PrimaryDamageRadius = 10 ;100
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
+Weapon NukeMissileRadiationHazardFieldWeapon
+  PrimaryDamage = 10000
+  PrimaryDamageRadius = 10 ;100
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 5
+  ClipSize = 1
+  ClipReloadTime = 999999
+End
+
 ;------------------------------------------------------------------------------
 Weapon LargePoisonFieldWeapon
   PrimaryDamage = 15.0


### PR DESCRIPTION
* Relates to #55

This change prioritizes larger Toxin and Radiation fields/puddles over smaller ones. Larger fields will require more hazard damage to clean up.

This change fixes the exploitative hazard field behavior where players would typically fire a single shot on any hazard field to remove it in an instant. It also fixes the bug where the death field of the Toxin Tractor would remove its Sprinkler contamination field.

## Original

| Field                                  | Health      | Hazard Damage |
|----------------------------------------|-------------|---------------|
| Small Poison and Radiation fields      | 100 or 120  | 200           |
| Medium Poison and Radiation fields     | 100 or 120  | 200           |
| Large Poison and Radiation fields      | 100 or 120  | 200           |
| Anthrax Bomb fields                    | 100 or 120  | 200           |
| Nuke Missile field                     | 150         | 200           |

## Patched

| Field                                  | Health      | Hazard Damage |
|----------------------------------------|-------------|---------------|
| Small Poison and Radiation field       | 100         | 100           |
| Medium Poison and Radiation field      | 1000        | 1000          |
| Large Poison and Radiation field       | 5000        | 5000          |
| Anthrax Bomb fields                    | 10000       | 10000         |
| Nuke Missile field                     | 10000       | 10000         |

# Consequences

Originally any field could be cleaned up with any other field. Now larger fields will require more damage from smaller fields to clean up. Fields of equal size clean up each other with one shot.

The Anthrax Bombs and Nuke Missiles now have the largest and therefore most persistent fields. They will take 100 small, 10 medium or 2 large field hazard damages to clean up.

Smaller fields can stack on top of larger fields now, as long as the smaller fields do not manage to clean up the bigger ones. But larger fields will always clean up smaller ones if they spawn afterwards and with their core inside the smaller field's object radius.

In practice it will take more than 5 Scorpions with Toxin Shells and no Junk Repair to clean the Anthrax Bomb field and more than 5 Nuke Battlemaster tanks to clean the Nuke Missile field before the tanks die on the respective fields. The more tanks the quicker the cleanup can be completed.

A single USA Ambulance will take 200 frames, or 6.66 seconds to cleanup the Anthrax Bomb and Nuke Missile. The more Ambulances the quicker the cleanup can be completed.

## 6 Scorpions with Toxin Shells vs Anthrax Bomb toxins

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/51ce4b08-6034-40f0-9da9-af11f9043317

## 6 Battlemasters vs Nuke Missile radiation

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/5f3ba670-0e40-4738-bac1-1e7090e7df1e

## Ambulances vs Anthrax Bomb

The Anthrax Bomb takes

* 15 frames (500 ms) to kill Humvee when it is inside the initial explosion radius
* 165 frames (5500 ms) to kill Humvee when it is outside the initial explosion radius

This means with patched hazard cleanup setup, 1 USA Ambulance will not be enough to a save group of Humvees on the Anthrax Bomb puddle. 2 USA Ambulances are required.

Humvees, Ambulances survive the initial Anthrax Bomb explosion with around 10% health.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/f8d41b48-61f3-4d65-af6a-a8933ffc012e

# Rationale

This change mitigates the power of the field cleanup exploit where a single hazard field would clean up any other hazard field in a matter of milliseconds. With this change it requires more effort and time to cleanup a field of significant size, while still retaining the original design where hazard fields of the opposition can be cleaned. As a result all Toxin and Radiation field weapons become better.

## Anthrax Bomb

The increased difficulty of the hazard cleanup is analogous to the expected strength of the Anthrax Bomb's Anthrax field. The field is supposed to last 60 seconds at most. Assuming a player cleans it up in 10 seconds means that the Anthrax Bomb effectiveness is reduced by 83%, ignoring the damage dealt by the initial bomb explosion. Cleaning it in 20 seconds means the Anthrax Bomb effectiveness is reduced by 66%. It is well within the realm of possibilities to clean the Anthrax field within 60 seconds or shoot down the plane before the bomb drop.