### PR TITLE
Change: Replace 40% of Rangers with Missile Defenders in USA Paradrops

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2026_usa_paradrop_payload.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2026_usa_paradrop_payload.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-21
+
+title: Replaces 40% of Rangers with Missile Defenders in USA Paradrops
+
+changes:
+  - tweak: Replaces 40% of Rangers with Missile Defenders in USA Paradrops. Rank 1 drops 3 Rangers and 2 Missile Defenders, Rank 2 drops 6 Rangers and 4 Missile Defenders and Rank 3 drops 12 Rangers and 8 Missile Defenders.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - major
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2026
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6181,6 +6181,7 @@ ObjectCreationList SUPERWEAPON_AnthraxBombGamma
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6192,7 +6193,8 @@ ObjectCreationList SUPERWEAPON_Paradrop1
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AmericaInfantryRanger 5
+    Payload = AmericaInfantryRanger 3
+    Payload = AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6210,6 +6212,7 @@ ObjectCreationList SUPERWEAPON_Paradrop1
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6221,7 +6224,8 @@ ObjectCreationList SUPERWEAPON_Paradrop2
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AmericaInfantryRanger 10
+    Payload = AmericaInfantryRanger 6
+    Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6239,6 +6243,7 @@ ObjectCreationList SUPERWEAPON_Paradrop2
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6250,7 +6255,8 @@ ObjectCreationList SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AmericaInfantryRanger 10
+    Payload = AmericaInfantryRanger 6
+    Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6274,7 +6280,8 @@ ObjectCreationList SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AmericaInfantryRanger 10
+    Payload = AmericaInfantryRanger 6
+    Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6294,6 +6301,7 @@ End
 ; Patch104p @bugfix commy2 11/09/2021 Lists used to spawn sub-faction specific Rangers via Paradrop ability.
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList AirF_SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6305,7 +6313,8 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop1
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AirF_AmericaInfantryRanger 5
+    Payload = AirF_AmericaInfantryRanger 3
+    Payload = AirF_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6323,6 +6332,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop1
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList AirF_SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6334,7 +6344,8 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop2
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AirF_AmericaInfantryRanger 10
+    Payload = AirF_AmericaInfantryRanger 6
+    Payload = AirF_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6352,6 +6363,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop2
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList AirF_SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6363,7 +6375,8 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AirF_AmericaInfantryRanger 10
+    Payload = AirF_AmericaInfantryRanger 6
+    Payload = AirF_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6387,7 +6400,8 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AirF_AmericaInfantryRanger 10
+    Payload = AirF_AmericaInfantryRanger 6
+    Payload = AirF_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6405,6 +6419,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop3
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList SupW_SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6416,7 +6431,8 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop1
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = SupW_AmericaInfantryRanger 5
+    Payload = SupW_AmericaInfantryRanger 3
+    Payload = SupW_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6434,6 +6450,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop1
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList SupW_SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6445,7 +6462,8 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop2
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = SupW_AmericaInfantryRanger 10
+    Payload = SupW_AmericaInfantryRanger 6
+    Payload = SupW_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6463,6 +6481,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop2
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList SupW_SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6474,7 +6493,8 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = SupW_AmericaInfantryRanger 10
+    Payload = SupW_AmericaInfantryRanger 6
+    Payload = SupW_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6498,7 +6518,8 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = SupW_AmericaInfantryRanger 10
+    Payload = SupW_AmericaInfantryRanger 6
+    Payload = SupW_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6516,6 +6537,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop3
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList Lazr_SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6527,7 +6549,8 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop1
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = Lazr_AmericaInfantryRanger 5
+    Payload = Lazr_AmericaInfantryRanger 3
+    Payload = Lazr_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6545,6 +6568,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop1
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList Lazr_SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6556,7 +6580,8 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop2
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = Lazr_AmericaInfantryRanger 10
+    Payload = Lazr_AmericaInfantryRanger 6
+    Payload = Lazr_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6574,6 +6599,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop2
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
 ; -----------------------------------------------------------------------------
 ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6585,7 +6611,8 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = Lazr_AmericaInfantryRanger 10
+    Payload = Lazr_AmericaInfantryRanger 6
+    Payload = Lazr_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -6609,7 +6636,8 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = Lazr_AmericaInfantryRanger 10
+    Payload = Lazr_AmericaInfantryRanger 6
+    Payload = Lazr_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50


### PR DESCRIPTION
* Relates to #705

This change replaces 40% of Rangers with Missile Defenders in USA Paradrops.

The latin localization has been updated accordingly.

## Original

Paradrop Level 1: 5 Ranger
Paradrop Level 2: 10 Ranger
Paradrop Level 3: 20 Ranger

## Patched

Paradrop Level 1: 3 Rangers + 2 Missile Defenders
Paradrop Level 2: 6 Rangers + 4 Missile Defenders
Paradrop Level 3: 12 Rangers + 8 Missile Defenders

![shot_20230621_180828_2](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/969a4386-b374-41e5-8611-a65d711675cb)

![shot_20230621_180842_3](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/7724f017-8a8e-4ee5-8153-36731461839b)

![shot_20230621_180851_4](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/b8ee9141-c679-42b6-975e-a900dbca9d02)

# Rationale

The original USA Paradrop is seldom used, because the Spectre Gunship and A10 powers are typically better value than a group of Rangers. The newly added Missile Defenders increase the usefulness of the Paradrop, because it can now also engage vehicles, helicopters and planes in both offense and defense.

The maximum monetary value of the spawned infantry increases by 600, from 4500 to 5100.