### PR TITLE
Change: Increase armor of China Internet Center against Aurora bomb by 30%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1989_internet_center_explosion_armor.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1989_internet_center_explosion_armor.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-04
+
+title: Increases armor of China Internet Center against Explosion attacks by 28.5%
+
+changes:
+  - tweak: Increases the armor of the China Internet Center against Explosion attacks by 28.5%. This way GLA Scud Storms, China Nuke Missiles and all Generals Powers are no longer able to kill the pristine Internet Center and all its Hackers with a single strike.
+
+labels:
+  - buff
+  - china
+  - controversial
+  - design
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1989
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/1989_internet_center_particle_beam_armor.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1989_internet_center_particle_beam_armor.yaml
@@ -1,11 +1,10 @@
 ---
 date: 2023-06-04
 
-title: Increases armor of China Internet Center against Particle Cannon beams by 25% and Explosion attacks by 28.5%
+title: Increases armor of China Internet Center against Particle Cannon beams by 25%
 
 changes:
   - tweak: Increases the armor of the China Internet Center against Particle Cannon beams by 25%. This way the Particle Cannon is no longer able to kill the pristine Internet Center with a single strike.
-  - tweak: Increases the armor of the China Internet Center against Explosion attacks by 25%. This way GLA Scud Storms, China Nuke Missiles and all Generals Powers are no longer able to kill the pristine Internet Center and all its Hackers with a single strike.
 
 labels:
   - buff

--- a/Patch104pZH/Design/Changes/v1.0/2027_internet_center_aurora_bomb_armor.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2027_internet_center_aurora_bomb_armor.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-22
+
+title: Increases armor of China Internet Center against Aurora bombs by 30%
+
+changes:
+  - tweak: Increases the armor of the China Internet Center against Aurora bombs by 30%. This way it takes one more Aurora or Alpha Aurora to take out the pristine Internet Center.
+
+labels:
+  - buff
+  - china
+  - controversial
+  - design
+  - major
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2027
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -1157,6 +1157,7 @@ End
 
 ; Patch104p @tweak xezon 04/06/2023 Change PARTICLE_BEAM armor from 20% to let healthy structure survive a single Particle Cannon attack. (#1989)
 ; Patch104p @tweak xezon 04/06/2023 Change EXPLOSION armor from 70% to let healthy structure survive a single Nuke Missile and Scud Storm Missile attack. (#1989)
+; Patch104p @tweak xezon 22/06/2023 Change AURORA_BOMB armor from 250%. (#2027)
 Armor StructureArmorInternetCenter
   Armor = DEFAULT           100%    ; this sets the level for all nonspecified damage types
   Armor = SMALL_ARMS         50%
@@ -1173,7 +1174,7 @@ Armor StructureArmorInternetCenter
   Armor = PARTICLE_BEAM      15%  ;orbital beams should be devastating to buildings, but buildings have a lot of hitpoints so extra damage is good...
   Armor = KILL_PILOT          0%      ;Jarmen Kell uses against vehicles only.
   Armor = SURRENDER           0%    ;Capture type weapons are effective only against infantry.
-  Armor = AURORA_BOMB       250%
+  Armor = AURORA_BOMB       175%
   Armor = LAND_MINE           0%    ;buildings take no damage from mines
   Armor = FLAME              50%
   Armor = EXPLOSION          50%  ;makes these buildings more resistant to nuclear attacks, among other things


### PR DESCRIPTION
* Follow up for #1989
* Relates to #223
* Relates to #754

This change increase the armor of the China Internet Center against the Aurora bomb by 30%.

The Internet Center becomes more difficult to take down with Aurora bombers.

| Structure                          | No. Auroras to kill | No. Alpha Auroras to kill |
|------------------------------------|---------------------|---------------------------|
| China Propaganda Center            |  1                  |  1                        |
| China Airfield                     |  2                  |  1                        |
| China War Factory                  |  2                  |  2                        |
| China Command Center               |  5                  |  3                        |
| Original Internet Center           |  3                  |  2 (Hackers alive)        |
| **Patched Internet Center (this)** |  4                  |  3 (Hackers dead)         |

## Original Damages

| Weapon                                | Internet Center Damage | Hackers killed       |
|---------------------------------------|------------------------|----------------------|
| **USA Alpha Aurora**                  | 58%                    | No                   |
| **USA Aurora**                        | 40%                    | No                   |

## Patched Damages

| Weapon                                | Internet Center Damage | Hackers killed       |
|---------------------------------------|------------------------|----------------------|
| USA Carpet Bomb + Lvl 2 A10           | 100%                   | Yes                  |
| USA Lvl 1 Spectre + Lvl 2 A10         | 100%                   | Yes                  |
| USA Lvl 2 Spectre + Lvl 1 A10         | 100%                   | No                   |
| GLA Demo Scud Storm                   | 100%                   | No                   |
| GLA Lvl 3 Demo Rebel Ambush           | 100%                   | No                   |
| USA Lvl 3 Spectre                     | 99%                    | No                   |
| USA Carpet Bomb + Lvl 1 Spectre       | 99%                    | No                   |
| China Carpet Bomb + Lvl 2 Artillery   | 98%                    | No                   |
| Patched GLA Anthrax Gamma Scud Storm  | 92%                    | No                   |
| GLA Scud Storm                        | 92%                    | No                   |
| USA Lvl 3 A10                         | 90%                    | No                   |
| China Nuke Missile                    | 85%                    | No                   |
| USA Particle Cannon                   | 85%                    | No                   |
| USA Carpet Bomb + Lvl 1 A10           | 79%                    | No                   |
| USA Lvl 1 Spectre + Lvl 1 A10         | 77%                    | No                   |
| China Lvl 3 Artillery                 | 76%                    | No                   |
| USA Lvl 2 Spectre                     | 72%                    | No                   |
| USA Lvl 2 A10                         | 61%                    | No                   |
| China Lvl 2 Artillery                 | 51%                    | No                   |
| China Carpet Bomb                     | 48%                    | No                   |
| USA Carpet Bomb                       | 48%                    | No                   |
| USA Lvl 1 Spectre                     | 47%                    | No                   |
| **USA Alpha Aurora (This)**           | **47%**                | **No**               |
| USA Fuel Bomb                         | 40%                    | No                   |
| USA MOAB                              | 40%                    | No                   |
| USA Lvl 1 A10                         | 31%                    | No                   |
| **USA Aurora (This)**                 | **29%**                | **No**               |
| China Lvl 1 Artillery                 | 26%                    | No                   |




# Rationale

China Hackers are typically vulnerable when out in the open and are easy to kill with most weapons. The Internet Center is the only safe refuge for China Hackers, but it can be built just once and accommodate a maximum of 8 Hackers only. It costs 7500 to build the Internet Center and the 8 Hackers.

This change gives China better chances to protect 8 valuable Hackers in late game to secure a life line while the majority of China's Hackers will remain vulnerable out in the open. Enemy players now need to combine more weapons and strikes to take out the Internet Center and its Hackers.