### PR TITLE
Fix Supply Lines bonus value on USA Supply Drop Zone crates

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1390_drop_zone_crate_count.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1390_drop_zone_crate_count.yaml
@@ -17,6 +17,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1390
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2028
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Crate.ini
@@ -549,10 +549,13 @@ Object SupplyDropZoneCrate
 
   ; *** ENGINEERING Parameters ***
   KindOf = PARACHUTABLE CRATE INERT
+
+  ; Patch104p @tweak xezon 18/10/2022 Changes provided money from 250 because the dropped crate count is halved. (#1390)
+  ; Patch104p @tweak xezon 22/06/2023 Changes upgrade boost value from 25 too. (#2028)
   Behavior = MoneyCrateCollide      ModuleTag_ForbiddenChanges
     ForbiddenKindOf = PROJECTILE
-    MoneyProvided = 500 ; Patch104p @tweak from 250
-    UpgradedBoost = UpgradeType:Upgrade_AmericaSupplyLines  Boost:25
+    MoneyProvided = 500
+    UpgradedBoost = UpgradeType:Upgrade_AmericaSupplyLines  Boost:50
     BuildingPickup = Yes
     ;ExecuteFX = FX_CratePickup
     ExecuteAnimation       = MoneyPickUp


### PR DESCRIPTION
* Follow up for #1390

This change fixes a mistake introduced by #1390. The Supply Lines would add just 5% bonus instead of 10% bonus for Supply Drop Zones crates. This is now fixed.