### PR TITLE
Change: Improve tool tip text of China Internet Center

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2029_internet_center_tooltip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2029_internet_center_tooltip_text.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-06-23
+
+title: Improves tool tip text of China Internet Center
+
+changes:
+  - tweak: Improves the tool tip text of the China Internet Center. It now clarifies that the structure protects hackers and helps them generate money faster.
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2029
+
+authors:
+  - xezon


### PR DESCRIPTION
This change improves the tool tip text of the China Internet Center from

> Helps hackers bring in money. Can be upgraded to spy on opponents

to

> Protects Hackers and helps them bring in money faster. Can be upgraded to spy on opponents

for US, DE, FR, ES, IT, BP, PL, RU.