### PR TITLE
Null clip sizes of all stream weapons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2494,6 +2494,7 @@ Weapon HijackVehicle
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon BlackLotusBuildingCaptureHack
   LeechRangeWeapon = Yes
   PrimaryDamage = 0.0
@@ -2509,13 +2510,14 @@ Weapon BlackLotusBuildingCaptureHack
   FireSound = DragonTankWeaponLoop
   FireSoundLoopTime = 80                ; loop the firing sound until there's this much delay between shots
   DelayBetweenShots = 40                ; time between shots, msec
-  ClipSize = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime = 40                   ; how long to reload a Clip, msec
+  ClipSize = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime = 0 ; how long to reload a Clip, msec
   ProjectileStreamName = FlamethrowerProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
 
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon BlackLotusVehicleDisableHack
   LeechRangeWeapon = Yes
   PrimaryDamage = 0.0
@@ -2531,12 +2533,13 @@ Weapon BlackLotusVehicleDisableHack
   FireSound = DragonTankWeaponLoop
   FireSoundLoopTime = 80                ; loop the firing sound until there's this much delay between shots
   DelayBetweenShots = 40                ; time between shots, msec
-  ClipSize = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime = 40                   ; how long to reload a Clip, msec
+  ClipSize = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime = 0 ; how long to reload a Clip, msec
   ProjectileStreamName = FlamethrowerProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon BlackLotusStealCashHack
   LeechRangeWeapon = Yes
   PrimaryDamage = 0.0
@@ -2552,12 +2555,13 @@ Weapon BlackLotusStealCashHack
   FireSound = DragonTankWeaponLoop
   FireSoundLoopTime = 80                ; loop the firing sound until there's this much delay between shots
   DelayBetweenShots = 40                ; time between shots, msec
-  ClipSize = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime = 40                   ; how long to reload a Clip, msec
+  ClipSize = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime = 0 ; how long to reload a Clip, msec
   ProjectileStreamName = FlamethrowerProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon HackerDisableBuildingHack
   LeechRangeWeapon = Yes
   PrimaryDamage = 0.0
@@ -2573,8 +2577,8 @@ Weapon HackerDisableBuildingHack
   FireSound = DragonTankWeaponLoop
   FireSoundLoopTime = 80                ; loop the firing sound until there's this much delay between shots
   DelayBetweenShots = 40                ; time between shots, msec
-  ClipSize = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime = 40                   ; how long to reload a Clip, msec
+  ClipSize = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime = 0 ; how long to reload a Clip, msec
   ProjectileStreamName = FlamethrowerProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
 End
 
@@ -2998,6 +3002,7 @@ Weapon TomahawkMissileWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon AmbulanceCleanHazardWeapon
   PrimaryDamage               = 100.0
   PrimaryDamageRadius         = 50.0
@@ -3017,8 +3022,8 @@ Weapon AmbulanceCleanHazardWeapon
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = CleanupHazardProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
 
   ; note, these only apply to units that aren't the explicit target
@@ -3028,6 +3033,7 @@ Weapon AmbulanceCleanHazardWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon BioHazardTechCleanHazardWeapon
   PrimaryDamage               = 4.0
   PrimaryDamageRadius         = 25.0
@@ -3044,8 +3050,8 @@ Weapon BioHazardTechCleanHazardWeapon
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = CleanupHazardProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
 
   ; note, these only apply to units that aren't the explicit target
@@ -3055,6 +3061,7 @@ Weapon BioHazardTechCleanHazardWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon DragonTankFlameWeapon
   PrimaryDamage               = 10.0
   PrimaryDamageRadius         = 5.0
@@ -3074,8 +3081,8 @@ Weapon DragonTankFlameWeapon
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = FlamethrowerProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes
@@ -3167,6 +3174,7 @@ Weapon DragonTankFireWallWeaponUpgraded
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon ToxinTruckGun
   PrimaryDamage               = 10.0
   PrimaryDamageRadius         = 10.0
@@ -3184,14 +3192,15 @@ Weapon ToxinTruckGun
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = ToxinTruckProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon ToxinTruckGunUpgraded
   PrimaryDamage               = 12.5
   PrimaryDamageRadius         = 10.0
@@ -3209,8 +3218,8 @@ Weapon ToxinTruckGunUpgraded
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = ToxinTruckProjectileStreamUpgraded ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes
@@ -3267,6 +3276,7 @@ Weapon ToxinTruckSprayerUpgraded
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon ToxinTruckGunPlusOne
   PrimaryDamage               = 12.5
   PrimaryDamageRadius         = 10.0
@@ -3284,14 +3294,15 @@ Weapon ToxinTruckGunPlusOne
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = ToxinTruckProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon ToxinTruckGunUpgradedPlusOne
   PrimaryDamage               = 15.0
   PrimaryDamageRadius         = 10.0
@@ -3309,8 +3320,8 @@ Weapon ToxinTruckGunUpgradedPlusOne
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = ToxinTruckProjectileStreamUpgraded ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes
@@ -3367,6 +3378,7 @@ Weapon ToxinTruckSprayerUpgradedPlusOne
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon ToxinTruckGunPlusTwo
   PrimaryDamage               = 15.0
   PrimaryDamageRadius         = 10.0
@@ -3384,14 +3396,15 @@ Weapon ToxinTruckGunPlusTwo
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = ToxinTruckProjectileStream ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @refactor xezon 23/06/2023 Changes ClipSize from 30, ClipReloadTime from 40. (#2030)
 Weapon ToxinTruckGunUpgradedPlusTwo
   PrimaryDamage               = 20.0
   PrimaryDamageRadius         = 10.0
@@ -3409,8 +3422,8 @@ Weapon ToxinTruckGunUpgradedPlusTwo
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 30                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 40                   ; how long to reload a Clip, msec
+  ClipSize                    = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 0 ; how long to reload a Clip, msec
   ProjectileStreamName        = ToxinTruckProjectileStreamUpgraded ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes


### PR DESCRIPTION
This change nulls the clip sizes of all stream weapons. Some stream weapons already have this setup. Game play wise this makes no difference.