### PR TITLE
Remove unnecessary definitions from DummyWeaponProjectile

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2031_dummy_weapon_attack_notification.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2031_dummy_weapon_attack_notification.txt
@@ -1,0 +1,1 @@
+279_dummy_weapon_attack_notification.yaml

--- a/Patch104pZH/Design/Changes/v1.0/279_dummy_weapon_attack_notification.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/279_dummy_weapon_attack_notification.yaml
@@ -4,7 +4,7 @@ date: 2021-09-10
 title: Fixes dummy weapons invoking confusing attack effects and notifications
 
 changes:
-  - fix: Objects with dummy weapons no longer do tiny amount of damages that trigger hit particle effects the "We're under attack!" notification.
+  - fix: Objects with dummy weapons no longer do tiny amount of damages that trigger hit particle effects and the "We are under attack!" notification.
 
 labels:
   - bug
@@ -13,6 +13,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/279
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2031
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3051,14 +3051,14 @@ End
 
 
 
-; Patch104p @bugfix commy2 10/09/2021 Adds dummy weapon projectile to avoid hit notifications for dummy weapons (#279).
+; Patch104p @bugfix commy2 10/09/2021 Adds dummy weapon projectile to avoid hit notifications for dummy weapons. (#279) (#2031)
 ;------------------------------------------------------------------------------
 Object DummyWeaponProjectile
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:RangerTeamMissile
-  EditorSorting   = SYSTEM
+  EditorSorting = SYSTEM
   VisionRange = 0.0
+
   ArmorSet
     Conditions      = None
     Armor           = InvulnerableAllArmor
@@ -3067,29 +3067,15 @@ Object DummyWeaponProjectile
 
   ; *** ENGINEERING Parameters ***
   KindOf = PROJECTILE
-  Body = ActiveBody ModuleTag_02
+
+  Body = ActiveBody ModuleTag_01
     MaxHealth       = 100.0
     InitialHealth   = 100.0
-
-    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
-    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
-    ; A projectile is not disabled, but instead loses target and scatters
-    SubdualDamageCap = 200
-    SubdualDamageHealRate = 100000
-    SubdualDamageHealAmount = 50
   End
 
-  Behavior = PhysicsBehavior ModuleTag_06
-    Mass = 1
+  Behavior = DestroyDie ModuleTag_02
   End
-  Behavior = MissileAIUpdate ModuleTag_07
-    TryToFollowTarget               = Yes;;;;;;;;;No
-    FuelLifetime                    = 1
-    InitialVelocity                 = 0                ; in dist/sec
-    IgnitionDelay                   = 0
-    DistanceToTravelBeforeTurning   = 0
-  End
-  Locomotor = SET_NORMAL MissileDefenderMissileLocomotor
+
   Geometry = Sphere
   GeometryIsSmall = Yes
   GeometryMajorRadius = 2.0


### PR DESCRIPTION
* Follow up for #279

This change removes unnecessary physics and ai update definitions from DummyWeaponProjectile.