### PR TITLE
Optimization: Minimize spawn count of DummyWeaponProjectile

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2032_dummy_weapon_attack_notification.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2032_dummy_weapon_attack_notification.txt
@@ -1,0 +1,1 @@
+279_dummy_weapon_attack_notification.yaml

--- a/Patch104pZH/Design/Changes/v1.0/279_dummy_weapon_attack_notification.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/279_dummy_weapon_attack_notification.yaml
@@ -5,6 +5,7 @@ title: Fixes dummy weapons invoking confusing attack effects and notifications
 
 changes:
   - fix: Objects with dummy weapons no longer do tiny amount of damages that trigger hit particle effects and the "We are under attack!" notification.
+  - optimization: Minimizes the spawn count of the dummy projectile objects.
 
 labels:
   - bug
@@ -14,6 +15,8 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/279
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2031
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2032
 
 authors:
   - commy2
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -576,6 +576,8 @@ Weapon TunnelNetworkGun
 End
 
 ;-------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count. (#2032)
 Weapon TunnelNetworkGunDUMMY
   PrimaryDamage = 0.01
   PrimaryDamageRadius = 0.0
@@ -583,8 +585,8 @@ Weapon TunnelNetworkGunDUMMY
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 99999         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
-  DelayBetweenShots = 1000         ; time between shots, msec
+  ProjectileObject = DummyWeaponProjectile
+  DelayBetweenShots = 999999         ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
 End
@@ -683,6 +685,8 @@ Weapon HumveeMissileWeaponAir
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count. (#2032)
 Weapon HumveeMissileWeaponAirDummy
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
@@ -690,9 +694,9 @@ Weapon HumveeMissileWeaponAirDummy
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 500
+  DelayBetweenShots = 999999
   ClipSize = 0
   ClipReloadTime = 0
   AutoReloadsClip = Yes
@@ -1321,8 +1325,9 @@ End
 ;------------------------------------------------------------------------------
 ; Given to the overlord tank so it's AI can target air manually from out of range.
 ; Must match GattlingBuildingGunAir's range.
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
-;------------------------------------------------------------------------------
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count. (#2032)
 Weapon GattlingBuildingGunAirDummy
   PrimaryDamage         = 0.0001
   PrimaryDamageRadius   = 0.0            ; 0 primary radius means "hits only intended victim"
@@ -1330,9 +1335,9 @@ Weapon GattlingBuildingGunAirDummy
   DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0       ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 500            ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0              ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AntiAirborneVehicle   = Yes
@@ -3928,6 +3933,8 @@ Weapon BlackNapalmFirestormSmallCreationWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count. (#2032)
 Weapon TroopCrawlerAssault
   PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
@@ -3935,16 +3942,18 @@ Weapon TroopCrawlerAssault
   DamageType = DEPLOY
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 1000               ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta = 180
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count. (#2032)
 Weapon AircraftCarrierOrderLaunch
   PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
@@ -3952,9 +3961,9 @@ Weapon AircraftCarrierOrderLaunch
   DamageType = DEPLOY
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
-  DelayBetweenShots = 1000               ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta = 180
@@ -4583,6 +4592,7 @@ Weapon NukeMissileWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 Weapon BattleshipBogusGun
   ; We need to have the weapon do some damage, or attacking will not occur because it's
   ; rejected as not having any kind of weapon that does damage
@@ -4594,7 +4604,7 @@ Weapon BattleshipBogusGun
   DamageType = UNRESISTABLE
   DeathType = NORMAL
   WeaponSpeed = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = WeaponFX_BattleshipBogusGun
   FireSound = BattleshipWeapon
   RadiusDamageAffects = ENEMIES NEUTRALS
@@ -4762,6 +4772,8 @@ End
 ;------------------------------------------------------------------------------
 ;----  ANGRY MOB  WEAPONS  ----------------------------------------------------
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 99999 to minimize object spawn count. (#2032)
 Weapon GLAAngryMobNexusHarmlessWeapon
 
   ;;; allows AI to set targets and victims and condition states
@@ -4773,10 +4785,10 @@ Weapon GLAAngryMobNexusHarmlessWeapon
   DamageType = UNRESISTABLE
   DeathType = NORMAL
   WeaponSpeed = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = NONE
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 99999        ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; Armor Piercing Bullets
@@ -4865,6 +4877,8 @@ Weapon GLAAngryMobAK47Weapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 99999 to minimize object spawn count. (#2032)
 Weapon GLAAngryMobAK47NoDamageWeapon
   PrimaryDamage         = 0.001 ; THIS IS A SPECIAL NO-DAMAGE AK47
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -4872,12 +4886,12 @@ Weapon GLAAngryMobAK47NoDamageWeapon
   DamageType            = MOLOTOV_COCKTAIL  ;SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   FireFX                = WeaponFX_RangerAdvancedCombatRifleFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicRangerAdvancedCombatRifleFire
   FireSound             = AngryMobWeaponAK47
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 99999         ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; Armor Piercing Bullets
@@ -5961,9 +5975,9 @@ End
 ;  DamageType                  = COMANCHE_VULCAN  ;used only for this weapon so stinger sites don't lose their guys but otherwise acts just like Small_Arms
 ;  DeathType                   = NORMAL
 ;  WeaponSpeed                 = 999999.0          ; dist/sec (huge value == effectively instant)
-;  ProjectileObject            = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+;  ProjectileObject            = DummyWeaponProjectile
 ;  RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
-;  DelayBetweenShots           = 100         ; time between shots, msec
+;  DelayBetweenShots           = 999999 ; time between shots, msec
 ;  ClipSize                    = 0                    ; how many shots in a Clip (0 == infinite)
 ;  ClipReloadTime              = 0              ; how long to reload a Clip, msec
 ;  AntiAirborneVehicle         = No
@@ -6092,6 +6106,8 @@ Weapon Chem_ToxinTruckSprayerGammaPlusTwo
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count. (#2032)
 Weapon RadarVanBogusWeapon
   PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
@@ -6099,10 +6115,10 @@ Weapon RadarVanBogusWeapon
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 1000               ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta = 180
@@ -6962,6 +6978,8 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count. (#2032)
 Weapon ListeningOutpostUpgradedDummyWeapon
   PrimaryDamage         = 0.1
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -6969,9 +6987,9 @@ Weapon ListeningOutpostUpgradedDummyWeapon
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 1000               ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
@@ -6980,6 +6998,8 @@ Weapon ListeningOutpostUpgradedDummyWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 10000 to minimize object spawn count. (#2032)
 Weapon BattleBusPassengerDummyWeapon
   PrimaryDamage         = 0.001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -6987,9 +7007,9 @@ Weapon BattleBusPassengerDummyWeapon
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 10000               ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
@@ -6997,7 +7017,8 @@ End
 
 ;------------------------------------------------------------------------------
 ; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
-;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 10000 to minimize object spawn count. (#2032)
 Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
   PrimaryDamage         = 0.001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -7005,9 +7026,9 @@ Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
   DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 10000               ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
@@ -8952,6 +8973,8 @@ Weapon DemoScorpionTankGunFXWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 200 to minimize object spawn count. (#2032)
 Weapon AvengerAirLaserDummy
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
@@ -8959,9 +8982,9 @@ Weapon AvengerAirLaserDummy
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 999999.0
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 200
+  DelayBetweenShots = 999999
   ClipSize = 0
   ClipReloadTime = 0
   AntiAirborneVehicle = Yes
@@ -8972,6 +8995,8 @@ Weapon AvengerAirLaserDummy
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @performance xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count. (#2032)
 Weapon BattleBusDummyWeapon
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
@@ -8979,9 +9004,9 @@ Weapon BattleBusDummyWeapon
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 500
+  DelayBetweenShots = 999999
   ClipSize = 0
   ClipReloadTime = 0
   AutoReloadsClip = Yes


### PR DESCRIPTION
* Follow up for #279

This change minimizes the dummy weapon firing interval and spawn count of DummyWeaponProjectile.