### PR TITLE
Fix: Minimize dummy weapon damage

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -576,6 +576,8 @@ Weapon TunnelNetworkGun
 End
 
 ;-------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count.
 Weapon TunnelNetworkGunDUMMY
   PrimaryDamage = 0.01
   PrimaryDamageRadius = 0.0
@@ -583,8 +585,8 @@ Weapon TunnelNetworkGunDUMMY
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 99999         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
-  DelayBetweenShots = 1000         ; time between shots, msec
+  ProjectileObject = DummyWeaponProjectile
+  DelayBetweenShots = 999999         ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
 End
@@ -683,6 +685,8 @@ Weapon HumveeMissileWeaponAir
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count.
 Weapon HumveeMissileWeaponAirDummy
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
@@ -690,9 +694,9 @@ Weapon HumveeMissileWeaponAirDummy
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 500
+  DelayBetweenShots = 999999
   ClipSize = 0
   ClipReloadTime = 0
   AutoReloadsClip = Yes
@@ -1321,8 +1325,9 @@ End
 ;------------------------------------------------------------------------------
 ; Given to the overlord tank so it's AI can target air manually from out of range.
 ; Must match GattlingBuildingGunAir's range.
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
-;------------------------------------------------------------------------------
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count.
 Weapon GattlingBuildingGunAirDummy
   PrimaryDamage         = 0.0001
   PrimaryDamageRadius   = 0.0            ; 0 primary radius means "hits only intended victim"
@@ -1330,9 +1335,9 @@ Weapon GattlingBuildingGunAirDummy
   DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0       ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 500            ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0              ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AntiAirborneVehicle   = Yes
@@ -3845,6 +3850,8 @@ Weapon BlackNapalmFirestormSmallCreationWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count.
 Weapon TroopCrawlerAssault
   PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
@@ -3852,16 +3859,18 @@ Weapon TroopCrawlerAssault
   DamageType = DEPLOY
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 1000               ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta = 180
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count.
 Weapon AircraftCarrierOrderLaunch
   PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
@@ -3869,9 +3878,9 @@ Weapon AircraftCarrierOrderLaunch
   DamageType = DEPLOY
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
-  DelayBetweenShots = 1000               ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta = 180
@@ -4500,6 +4509,8 @@ Weapon NukeMissileWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 750, ClipSize from 3, ClipReloadTime from 1500 to minimize object spawn count.
 Weapon BattleshipBogusGun
   ; We need to have the weapon do some damage, or attacking will not occur because it's
   ; rejected as not having any kind of weapon that does damage
@@ -4511,13 +4522,13 @@ Weapon BattleshipBogusGun
   DamageType = UNRESISTABLE
   DeathType = NORMAL
   WeaponSpeed = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = WeaponFX_BattleshipBogusGun
   FireSound = BattleshipWeapon
   RadiusDamageAffects = ENEMIES NEUTRALS
-  DelayBetweenShots = 750         ; time between shots, msec
-  ClipSize = 3                    ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime = 1500           ; how long to reload a Clip, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
+  ClipSize = 0 ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime = 0 ; how long to reload a Clip, msec
 End
 
 ;------------------------------------------------------------------------------
@@ -4679,6 +4690,8 @@ End
 ;------------------------------------------------------------------------------
 ;----  ANGRY MOB  WEAPONS  ----------------------------------------------------
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 99999 to minimize object spawn count.
 Weapon GLAAngryMobNexusHarmlessWeapon
 
   ;;; allows AI to set targets and victims and condition states
@@ -4690,10 +4703,10 @@ Weapon GLAAngryMobNexusHarmlessWeapon
   DamageType = UNRESISTABLE
   DeathType = NORMAL
   WeaponSpeed = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = NONE
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 99999        ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   WeaponBonus = PLAYER_UPGRADE DAMAGE 125% ; Armor Piercing Bullets
@@ -4782,6 +4795,8 @@ Weapon GLAAngryMobAK47Weapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 99999 to minimize object spawn count.
 Weapon GLAAngryMobAK47NoDamageWeapon
   PrimaryDamage         = 0.001 ; THIS IS A SPECIAL NO-DAMAGE AK47
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -4789,12 +4804,12 @@ Weapon GLAAngryMobAK47NoDamageWeapon
   DamageType            = MOLOTOV_COCKTAIL  ;SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   FireFX                = WeaponFX_RangerAdvancedCombatRifleFire
   VeterancyFireFX       = HEROIC WeaponFX_HeroicRangerAdvancedCombatRifleFire
   FireSound             = AngryMobWeaponAK47
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 99999         ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; Armor Piercing Bullets
@@ -5878,7 +5893,7 @@ End
 ;  DamageType                  = COMANCHE_VULCAN  ;used only for this weapon so stinger sites don't lose their guys but otherwise acts just like Small_Arms
 ;  DeathType                   = NORMAL
 ;  WeaponSpeed                 = 999999.0          ; dist/sec (huge value == effectively instant)
-;  ProjectileObject            = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+;  ProjectileObject            = DummyWeaponProjectile
 ;  RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
 ;  DelayBetweenShots           = 100         ; time between shots, msec
 ;  ClipSize                    = 0                    ; how many shots in a Clip (0 == infinite)
@@ -6009,6 +6024,8 @@ Weapon Chem_ToxinTruckSprayerGammaPlusTwo
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count.
 Weapon RadarVanBogusWeapon
   PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
@@ -6016,10 +6033,10 @@ Weapon RadarVanBogusWeapon
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 0         ; dist/sec
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   FireFX = None
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 1000               ; time between shots, msec
+  DelayBetweenShots = 999999 ; time between shots, msec
   ClipSize = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta = 180
@@ -6879,6 +6896,8 @@ End
 
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count.
 Weapon ListeningOutpostUpgradedDummyWeapon
   PrimaryDamage         = 0.1
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -6886,9 +6905,9 @@ Weapon ListeningOutpostUpgradedDummyWeapon
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 1000               ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
@@ -6897,6 +6916,8 @@ Weapon ListeningOutpostUpgradedDummyWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 10000 to minimize object spawn count.
 Weapon BattleBusPassengerDummyWeapon
   PrimaryDamage         = 0.001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -6904,9 +6925,9 @@ Weapon BattleBusPassengerDummyWeapon
   DamageType            = SMALL_ARMS
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 10000               ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
@@ -6914,7 +6935,8 @@ End
 
 ;------------------------------------------------------------------------------
 ; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
-;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 10000 to minimize object spawn count.
 Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
   PrimaryDamage         = 0.001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
@@ -6922,9 +6944,9 @@ Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
   DamageType            = GATTLING
   DeathType             = NORMAL
   WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
-  ProjectileObject      = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject      = DummyWeaponProjectile
   RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots     = 10000               ; time between shots, msec
+  DelayBetweenShots     = 999999 ; time between shots, msec
   ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 0              ; how long to reload a Clip, msec
   AcceptableAimDelta    = 180 ; I'm not really shooting, my buddies are.  So no need to turn
@@ -8869,6 +8891,8 @@ Weapon DemoScorpionTankGunFXWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 200 to minimize object spawn count.
 Weapon AvengerAirLaserDummy
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
@@ -8876,9 +8900,9 @@ Weapon AvengerAirLaserDummy
   DamageType = SMALL_ARMS
   DeathType = NORMAL
   WeaponSpeed = 999999.0
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 200
+  DelayBetweenShots = 999999
   ClipSize = 0
   ClipReloadTime = 0
   AntiAirborneVehicle = Yes
@@ -8889,6 +8913,8 @@ Weapon AvengerAirLaserDummy
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
+; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count.
 Weapon BattleBusDummyWeapon
   PrimaryDamage = 0.0001
   PrimaryDamageRadius = 0.0
@@ -8896,9 +8922,9 @@ Weapon BattleBusDummyWeapon
   DamageType = EXPLOSION
   DeathType = EXPLODED
   WeaponSpeed = 999999.0
-  ProjectileObject = DummyWeaponProjectile ; Patch104p @bugfix from NONE
+  ProjectileObject = DummyWeaponProjectile
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
-  DelayBetweenShots = 500
+  DelayBetweenShots = 999999
   ClipSize = 0
   ClipReloadTime = 0
   AutoReloadsClip = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -578,8 +578,9 @@ End
 ;-------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.01 to minimize dealt damage.
 Weapon TunnelNetworkGunDUMMY
-  PrimaryDamage = 0.01
+  PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
   AttackRange = 175.0
   DamageType = SMALL_ARMS
@@ -687,8 +688,9 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.0001 to minimize dealt damage.
 Weapon HumveeMissileWeaponAirDummy
-  PrimaryDamage = 0.0001
+  PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
   AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Humvee freezing when ordered to attack out of range airborne targets. 150.0 was determined to be the highest range where missile infantry passengers reliably engaged the target.
   DamageType = EXPLOSION
@@ -1328,8 +1330,9 @@ End
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.0001 to minimize dealt damage.
 Weapon GattlingBuildingGunAirDummy
-  PrimaryDamage         = 0.0001
+  PrimaryDamage         = 0.00001
   PrimaryDamageRadius   = 0.0            ; 0 primary radius means "hits only intended victim"
   AttackRange           = 400.0
   DamageType            = GATTLING
@@ -4692,12 +4695,13 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 99999 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.001 to minimize dealt damage.
 Weapon GLAAngryMobNexusHarmlessWeapon
 
   ;;; allows AI to set targets and victims and condition states
   ;;; without really doing any harm
 
-  PrimaryDamage = 0.001
+  PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange = 90.0 ;70.0 ;; small so the whole mob can get in close
   DamageType = UNRESISTABLE
@@ -4797,8 +4801,9 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 99999 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.001 to minimize dealt damage.
 Weapon GLAAngryMobAK47NoDamageWeapon
-  PrimaryDamage         = 0.001 ; THIS IS A SPECIAL NO-DAMAGE AK47
+  PrimaryDamage         = 0.00001 ; THIS IS A SPECIAL NO-DAMAGE AK47
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 120.0
   DamageType            = MOLOTOV_COCKTAIL  ;SMALL_ARMS
@@ -6898,8 +6903,9 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 1000 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.1 to minimize dealt damage.
 Weapon ListeningOutpostUpgradedDummyWeapon
-  PrimaryDamage         = 0.1
+  PrimaryDamage         = 0.00001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 90.0
   DamageType            = SMALL_ARMS
@@ -6918,8 +6924,9 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 10000 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.001 to minimize dealt damage.
 Weapon BattleBusPassengerDummyWeapon
-  PrimaryDamage         = 0.001
+  PrimaryDamage         = 0.00001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 90.0
   DamageType            = SMALL_ARMS
@@ -6937,8 +6944,9 @@ End
 ; Patch104p @tweak xezon 02/02/2023 Change DamageType from SMALL_ARMS.
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 10000 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.001 to minimize dealt damage.
 Weapon Infa_ChinaVehicleTroopCrawlerDummyWeapon
-  PrimaryDamage         = 0.001
+  PrimaryDamage         = 0.00001
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 60.0 ; Small enough that the minigunners at their bones can shoot their gun.
   DamageType            = GATTLING
@@ -8893,8 +8901,9 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 200 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.0001 to minimize dealt damage.
 Weapon AvengerAirLaserDummy
-  PrimaryDamage = 0.0001
+  PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
   AttackRange = 175.0
   DamageType = SMALL_ARMS
@@ -8915,8 +8924,9 @@ End
 ;------------------------------------------------------------------------------
 ; Patch104p @bugfix commy2 10/09/2021 Changes ProjectileObject from NONE to remove hit effects. (#279)
 ; Patch104p @optimization xezon 23/06/2023 Changes DelayBetweenShots from 500 to minimize object spawn count.
+; Patch104p @tweak xezon 23/06/2023 Changes PrimaryDamage from 0.0001 to minimize dealt damage.
 Weapon BattleBusDummyWeapon
-  PrimaryDamage = 0.0001
+  PrimaryDamage = 0.00001
   PrimaryDamageRadius = 0.0
   AttackRange = 150.0 ; Patch104p @bugfix commy2 10/09/2021 Fix Bus freezing when ordered to attack out of range airborne targets. 150.0 was determined to be the highest range where missile infantry passengers reliably engaged the target.
   DamageType = EXPLOSION


### PR DESCRIPTION
This change minimizes dummy weapon damage. This way it will be very unlikely to ever kill a unit.