### PR TITLE
Optimization: Decrease cost of toxin and hazard cleanup stream trail particles by around 50%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2034_hazard_cleanup_stream_trail_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2034_hazard_cleanup_stream_trail_performance.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-24
+
+title: Decreases performance cost of hazard cleanup stream trail effects by 50% to 57%
+
+changes:
+  - optimization: Decreases the performance cost of hazard cleanup stream trail effects by 50% to 57%. Affects USA Ambulance.
+
+labels:
+  - art
+  - major
+  - performance
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2034
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2034_toxin_stream_trail_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2034_toxin_stream_trail_performance.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-24
+
+title: Decreases performance cost of toxin stream trail effects by 50% to 65%
+
+changes:
+  - optimization: Decreases the performance cost of toxin stream trail effects by 50% to 65%. Affects GLA Toxin Tractor, Toxin Rebel and Toxin Tunnel.
+
+labels:
+  - art
+  - gla
+  - major
+  - performance
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2034
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -22341,7 +22341,7 @@ End
 
 
 ;------------------------------------------------------------------------------
-Object Chem_ToxinStreamProjectile
+Object Chem_ToxinStreamProjectile ; unused
 
 ; Explanation - Particles can't do damage, so this is a fast shooting low
 ; damage invisible missile launcher with a toxin trail for exhaust

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -4706,6 +4706,7 @@ ParticleSystem NukeBaikonurMushroomStem
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 65% (#2034)
 ParticleSystem AnthraxTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -4718,10 +4719,10 @@ ParticleSystem AnthraxTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 20
+  SystemLifetime = 10 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
-  SizeRate = -1.00 1.00
+  SizeRate = -0.33 1.00 ; Patch104p @tweak from -1.00 1.00 to decrease the number of tiny particles
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 0
   Alpha2 = 1.00 1.00 5
@@ -4740,7 +4741,7 @@ ParticleSystem AnthraxTrail01
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 1.00 0.00
-  BurstDelay = 0.00 1.00
+  BurstDelay = 0.00 2.00 ; Patch104p @performance from 0.00 1.00 to increase the spawn interval at random
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
@@ -12930,6 +12931,7 @@ ParticleSystem SmokeSmall
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 65% (#2034)
 ParticleSystem GC_Chem_ToxinTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -12942,10 +12944,10 @@ ParticleSystem GC_Chem_ToxinTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 20
+  SystemLifetime = 10 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
-  SizeRate = -1.00 1.00
+  SizeRate = -0.33 1.00 ; Patch104p @tweak from -1.00 1.00 to decrease the number of tiny particles
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 0
   Alpha2 = 1.00 1.00 5
@@ -12964,7 +12966,7 @@ ParticleSystem GC_Chem_ToxinTrail01
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 1.00 0.00
-  BurstDelay = 0.00 1.00
+  BurstDelay = 0.00 2.00 ; Patch104p @performance from 0.00 1.00 to increase the spawn interval at random
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
@@ -12986,6 +12988,7 @@ ParticleSystem GC_Chem_ToxinTrail01
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 65% (#2034)
 ParticleSystem ToxinTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -12998,10 +13001,10 @@ ParticleSystem ToxinTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 20
+  SystemLifetime = 10 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
-  SizeRate = -1.00 1.00
+  SizeRate = -0.33 1.00 ; Patch104p @tweak from -1.00 1.00 to decrease the number of tiny particles
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 0
   Alpha2 = 1.00 1.00 5
@@ -13020,7 +13023,7 @@ ParticleSystem ToxinTrail01
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 1.00 0.00
-  BurstDelay = 0.00 1.00
+  BurstDelay = 0.00 2.00 ; Patch104p @performance from 0.00 1.00 to increase the spawn interval at random
   BurstCount = 1.00 1.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
@@ -13098,7 +13101,7 @@ ParticleSystem FlameThrowerSmoke01
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem ToxinTrail02
+ParticleSystem ToxinTrail02 ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -20824,6 +20824,7 @@ ParticleSystem _FireTest
 End
 
 ; Patch104p @fix xezon 25/06/2023 Adjusts particle colors to better blend with the cyan excleanupstream texture. (#2041)
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 57% (#2034)
 ParticleSystem CleanupTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -20836,14 +20837,14 @@ ParticleSystem CleanupTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 20
+  SystemLifetime = 12 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
   SizeRate = 1.00 1.00
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 0
   Alpha2 = 1.00 1.00 5
-  Alpha3 = 0.00 0.00 10 ; Patch104p @tweak from 20
+  Alpha3 = 0.00 0.00 20
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
   Alpha6 = 0.00 0.00 0
@@ -20858,7 +20859,7 @@ ParticleSystem CleanupTrail01
   Color7 = R:0 G:0 B:0 0
   Color8 = R:0 G:0 B:0 0
   ColorScale = 1.00 0.00
-  BurstDelay = 0.00 1.00
+  BurstDelay = 0.00 2.00 ; Patch104p @performance from 0.00 1.00 to increase the spawn interval at random
   BurstCount = 2.00 2.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00


### PR DESCRIPTION
**Merge with Rebase**

* Relates to TheSuperHackers/GeneralsGameCode#124

This change decreases the cost of toxin and hazard cleanup stream trail particles by around 50%. The overall performance improvement of the stream weapon is significantly less than that, because there are other expensive components.

Affects

* GLA Toxin Truck
* GLA Toxin Rebel
* GLA Toxin Tunnel
* USA Ambulance

## Before

Expensive stream particle effects.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/9dfb0010-68ba-436d-8435-4d924ab0d83c

## After (Outdated)

The original look was preserved as much as possible. At a glance the effects look very similar.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/8f63d393-08b4-4599-bea5-fe3c0a5f693f
