### PR TITLE
Optimization: Decrease performance cost of toxin and hazard cleanup stream splash effects by 20%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2035_toxin_stream_splash_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2035_toxin_stream_splash_performance.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-25
+
+title: Decreases performance cost of toxin and hazard cleanup stream splash effects by 20%
+
+changes:
+  - optimization: Decreases performance cost of toxin and hazard cleanup stream splash effects by 20%. Affects GLA Toxin Tractor, Toxin Rebel, Toxin Tunnel and USA Ambulance.
+
+labels:
+  - art
+  - gla
+  - minor
+  - performance
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2035
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -26104,6 +26104,7 @@ ParticleSystem AutoFireLarge01
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of stream hit splash effect by 20% (#2035)
 ParticleSystem ToxinTarget
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No
@@ -26115,15 +26116,15 @@ ParticleSystem ToxinTarget
   AngularDamping = 0.00 0.00
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
-  Lifetime = 25.00 25.00
+  Lifetime = 20.00 20.00 ; Patch104p @tweak from 25.00 25.00
   SystemLifetime = 1
-  Size = 1.00 2.00
+  Size = 1.20 2.40 ; Patch104p @tweak from 1.00 2.00 to scale with new lifetime
   StartSizeRate = 0.00 0.00
-  SizeRate = 1.00 3.00
+  SizeRate = 1.40 4.20 ; Patch104p @tweak from 1.00 3.00 to scale with new lifetime (+40%)
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 1
-  Alpha2 = 1.00 1.00 5
-  Alpha3 = 0.00 0.00 25
+  Alpha2 = 1.00 1.00 4 ; Patch104p @tweak from 5 to scale with new lifetime
+  Alpha3 = 0.00 0.00 20 ; Patch104p @tweak from 25 to scale with new lifetime
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
   Alpha6 = 0.00 0.00 0
@@ -49725,7 +49726,8 @@ ParticleSystem AvalancheDebrisSnow1
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AnthraxTarget
+; Patch104p @performance xezon 24/06/2023 Decreases cost of stream hit splash effect by 20% (#2035)
+ParticleSystem AnthraxTarget ; Alias AnthraxToxinTarget
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No
   Shader = ALPHA
@@ -49736,15 +49738,15 @@ ParticleSystem AnthraxTarget
   AngularDamping = 0.00 0.00
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
-  Lifetime = 25.00 25.00
+  Lifetime = 20.00 20.00 ; Patch104p @tweak from 25.00 25.00
   SystemLifetime = 1
-  Size = 1.00 2.00
+  Size = 1.20 2.40 ; Patch104p @tweak from 1.00 2.00 to scale with new lifetime
   StartSizeRate = 0.00 0.00
-  SizeRate = 1.00 3.00
+  SizeRate = 1.40 4.20 ; Patch104p @tweak from 1.00 3.00 to scale with new lifetime (+40%)
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 1
-  Alpha2 = 1.00 1.00 5
-  Alpha3 = 0.00 0.00 25
+  Alpha2 = 1.00 1.00 4 ; Patch104p @tweak from 5 to scale with new lifetime
+  Alpha3 = 0.00 0.00 20 ; Patch104p @tweak from 25 to scale with new lifetime
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
   Alpha6 = 0.00 0.00 0
@@ -52902,6 +52904,7 @@ ParticleSystem TrainWreckTrailExplosion
 End
 
 ; Patch104p @fix xezon 25/06/2023 Adjusts particle colors to better blend with the cyan excleanupstream texture. (#2041)
+; Patch104p @performance xezon 24/06/2023 Decreases cost of stream hit splash effect by 20% (#2035)
 ParticleSystem CleanupTarget
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No
@@ -52913,15 +52916,15 @@ ParticleSystem CleanupTarget
   AngularDamping = 0.00 0.00
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
-  Lifetime = 25.00 25.00
+  Lifetime = 20.00 20.00 ; Patch104p @tweak from 25.00 25.00
   SystemLifetime = 1
-  Size = 1.00 2.00
+  Size = 1.20 2.40 ; Patch104p @tweak from 1.00 2.00 to scale with new lifetime
   StartSizeRate = 0.00 0.00
-  SizeRate = 1.00 3.00
+  SizeRate = 1.40 4.20 ; Patch104p @tweak from 1.00 3.00 to scale with new lifetime (+40%)
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 1
-  Alpha2 = 1.00 1.00 5
-  Alpha3 = 0.00 0.00 25
+  Alpha2 = 1.00 1.00 4 ; Patch104p @tweak from 5 to scale with new lifetime
+  Alpha3 = 0.00 0.00 20 ; Patch104p @tweak from 25 to scale with new lifetime
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
   Alpha6 = 0.00 0.00 0
@@ -52929,7 +52932,7 @@ ParticleSystem CleanupTarget
   Alpha8 = 0.00 0.00 0
   Color1 = R:35 G:105 B:247 0 ; Patch104p @tweak from Patch104p @tweak from R:64 G:0 B:255 0
   Color2 = R:64 G:0 B:255 10 ; Patch104p @tweak from Patch104p @tweak from R:0 G:0 B:0 0
-  Color3 = R:0 G:0 B:0 25 ; Patch104p @tweak from Patch104p @tweak from R:0 G:0 B:0 0
+  Color3 = R:0 G:0 B:0 20 ; Patch104p @tweak from Patch104p @tweak from R:0 G:0 B:0 0
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -55859,6 +55862,7 @@ ParticleSystem NukeBaikonurFlare
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of stream hit splash effect by 20% (#2035)
 ParticleSystem GC_Chem_ToxinTarget ; Alias AnthraxGammaTarget
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No
@@ -55870,15 +55874,15 @@ ParticleSystem GC_Chem_ToxinTarget ; Alias AnthraxGammaTarget
   AngularDamping = 0.00 0.00
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
-  Lifetime = 25.00 25.00
+  Lifetime = 20.00 20.00 ; Patch104p @tweak from 25.00 25.00
   SystemLifetime = 1
-  Size = 1.00 2.00
+  Size = 1.20 2.40 ; Patch104p @tweak from 1.00 2.00 to scale with new lifetime
   StartSizeRate = 0.00 0.00
-  SizeRate = 1.00 3.00
+  SizeRate = 1.40 4.20 ; Patch104p @tweak from 1.00 3.00 to scale with new lifetime (+40%)
   SizeRateDamping = 0.90 0.95
   Alpha1 = 0.00 0.00 1
-  Alpha2 = 1.00 1.00 5
-  Alpha3 = 0.00 0.00 25
+  Alpha2 = 1.00 1.00 4 ; Patch104p @tweak from 5 to scale with new lifetime
+  Alpha3 = 0.00 0.00 20 ; Patch104p @tweak from 25 to scale with new lifetime
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
   Alpha6 = 0.00 0.00 0


### PR DESCRIPTION
* Relates to TheSuperHackers/GeneralsGameCode#124

This change decreases the cost of toxin and hazard cleanup stream hit splash effects by 40%. The overall performance improvement of the stream weapon is significantly less than that, because there are other expensive components.

Affects

* GLA Toxin Truck
* GLA Toxin Rebel
* GLA Toxin Tunnel
* USA Ambulance

## Before

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/687f2c7d-3ad8-49bf-b013-ba3026091118

## After (Outdated)

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/989d51d8-9c6d-4d0d-89dc-ab451473acfc
