### PR TITLE
Optimization: Decrease performance cost of toxin stream puddles by 70%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2036_toxin_stream_puddle_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2036_toxin_stream_puddle_performance.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-24
+
+title: Decreases performance cost of toxin stream puddles by 70%
+
+changes:
+  - optimization: Decreases performance cost of toxin stream puddles by 70%. Affects GLA Toxin Tractor, Toxin Rebel and Toxin Tunnel.
+
+labels:
+  - art
+  - gla
+  - major
+  - performance
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2036
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -14122,6 +14122,7 @@ ParticleSystem MOABMushroomStem
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of puddle by 70% (#2036)
 ParticleSystem ToxinPuddle
   Priority = AREA_EFFECT
   IsOneShot = No
@@ -14133,14 +14134,14 @@ ParticleSystem ToxinPuddle
   AngularDamping = 1.00 1.00
   VelocityDamping = 0.20 0.20
   Gravity = 0.00
-  Lifetime = 100.00 100.00
+  Lifetime = 30.00 30.00 ; Patch104p @performance from 100.00 100.00
   SystemLifetime = 1
   Size = 2.00 2.00 ; Patch104p @tweak from 5.00 5.00 to better match damage radius of Toxin Tractor
   StartSizeRate = 0.00 0.00
   SizeRate = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to better match damage radius of Toxin Tractor
   SizeRateDamping = 0.90 0.85
   Alpha1 = 1.00 1.00 0
-  Alpha2 = 0.00 0.00 100
+  Alpha2 = 0.00 0.00 30 ; Patch104p @tweak from 100 to scale with new lifetime
   Alpha3 = 0.00 0.00 0
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
@@ -14148,8 +14149,8 @@ ParticleSystem ToxinPuddle
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
-  Color2 = R:102 G:247 B:31 50 ; Patch104p @tweak Toxin color
-  Color3 = R:0 G:0 B:0 100
+  Color2 = R:102 G:247 B:31 15 ; Patch104p @tweak from 50 to scale with new lifetime, changes Toxin color
+  Color3 = R:0 G:0 B:0 30 ; Patch104p @tweak from 100 to scale with new lifetime
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -38100,7 +38101,8 @@ ParticleSystem ScudMissleLauncherToxinExplosionTrailSmoke
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem AnthraxPuddle
+; Patch104p @performance xezon 24/06/2023 Decreases cost of puddle by 70% (#2036)
+ParticleSystem AnthraxPuddle ; Alias AnthraxToxinPuddle
   Priority = AREA_EFFECT
   IsOneShot = No
   Shader = ADDITIVE
@@ -38111,14 +38113,14 @@ ParticleSystem AnthraxPuddle
   AngularDamping = 1.00 1.00
   VelocityDamping = 0.20 0.20
   Gravity = 0.00
-  Lifetime = 100.00 100.00
+  Lifetime = 30.00 30.00 ; Patch104p @performance from 100.00 100.00
   SystemLifetime = 1
   Size = 2.00 2.00 ; Patch104p @tweak from 2.00 5.00 to better match damage radius of Toxin Tractor
   StartSizeRate = 0.00 0.00
   SizeRate = 2.00 2.00 ; Patch104p @tweak from 1.00 3.00 to better match damage radius of Toxin Tractor
   SizeRateDamping = 0.90 0.85
   Alpha1 = 1.00 1.00 0
-  Alpha2 = 0.00 0.00 100
+  Alpha2 = 0.00 0.00 30 ; Patch104p @tweak from 100 to scale with new lifetime
   Alpha3 = 0.00 0.00 0
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
@@ -38126,8 +38128,8 @@ ParticleSystem AnthraxPuddle
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
-  Color2 = R:96 G:112 B:220 50 ; Patch104p @tweak Anthrax color
-  Color3 = R:0 G:0 B:0 100
+  Color2 = R:96 G:112 B:220 15 ; Patch104p @tweak from 50 to scale with new lifetime, changes Anthrax color
+  Color3 = R:0 G:0 B:0 30 ; Patch104p @tweak from 100 to scale with new lifetime
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0
@@ -45238,14 +45240,14 @@ ParticleSystem GC_Chem_ToxinPuddle ; Alias AnthraxGammaPuddle
   AngularDamping = 1.00 1.00
   VelocityDamping = 0.20 0.20
   Gravity = 0.00
-  Lifetime = 100.00 100.00 ; Patch104p @tweak from 10.00 10.00 to match ToxinPuddle
+  Lifetime = 30.00 30.00 ; Patch104p @tweak from 10.00 10.00 to match ToxinPuddle : Increases cost by 200%, but is ok. (#2036)
   SystemLifetime = 1
   Size = 2.00 2.00
   StartSizeRate = 0.00 0.00
   SizeRate = 2.00 2.00 ; Patch104p @tweak from 3.00 3.00 to better match damage radius of Toxin Tractor
   SizeRateDamping = 0.90 0.85
   Alpha1 = 1.00 1.00 0
-  Alpha2 = 0.00 0.00 100
+  Alpha2 = 0.00 0.00 30 ; Patch104p @tweak from 100 to scale with new lifetime
   Alpha3 = 0.00 0.00 0
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0
@@ -45253,8 +45255,8 @@ ParticleSystem GC_Chem_ToxinPuddle ; Alias AnthraxGammaPuddle
   Alpha7 = 0.00 0.00 0
   Alpha8 = 0.00 0.00 0
   Color1 = R:0 G:0 B:0 0
-  Color2 = R:128 G:55 B:217 50
-  Color3 = R:0 G:0 B:0 100
+  Color2 = R:128 G:55 B:217 15 ; Patch104p @tweak from 50 to scale with new lifetime
+  Color3 = R:0 G:0 B:0 30 ; Patch104p @tweak from 100 to scale with new lifetime
   Color4 = R:0 G:0 B:0 0
   Color5 = R:0 G:0 B:0 0
   Color6 = R:0 G:0 B:0 0


### PR DESCRIPTION
* Relates to TheSuperHackers/GeneralsGameCode#124

This change decreases the cost of toxin stream puddles by 70%. The overall performance improvement of the stream weapon is significantly less than that, because there are other expensive components.

Affects

* GLA Toxin Truck
* GLA Toxin Rebel
* GLA Toxin Tunnel

The performance increase is achieved by reducing the puddle lifetime from 100 to 30 frames. Design wise the shorter puddle lifetime also makes more sense, because the visual puddle itself deals no damage and the slow fade out of 100 frames would indicate that the location is still hazardous when it actually is not.

The cleanup puddle of the USA Ambulance already has a lifetime of 30 frames.

## Before

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/687f2c7d-3ad8-49bf-b013-ba3026091118

## After

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/4e5aaac7-440b-4c88-afaf-6cc14dcd2da2
