### PR TITLE
Restore original China Overlord upgrade command button order in core bundle pack

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1896_overlord_upgrade_buttons_and_icons.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1896_overlord_upgrade_buttons_and_icons.yaml
@@ -4,17 +4,20 @@ date: 2023-05-01
 title: Improves upgrade command button and upgrade cameo icon placements of China Overlord and Emperor
 
 changes:
-  - tweak: Matches the position and order of the China Overlord and Emperor upgrade command button with those of the China Helix.
-  - fix: Matches the order of the China Overlord and Emperor upgrade cameo icons with the order of the command buttons.
+  - tweak: Matches the position of the China Overlord and Emperor upgrade command button with those of the China Helix.
+  - tweak: Optionally matches the order of the China Overlord and Emperor upgrade command button with those of the China Helix.
+  - tweak: Matches the order of the China Overlord and Emperor upgrade cameo icons with the order of the command buttons.
 
 labels:
   - china
   - gui
   - minor
+  - optional
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1896
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2037
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2037_overlord_upgrade_buttons.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2037_overlord_upgrade_buttons.txt
@@ -1,0 +1,1 @@
+1896_overlord_upgrade_buttons_and_icons.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -1259,7 +1259,7 @@ CommandButton Command_UpgradeChinaOverlordGattlingCannon
   UnitSpecificSound       = OverlordTankVoiceModeGattling
 End
 
-; Patch104p @tweak xezon 01/05/2023 Adds a new button variant for the Gattling Cannon upgrade that works for both Overlord and Emperor.
+; Patch104p @tweak xezon 01/05/2023 Adds a new button variant for the Gattling Cannon upgrade that works for both Overlord and Emperor. (#1896)
 ;   This allows the button to be used in Overlord and Emperor group selections.
 CommandButton Multi_Command_UpgradeChinaOverlordGattlingCannon
   Command       = OBJECT_UPGRADE

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -687,14 +687,21 @@ CommandSet ChinaTankBattlemasterCommandSet
 End
 
 ;--------------------------------------------
-; Patch104p @tweak xezon 01/05/2023 Repositions and reorders the attachment upgrades to match the position and order of the Helix ones.
+; Patch104p @tweak xezon 01/05/2023 Repositions and optionally reorders the attachment upgrades to match the position and order of the Helix ones. (#1896) (#2037)
 CommandSet ChinaTankOverlordDefaultCommandSet
   ;1  = Command_UpgradeChinaOverlordBattleBunker
   ;3  = Command_UpgradeChinaOverlordGattlingCannon
   ;5  = Command_UpgradeChinaOverlordPropagandaTower
+;patch104p-core-begin
+  6  = Command_UpgradeChinaOverlordBattleBunker
+  8  = Multi_Command_UpgradeChinaOverlordGattlingCannon
+  10 = Command_UpgradeChinaOverlordPropagandaTower
+;patch104p-core-end
+;patch104p-optional-begin
   6  = Command_UpgradeChinaOverlordBattleBunker
   8  = Command_UpgradeChinaOverlordPropagandaTower
   10 = Multi_Command_UpgradeChinaOverlordGattlingCannon
+;patch104p-optional-end
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop
@@ -702,17 +709,24 @@ End
 
 ; Patch104p @tweak from Command_Evacuate to Command_EmptyCrawler, so that all vehicles use same evacuate command button.
 ; Patch104p @tweak xezon 30/04/2023 Moves Command_EmptyCrawler from 6 to 9, so that it can be evacuated together with other ground vehicles.
-; Patch104p @tweak xezon 01/05/2023 Adds the attachment upgrades to keep them usable in group selections always.
-; Patch104p @tweak xezon 01/05/2023 Uses the multi button variant for the Gattling Cannon upgrade so that the Overlord and Emperor can use this button in a group selection.
+; Patch104p @tweak xezon 01/05/2023 Adds the attachment upgrades to keep them usable in group selections always. (#1896) (#2037)
+; Patch104p @tweak xezon 01/05/2023 Uses the multi button variant for the Gattling Cannon upgrade so that the Overlord and Emperor can use this button in a group selection. (#1896)
 CommandSet ChinaTankOverlordBattleBunkerCommandSet
   1 = Command_TransportExit
   2 = Command_TransportExit
   3 = Command_TransportExit
   4 = Command_TransportExit
   5 = Command_TransportExit
+;patch104p-core-begin
+  6  = Command_UpgradeChinaOverlordBattleBunker
+  8  = Multi_Command_UpgradeChinaOverlordGattlingCannon
+  10 = Command_UpgradeChinaOverlordPropagandaTower
+;patch104p-core-end
+;patch104p-optional-begin
   6  = Command_UpgradeChinaOverlordBattleBunker
   8  = Command_UpgradeChinaOverlordPropagandaTower
   10 = Multi_Command_UpgradeChinaOverlordGattlingCannon
+;patch104p-optional-end
   9 = Command_EmptyCrawler
   11 = Command_AttackMove
   13 = Command_Guard
@@ -5326,11 +5340,16 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
   14 = Command_Stop
 End
 
-; Patch104p @tweak xezon 01/05/2023 Repositions the attachment upgrade to match the position of the Overlord and Helix one.
-; Patch104p @tweak xezon 01/05/2023 Uses the multi button variant for the Gattling Cannon upgrade so that the Overlord and Emperor can use this button in a group selection.
+; Patch104p @tweak xezon 01/05/2023 Repositions the attachment upgrade to match the position of the Overlord and Helix one. (#1896) (#2037)
+; Patch104p @tweak xezon 01/05/2023 Uses the multi button variant for the Gattling Cannon upgrade so that the Overlord and Emperor can use this button in a group selection. (#1896)
 CommandSet Tank_ChinaTankEmperorDefaultCommandSet
   ;3  = Tank_Command_UpgradeChinaOverlordGattlingCannon
+;patch104p-core-begin
+   8 = Multi_Command_UpgradeChinaOverlordGattlingCannon
+;patch104p-core-end
+;patch104p-optional-begin
   10 = Multi_Command_UpgradeChinaOverlordGattlingCannon
+;patch104p-optional-end
   11 = Command_AttackMove
   13 = Command_Guard
   14 = Command_Stop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -227,7 +227,7 @@ Object ChinaTankOverlord
   SelectPortrait         = SNOverlord_L
   ButtonImage            = SNOverlord
 
-  ; Patch104p @tweak xezon 30/04/2023 Moves attachment upgrade icons into same order as new optional upgrade buttons and Helix icons.
+  ; Patch104p @tweak xezon 30/04/2023 Moves attachment upgrade icons into same order as new optional upgrade buttons and Helix icons. (#1896)
 
   UpgradeCameo1 = Upgrade_ChinaUraniumShells
   UpgradeCameo2 = Upgrade_ChinaNuclearTanks

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17143,7 +17143,7 @@ Object Nuke_ChinaTankOverlord
 
   ; Patch104p @refactor xezon 08/04/2023 Comments the incorrect and unused Nuke upgrades.
   ; Patch104p @bugfix xezon 08/04/2023 Adds missing IsotopeStability icon.
-  ; Patch104p @tweak xezon 30/04/2023 Moves attachment upgrade icons into same order as new optional upgrade buttons and Helix icons.
+  ; Patch104p @tweak xezon 30/04/2023 Moves attachment upgrade icons into same order as new optional upgrade buttons and Helix icons. (#1896)
 
   ;UpgradeCameo1 = Nuke_Upgrade_ChinaWGUraniumShells
   ;UpgradeCameo2 = Nuke_Upgrade_ChinaFusionReactors


### PR DESCRIPTION
* Follow up for #1896

This change restores the original China Overlord upgrade command button order (before #1896) in the core bundle pack. Reason being, the changed order can conflict with the memory of legacy players. Therefore it is better to keep the corrected order in the optional bundle pack only.