### PR TITLE
Optimization: Decrease performance cost of Inferno Cannon fire particles by 36%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2039_inferno_cannon_fire_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2039_inferno_cannon_fire_performance.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-25
+
+title: Decreases performance cost of Inferno Cannon fire particles by 36%
+
+changes:
+  - optimization: Decreases the performance cost of Inferno Cannon fire particles by 36%. Affects China Inferno Cannon shells and Mig Jet missiles.
+
+labels:
+  - art
+  - china
+  - minor
+  - performance
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2039
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2039_inferno_cannon_shell_hit_effects.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2039_inferno_cannon_shell_hit_effects.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-06-25
+
+title: Removes distracting smoke effect from the center of the Inferno Cannon fire particles
+
+changes:
+  - fix: The distracting smoke effect at the center of the Inferno Cannon fire particles is now removed.
+
+labels:
+  - art
+  - china
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2039
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -882,9 +882,10 @@ FXList WeaponFX_InfernoTankShellDetonation
     Name = BuggyMissileExplosion
     UseCallersRadius = Yes ; Override the radius with the damage radius of the weapon.
   End
-  ParticleSystem
-    Name = BuggyMissileExplosionSmoke
-  End
+  ; Patch104p @fix xezon 25/06/2023 Remove distracting smoke from center of impact.
+  ;ParticleSystem
+  ;  Name = BuggyMissileExplosionSmoke
+  ;End
 End
 
 ; ----------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -9743,6 +9743,7 @@ ParticleSystem NukeCannonMuzzleWave
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 25/06/2023 Decrease cost of particles by 36%
 ParticleSystem InfernoCannonFireUpgraded
   Priority = WEAPON_EXPLOSION
   IsOneShot = No
@@ -9778,7 +9779,7 @@ ParticleSystem InfernoCannonFireUpgraded
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
   BurstDelay = 1.00 1.00
-  BurstCount = 5.00 6.00
+  BurstCount = 3.00 4.00 ; Patch104p @performance from 5.00 6.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.08 Y:0.16 Z:0.01
   VelocityType = OUTWARD
@@ -14013,6 +14014,7 @@ ParticleSystem AvalancheTrailArms
   WindPingPongEndAngleMax = 0.000000
 End
 
+; Patch104p @performance xezon 25/06/2023 Decrease cost of particles by 36%
 ParticleSystem InfernoCannonFire
   Priority = WEAPON_EXPLOSION
   IsOneShot = No
@@ -14048,7 +14050,7 @@ ParticleSystem InfernoCannonFire
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
   BurstDelay = 1.00 1.00
-  BurstCount = 5.00 6.00
+  BurstCount = 3.00 4.00 ; Patch104p @performance from 5.00 6.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.08 Y:0.16 Z:0.01
   VelocityType = OUTWARD
@@ -26283,7 +26285,7 @@ ParticleSystem SpectreHowitzerDebris
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FireStormBranch1
+ParticleSystem FireStormBranch1 ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -26399,7 +26401,7 @@ ParticleSystem BattleMasterTankExplosionSmoke
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FireStormBranch2
+ParticleSystem FireStormBranch2 ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -26514,7 +26516,7 @@ ParticleSystem HelixRotorWashRing
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FireStormBranch3
+ParticleSystem FireStormBranch3 ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE


### PR DESCRIPTION
This change decreases the cost of the Inferno Cannon fire particles by 36%.

## Original Napalm

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/17dd7eca-a2c6-45ad-b7c8-305d86bbc7fd

## Patched Napalm

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/2ddef2d3-863a-4f6c-9783-ece97fe1b646

## Original Black Napalm

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/73154993-16b3-4f18-9c79-52045f54c903

## Patched Black Napalm

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/f6c11e5d-3d8a-4d20-9218-c5f790c03e56
