### PR TITLE
Optimization: Decrease performance cost of a few Flame Thrower particles by 50%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2040_flame_thrower_nozzle_light_particle_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2040_flame_thrower_nozzle_light_particle_performance.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-24
+
+title: Decreases performance cost of flame thrower nozzle light particles by 50%
+
+changes:
+  - optimization: The performance cost of the China Dragon Tank's flame thrower nozzle light particles is cut by 50%.
+
+labels:
+  - art
+  - china
+  - minor
+  - performance
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2040
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2040_flame_thrower_spray_particle_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2040_flame_thrower_spray_particle_performance.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-24
+
+title: Decreases performance cost of flame thrower spray particles by 50%
+
+changes:
+  - optimization: The performance cost of the China Dragon Tank's flame thrower spray particles is cut by 50%.
+
+labels:
+  - art
+  - china
+  - minor
+  - performance
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2040
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -882,7 +882,7 @@ FXList WeaponFX_InfernoTankShellDetonation
     Name = BuggyMissileExplosion
     UseCallersRadius = Yes ; Override the radius with the damage radius of the weapon.
   End
-  ; Patch104p @fix xezon 25/06/2023 Remove distracting smoke from center of impact.
+  ; Patch104p @fix xezon 25/06/2023 Remove distracting smoke from center of impact. (#2039)
   ;ParticleSystem
   ;  Name = BuggyMissileExplosionSmoke
   ;End
@@ -3950,11 +3950,11 @@ End
 ; ----------------------------------------------
 FXList WeaponFX_DragonTankMissileDetonation
   ParticleSystem
-    Name = FlamethrowerTarget
+    Name = FlamethrowerTarget ; big flames
     OrientToObject = Yes
   End
   ParticleSystem
-    Name = FlameThrowerSpray
+    Name = FlameThrowerSpray ; small scattered fire balls
     OrientToObject = Yes
   End
 End
@@ -3962,11 +3962,11 @@ End
 ; ----------------------------------------------
 FXList WeaponFX_DragonTankMissileDetonationUpgraded
   ParticleSystem
-    Name = FlamethrowerTargetUpgraded
+    Name = FlamethrowerTargetUpgraded ; big flames
     OrientToObject = Yes
   End
   ParticleSystem
-    Name = FlameThrowerSprayUpgraded
+    Name = FlameThrowerSprayUpgraded ; small scattered fire balls
     OrientToObject = Yes
   End
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4097,14 +4097,14 @@ Object DragonTankFlameProjectile
   End
   Locomotor = SET_NORMAL DragonTankFlameLocomotor
 
+  ; Patch104p @refactor xezon 24/06/2023 Removes obsolete particle effects. (#2040)
   Behavior = BoneFXUpdate ModuleTag_06
-    PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail01 ; Covers gap at beginning of line
-    PristineParticleSystem2  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail02
-    PristineParticleSystem3  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail03
-    PristineParticleSystem4 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail04
-    PristineParticleSystem5 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail06
-
-    PristineParticleSystem6 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerSmoke01
+    PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail01 ; Small light at the tip of the nozzle, covers gap at beginning of line
+    PristineParticleSystem2  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail02 ; Fire balls around the fire stream
+    PristineParticleSystem3  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail03 ; Faint light around the fire stream
+    ;PristineParticleSystem4 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail04 ; Does nothing
+    ;PristineParticleSystem5 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail06 ; Does nothing
+    ;PristineParticleSystem6 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerSmoke01 ; Does nothing
   End
 
   Behavior = BoneFXDamage ModuleTag_07
@@ -4192,14 +4192,14 @@ Object DragonTankFlameProjectileUpgraded
   End
   Locomotor = SET_NORMAL DragonTankFlameLocomotor
 
+  ; Patch104p @refactor xezon 24/06/2023 Removes obsolete particle effects. (#2040)
   Behavior = BoneFXUpdate ModuleTag_06
-    PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail01Upgraded ; Covers gap at beginning of line
-    PristineParticleSystem2  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail02Upgraded
-    PristineParticleSystem3  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail03Upgraded
-    PristineParticleSystem4 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail04Upgraded
-    PristineParticleSystem5 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail06Upgraded
-
-    PristineParticleSystem6 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerSmoke01
+    PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail01Upgraded ; Small light at the tip of the nozzle, covers gap at beginning of line
+    PristineParticleSystem2  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail02Upgraded ; Fire balls around the fire stream
+    PristineParticleSystem3  = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail03Upgraded ; Faint light around the fire stream
+    ;PristineParticleSystem4 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail04Upgraded ; Does nothing
+    ;PristineParticleSystem5 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerTrail06Upgraded ; Does nothing
+    ;PristineParticleSystem6 = bone:NULL OnlyOnce:Yes  0  0 PSys:FlameThrowerSmoke01 ; Does nothing
   End
 
   Behavior = BoneFXDamage ModuleTag_07

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -1418,6 +1418,7 @@ ParticleSystem BlackNapalmSparks
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of scattered fire ball particles by 50% (#2040)
 ParticleSystem FlameThrowerSprayUpgraded
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No
@@ -1453,7 +1454,7 @@ ParticleSystem FlameThrowerSprayUpgraded
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
   BurstDelay = 0.00 1.00
-  BurstCount = 2.00 2.00
+  BurstCount = 1.00 1.00 ; Patch104p @performance from 2.00 2.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
   VelocityType = ORTHO
@@ -37486,6 +37487,7 @@ ParticleSystem JetSmokeLarge
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of scattered fire ball particles by 50% (#2040)
 ParticleSystem FlameThrowerSpray
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No
@@ -37521,7 +37523,7 @@ ParticleSystem FlameThrowerSpray
   Color8 = R:0 G:0 B:0 0
   ColorScale = 0.00 0.00
   BurstDelay = 0.00 1.00
-  BurstCount = 2.00 2.00
+  BurstCount = 1.00 1.00 ; Patch104p @performance from 2.00 2.00
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.00 Y:0.00 Z:0.00
   VelocityType = ORTHO

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -35658,6 +35658,7 @@ ParticleSystem SonicRangeDownUpgraded
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of nozzle light particle by 50% (#2040)
 ParticleSystem FlameThrowerTrail01Upgraded
   Priority = CRITICAL
   IsOneShot = No
@@ -35670,7 +35671,7 @@ ParticleSystem FlameThrowerTrail01Upgraded
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
   Lifetime = 6.00 6.00
-  SystemLifetime = 2
+  SystemLifetime = 1 ; Patch104p @performance from 2
   Size = 5.00 5.00
   StartSizeRate = 0.00 0.00
   SizeRate = 0.25 0.25
@@ -47695,6 +47696,7 @@ ParticleSystem FlashBangBuildingFlash
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @performance xezon 24/06/2023 Decreases cost of nozzle light particle by 50% (#2040)
 ParticleSystem FlameThrowerTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -47707,7 +47709,7 @@ ParticleSystem FlameThrowerTrail01
   VelocityDamping = 1.00 1.00
   Gravity = 0.00
   Lifetime = 6.00 6.00
-  SystemLifetime = 2
+  SystemLifetime = 1 ; Patch104p @performance from 2
   Size = 5.00 5.00
   StartSizeRate = 0.00 0.00
   SizeRate = 0.25 0.25

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -2102,7 +2102,7 @@ ParticleSystem SneakAttackCrackDustSnow
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FlameThrowerTrail04Upgraded
+ParticleSystem FlameThrowerTrail04Upgraded ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ALPHA
@@ -9743,7 +9743,7 @@ ParticleSystem NukeCannonMuzzleWave
   WindPingPongEndAngleMax = 6.283185
 End
 
-; Patch104p @performance xezon 25/06/2023 Decrease cost of particles by 36%
+; Patch104p @performance xezon 25/06/2023 Decrease cost of particles by 36% (#2039)
 ParticleSystem InfernoCannonFireUpgraded
   Priority = WEAPON_EXPLOSION
   IsOneShot = No
@@ -13158,7 +13158,7 @@ ParticleSystem ToxinTrail02 ; unused
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FlameThrowerSmoke02
+ParticleSystem FlameThrowerSmoke02 ; unused
   Priority = WEAPON_TRAIL
   IsOneShot = No
   Shader = ALPHA
@@ -14014,7 +14014,7 @@ ParticleSystem AvalancheTrailArms
   WindPingPongEndAngleMax = 0.000000
 End
 
-; Patch104p @performance xezon 25/06/2023 Decrease cost of particles by 36%
+; Patch104p @performance xezon 25/06/2023 Decrease cost of particles by 36% (#2039)
 ParticleSystem InfernoCannonFire
   Priority = WEAPON_EXPLOSION
   IsOneShot = No
@@ -22415,7 +22415,7 @@ ParticleSystem ScudMissleExplosionTrailArms
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FlameThrowerTrail06Upgraded
+ParticleSystem FlameThrowerTrail06Upgraded ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE
@@ -48093,7 +48093,7 @@ ParticleSystem ParticleUplinkCannon_Magma
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FlameThrowerTrail04
+ParticleSystem FlameThrowerTrail04 ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ALPHA
@@ -48149,7 +48149,7 @@ ParticleSystem FlameThrowerTrail04
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FlameThrowerTrail05
+ParticleSystem FlameThrowerTrail05 ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = MULTIPLY
@@ -48204,7 +48204,7 @@ ParticleSystem FlameThrowerTrail05
   WindPingPongEndAngleMax = 6.283185
 End
 
-ParticleSystem FlameThrowerTrail06
+ParticleSystem FlameThrowerTrail06 ; unused
   Priority = CRITICAL
   IsOneShot = No
   Shader = ADDITIVE


### PR DESCRIPTION
**Merge with Rebase**

* Relates to TheSuperHackers/GeneralsGameCode#57

This change decreases the cost of 2 flame thrower particles of the China Dragon Tank by 50%. The overall performance improvement of the stream weapon is significantly less than that, because there are other expensive components.

~~Additionally it increases the visible segment length of the flame thrower stream from 4 to 5, because originally it does not reach far enough into the large target flame.~~

Breakdown:

* Flame thrower nozzle light cost decreased by 50%
* ~~Flame thrower stream light cost decreased by 25 to 33%~~
* Flame thrower spray cost decreased by 50%
* ~~Flame thrower target flame cost decreased by 50%~~

## Original Napalm Flame Thrower

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/d5771864-e257-4a27-b406-883148defd3e

## Patched Napalm Flame Thrower (Outdated)

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/88cb2c18-6168-4a15-9fa6-75eed8743ca6

## Original Black Napalm Flame Thrower

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/c53f3f33-37ab-450b-bfec-9fedc5432814

## Patched Black Napalm Flame Thrower (Outdated)

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/ec38d2e8-c5ef-417c-9e2f-404858a18be8
