### PR TITLE
Fix: Contaminate audio stutters with a group of GLA Toxin Tractors

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2043_toxin_tractor_contaminate_audio_stutter.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2043_toxin_tractor_contaminate_audio_stutter.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-06-26
+
+title: Fixes contaminate audio stutters with a group of GLA Toxin Tractors
+
+changes:
+  - fix: Fixes the contaminate audio stutters with a group of GLA Toxin Tractors.
+
+labels:
+  - audio
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2043
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -2980,7 +2980,7 @@ AudioEvent ToxinTractorContaminate
   VolumeShift = -20
   PitchShift = -5 5
   Volume = 70
-  Limit = 2
+  Limit = 5 ; Patch104p @bugfix xezon 26/06/2023 from 2 to avoid sound stutters in a group of sprayers. (#2043)
   Priority = normal
   Type = world shrouded everyone
 End


### PR DESCRIPTION
This change fixes contaminate audio stutters with a group of GLA Toxin Tractors by increasing the maximum concurrent audio instances.

## Original

3 spraying Toxin Tractors in the scene will introduce audio stutters.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/6e39b2b1-8423-42c2-a20f-59a0e92ff793

## Patched

Up to 5 Toxin Tractors will emit spray sound, but it still sounds ok with 6 Tractors too because there is an abundance of sounds to shadow any additional audio clipping.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/c485a71b-a85a-425c-a027-66623524ca4c
