### PR TITLE
Change: Decrease field damage of GLA Toxin Bomb by 20%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2044_anthrax_beta_field_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2044_anthrax_beta_field_damage.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-06-26
+
+title: Decreases Toxin Bomb poison field damage by 20%
+
+changes:
+  - tweak: The poison field of the regular Toxin Bomb now deals 20% less damage than the Anthrax Bomb.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - major
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2044
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -2234,7 +2234,7 @@ End
 
 ; Patch104p @bugfix commy2 31/07/2022 Green poison cloud created by Anthrax Bomb without upgrades.
 ;------------------------------------------------------------------------------
-Object PoisonFieldAnthraxBomb
+Object PoisonFieldAnthraxBomb ; Alias PoisonFieldToxinBomb
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3795,10 +3795,11 @@ Weapon SmallPoisonFieldWeapon
   DelayBetweenShots = 500                ; time between shots, msec
 End
 
-; Patch104p @bugfix commy2 31/07/2022 Over time damage inside green Anthrax Bomb cloud. Same damage as blue and pink variants.
+; Patch104p @bugfix commy2 31/07/2022 Over time damage inside green Anthrax Bomb cloud.
+; Patch104p @tweak xezon 26/06/2023 Changes primary damage from 40. (#2044)
 ;------------------------------------------------------------------------------
-Weapon AnthraxBombPoisonFieldWeapon
-  PrimaryDamage = 40.0
+Weapon AnthraxBombPoisonFieldWeapon ; Alias ToxinBombPoisonFieldWeapon
+  PrimaryDamage = 32.0
   PrimaryDamageRadius = 300.0
   AttackRange = 15.0
   MinimumAttackRange = 10.0


### PR DESCRIPTION
This change decreases the field damage of the GLA Toxin Bomb by 20%. The field damage of the Anthrax Beta Bomb is unchanged, which means the upgrade damage progression from the green to the blue toxin field is now consistent with all other toxin field weapons.

| Weapon                            | Original Damage (DPS) | Patched Damage (DPS) |
|-----------------------------------|:----------------------|:---------------------|
| SmallPoisonFieldWeapon            | 2.0 (3.75)            |                      |
| SmallPoisonFieldWeaponUpgraded    | 2.5 (4.69)            |                      |
| Chem_SmallPoisonFieldWeaponGamma  | 2.5 (4.69)            | 3.0 (5.63)           |
| MediumPoisonFieldWeapon           | 2.0 (3.75)            |                      |
| MediumPoisonFieldWeaponUpgraded   | 2.5 (4.69)            |                      |
| Chem_MediumPoisonFieldWeaponGamma | 2.5 (4.69)            | 3.0 (5.63)           |
| LargePoisonFieldWeapon            | 15 (28.1)             |                      |
| LargePoisonFieldWeaponUpgraded    | 25 (46.9)             |                      |
| Chem_LargePoisonFieldWeaponGamma  | 25 (46.9)             | 30 (56.3)            |
| AnthraxBombPoisonFieldWeapon      | 40 (75.0)             | 32 (60)              |
| AnthraxBetaBombPoisonFieldWeapon  | 40 (75.0)             |                      |
| AnthraxGammaBombPoisonFieldWeapon | 40 (75.0)             | 48 (90)              |

# Rationale

The Anthrax Beta upgrade has more utility now and the damage progression of the field weapon becomes consistent with that of other toxin fields. Although this change is a notable nerf, with #2023 there is a major buff that makes the Anthrax Bombs much better against GLA and USA. Overall, China benefits most from these changes.

This is a nerf for all GLA Generals, except Toxin General. Most notably it is a nerf for GLA Demolition General, because it natively does not have access to the Anthrax Beta upgrade. However, the Demolition General has many other perks, such as Demolition upgrade and stronger Scud Storms, which makes up for the weaker toxin puddles.

As for GLA General and GLA Stealth General, the nerf manifests before Anthrax Beta upgrade only. This gives more reward to the Anthrax Beta upgrade, which is originally seldom acquired with Stealth General.