### PR TITLE
Change: Increase field damage of GLA Anthrax Gamma Bomb by 20%

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2012_anthrax_gamma_field_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2012_anthrax_gamma_field_damage.yaml
@@ -4,18 +4,19 @@ date: 2023-06-17
 title: Increases Anthrax Gamma poison field damage bonus by 20%
 
 changes:
-  - tweak: Increases the Anthrax Gamma poison field damage bonus by 20%, except Anthrax Bomb.
+  - tweak: All Anthrax Gamma poison fields now deal 20% more damage than Anthrax Beta.
 
 labels:
   - buff
   - controversial
   - design
   - gla
-  - minor
+  - major
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2012
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2045
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2045_anthrax_gamma_field_damage.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2045_anthrax_gamma_field_damage.txt
@@ -1,0 +1,1 @@
+2012_anthrax_gamma_field_damage.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3830,9 +3830,10 @@ Weapon AnthraxBetaBombPoisonFieldWeapon
   DelayBetweenShots = 500                ; time between shots, msec
 End
 
+; Patch104p @tweak xezon 26/06/2023 Changes primary damage from 40. (#2045)
 ;------------------------------------------------------------------------------
 Weapon AnthraxGammaBombPoisonFieldWeapon
-  PrimaryDamage = 40.0
+  PrimaryDamage = 48.0
   PrimaryDamageRadius = 300.0
   AttackRange = 15.0
   MinimumAttackRange = 10.0


### PR DESCRIPTION
* Follow up for #2012

This change increases the field damage of the GLA Anthrax Gamma Bomb by 20%. The field damage of the Anthrax Beta Bomb is unchanged, which means the upgrade damage progression from the blue to the purple toxin field is now consistent with all other toxin field weapons.

| Weapon                            | Original Damage (DPS) | Patched Damage (DPS) |
|-----------------------------------|:----------------------|:---------------------|
| SmallPoisonFieldWeapon            | 2.0 (3.75)            |                      |
| SmallPoisonFieldWeaponUpgraded    | 2.5 (4.69)            |                      |
| Chem_SmallPoisonFieldWeaponGamma  | 2.5 (4.69)            | 3.0 (5.63)           |
| MediumPoisonFieldWeapon           | 2.0 (3.75)            |                      |
| MediumPoisonFieldWeaponUpgraded   | 2.5 (4.69)            |                      |
| Chem_MediumPoisonFieldWeaponGamma | 2.5 (4.69)            | 3.0 (5.63)           |
| LargePoisonFieldWeapon            | 15 (28.1)             |                      |
| LargePoisonFieldWeaponUpgraded    | 25 (46.9)             |                      |
| Chem_LargePoisonFieldWeaponGamma  | 25 (46.9)             | 30 (56.3)            |
| AnthraxBombPoisonFieldWeapon      | 40 (75.0)             |                      |
| AnthraxBetaBombPoisonFieldWeapon  | 40 (75.0)             |                      |
| AnthraxGammaBombPoisonFieldWeapon | 40 (75.0)             | 48 (90)              |

# Rationale

The Anthrax Gamma upgrade has more utility now and the damage progression of the field weapon becomes consistent with that of other toxin fields.

See

* #2012 

Although this change is a notable buff for GLA Toxin General, it has received a number of major nerfs too:

* https://github.com/TheSuperHackers/GeneralsGamePatch/pull/699
* https://github.com/TheSuperHackers/GeneralsGamePatch/pull/882
* https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2002

This buff does not affect the other GLA Generals, because they natively have no access to the Anthrax Gamma upgrade.
