### PR TITLE
Change: Add inherent hazard field cleanup abilities to GLA poison and China flame weapons

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1089,6 +1089,80 @@ Object GC_Chem_ToxinStreamProjectile ; Alias GC_Chem_ToxinTruckStreamProjectile
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @feature xezon 06/07/2023 Stream projectile for Toxin General, a copy of GC_Chem_ToxinStreamProjectile (#2049)
+Object GC_Chem_ToxinRebelStreamProjectile
+
+  ; Explanation - Particles can't do damage, so this is a fast shooting low
+  ; damage invisible missile launcher with a toxin trail for exhaust
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model = NONE
+    End
+  End
+  ; Must have a draw module to be allowed to draw detonation FX
+
+  ; ***DESIGN parameters ***
+  EditorSorting     = SYSTEM
+  VisionRange       = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = ProjectileArmor
+    DamageFX        = None
+  End
+
+  ; *** ENGINEERING Parameters ***
+  KindOf            = PROJECTILE
+  Body              = ActiveBody ModuleTag_02
+    MaxHealth       = 100.0
+    InitialHealth   = 100.0
+  End
+
+  Behavior = DestroyDie ModuleTag_03
+    ;nothing
+  End
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass                = 1
+    AllowCollideForce   = No  ; toxins collide, but never apply forces when they do so
+  End
+
+  Behavior = MissileAIUpdate ModuleTag_05
+    TryToFollowTarget               = No
+    FuelLifetime                    = 1000
+    InitialVelocity                 = 120                ; in dist/sec
+    IgnitionDelay                   = 0
+    DistanceToTravelBeforeTurning   = 2
+    GarrisonHitKillRequiredKindOf   = INFANTRY
+    GarrisonHitKillForbiddenKindOf  = NONE
+    GarrisonHitKillCount            = 2
+    GarrisonHitKillFX               = Chem_FX_ToxinStreamGammaGarrisonBuildingHit
+    DetonateCallsKill               = Yes
+  End
+
+  Locomotor = SET_NORMAL ToxinTruckStreamLocomotor
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = ToxinRebelGunHazardFieldWeapon
+    StartsActive = Yes
+  End
+
+  Behavior = BoneFXUpdate ModuleTag_06
+    PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:GC_Chem_ToxinTrail01 ; Covers gap at beginning of line
+  End
+
+  Behavior = BoneFXDamage ModuleTag_07
+    ;nothing
+  End
+
+  Geometry = Sphere
+  GeometryIsSmall = Yes
+  GeometryMajorRadius = 2.0
+
+End
+
+;------------------------------------------------------------------------------
 Object GC_Chem_ToxinProjectileStream
 
   ; *** ART Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1015,7 +1015,7 @@ End
 
 
 ;------------------------------------------------------------------------------
-Object GC_Chem_ToxinStreamProjectile
+Object GC_Chem_ToxinStreamProjectile ; Alias GC_Chem_ToxinTruckStreamProjectile
 
 ; Explanation - Particles can't do damage, so this is a fast shooting low
 ; damage invisible missile launcher with a toxin trail for exhaust
@@ -1063,9 +1063,16 @@ Object GC_Chem_ToxinStreamProjectile
     GarrisonHitKillForbiddenKindOf  = NONE
     GarrisonHitKillCount            = 2
     GarrisonHitKillFX               = Chem_FX_ToxinStreamGammaGarrisonBuildingHit   ; Patch104p @bugfix commy2 28/08/2021 Fix Gamma Anthrax effect to use pink instead of green color.
+    DetonateCallsKill               = Yes ; Patch104p @tweak xezon 27/06/2023 Adds DetonateCallsKill to fire weapon when dead.
   End
 
   Locomotor = SET_NORMAL ToxinTruckStreamLocomotor
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = ToxinTruckGunHazardFieldWeapon
+    StartsActive = Yes
+  End
 
   Behavior = BoneFXUpdate ModuleTag_06
     PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:GC_Chem_ToxinTrail01 ; Covers gap at beginning of line

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -1537,6 +1537,11 @@ Object FirestormSmall
     MaxLifetime = 6000
   End
 
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponUpdate ModuleTag_HazardFieldWeapon
+    Weapon = FireStormHazardFieldWeapon
+  End
+
   Geometry            = CYLINDER
   GeometryMajorRadius = 1.0
   GeometryMinorRadius = 1.0
@@ -1595,6 +1600,11 @@ Object BlackNapalmFirestormSmall
     MaxLifetime = 6000
   End
 
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponUpdate ModuleTag_HazardFieldWeapon
+    Weapon = FireStormHazardFieldWeapon
+  End
+
   Geometry            = CYLINDER
   GeometryMajorRadius = 1.0
   GeometryMinorRadius = 1.0
@@ -1632,6 +1642,11 @@ Object FireWallSegment
 
   Behavior = FireWeaponUpdate ModuleTag_05
     Weapon = FireWallSegmentWeapon
+  End
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponUpdate ModuleTag_HazardFieldWeapon
+    Weapon = DragonTankFireWallHazardFieldWeapon
   End
 
   Behavior = DeletionUpdate ModuleTag_06
@@ -1679,6 +1694,11 @@ Object FireWallSegmentUpgraded
     Weapon = FireWallSegmentUpgradedWeapon
   End
 
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponUpdate ModuleTag_HazardFieldWeapon
+    Weapon = DragonTankFireWallHazardFieldWeapon
+  End
+
   Behavior = DeletionUpdate ModuleTag_06
     MinLifetime = 4000
     MaxLifetime = 4000
@@ -1693,7 +1713,7 @@ Object FireWallSegmentUpgraded
 End
 
 ;------------------------------------------------------------------------------
-Object FireFieldSmall
+Object FireFieldSmall ; Used by Inferno Tank, Mig Jet
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -1717,6 +1737,11 @@ Object FireFieldSmall
     Weapon = SmallFireFieldWeapon
   End
 
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponUpdate ModuleTag_HazardFieldWeapon
+    Weapon = SmallFireFieldHazardFieldWeapon
+  End
+
   Behavior = DeletionUpdate ModuleTag_04
     MinLifetime = 2500
     MaxLifetime = 2500
@@ -1731,7 +1756,7 @@ Object FireFieldSmall
 End
 
 ;------------------------------------------------------------------------------
-Object FireFieldUpgradedSmall
+Object FireFieldUpgradedSmall ; Used by Inferno Tank, Mig Jet
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
@@ -1753,6 +1778,11 @@ Object FireFieldUpgradedSmall
   End
   Behavior = FireWeaponUpdate ModuleTag_03
     Weapon = SmallFireFieldWeaponUpgraded
+  End
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponUpdate ModuleTag_HazardFieldWeapon
+    Weapon = SmallFireFieldHazardFieldWeapon
   End
 
   Behavior = DeletionUpdate ModuleTag_04

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -4113,9 +4113,15 @@ Object DragonTankFlameProjectile
     GarrisonHitKillCount = 2
     GarrisonHitKillFX = FX_DragonFlameGarrisonBuildingHit
     DistanceToTargetForLock = 0  ; If it gets within 100 of the target, it kills the target.
-
+    DetonateCallsKill = Yes ; Patch104p @tweak xezon 27/06/2023 Adds DetonateCallsKill to fire weapon when dead.
   End
   Locomotor = SET_NORMAL DragonTankFlameLocomotor
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = DragonTankFlameHazardFieldWeapon
+    StartsActive = Yes
+  End
 
   ; Patch104p @refactor xezon 24/06/2023 Removes obsolete particle effects. (#2040)
   Behavior = BoneFXUpdate ModuleTag_06
@@ -4208,9 +4214,15 @@ Object DragonTankFlameProjectileUpgraded
     GarrisonHitKillCount = 2
     GarrisonHitKillFX = FX_DragonFlameGarrisonBuildingHit
     DistanceToTargetForLock = 0  ; If it gets within 100 of the target, it kills the target.
-
+    DetonateCallsKill = Yes ; Patch104p @tweak xezon 27/06/2023 Adds DetonateCallsKill to fire weapon when dead.
   End
   Locomotor = SET_NORMAL DragonTankFlameLocomotor
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = DragonTankFlameHazardFieldWeapon
+    StartsActive = Yes
+  End
 
   ; Patch104p @refactor xezon 24/06/2023 Removes obsolete particle effects. (#2040)
   Behavior = BoneFXUpdate ModuleTag_06

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3707,9 +3707,16 @@ Object ToxinTruckStreamProjectile
     GarrisonHitKillForbiddenKindOf  = NONE
     GarrisonHitKillCount            = 2
     GarrisonHitKillFX               = FX_ToxinStreamGarrisonBuildingHit
+    DetonateCallsKill               = Yes ; Patch104p @tweak xezon 27/06/2023 Adds DetonateCallsKill to fire weapon when dead.
   End
 
   Locomotor = SET_NORMAL ToxinTruckStreamLocomotor
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = ToxinTruckGunHazardFieldWeapon
+    StartsActive = Yes
+  End
 
   Behavior = BoneFXUpdate ModuleTag_06
     PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:ToxinTrail01 ; Covers gap at beginning of line
@@ -3774,8 +3781,15 @@ Object ToxinTruckStreamProjectileUpgraded
     GarrisonHitKillForbiddenKindOf  = NONE
     GarrisonHitKillCount            = 2
     GarrisonHitKillFX               = FX_ToxinStreamUpgradedGarrisonBuildingHit
+    DetonateCallsKill               = Yes ; Patch104p @tweak xezon 27/06/2023 Adds DetonateCallsKill to fire weapon when dead.
   End
   Locomotor = SET_NORMAL ToxinTruckStreamLocomotor
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = ToxinTruckGunHazardFieldWeapon
+    StartsActive = Yes
+  End
 
   Behavior = BoneFXUpdate ModuleTag_06
     PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:AnthraxTrail01 ; Covers gap at beginning of line
@@ -3878,10 +3892,16 @@ Object ToxinTruckSprayProjectile
     IgnitionDelay = 0
     DistanceToTravelBeforeTurning = 0
     DistanceToTargetForLock = 0  ; If it gets within 100 of the target, it kills the target.
-
+    DetonateCallsKill = Yes ; Patch104p @tweak xezon 27/06/2023 Adds DetonateCallsKill to fire weapon when dead.
   End
 
   Locomotor = SET_NORMAL ToxinTruckDribbleLocomotor
+
+  ; Patch104p @feature xezon 27/06/2023 Adds new hazard cleanup field weapon to this weapon object.
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = ToxinTruckSprayerHazardFieldWeapon
+    StartsActive = Yes
+  End
 
   Geometry = Sphere
   GeometryIsSmall = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3806,6 +3806,79 @@ Object ToxinTruckStreamProjectileUpgraded
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @feature xezon 06/07/2023 Stream projectile for Toxin General, a copy of ToxinTruckStreamProjectileUpgraded (#2049)
+Object ToxinRebelStreamProjectileUpgraded
+
+  ; Explanation - Particles can't do damage, so this is a fast shooting low
+  ; damage invisible missile launcher with a toxin trail for exhaust
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model = NONE
+    End
+  End
+  ; Must have a draw module to be allowed to draw detonation FX
+
+  ; ***DESIGN parameters ***
+  EditorSorting     = SYSTEM
+  VisionRange       = 0.0
+  ArmorSet
+    Conditions      = None
+    Armor           = ProjectileArmor
+    DamageFX        = None
+  End
+
+  ; *** ENGINEERING Parameters ***
+  KindOf            = PROJECTILE
+  Body              = ActiveBody ModuleTag_02
+    MaxHealth       = 100.0
+    InitialHealth   = 100.0
+  End
+
+  Behavior = DestroyDie ModuleTag_03
+    ;nothing
+  End
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 1
+    AllowCollideForce = No  ; flames collide, but never apply forces when they do so
+  End
+
+  Behavior = MissileAIUpdate ModuleTag_05
+    TryToFollowTarget               = No
+    FuelLifetime                    = 1000
+    InitialVelocity                 = 120                ; in dist/sec
+    IgnitionDelay                   = 0
+    DistanceToTravelBeforeTurning   = 2
+    GarrisonHitKillRequiredKindOf   = INFANTRY
+    GarrisonHitKillForbiddenKindOf  = NONE
+    GarrisonHitKillCount            = 2
+    GarrisonHitKillFX               = FX_ToxinStreamUpgradedGarrisonBuildingHit
+    DetonateCallsKill               = Yes
+  End
+  Locomotor = SET_NORMAL ToxinTruckStreamLocomotor
+
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag_HazardFieldWeapon
+    DeathWeapon = ToxinRebelGunHazardFieldWeapon
+    StartsActive = Yes
+  End
+
+  Behavior = BoneFXUpdate ModuleTag_06
+    PristineParticleSystem1  = bone:NULL OnlyOnce:Yes  0  0 PSys:AnthraxTrail01 ; Covers gap at beginning of line
+  End
+
+  Behavior = BoneFXDamage ModuleTag_07
+    ;nothing
+  End
+
+  Geometry = Sphere
+  GeometryIsSmall = Yes
+  GeometryMajorRadius = 2.0
+
+End
+
+;------------------------------------------------------------------------------
 Object ToxinTruckProjectileStream
 
   ; *** ART Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3687,6 +3687,46 @@ Weapon ToxinTruckSprayerHazardFieldWeapon
   ClipReloadTime = 0
 End
 
+Weapon DragonTankFlameHazardFieldWeapon
+  PrimaryDamage = 25
+  PrimaryDamageRadius = 10
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+End
+
+Weapon DragonTankFireWallHazardFieldWeapon
+  PrimaryDamage = 2.5
+  PrimaryDamageRadius = 10 ;15
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 466 ; This will tick 8 times during fire segment lifetime of 4000
+  ClipSize = 8
+  ClipReloadTime = 999999
+End
+
+Weapon SmallFireFieldHazardFieldWeapon
+  PrimaryDamage = 100
+  PrimaryDamageRadius = 10 ;30
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 466 ; This will tick 5 times during fire field lifetime of 2500
+  ClipSize = 5
+  ClipReloadTime = 999999
+End
+
+Weapon FireStormHazardFieldWeapon
+  PrimaryDamage = 250
+  PrimaryDamageRadius = 10 ;1-90
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 466 ; This will tick 12 times during fire storm lifetime of 6000
+  ClipSize = 12
+  ClipReloadTime = 999999
+End
+
 ;------------------------------------------------------------------------------
 Weapon LargePoisonFieldWeapon
   PrimaryDamage = 15.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3687,6 +3687,16 @@ Weapon ToxinTruckSprayerHazardFieldWeapon
   ClipReloadTime = 0
 End
 
+Weapon ToxinRebelGunHazardFieldWeapon
+  PrimaryDamage = 10
+  PrimaryDamageRadius = 10
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+End
+
 Weapon DragonTankFlameHazardFieldWeapon
   PrimaryDamage = 25
   PrimaryDamageRadius = 10
@@ -5790,7 +5800,7 @@ Weapon GC_Chem_GLARebelGunBeta
   DeathType                   = POISONED_BETA
   WeaponSpeed                 = 600                     ;  dist/sec
   WeaponRecoil                = 0                      ; angle to deflect the model when firing
-  ProjectileObject            = ToxinTruckStreamProjectileUpgraded
+  ProjectileObject            = ToxinRebelStreamProjectileUpgraded ; Patch104p @tweak from ToxinTruckStreamProjectileUpgraded
   FireFX                      = WeaponFX_ToxinTruckFlameWeaponUpgraded
   ProjectileDetonationFX      = WeaponFX_ToxinTruckMissileDetonationUpgraded
   FireSound                   = ToxinTractorWeaponLoop
@@ -5814,7 +5824,7 @@ Weapon GC_Chem_GLARebelGunGamma
   DeathType                   = POISONED_GAMMA
   WeaponSpeed                 = 600                     ;  dist/sec
   WeaponRecoil                = 0                      ; angle to deflect the model when firing
-  ProjectileObject            = GC_Chem_ToxinStreamProjectile
+  ProjectileObject            = GC_Chem_ToxinRebelStreamProjectile ; Patch104p @tweak from GC_Chem_ToxinStreamProjectile
   FireFX                      = GC_Chem_WeaponFX_ToxinFlameWeaponGamma
   ProjectileDetonationFX      = GC_Chem_WeaponFX_ToxinMissileDetonationGamma
   FireSound                   = ToxinTractorWeaponLoop
@@ -5841,7 +5851,7 @@ Weapon Chem_TunnelNetworkGunBeta
   DeathType                   = POISONED_BETA
   WeaponSpeed                 = 600                     ;  dist/sec
   WeaponRecoil                = 0                      ; angle to deflect the model when firing
-  ProjectileObject            = ToxinTruckStreamProjectileUpgraded
+  ProjectileObject            = ToxinRebelStreamProjectileUpgraded ; Patch104p @tweak from ToxinTruckStreamProjectileUpgraded
   FireFX                      = WeaponFX_ToxinTruckFlameWeaponUpgraded
   ProjectileDetonationFX      = WeaponFX_ToxinTruckMissileDetonationUpgraded
   FireSound                   = ToxinTractorWeaponLoop
@@ -5866,7 +5876,7 @@ Weapon Chem_TunnelNetworkGunGamma
   DeathType                   = POISONED_GAMMA
   WeaponSpeed                 = 600                     ;  dist/sec
   WeaponRecoil                = 0                      ; angle to deflect the model when firing
-  ProjectileObject            = GC_Chem_ToxinStreamProjectile
+  ProjectileObject            = GC_Chem_ToxinRebelStreamProjectile ; Patch104p @tweak from GC_Chem_ToxinStreamProjectile
   FireFX                      = GC_Chem_WeaponFX_ToxinFlameWeaponGamma
   ProjectileDetonationFX      = GC_Chem_WeaponFX_ToxinMissileDetonationGamma
   FireSound                   = ToxinTractorWeaponLoop

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3003,7 +3003,7 @@ Weapon TomahawkMissileWeapon
 End
 
 ;------------------------------------------------------------------------------
-Weapon AmbulanceCleanHazardWeapon
+Weapon AmbulanceCleanHazardWeapon ; Alias AmbulanceCleanHazardFieldWeapon
   PrimaryDamage               = 100.0
   PrimaryDamageRadius         = 50.0
   AttackRange                 = 100.0
@@ -3665,6 +3665,26 @@ Weapon NukeMissileRadiationHazardFieldWeapon
   DelayBetweenShots = 5
   ClipSize = 1
   ClipReloadTime = 999999
+End
+
+Weapon ToxinTruckGunHazardFieldWeapon
+  PrimaryDamage = 25
+  PrimaryDamageRadius = 10
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
+End
+
+Weapon ToxinTruckSprayerHazardFieldWeapon
+  PrimaryDamage = 75
+  PrimaryDamageRadius = 10 ;75
+  DamageType = HAZARD_CLEANUP
+  RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots = 0
+  ClipSize = 1
+  ClipReloadTime = 0
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
**Merge with Rebase**

* Relates to #55
* Follow up for #2023
* Closes #1109

This change adds inherent hazard field cleanup abilities to all GLA poison and China flame weapons. This affects

* GLA Toxin Rebel gun
* GLA Toxin Tunnel gun
* GLA Toxin Tractor gun
* GLA Toxin Tractor sprayer
* China Dragon Tank flame thrower
* China Dragon Tank flame thrower + fire wall
* China Mig fire field
* China Mig fire storm
* China Helix fire storm
* China Inferno Cannon fire field
* China Inferno Cannon fire storm

## Patched hazard field cleanup setup

| Hazard Field Cleanup weapon          | Health | Hazard Dmg | Duration ms | Hazard Dmg in 1000 ms |
|--------------------------------------|--------|------------|-------------|-----------------------|
| Small Poison and Radiation field     | 100    | 100        | -           | 100
| Medium Poison and Radiation field    | 1000   | 1000       | -           | 1000
| Large Poison and Radiation field     | 5000   | 5000       | -           | 5000
| Anthrax Bomb fields                  | 10000  | 10000      | -           | 10000
| Nuke Missile field                   | 10000  | 10000      | -           | 10000
| USA Ambulance                        | -      | 100        | 66          | 1500
| Toxin Tractor stream                 | -      | 25         | 66          | 375
| Toxin Tractor sprayer                | -      | 75         | 200         | 375
| Toxin Rebel stream                   | -      | 10         | 66          | 150
| Toxin Tunnel stream                  | -      | 10         | 66          | 150
| Dragon Tank flame thrower            | -      | 25         | 66          | 375
| Dragon Tank fire wall (*1)           | -      | 5 to 20    | 66          | 75 to 300
| China Mig fire field                 | -      | 500        | 2500        | 200
| China Mig fire storm (*2)            | -      | 3000       | 6000        | 500
| China Helix fire storm               | -      | 3000       | 6000        | 500
| China Inferno Cannon fire field      | -      | 500        | 2500        | 200
| China Inferno Cannon fire storm (*2) | -      | 3000       | 6000        | 500

(*1) The Fire Wall hazard damage will stack on top of flame thrower damage, because the Dragon Tank fire wall ability has 2 weapons.

(*2) The Fire Storm hazard damage stacks on top of fire field damage. So 3 shell hits with 500 hazard damage each + fire storm with 3000 hazard damage.

## Toxin stream vs Anthrax Bomb field (Anthrax Beta damage)

2 Toxin Tractors can cleanup the Anthrax Bomb effortlessly. Toxin Tractor is immune to Poison and Radiation.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/2f6cee58-d9dc-477d-beef-3e83a940741e

## Flame thrower vs Anthrax Bomb field (Anthrax Beta damage)

2 Dragon Tanks can cleanup the Anthrax Bomb when well positioned. They do take poison damage.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/6d2b5d12-5ee0-4c71-b5f2-d4136d79bb7e

## Fire wall vs Anthrax Bomb field (Anthrax Beta damage)

2 Dragon Tanks can cleanup the Anthrax Bomb when well positioned. They do take poison damage.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/b5631ab6-4025-420d-9424-07d38b1cb098


## Fire storm vs Anthrax Bomb field (Anthrax Beta damage)

2 Fire Storms with 4 Inferno Cannons clean up the Anthrax Bomb.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/dd1d01de-92ee-4555-b21c-d277fb2f6b6c


# Rationale

The new hazard field cleanup setup gives all China and GLA factions the ability to cleanup hazards reliably with various weapons. Originally only radiation and poison fields could do cleanups and it was counter-intuitive that some poison weapons, such as Toxin Tractor streams, did not cleanup hazard fields, while Toxin Shells from Scorpion Tanks did.

China greatly profits from hazard field cleanups with flame weapons due their availability. Originally only Nuke Battle Masters, Nuke Cannons, Nuke missiles and destroyed Nuke Reactors and destroyed Nuke Silos could cleanup hazard fields.

USA only has the Ambulance for hazard cleanups, however it is the superior cleaner, because it cleans the fastest, is immune to toxin and radiation and is easily available at any stage of a match.

This change makes it much more intuitive to perform hazard field cleanups with the various factions, while at the same time the hazard fields pose a greater threat due their durability.

Overall China benefits most from the hazard cleanup design changes, because although it will be challenging to cleanup, it no longer is unpractical to do so.