### PR TITLE
Fix: Incorrect clip size and reload time of China Dragon Tank flame thrower with Black Napalm

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1588_dragon_min_attack_range.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1588_dragon_min_attack_range.yaml
@@ -1,10 +1,10 @@
 ---
 date: 2022-11-03
 
-title: Removes the minimum attack range of China Dragon Tank with Napalm Upgrade
+title: Fixes incorrect minimum attack range of China Dragon Tank flame thrower with Black Napalm 
 
 changes:
-  - fix: Decreases the minimum attack range of China Dragon Tank with Napalm Upgrade from 10 to 0. This range matches the unupgraded Dragon Tank attack range.
+  - fix: Decreases the minimum attack range of the China Dragon Tank flame thrower with Napalm Upgrade from 10 to 0. This range matches the unupgraded Dragon Tank flame thrower attack range.
 
 labels:
   - buff

--- a/Patch104pZH/Design/Changes/v1.0/2050_dragon_black_napalm_flamethrower_clip_size.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2050_dragon_black_napalm_flamethrower_clip_size.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-06-29
+
+title: Fixes incorrect clip size and reload time of China Dragon Tank flame thrower with Black Napalm
+
+changes:
+  - fix: The clip size and reload time of the China Dragon Tank flame thrower with Black Napalm now matches the unupgraded one.
+
+labels:
+  - china
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2050
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -3116,6 +3116,7 @@ Weapon DragonTankFireWallWeapon
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @fix xezon 29/06/2023 Changes ClipSize from 0, ClipReloadTime from 0, to be consistent with setup of unupgraded weapon. (#2050)
 Weapon DragonTankFlameWeaponUpgraded
   PrimaryDamage               = 12.5
   PrimaryDamageRadius         = 5.0
@@ -3135,8 +3136,8 @@ Weapon DragonTankFlameWeaponUpgraded
   FireSoundLoopTime           = 80                ; loop the firing sound until there's this much delay between shots
   RadiusDamageAffects         = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots           = 40                ; time between shots, msec
-  ClipSize                    = 0                         ; how many shots in a Clip (0 == infinite)
-  ClipReloadTime              = 0                   ; how long to reload a Clip, msec
+  ClipSize                    = 30                        ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime              = 40                  ; how long to reload a Clip, msec
   ProjectileStreamName        = FlamethrowerProjectileStreamUpgraded ; Drawing helper for this weapon.  Tracks all projectiles in air
   ProjectileCollidesWith      = ENEMIES STRUCTURES WALLS SHRUBBERY
   AllowAttackGarrisonedBldgs  = Yes


### PR DESCRIPTION
* Similar to #1588

This change fixes the incorrect clip size and reload time of the China Dragon Tank Black Napalm flame thrower.

It is not clear to me if this is a bug per se, but now it is consistent with the setups of the other stream weapons. For human matches nothing changes.