### PR TITLE
Add dedicated armor class to USA Ambulance

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -270,6 +270,28 @@ Armor HumveeArmor
   Armor = SUBDUAL_BUILDING     0%
 End
 
+; Patch104p @refactor A copy of ToxinTruckArmor, is immune to poison and radiation. (#2051)
+Armor MedicArmor
+  Armor = CRUSH             50%
+  Armor = SMALL_ARMS        50%
+  Armor = GATTLING          50%
+  Armor = COMANCHE_VULCAN   50%
+  Armor = POISON            0%
+  Armor = RADIATION         0%
+  Armor = MICROWAVE         0%
+  Armor = SNIPER            0%
+  Armor = MELEE             0%
+  Armor = LASER             0%
+  Armor = HAZARD_CLEANUP    0%
+  Armor = KILL_PILOT        100%
+  Armor = SURRENDER         0%
+  Armor = MOLOTOV_COCKTAIL  20%
+  Armor = INFANTRY_MISSILE  20%
+  Armor = SUBDUAL_MISSILE   0%
+  Armor = SUBDUAL_VEHICLE   100%
+  Armor = SUBDUAL_BUILDING  0%
+End
+
 Armor AvengerArmor
   Armor = JET_MISSILES        23%
   Armor = STEALTHJET_MISSILES 30%

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -5660,7 +5660,7 @@ Object AirF_AmericaVehicleMedic
   End
   ArmorSet
     Conditions      = None
-    Armor           = ToxinTruckArmor
+    Armor           = MedicArmor ; Patch104p @tweak from ToxinTruckArmor (#2051)
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 700

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -572,7 +572,7 @@ Object AmericaVehicleMedic
   End
   ArmorSet
     Conditions      = None
-    Armor           = ToxinTruckArmor
+    Armor           = MedicArmor ; Patch104p @tweak from ToxinTruckArmor (#2051)
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -4886,7 +4886,7 @@ Object Lazr_AmericaVehicleMedic
   End
   ArmorSet
     Conditions      = None
-    Armor           = ToxinTruckArmor
+    Armor           = MedicArmor ; Patch104p @tweak from ToxinTruckArmor (#2051)
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 600

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5368,7 +5368,7 @@ Object SupW_AmericaVehicleMedic
   End
   ArmorSet
     Conditions      = None
-    Armor           = ToxinTruckArmor
+    Armor           = MedicArmor ; Patch104p @tweak from ToxinTruckArmor (#2051)
     DamageFX        = TruckDamageFX
   End
   BuildCost       = 700


### PR DESCRIPTION
This change adds a dedicated armor class to the USA Ambulance. This way it no longer shares the same armor definition with the Toxin Tractor, but keeps the original settings.