### PR TITLE
Fix: Remove radiation hazard immunity from GLA Toxin Tractor

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2051_toxin_tractor_radiation_armor.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2051_toxin_tractor_radiation_armor.yaml
@@ -1,0 +1,22 @@
+---
+date: 2023-06-29
+
+title: Changes radiation armor of GLA Toxin Tractor from 0% to 50%
+
+changes:
+  - fix: Changes the radiation armor of the GLA Toxin Tractor from 0% to 50%. It is no longer immune to radiation damage.
+
+labels:
+  - bug
+  - controversial
+  - design
+  - gla
+  - minor
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2052
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -320,7 +320,7 @@ Armor ToxinTruckArmor ;TruckArmor that is immune to poison
   Armor = GATTLING          50%    ;resistant to gattling tank
   Armor = COMANCHE_VULCAN   50%
   Armor = POISON            0%    ;IMMUNE! It spews poison :)
-  Armor = RADIATION         0%
+  Armor = RADIATION         50%   ; Patch104p @tweak xezon 29/06/2023 from 0% (#2052)
   Armor = MICROWAVE         0%
   Armor = SNIPER            0%
   Armor = MELEE             0%    ;trucks don't generally take much damage other than paint damage from MELEE weapons


### PR DESCRIPTION
* Follow up for #2051

This change removes the radiation hazard immunity from the GLA Toxin Tractor. It now has the same resistance as the China Dragon Tank, 50%.