### PR TITLE
Change: Infantry paradrop parachutes can be controlled by player

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -4815,7 +4815,7 @@ Object AirF_ComancheBlades
 End
 
 ;------------------------------------------------------------------------------
-Object AirF_AmericaParachute
+Object AirF_AmericaParachute ; unused
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -143,6 +143,90 @@ Object AmericaParachute
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @feature xezon 01/07/2023 Adds new parachute identical to AmericaParachute,
+;   but selectable and controllable for the duration of its lifetime.
+Object AmericaControllableParachute
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    OkToChangeModelColor = Yes
+    DefaultConditionState
+      Model = PMparacht_SKNc
+      Animation = PMparacht_SKL.PMparacht_FAL
+      AnimationMode = LOOP
+    End
+    ConditionState = PARACHUTING
+      Model = PMparacht_SKNc
+      Animation = PMparacht_SKL.PMparacht_OPN
+      AnimationMode = ONCE
+    End
+    ConditionState = RUBBLE
+      Model = PMparacht_SKNc
+      Animation = PMparacht_SKL.PMparacht_DRP
+      AnimationMode = ONCE
+    End
+    ; this is a weird state to resolve an ambiguity: sometimes
+    ; we can have a "rubble" parachute momentarily, that doesn't
+    ; know that it has finished parachuting yet...
+    ConditionState = RUBBLE PARACHUTING
+      Model = PMparacht_SKNc
+      Animation = PMparacht_SKL.PMparacht_DRP
+      AnimationMode = ONCE
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  Side                = America
+  EditorSorting       = SYSTEM
+  TransportSlotCount  = 0
+  VisionRange         = 300.0
+  ShroudClearingRange = 300
+  IsTrainable         = No  ;Can gain experience
+  KindOf              = PRELOAD PARACHUTE UNATTACKABLE SELECTABLE
+
+  ; *** AUDIO Parameters ***
+
+  ; *** ENGINEERING Parameters ***
+  Behavior = AIUpdateInterface ModuleTag_02
+    ; nothing
+  End
+  Locomotor = SET_NORMAL ParachuteLocomotor
+  Locomotor = SET_FREEFALL FreeFallLocomotor
+
+  Body = ActiveBody ModuleTag_03
+    MaxHealth       = 100000.0
+    InitialHealth   = 100000.0
+  End
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 5.0
+  End
+
+  Behavior = ParachuteContain ModuleTag_05
+    PitchRateMax = 60           ; deg/sec
+    RollRateMax = 60            ; deg/sec
+    LowAltitudeDamping  = 0.2   ; how much to damp swaying when we get "close" to the ground
+    ParachuteOpenDist   = 25.0  ; how far we have to fall 'till we open our 'chute
+    AllowInsideKindOf   = INFANTRY PARACHUTABLE
+    ParachuteOpenSound  = ParachuteOpen
+  End
+
+  Behavior = SlowDeathBehavior ModuleTag_06
+    SinkDelay = 1000
+    SinkRate = 1     ; in Dist/Sec
+    DestructionDelay = 4000
+  End
+
+  RadarPriority = NOT_ON_RADAR
+  Geometry = CYLINDER
+  GeometryMajorRadius = 15.0
+  GeometryHeight = 10.0
+  GeometryIsSmall = Yes
+  Shadow = SHADOW_VOLUME
+
+End
+
+;------------------------------------------------------------------------------
 Object AmericaCrateParachute
 
   ; *** ART Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6192,7 +6192,7 @@ ObjectCreationList SUPERWEAPON_Paradrop1
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AmericaInfantryRanger 3
     Payload = AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6223,7 +6223,7 @@ ObjectCreationList SUPERWEAPON_Paradrop2
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AmericaInfantryRanger 6
     Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6254,7 +6254,7 @@ ObjectCreationList SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AmericaInfantryRanger 6
     Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6279,7 +6279,7 @@ ObjectCreationList SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AmericaInfantryRanger 6
     Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6312,7 +6312,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop1
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AirF_AmericaInfantryRanger 3
     Payload = AirF_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6343,7 +6343,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop2
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AirF_AmericaInfantryRanger 6
     Payload = AirF_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6374,7 +6374,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AirF_AmericaInfantryRanger 6
     Payload = AirF_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6399,7 +6399,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = AirF_AmericaInfantryRanger 6
     Payload = AirF_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6430,7 +6430,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop1
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = SupW_AmericaInfantryRanger 3
     Payload = SupW_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6461,7 +6461,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop2
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = SupW_AmericaInfantryRanger 6
     Payload = SupW_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6492,7 +6492,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = SupW_AmericaInfantryRanger 6
     Payload = SupW_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6517,7 +6517,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = SupW_AmericaInfantryRanger 6
     Payload = SupW_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6548,7 +6548,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop1
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 3
     Payload = Lazr_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6579,7 +6579,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop2
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 6
     Payload = Lazr_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6610,7 +6610,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 6
     Payload = Lazr_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -6635,7 +6635,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 6
     Payload = Lazr_AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -9418,7 +9418,7 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop1
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 5
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
@@ -9447,7 +9447,7 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop2
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 10
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
@@ -9476,7 +9476,7 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 8
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
@@ -9500,7 +9500,7 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop3
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
-    PutInContainer = AmericaParachute
+    PutInContainer = AmericaControllableParachute ; Patch104p @tweak from AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 7
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery


### PR DESCRIPTION
* Relates to #705

With this change all infantry paradrop parachutes can be controlled by the owning player. Tank paradrop parachutes can not be controlled.

## Sample execution 1

In this sample a few of the initial parachutes are selected, then E button is pressed and move command is given several times to select and move all parachutes.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/35807a68-60a0-4d66-b79a-0e05bcdb5667

## Sample execution 2

In this sample a few of the initial parachutes are selected, then E button and X button are pressed several times to select and scatter all parachutes.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/892c62e1-b318-4b0f-9604-0309be7cd441

# Rationale

This change slightly increases the usefulness of the infantry paradrop abilities by expanding its capabilities. It allows the player to optimize the drop location on arrival. This can make a difference in how successful the paradrop becomes, depending on the terrain conditions underneath. It adds more depth to the game and requires a bit of micro and attention to execute.