### PR TITLE
Fix: Optimize drop location and spacing of China Infantry Paradrops

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -9408,6 +9408,9 @@ End
 ; -----------------------------------------------------------------------------
 ; Infantry General
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
+; Patch104p @tweak xezon 01/07/2023 Decreases DropDelay from 150 to tighten spacing.
+; Patch104p @tweak xezon 01/07/2023 Decreases PreOpenDistance from 300 to drop payload closer to target destination.
 ; -----------------------------------------------------------------------------
 ObjectCreationList Infa_SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -9416,12 +9419,12 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop1
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
-    DropDelay = 150         ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    DropDelay = 80         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 5
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 245 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -9437,6 +9440,7 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop1
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList Infa_SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -9446,7 +9450,7 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop2
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 10
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
@@ -9466,6 +9470,8 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop2
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
+; Patch104p @tweak xezon 01/07/2023 Decreases PreOpenDistance from 300 to drop payload closer to target destination.
 ; -----------------------------------------------------------------------------
 ObjectCreationList Infa_SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -9475,11 +9481,11 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 8
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 265 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -9499,11 +9505,11 @@ ObjectCreationList Infa_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Infa_ChinaInfantryMiniGunner 7
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 265 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA


### PR DESCRIPTION
This change optimizes the drop location and spacing of the China Infantry Paradrops. The soldiers now fall into a line and no longer charge towards to same position. The spacing is tightened consistently and they fall as close to the drop center as possible.

Optimized for fix https://github.com/TheAssemblyArmada/Thyme/pull/752.

## Patched (+Thyme 752)

![shot_20230701_175220_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/26e7846a-d360-47ca-8019-74ac38a32610)

![shot_20230701_175256_2](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/23598d49-985c-44d3-b639-6a5b8177a583)

![shot_20230701_175320_3](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/e4ef8f03-d95e-4d8b-81d3-9b2a6289389e)
