### PR TITLE
Fix: Optimize drop location and spacing of USA Paradrops

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6182,6 +6182,9 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
+; Patch104p @tweak xezon 01/07/2023 Decreases DropDelay from 150 to tighten spacing.
+; Patch104p @tweak xezon 01/07/2023 Decreases PreOpenDistance from 300 to drop payload closer to target destination.
 ; -----------------------------------------------------------------------------
 ObjectCreationList SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6190,13 +6193,13 @@ ObjectCreationList SUPERWEAPON_Paradrop1
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
-    DropDelay = 150         ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    DropDelay = 80         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AmericaInfantryRanger 3
     Payload = AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 225 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -6213,6 +6216,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6222,7 +6226,7 @@ ObjectCreationList SUPERWEAPON_Paradrop2
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AmericaInfantryRanger 6
     Payload = AmericaInfantryMissileDefender 4
@@ -6244,6 +6248,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6253,12 +6258,12 @@ ObjectCreationList SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AmericaInfantryRanger 6
     Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 300;450;300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -6278,12 +6283,12 @@ ObjectCreationList SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AmericaInfantryRanger 6
     Payload = AmericaInfantryMissileDefender 4
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 300;450;300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -6302,6 +6307,9 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
+; Patch104p @tweak xezon 01/07/2023 Decreases DropDelay from 150 to tighten spacing.
+; Patch104p @tweak xezon 01/07/2023 Decreases PreOpenDistance from 300 to drop payload closer to target destination.
 ; -----------------------------------------------------------------------------
 ObjectCreationList AirF_SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6310,13 +6318,13 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop1
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
-    DropDelay = 150         ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    DropDelay = 80         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AirF_AmericaInfantryRanger 3
     Payload = AirF_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 225 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -6333,6 +6341,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList AirF_SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6342,7 +6351,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop2
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AirF_AmericaInfantryRanger 6
     Payload = AirF_AmericaInfantryMissileDefender 4
@@ -6364,6 +6373,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList AirF_SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6373,7 +6383,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AirF_AmericaInfantryRanger 6
     Payload = AirF_AmericaInfantryMissileDefender 4
@@ -6398,7 +6408,7 @@ ObjectCreationList AirF_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = AirF_AmericaInfantryRanger 6
     Payload = AirF_AmericaInfantryMissileDefender 4
@@ -6420,6 +6430,9 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
+; Patch104p @tweak xezon 01/07/2023 Decreases DropDelay from 150 to tighten spacing.
+; Patch104p @tweak xezon 01/07/2023 Decreases PreOpenDistance from 300 to drop payload closer to target destination.
 ; -----------------------------------------------------------------------------
 ObjectCreationList SupW_SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6428,13 +6441,13 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop1
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
-    DropDelay = 150         ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    DropDelay = 80         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = SupW_AmericaInfantryRanger 3
     Payload = SupW_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 225 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -6451,6 +6464,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList SupW_SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6460,7 +6474,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop2
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = SupW_AmericaInfantryRanger 6
     Payload = SupW_AmericaInfantryMissileDefender 4
@@ -6482,6 +6496,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList SupW_SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6491,7 +6506,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = SupW_AmericaInfantryRanger 6
     Payload = SupW_AmericaInfantryMissileDefender 4
@@ -6516,7 +6531,7 @@ ObjectCreationList SupW_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = SupW_AmericaInfantryRanger 6
     Payload = SupW_AmericaInfantryMissileDefender 4
@@ -6538,6 +6553,9 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 5 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
+; Patch104p @tweak xezon 01/07/2023 Decreases DropDelay from 150 to tighten spacing.
+; Patch104p @tweak xezon 01/07/2023 Decreases PreOpenDistance from 300 to drop payload closer to target destination.
 ; -----------------------------------------------------------------------------
 ObjectCreationList Lazr_SUPERWEAPON_Paradrop1
   DeliverPayload
@@ -6546,13 +6564,13 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop1
     StartAtMaxSpeed = Yes
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
-    DropDelay = 150         ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    DropDelay = 80         ; time in between each item dropped (if more than one)
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 3
     Payload = Lazr_AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
-    PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
+    PreOpenDistance = 225 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
     DeliveryDecal
       Texture           = SCCParadrop_USA
@@ -6569,6 +6587,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 10 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList Lazr_SUPERWEAPON_Paradrop2
   DeliverPayload
@@ -6578,7 +6597,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop2
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 6
     Payload = Lazr_AmericaInfantryMissileDefender 4
@@ -6600,6 +6619,7 @@ End
 
 ; -----------------------------------------------------------------------------
 ; Patch104p @tweak xezon 21/06/2023 Changes payload from 20 Rangers. (#2026)
+; Patch104p @tweak xezon 01/07/2023 Disables ParachuteDirectly to drop payload nicely spaced in a line.
 ; -----------------------------------------------------------------------------
 ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
   DeliverPayload
@@ -6609,7 +6629,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 6
     Payload = Lazr_AmericaInfantryMissileDefender 4
@@ -6634,7 +6654,7 @@ ObjectCreationList Lazr_SUPERWEAPON_Paradrop3
     MaxAttempts = 4
     DropOffset = X:0 Y:0 Z:-10
     DropDelay = 80        ; time in between each item dropped (if more than one)
-    ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
+    ParachuteDirectly = No
     PutInContainer = AmericaParachute
     Payload = Lazr_AmericaInfantryRanger 6
     Payload = Lazr_AmericaInfantryMissileDefender 4


### PR DESCRIPTION
This change optimizes the drop location and spacing of the USA Paradrops. The soldiers now fall into a line and no longer charge towards to same position. The spacing is tightened consistently and they fall as close to the drop center as possible.

Optimized for fix https://github.com/TheAssemblyArmada/Thyme/pull/752.

## Original

Paradrop 1 spacing is not tight. Soldier fall too far behind.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/8bb69c38-ede8-4d90-9ea4-e764ca4e9666

Paradrop 3 is poorly executed. Depending on drop angle, planes will return a second time.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/22f0cba7-598f-4922-906e-b7cebcf9b98c

## Patched (+Thyme 752)

Paradrop 1 is nice.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/fbb671fc-6c0b-42af-812b-8858d2735179

Paradrop 3 is nice.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/d1a435a4-054f-4826-abfc-c0b5eed4039f
