### PR TITLE
Fix: GLA Toxin Tunnel stream no longer times out

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2063_toxin_tunnel_stream_timeout.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2063_toxin_tunnel_stream_timeout.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-07-06
+
+title: Fixes toxin stream timeout of GLA Toxin Tunnel
+
+changes:
+  - fix: The toxin stream of the GLA Toxin Tunnel no longer times out when firing on distant terrain or allied units.
+
+labels:
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2063
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1120,9 +1120,10 @@ Object GC_Chem_ToxinStreamProjectile
     AllowCollideForce   = No  ; toxins collide, but never apply forces when they do so
   End
 
+  ; Patch104p @bugfix xezon 06/07/2023 Changes fuel lifetime from 500 to avoid fuel timeouts. (#2063)
   Behavior = MissileAIUpdate ModuleTag_05
     TryToFollowTarget               = No
-    FuelLifetime                    = 500
+    FuelLifetime                    = 1000
     InitialVelocity                 = 120                ; in dist/sec
     IgnitionDelay                   = 0
     DistanceToTravelBeforeTurning   = 2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -3697,9 +3697,10 @@ Object ToxinTruckStreamProjectile
     AllowCollideForce   = No  ; toxins collide, but never apply forces when they do so
   End
 
+  ; Patch104p @bugfix xezon 06/07/2023 Changes fuel lifetime from 500 to avoid fuel timeouts. (#2063)
   Behavior = MissileAIUpdate ModuleTag_05
     TryToFollowTarget               = No
-    FuelLifetime                    = 500
+    FuelLifetime                    = 1000
     InitialVelocity                 = 120                ; in dist/sec
     IgnitionDelay                   = 0
     DistanceToTravelBeforeTurning   = 2
@@ -3764,9 +3765,10 @@ Object ToxinTruckStreamProjectileUpgraded
     AllowCollideForce = No  ; flames collide, but never apply forces when they do so
   End
 
+  ; Patch104p @bugfix xezon 06/07/2023 Changes fuel lifetime from 500 to avoid fuel timeouts. (#2063)
   Behavior = MissileAIUpdate ModuleTag_05
     TryToFollowTarget               = No
-    FuelLifetime                    = 500
+    FuelLifetime                    = 1000
     InitialVelocity                 = 120                ; in dist/sec
     IgnitionDelay                   = 0
     DistanceToTravelBeforeTurning   = 2


### PR DESCRIPTION
With this change the GLA Toxin Tunnel stream no longer times out.

It mostly is a problem with targeting the ground or allied units. When targeting enemy units, the stream will collide and deal damage up to max range. So this fix luckily is no practical buff.

## Original

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/a9a3a27c-a540-4658-8119-ebd8639acc0e
