### PR TITLE
Change: Decrease kill experience reward of veteran USA Burton to match other heroes

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2064_burton_experience_reward.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2064_burton_experience_reward.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-07-07
+
+title: Decreases kill experience reward of veteran USA Burton to match other heroes
+
+changes:
+  - tweak: The USA Burton now rewards 50 50 100 150 instead of 50 100 100 150 experience on kill.
+
+labels:
+  - controversial
+  - design
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2064
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -3114,7 +3114,8 @@ Object AirF_AmericaInfantryColonelBurton
   BuildCost = 1500
   BuildTime = 20.0          ;in seconds
 
-  ExperienceValue     = 50 100 100 150  ; Experience point value at each level
+  ; Patch104p @tweak xezon 07/07/2023 Changes experience value from 50 100 100 150 to match the other heroes. (#2064)
+  ExperienceValue     = 50 50 100 150  ; Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CrushableLevel      = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -334,7 +334,8 @@ Object AmericaInfantryColonelBurton
   BuildCost = 1500
   BuildTime = 20.0          ;in seconds
 
-  ExperienceValue     = 50 100 100 150  ; Experience point value at each level
+  ; Patch104p @tweak xezon 07/07/2023 Changes experience value from 50 100 100 150 to match the other heroes. (#2064)
+  ExperienceValue     = 50 50 100 150  ; Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CrushableLevel      = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -17033,7 +17033,8 @@ Object Boss_InfantryColonelBurton
   BuildCost = 1500
   BuildTime = 20.0          ;in seconds
 
-  ExperienceValue     = 50 100 100 150  ; Experience point value at each level
+  ; Patch104p @tweak xezon 07/07/2023 Changes experience value from 50 100 100 150 to match the other heroes. (#2064)
+  ExperienceValue     = 50 50 100 150  ; Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CrushableLevel      = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -2659,7 +2659,8 @@ Object Lazr_AmericaInfantryColonelBurton
   BuildCost = 1500
   BuildTime = 20.0          ;in seconds
 
-  ExperienceValue     = 50 100 100 150  ; Experience point value at each level
+  ; Patch104p @tweak xezon 07/07/2023 Changes experience value from 50 100 100 150 to match the other heroes. (#2064)
+  ExperienceValue     = 50 50 100 150  ; Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CrushableLevel      = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -3138,7 +3138,8 @@ Object SupW_AmericaInfantryColonelBurton
   BuildCost = 1200
   BuildTime = 20.0          ;in seconds
 
-  ExperienceValue     = 50 100 100 150  ; Experience point value at each level
+  ; Patch104p @tweak xezon 07/07/2023 Changes experience value from 50 100 100 150 to match the other heroes. (#2064)
+  ExperienceValue     = 50 50 100 150  ; Experience point value at each level
   ExperienceRequired  = 0 200 300 600   ; Experience points needed to gain each level
   IsTrainable         = Yes             ; Can gain experience
   CrushableLevel      = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles


### PR DESCRIPTION
* Resolves #2025

This change streamlines the kill XP progression of USA Burton with other heroes and infantry.

### Before

```
ChinaInfantryBlackLotus
  ExperienceValue = 50 50 100 150  ; Experience point value at each level

AmericaInfantryColonelBurton
  ExperienceValue = 50 100 100 150  ; Experience point value at each level

GLAInfantryJarmenKell
  ExperienceValue = 50 50 100 150  ;Experience point value at each level
```

### After

```
ChinaInfantryBlackLotus
  ExperienceValue = 50 50 100 150  ; Experience point value at each level

AmericaInfantryColonelBurton
  ExperienceValue = 50 50 100 150  ; Experience point value at each level

GLAInfantryJarmenKell
  ExperienceValue = 50 50 100 150  ;Experience point value at each level
```

# Rationale

Originally the Vet 1 Burton gives twice as much kill experience as the other Heros for no apparent reason. It is not particularly harder to kill or more dangerous than the Vet 1 Jarmen Kell.

The Burton kill experience progression mismatches with the global unit experience progression, which typically looks like so: X X Y Z.
