### PR TITLE
Revert system lifetime changes of stream trail effects

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2034_hazard_cleanup_stream_trail_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2034_hazard_cleanup_stream_trail_performance.yaml
@@ -1,10 +1,10 @@
 ---
 date: 2023-06-24
 
-title: Decreases performance cost of hazard cleanup stream trail effects by 50% to 57%
+title: Decreases performance cost of hazard cleanup stream trail effects by 50%
 
 changes:
-  - optimization: Decreases the performance cost of hazard cleanup stream trail effects by 50% to 57%. Affects USA Ambulance.
+  - optimization: Decreases the performance cost of hazard cleanup stream trail effects by 50%. Affects USA Ambulance.
 
 labels:
   - art
@@ -15,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2034
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2065
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2034_toxin_stream_trail_performance.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2034_toxin_stream_trail_performance.yaml
@@ -1,10 +1,10 @@
 ---
 date: 2023-06-24
 
-title: Decreases performance cost of toxin stream trail effects by 50% to 65%
+title: Decreases performance cost of toxin stream trail effects by 50%
 
 changes:
-  - optimization: Decreases the performance cost of toxin stream trail effects by 50% to 65%. Affects GLA Toxin Tractor, Toxin Rebel and Toxin Tunnel.
+  - optimization: Decreases the performance cost of toxin stream trail effects by 50%. Affects GLA Toxin Tractor, Toxin Rebel and Toxin Tunnel.
 
 labels:
   - art
@@ -15,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2034
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2065
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -4707,7 +4707,7 @@ ParticleSystem NukeBaikonurMushroomStem
   WindPingPongEndAngleMax = 6.283185
 End
 
-; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 65% (#2034)
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% (#2034) (#2065)
 ParticleSystem AnthraxTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -4720,7 +4720,7 @@ ParticleSystem AnthraxTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 10 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
+  SystemLifetime = 20
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
   SizeRate = -0.33 1.00 ; Patch104p @tweak from -1.00 1.00 to decrease the number of tiny particles
@@ -12933,7 +12933,7 @@ ParticleSystem SmokeSmall
   WindPingPongEndAngleMax = 6.283185
 End
 
-; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 65% (#2034)
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% (#2034) (#2065)
 ParticleSystem GC_Chem_ToxinTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -12946,7 +12946,7 @@ ParticleSystem GC_Chem_ToxinTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 10 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
+  SystemLifetime = 20
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
   SizeRate = -0.33 1.00 ; Patch104p @tweak from -1.00 1.00 to decrease the number of tiny particles
@@ -12990,7 +12990,7 @@ ParticleSystem GC_Chem_ToxinTrail01
   WindPingPongEndAngleMax = 6.283185
 End
 
-; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 65% (#2034)
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% (#2034) (#2065)
 ParticleSystem ToxinTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -13003,7 +13003,7 @@ ParticleSystem ToxinTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 10 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
+  SystemLifetime = 20
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
   SizeRate = -0.33 1.00 ; Patch104p @tweak from -1.00 1.00 to decrease the number of tiny particles
@@ -20827,7 +20827,7 @@ ParticleSystem _FireTest
 End
 
 ; Patch104p @fix xezon 25/06/2023 Adjusts particle colors to better blend with the cyan excleanupstream texture. (#2041)
-; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% to 57% (#2034)
+; Patch104p @performance xezon 24/06/2023 Decreases cost of trail by 50% (#2034) (#2065)
 ParticleSystem CleanupTrail01
   Priority = CRITICAL
   IsOneShot = No
@@ -20840,7 +20840,7 @@ ParticleSystem CleanupTrail01
   VelocityDamping = 0.80 0.90
   Gravity = -0.10
   Lifetime = 10.00 10.00
-  SystemLifetime = 12 ; Patch104p @performance from 20 to decrease the maximum number of instances on the stream, maximum system lifetime is 14
+  SystemLifetime = 20
   Size = 1.00 2.00
   StartSizeRate = 0.00 0.00
   SizeRate = 1.00 1.00


### PR DESCRIPTION
* Follow up for #2034

This change reverts system lifetime changes of stream trail effects. It did not look proper on Toxin Tunnel stream, which is longer than the other ones.