### PR TITLE
Change: Infantry killed by USA Laser Turret and Laser Crusader will burn

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2067_laser_weapons_infantry_burn.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2067_laser_weapons_infantry_burn.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-07-08
+
+title: Enables Laser weapons to burn killed infantry units
+
+changes:
+  - tweak: The USA Laser Turret now burns infantry on kill. It does not change gameplay.
+  - tweak: The USA Laser Crusader now burns infantry on kill. The burned death now triggers the suicide explosion of the GLA Terrorist.
+
+labels:
+  - controversial
+  - design
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2067
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6745,6 +6745,7 @@ Weapon GC_Slth_QuadCannonSnipeGun
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 08/07/2023 Changes DeathType from NORMAL to burn infantry on kill. (#2067)
 Weapon Lazr_CrusaderTankGun
   PrimaryDamage           = 80.0
   PrimaryDamageRadius     = 5.0
@@ -6753,7 +6754,7 @@ Weapon Lazr_CrusaderTankGun
   MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
   MaxTargetPitch          = 15                          ; ditto
   DamageType              = ARMOR_PIERCING
-  DeathType               = NORMAL
+  DeathType               = BURNED
   WeaponSpeed             = 99999                           ; dist/sec
   WeaponRecoil            = 5                            ; angle to deflect the model when firing
   LaserName               = Lazr_CrusaderLaserBeam
@@ -6790,6 +6791,7 @@ Weapon Lazr_PaladinTankGun
 End
 
 ; Patch104p @tweak commy2 10/09/2022 Auto reload missile battery when idle.
+; Patch104p @tweak xezon 08/07/2023 Changes DeathType from EXPLODED to burn infantry on kill. (#2067)
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeapon
   PrimaryDamage               =  40.0
@@ -6797,7 +6799,7 @@ Weapon Lazr_PatriotMissileWeapon
   ScatterRadiusVsInfantry     =  10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 225.0
   DamageType                  = EXPLOSION
-  DeathType                   = EXPLODED
+  DeathType                   = BURNED
   WeaponSpeed                 = 999999.0
   LaserName               = Lazr_PatriotLaserBeam
   LaserBoneName           = WEAPONA01
@@ -6819,13 +6821,14 @@ End
 
 ; Patch104p @bugfix commy2 13/09/2021 Fix sound and effect used against airborne targets and when assisting to match normal anti ground weapon.
 ; Patch104p @bugfix commy2 13/09/2021 Reduce ammo against air and when assisting to match normal anti ground weapon.
+; Patch104p @tweak xezon 08/07/2023 Changes DeathType from EXPLODED. (#2067)
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeaponAir
   PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 3.0
   AttackRange                 = 350.0
   DamageType                  = EXPLOSION
-  DeathType                   = EXPLODED
+  DeathType                   = BURNED
   WeaponSpeed                 = 999999.0
   LaserName               = Lazr_PatriotLaserBeam
   LaserBoneName           = WEAPONA01
@@ -6849,13 +6852,14 @@ End
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 ; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
 ; Patch104p @fix xezon 21/01/2023 Changes clip reload time from 1000 to match non-assist Patriot weapons.
+; Patch104p @tweak xezon 08/07/2023 Changes DeathType from EXPLODED to burn infantry on kill. (#2067)
 Weapon Lazr_PatriotMissileAssistWeapon
   PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 3.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range
   DamageType                  = EXPLOSION          ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = BURNED
   WeaponSpeed                 = 999999.0               ; ignored for projectile weapons
   LaserName               = Lazr_PatriotLaserBeam
   LaserBoneName           = WEAPONA01


### PR DESCRIPTION
* Closes #1848

This change makes USA Laser Turret and Laser Crusader weapons burn killed infantry. ~~This change is cosmetic only.~~

The Laser Crusader now also triggers the ~~suicide weapon~~ weak crush explosion (#2081) of Terrorist and Demolition units, which makes it more vulnerable in return, but consistent with how the ~~Laser Turret~~ point defense laser of the USA Paladin Tank behaves.

## Patched

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/4498eacc-0a22-49b1-998b-bd1eecf96b01
