### PR TITLE
Change: Remove infantry target scatter from USA Laser Turret

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6790,11 +6790,11 @@ Weapon Lazr_PaladinTankGun
 End
 
 ; Patch104p @tweak commy2 10/09/2022 Auto reload missile battery when idle.
+; Patch104p @tweak xezon 08/07/2023 Removes ScatterRadiusVsInfantry of 10 to no longer miss infantry.
 ;------------------------------------------------------------------------------
 Weapon Lazr_PatriotMissileWeapon
   PrimaryDamage               =  40.0
   PrimaryDamageRadius         =   3.0
-  ScatterRadiusVsInfantry     =  10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 225.0
   DamageType                  = EXPLOSION
   DeathType                   = EXPLODED
@@ -6849,10 +6849,10 @@ End
 ; For use with the Assisted Targeting Update.  No Assist Listing and longer range
 ; Patch104p @fix xezon 21/01/2023 Enables automatic reload when idle.
 ; Patch104p @fix xezon 21/01/2023 Changes clip reload time from 1000 to match non-assist Patriot weapons.
+; Patch104p @tweak xezon 08/07/2023 Removes ScatterRadiusVsInfantry of 10 to no longer miss infantry.
 Weapon Lazr_PatriotMissileAssistWeapon
   PrimaryDamage               = 40.0
   PrimaryDamageRadius         = 3.0
-  ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange                 = 450.0 ; at least Regular's range + regular's request assist range
   DamageType                  = EXPLOSION          ; ignored for projectile weapons
   DeathType                   = EXPLODED


### PR DESCRIPTION
This change removes the infantry target scatter from the USA Laser Turret. It will no longer miss infantry at random. The miss chance was around 25% (sampled). This makes its targeting performance consistent with the USA Laser Crusader, that, despite having scatter too, never misses its infantry targets in practice.

The regular USA Patriot also has infantry target scatter, but will not fail to damage infantry when stationary, due its larger primary damage radius.

## TODO

- [ ] Re-add a bit of scatter vs Infantry so it looks nice
- [ ] Add DamageType=TOPPLING to Laser Patriot

## Before

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/c8220727-7fc1-4ef8-b88b-285d48bf58f3

# Rationale

The Laser weapon now works as one would expect without random misses. Performs consistent with USA Laser Crusader.
