### PR TITLE
Change: Remove infantry target scatter from USA Laser Crusader weapon

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6745,10 +6745,10 @@ Weapon GC_Slth_QuadCannonSnipeGun
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 08/07/2023 Removes ScatterRadiusVsInfantry of 10 to point the laser on the target always. Does not change effectiveness.
 Weapon Lazr_CrusaderTankGun
   PrimaryDamage           = 80.0
   PrimaryDamageRadius     = 5.0
-  ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange             = 150.0
   MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
   MaxTargetPitch          = 15                          ; ditto
@@ -6768,10 +6768,10 @@ Weapon Lazr_CrusaderTankGun
 End
 
 ;------------------------------------------------------------------------------
+; Patch104p @tweak xezon 08/07/2023 Removes ScatterRadiusVsInfantry of 10 to point the laser on the target always.
 Weapon Lazr_PaladinTankGun
   PrimaryDamage = 70.0
   PrimaryDamageRadius = 3.0
-  ScatterRadiusVsInfantry = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.
   AttackRange = 150.0
   MinTargetPitch = -15                         ; we may not target anything outside of this pitch range
   MaxTargetPitch = 15                          ; ditto


### PR DESCRIPTION
* Follow up for #2068

This change removes the infantry target scatter from the USA Laser Crusader (and USA Laser Paladin). Performance wise nothing changes. The infantry target scatter in practice never missed infantry. Therefore this change ~~is cosmetic only~~ does not change gameplay.

## Before

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/c8220727-7fc1-4ef8-b88b-285d48bf58f3
