### PR TITLE
Fix: Point Defense Laser of USA Paladin no longer attacks dead infantry

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2072_paladin_laser_attack_dead_infantry.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2072_paladin_laser_attack_dead_infantry.txt
@@ -1,0 +1,1 @@
+75_dead_target_bug.yaml

--- a/Patch104pZH/Design/Changes/v1.0/75_dead_target_bug.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/75_dead_target_bug.yaml
@@ -4,16 +4,18 @@ date: 2021-08-27
 title: Fixes units shooting at already killed infantry units
 
 changes:
-  - fix: Units no longer shoot at killed infantry units.
+  - fix: Combat units no longer attack killed infantry units.
+  - fix: The Point Defense Laser of the USA Paladin no longer attacks killed infantry units.
 
 labels:
   - bug
-  - gla
   - minor
   - v1.0
 
 links:
-- https://github.com/TheSuperHackers/GeneralsGamePatch/pull/75
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/75
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2072
 
 authors:
   - hanfield
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -1211,7 +1211,8 @@ Object FirestormTestObject
 
 End
 
-; Patch104p @bugfix hanfield 27/08/2021 UNATTACKABLE fixes burning and poisoned infantry drawing enemy fire
+; Patch104p @bugfix hanfield 27/08/2021 UNATTACKABLE fixes burning and poisoned infantry drawing enemy fire (#75)
+; Patch104p @bugfix xezon 08/07/2023 Removes INFANTRY flag to avoid PointDefenseLaserUpdate modules targeting this object. (#2072)
 ;------------------------------------------------------------------------------
 Object FlamingInfantry
 
@@ -1260,7 +1261,7 @@ Object FlamingInfantry
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY UNATTACKABLE
+  KindOf = CAN_CAST_REFLECTIONS UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0
@@ -1309,7 +1310,8 @@ Object FlamingInfantry
 
 End
 
-; Patch104p @bugfix hanfield 27/08/2021 UNATTACKABLE fixes burning and poisoned infantry drawing enemy fire
+; Patch104p @bugfix hanfield 27/08/2021 UNATTACKABLE fixes burning and poisoned infantry drawing enemy fire (#75)
+; Patch104p @bugfix xezon 08/07/2023 Removes INFANTRY flag to avoid PointDefenseLaserUpdate modules targeting this object. (#2072)
 ;------------------------------------------------------------------------------
 Object ToxicInfantry
   ; *** ART Parameters ***
@@ -1340,7 +1342,7 @@ Object ToxicInfantry
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY UNATTACKABLE
+  KindOf = CAN_CAST_REFLECTIONS UNATTACKABLE
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0


### PR DESCRIPTION
* Fixes #2070
* Follow up for #75

With this change the Point Defense Laser of the USA Paladin no longer attacks dead infantry.
