### PR TITLE
Fix: Adds missing damaged condition states to AmericaInfantryOfficer, AmericaInfantryCIAOfficer, ChinaInfantryOfficer

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -622,7 +622,9 @@ End
 ; This unit is never human-controllable!
 ;
 Object AmericaInfantryOfficer
+
     ; *** ART Parameters ***
+  ; Patch104p @bugfix xezon 08/07/2023 Adds missing condition states for REALLYDAMAGED.
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -638,12 +640,14 @@ Object AmericaInfantryOfficer
       WeaponMuzzleFlash = PRIMARY MuzzleFX
       TransitionKey = TRANS_STAND
     End
+    AliasConditionState = REALLYDAMAGED
 
     ConditionState    = MOVING
       Animation       = AIOFCR_SKL.AIOFCR_RNA
       AnimationMode   = LOOP
       ParticleSysBone     = None InfantryDustTrails
     End
+    AliasConditionState = REALLYDAMAGED MOVING
 
     ; NORMAL ATTACK
     ;--------------------------------------------------------
@@ -655,6 +659,10 @@ Object AmericaInfantryOfficer
     AliasConditionState = PREATTACK_A MOVING
     AliasConditionState = PREATTACK_A FIRING_A
     AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A MOVING
+    AliasConditionState = REALLYDAMAGED PREATTACK_A FIRING_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A BETWEEN_FIRING_SHOTS_A
 
     ; Firing gun
     ConditionState  = FIRING_A
@@ -662,6 +670,8 @@ Object AmericaInfantryOfficer
       AnimationMode = LOOP
       TransitionKey = TRANS_FIRING_A
     End
+    AliasConditionState = REALLYDAMAGED FIRING_A
+
     ConditionState  = BETWEEN_FIRING_SHOTS_A
       Animation     = AIOFCR_SKL.AIOFCR_ATALP
       AnimationMode = LOOP
@@ -671,6 +681,11 @@ Object AmericaInfantryOfficer
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED RELOADING_A
+    AliasConditionState = REALLYDAMAGED MOVING FIRING_A
+    AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED MOVING RELOADING_A
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_A TRANS_STAND
@@ -877,6 +892,8 @@ Object AmericaInfantrySecretService
       AnimationMode = ONCE
       TransitionKey = TRANS_Stand
     End
+
+    ; Patch104p @todo Add models and condition states.
   End
 
   ; ***DESIGN parameters ***
@@ -1896,6 +1913,7 @@ Object AmericaInfantryCIAOfficer
   ButtonImage = SACIAOff_L
 
     ; *** ART Parameters ***
+  ; Patch104p @bugfix xezon 08/07/2023 Adds missing condition states for REALLYDAMAGED.
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -1911,12 +1929,14 @@ Object AmericaInfantryCIAOfficer
       WeaponMuzzleFlash = PRIMARY MuzzleFX
       TransitionKey = TRANS_STAND
     End
+    AliasConditionState = REALLYDAMAGED
 
     ConditionState    = MOVING
       Animation       = AIOFCR_SKL.AIOFCR_RNA
       AnimationMode   = LOOP
       ParticleSysBone     = None InfantryDustTrails
     End
+    AliasConditionState = REALLYDAMAGED MOVING
 
     ; NORMAL ATTACK
     ;--------------------------------------------------------
@@ -1928,6 +1948,10 @@ Object AmericaInfantryCIAOfficer
     AliasConditionState = PREATTACK_A MOVING
     AliasConditionState = PREATTACK_A FIRING_A
     AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A MOVING
+    AliasConditionState = REALLYDAMAGED PREATTACK_A FIRING_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A BETWEEN_FIRING_SHOTS_A
 
     ; Firing gun
     ConditionState  = FIRING_A
@@ -1935,6 +1959,8 @@ Object AmericaInfantryCIAOfficer
       AnimationMode = LOOP
       TransitionKey = TRANS_FIRING_A
     End
+    AliasConditionState = REALLYDAMAGED FIRING_A
+
     ConditionState  = BETWEEN_FIRING_SHOTS_A
       Animation     = AIOFCR_SKL.AIOFCR_ATALP
       AnimationMode = LOOP
@@ -1944,6 +1970,11 @@ Object AmericaInfantryCIAOfficer
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED RELOADING_A
+    AliasConditionState = REALLYDAMAGED MOVING FIRING_A
+    AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED MOVING RELOADING_A
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_A TRANS_STAND

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -523,6 +523,7 @@ End
 Object ChinaInfantryOfficer
 
     ; *** ART Parameters ***
+  ; Patch104p @bugfix xezon 08/07/2023 Adds missing condition states for REALLYDAMAGED.
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -538,12 +539,14 @@ Object ChinaInfantryOfficer
       WeaponMuzzleFlash = PRIMARY MuzzleFX
       TransitionKey = TRANS_STAND
     End
+    AliasConditionState = REALLYDAMAGED
 
     ConditionState    = MOVING
       Animation       = NIOFCR_SKL.NIOFCR_RNA
       AnimationMode   = LOOP
       ParticleSysBone     = None InfantryDustTrails
     End
+    AliasConditionState = REALLYDAMAGED MOVING
 
     ; NORMAL ATTACK
     ;--------------------------------------------------------
@@ -555,6 +558,10 @@ Object ChinaInfantryOfficer
     AliasConditionState = PREATTACK_A MOVING
     AliasConditionState = PREATTACK_A FIRING_A
     AliasConditionState = PREATTACK_A BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A MOVING
+    AliasConditionState = REALLYDAMAGED PREATTACK_A FIRING_A
+    AliasConditionState = REALLYDAMAGED PREATTACK_A BETWEEN_FIRING_SHOTS_A
 
     ; Firing gun
     ConditionState  = FIRING_A
@@ -562,6 +569,8 @@ Object ChinaInfantryOfficer
       AnimationMode = LOOP
       TransitionKey = TRANS_FIRING_A
     End
+    AliasConditionState = REALLYDAMAGED FIRING_A
+
     ConditionState  = BETWEEN_FIRING_SHOTS_A
       Animation     = NIOFCR_SKL.NIOFCR_ATALP
       AnimationMode = LOOP
@@ -571,6 +580,11 @@ Object ChinaInfantryOfficer
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
     AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = REALLYDAMAGED BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED RELOADING_A
+    AliasConditionState = REALLYDAMAGED MOVING FIRING_A
+    AliasConditionState = REALLYDAMAGED MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = REALLYDAMAGED MOVING RELOADING_A
 
     ; This transition allows him to put his gun away when he's finished attacking.
     TransitionState = TRANS_FIRING_A TRANS_STAND


### PR DESCRIPTION
This change adds the missing damaged condition states to

* AmericaInfantryOfficer
* AmericaInfantryCIAOfficer
* ChinaInfantryOfficer

This way it no longer shows wrong animation(s) when damaged.

## Original

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/8fe45dc3-1eec-420e-8866-3046f56b65d3
