### PR TITLE
Fix: Infantry death modules

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2074_infantry_death_module_fixes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2074_infantry_death_module_fixes.yaml
@@ -1,0 +1,30 @@
+---
+date: 2023-07-08
+
+title: Fixes missing and broken infantry death modules
+
+changes:
+  - fix: Adds missing crushed, exploded, burned, poisoned death modules to AmericaInfantrySecretService.
+  - fix: Adds missing crushed, exploded, burned, poisoned death modules to ChinaInfantrySecretPolice, ChinaAmbassador, ChinaInfantryAgent.
+  - fix: Adds missing poisoned death modules to ChinaInfantryOfficer.
+  - fix: Adds missing crushed, exploded death modules to MogadishuMaleCivilian01, MogadishuMaleCivilian02.
+  - fix: Adds missing crushed, exploded death modules to MogadishuFemaleCivilian01, MogadishuFemaleCivilian02.
+  - fix: Adds missing crushed, exploded, burned, poisoned death modules to Partisan01, Partisan02, Partisan03.
+  - fix: Adds missing crushed, exploded death modules to GenericFemale01, AmericanFarmer01, AsianFarmer01, AsianFarmer02, AsianFarmer3.
+  - fix: Adds missing crushed, exploded death modules to HomelessGuy.
+  - fix: Adds missing crushed, exploded death modules to GenericMale02, GenericFemale02.
+
+labels:
+  - bug
+  - china
+  - civilian
+  - design
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2074
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaMiscUnit.ini
@@ -931,11 +931,6 @@ Object AmericaInfantrySecretService
   Behavior = PhysicsBehavior ModuleTag_05
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_06
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
 
   Behavior = ExperienceScalarUpgrade ModuleTag_07
     TriggeredBy = Upgrade_AmericaAdvancedTraining
@@ -946,15 +941,59 @@ Object AmericaInfantrySecretService
     ;nothing
   End
 
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
 
-  Behavior = FXListDie ModuleTag_09
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    DeathFX = FX_CIAAgentDie
+; --- begin Death modules --- AmericaInfantrySecretService
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CIAAgentDie
   End
-  Behavior = FXListDie ModuleTag_10
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CIAAgentDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death04
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireUSA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinUSA
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinUSA
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinUSA
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_11
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaMiscUnit.ini
@@ -61,26 +61,64 @@ Object ChinaInfantrySecretPolice
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    DeathFX = FX_RedGuardDie
+; --- begin Death modules --- ChinaInfantrySecretPolice
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_RedGuardDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_RedGuardDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death04
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireChina
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -474,24 +512,64 @@ Object ChinaAmbassador
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    DeathFX = FX_RedGuardDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- ChinaAmbassador
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_RedGuardDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_RedGuardDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death04
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireChina
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -687,10 +765,11 @@ Object ChinaInfantryOfficer
     ;nothing
   End
 
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
 
-; --- begin Death modules ---
+; --- begin Death modules --- ChinaInfantryOfficer
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -725,7 +804,20 @@ Object ChinaInfantryOfficer
     DeathTypes          = NONE +POISONED
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinChina
-    OCL                 = INITIAL OCL_
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  ; Patch104p @fix xezon 08/07/2023 Adds missing death modules.
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
 ; --- end Death modules ---
 
@@ -952,26 +1044,64 @@ Object ChinaInfantryAgent
   Behavior = PhysicsBehavior ModuleTag_06
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_07
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_08
     ;nothing
   End
 
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
 
-  Behavior = FXListDie ModuleTag_09
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    DeathFX = FX_RedGuardDie
+; --- begin Death modules --- ChinaInfantryAgent
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_RedGuardDie
   End
-  Behavior = FXListDie ModuleTag_10
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_RedGuardDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death04
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireChina
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_11
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -429,25 +429,49 @@ Object MogadishuMaleCivilian01
     Mass = 5.0
   End
 
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
-
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianArabMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- MogadishuMaleCivilian01
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -455,27 +479,13 @@ Object MogadishuMaleCivilian01
     FX                  = INITIAL FX_DieByToxinGLA
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -557,25 +567,50 @@ Object MogadishuMaleCivilian02
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianArabMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- MogadishuMaleCivilian02
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -583,27 +618,13 @@ Object MogadishuMaleCivilian02
     FX                  = INITIAL FX_DieByToxinGLA
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -876,26 +897,49 @@ Object MogadishuFemaleCivilian02
     Mass = 5.0
   End
 
-
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
-
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED -POISONED_BETA -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianArabFemaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- MogadishuFemaleCivilian02
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireFemale
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinFemale
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -903,33 +947,18 @@ Object MogadishuFemaleCivilian02
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinFemale
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
     PoisonDuration = 3000       ; ... for this long after last hit by poison damage
   End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireFemale
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Geometry = CYLINDER
   GeometryMajorRadius = 3.0
   GeometryMinorRadius = 3.0
@@ -1010,25 +1039,50 @@ Object MogadishuFemaleCivilian01
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianArabFemaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- MogadishuFemaleCivilian01
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireFemale
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinFemale
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -1036,33 +1090,18 @@ Object MogadishuFemaleCivilian01
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinFemale
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
     PoisonDuration = 3000       ; ... for this long after last hit by poison damage
   End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireFemale
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Geometry = CYLINDER
   GeometryMajorRadius = 3.0
   GeometryMinorRadius = 3.0
@@ -8846,25 +8885,64 @@ Object Partisan01
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    DeathFX = FX_CivilianArabMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- Partisan01
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -8929,25 +9007,64 @@ Object Partisan02
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    DeathFX = FX_CivilianArabMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- Partisan02
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinGLA
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -9013,25 +9130,64 @@ Object Partisan03
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED
-    DeathFX = FX_CivilianArabFemaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- Partisan03
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireFemale
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinFemale
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinFemale
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinFemale
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -9524,31 +9680,44 @@ Object GenericFemale01
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED -POISONED_BETA -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianArabFemaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- GenericFemale01
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
-  Behavior = SlowDeathBehavior ModuleTag_Death06
-    DeathTypes          = NONE +POISONED_BETA
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabFemaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinFemale
-    OCL                 = INITIAL OCL_ToxicInfantryBeta
+    FX                  = INITIAL FX_DieByFireFemale
+    OCL                 = INITIAL OCL_FlamingInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death05
     DeathTypes          = NONE +POISONED
@@ -9556,20 +9725,19 @@ Object GenericFemale01
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantry
   End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireFemale
-    OCL                 = INITIAL OCL_FlamingInfantry
+    FX                  = INITIAL FX_DieByToxinFemale
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -9673,54 +9841,64 @@ Object AmericanFarmer01
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianArabMaleDie
-  End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
-  End
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
 
-  Behavior = SlowDeathBehavior ModuleTag_Death06
-    DeathTypes          = NONE +POISONED_BETA
+; --- begin Death modules --- AmericanFarmer01
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
     DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinUSA
-    OCL                 = INITIAL OCL_ToxicInfantryBeta
+    FX                  = INITIAL FX_DieByFireUSA
+    OCL                 = INITIAL OCL_FlamingInfantry
   End
-
   Behavior = SlowDeathBehavior ModuleTag_Death05
     DeathTypes          = NONE +POISONED
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinUSA
     OCL                 = INITIAL OCL_ToxicInfantry
   End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
     DestructionDelay    = 0
-    FX                  = INITIAL DieByFireUSA
-    OCL                 = INITIAL OCL_FlamingInfantry
+    FX                  = INITIAL FX_DieByToxinUSA
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinUSA
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -9832,25 +10010,50 @@ Object AsianFarmer01
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianChinaMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- AsianFarmer01
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireChina
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -9858,27 +10061,13 @@ Object AsianFarmer01
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinChina
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireChina
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -9992,25 +10181,50 @@ Object HomelessGuy
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianChinaMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- HomelessGuy
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireChina
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -10018,27 +10232,13 @@ Object HomelessGuy
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinChina
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireChina
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -10144,25 +10344,50 @@ End
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianChinaMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- AsianFarmer02
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireChina
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -10170,33 +10395,18 @@ End
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinChina
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
     PoisonDuration = 3000       ; ... for this long after last hit by poison damage
   End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireChina
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Geometry = CYLINDER
   GeometryMajorRadius = 3.0
   GeometryMinorRadius = 3.0
@@ -10296,57 +10506,68 @@ Object AsianFarmer3
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianChinaMaleDie
-  End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
-  End
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
 
-  Behavior = PoisonedBehavior ModuleTag_09
-    PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
-    PoisonDuration = 3000       ; ... for this long after last hit by poison damage
+; --- begin Death modules --- AsianFarmer3
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death06
-    DeathTypes          = NONE +POISONED_BETA
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinChina
-    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinChina
-    OCL                 = INITIAL OCL_ToxicInfantry
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
   End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
   Behavior = SlowDeathBehavior ModuleTag_DeathBurned
     DeathTypes          = NONE +BURNED +LASERED
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByFireChina
     OCL                 = INITIAL OCL_FlamingInfantry
   End
-
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
+
+  Behavior = PoisonedBehavior ModuleTag_09
+    PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
+    PoisonDuration = 3000       ; ... for this long after last hit by poison damage
   End
 
   Geometry = CYLINDER
@@ -17437,25 +17658,50 @@ Object GenericMale02
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianChinaMaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- GenericMale02
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireChina
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinChina
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -17463,27 +17709,13 @@ Object GenericMale02
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinChina
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireChina
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinChina
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
@@ -17597,25 +17829,50 @@ Object GenericFemale02
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 5.0
   End
-  Behavior = SlowDeathBehavior ModuleTag_05
-    DeathTypes = ALL -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    SinkDelay = 3000
-    SinkRate = 0.5     ; in Dist/Sec
-    DestructionDelay = 8000
-  End
-
 
   Behavior = SquishCollide ModuleTag_06
     ;nothing
   End
 
-  Behavior = FXListDie ModuleTag_07
-    DeathTypes = ALL -CRUSHED -SPLATTED -POISONED_BETA -POISONED -BURNED -LASERED -POISONED_GAMMA
-    DeathFX = FX_CivilianChinaFemaleDie
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- GenericFemale02
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaFemaleDie
   End
-  Behavior = FXListDie ModuleTag_08
-    DeathTypes = NONE +CRUSHED +SPLATTED
-    DeathFX = FX_GIDieCrushed
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianChinaFemaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireFemale
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinFemale
+    OCL                 = INITIAL OCL_ToxicInfantry
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06
     DeathTypes          = NONE +POISONED_BETA
@@ -17623,27 +17880,13 @@ Object GenericFemale02
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantryBeta
   End
-
-  Behavior = SlowDeathBehavior ModuleTag_Death05
-    DeathTypes          = NONE +POISONED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByToxinFemale
-    OCL                 = INITIAL OCL_ToxicInfantry
-  End
-  ; Patch104p @tweak xezon 08/07/2023 Adds LASERED burn. (#2071)
-  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireFemale
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
-
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinFemale
     OCL                 = INITIAL OCL_ToxicInfantryGamma
   End
+; --- end Death modules ---
 
   Behavior = PoisonedBehavior ModuleTag_09
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...


### PR DESCRIPTION
**Merge with Rebase**

This change fixes and streamlines death modules of

* (USA) AmericaInfantrySecretService
* (China) ChinaInfantrySecretPolice
* (China) ChinaAmbassador
* (China) ChinaInfantryOfficer
* (China) ChinaInfantryAgent
* (Civilian) MogadishuMaleCivilian01
* (Civilian) MogadishuMaleCivilian02
* (Civilian) MogadishuFemaleCivilian02
* (Civilian) MogadishuFemaleCivilian01
* (Civilian) GenericFemale01
* (Civilian) AmericanFarmer01
* (Civilian) AsianFarmer01
* (Civilian) HomelessGuy
* (Civilian) AsianFarmer02
* (Civilian) AsianFarmer3
* (Civilian) GenericMale02
* (Civilian) GenericFemale02
* (Civilian) Partisan01
* (Civilian) Partisan02
* (Civilian) Partisan03

All infantry (except GLA Terrorist and CINE infantry) now have the same setup and will show burned, toxic and other special deaths properly.

The added setup already respects the modified LASERED setup of #2071.