### PR TITLE
Fix: GLA Terrorist explosion is no longer silent when not suicided

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2075_terrorist_death_explosion_sound_fix.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2075_terrorist_death_explosion_sound_fix.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-07-08
+
+title: Fixes silent death explosion of GLA Terrorists when not suicided
+
+changes:
+  - fix: The GLA Terrorists now also play their explosion sound when burned and exploded.
+  - fix: The GLA Terrorists now play a quieter explosion sound when crushed, splatted and lasered.
+
+labels:
+  - audio
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2075
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -3329,11 +3329,9 @@ FXList FX_GenericCarExplode
   End
 End
 
+; Patch104p @bugfix xezon 08/07/2023 Removes explosion sound effect and adds it to weapon effects, so it can be heard in all death conditions. (#2075)
 ; ----------------------------------------------
-FXList FX_TerroristExplode
-  Sound
-    Name = TerroristSuicides
-  End
+FXList FX_TerroristExplode ; Alias FX_TerroristSuicide
   ParticleSystem
     Name = Explosion
   End
@@ -4195,6 +4193,9 @@ End
 ; Patch104p @feature commy2 02/09/2022 Adds crush detonation effect to make it look different to suicide detonation effect. (#1082)
 ; ----------------------------------------------
 FXList WeaponFX_CrushedDynamitePackDetonation
+  Sound
+    Name = TerroristCrushed
+  End
   ParticleSystem
     Name = Explosion
   End
@@ -4207,8 +4208,12 @@ FXList WeaponFX_CrushedDynamitePackDetonation
   End
 End
 
+; Patch104p @bugfix xezon 08/07/2023 Adds sound effect here so it is bound to weapon. Was previously referenced in FX_TerroristExplode. (#2075)
 ; ----------------------------------------------
 FXList WeaponFX_SuicideDynamitePackDetonation
+  Sound
+    Name = TerroristSuicides
+  End
   ParticleSystem
     Name = CarpetBombExplosionShockwave
   End
@@ -4228,7 +4233,7 @@ FXList WeaponFX_SuicideDynamitePackDetonation
 End
 
 ; ----------------------------------------------
-FXList WeaponFX_SuicideDynamitePackDetonationPlusFire
+FXList WeaponFX_SuicideDynamitePackDetonationPlusFire ; unused
   Sound
     Name = TerroristSuicides
   End
@@ -9780,6 +9785,9 @@ End
 ; Patch104p @feature commy2 02/09/2022 Adds crush detonation effect to make it look different to suicide detonation effect. (#1082)
 ; ----------------------------------------------
 FXList WeaponFX_DemoCrushedDynamitePackDetonation
+  Sound
+    Name = TerroristCrushed
+  End
   ParticleSystem
     Name = DemoExplosionSmoke
   End
@@ -9796,8 +9804,12 @@ FXList WeaponFX_DemoCrushedDynamitePackDetonation
   End
 End
 
+; Patch104p @bugfix xezon 08/07/2023 Adds sound effect here so it is bound to weapon. Was previously referenced in FX_TerroristExplode. (#2075)
 ; ----------------------------------------------
 FXList WeaponFX_DemoSuicideDynamitePackDetonation
+  Sound
+    Name = TerroristSuicides
+  End
   ParticleSystem
     Name = RedDonuteCloud
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -1753,6 +1753,18 @@ AudioEvent TerroristSuicides
   Type = world shrouded everyone
 End
 
+; Patch104p @feature xezon 08/07/2023 Adds new sound variant for crushed terrorist death. Is quieter than regular one.
+AudioEvent TerroristCrushed
+  Sounds = gexpmina gexpminb
+  Control = random interrupt
+  VolumeShift = -10
+  PitchShift = -5  5
+  Volume = 55
+  Limit = 2
+  Priority = normal
+  Type = world shrouded everyone
+End
+
 AudioEvent ExplosionRocketBuggyMissile
   Sounds = gexpifva gexpifvb gexpifvc
   Control = random interrupt


### PR DESCRIPTION
With this change the GLA Terrorist explosion is no longer silent when not suicided. Affects burned, exploded, crushed, splatted and lasered death. The smaller crushed, splatted and lasered death explosion gets a quieter sound.

## Before, Original

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/eabf7c6f-31f5-4228-aea1-f5cbaebdf217
