### PR TITLE
Fix: Demo GLA Barracks no longer spawns Terrorist explosion effects on death

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2076_demo_barracks_death_effect.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2076_demo_barracks_death_effect.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-07-08
+
+title: Removes wrong exploded death effects from GLA Demo Barracks
+
+changes:
+  - fix: The GLA Demo Barracks no longer spawns death effects of the Terrorist on death by explosions.
+
+labels:
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2076
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -8822,6 +8822,7 @@ End
 
 ;------------------------------------------------------------------------------
 ;GLA Barracks
+; Patch104p @bugfix xezon 08/07/2023 Removes wrong exploded death behaviour that would spawn Terrorist death effects. (#2076)
 Object Demo_GLABarracks
 
   ; *** ART Parameters ***
@@ -9563,19 +9564,6 @@ Object Demo_GLABarracks
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
-  End
-
-  ;I have just pulled my ripcord, and this ain't no parachute!
-  Behavior = SlowDeathBehavior ModuleTag_Death17
-    DeathTypes          = NONE +SUICIDED +EXPLODED
-    SinkDelay           = 3000
-    SinkRate            = 0.5     ; in Dist/Sec
-    DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
   End
 
   Behavior = CommandSetUpgrade ModuleTag_18


### PR DESCRIPTION
With this change the Demo GLA Barracks no longer spawns Terrorist explosion effects on death. It would happen when the Barracks was exploded.