### PR TITLE
Fix: Remove obsolete Worker command sets from GLA Demo Barracks

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -8823,6 +8823,7 @@ End
 ;------------------------------------------------------------------------------
 ;GLA Barracks
 ; Patch104p @bugfix xezon 08/07/2023 Removes wrong exploded death behaviour that would spawn Terrorist death effects. (#2076)
+; Patch104p @fix xezon 09/07/2023 Removes obsolete Worker command sets. (#2078)
 Object Demo_GLABarracks
 
   ; *** ART Parameters ***
@@ -9564,18 +9565,6 @@ Object Demo_GLABarracks
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionSmallSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionSmallExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionSmallShockwave
-  End
-
-  Behavior = CommandSetUpgrade ModuleTag_18
-    TriggeredBy = Upgrade_GLAWorkerFakeCommandSet
-    RemovesUpgrades = Upgrade_GLAWorkerRealCommandSet
-    CommandSet = Demo_GLAWorkerFakeBuildingsCommandSet
-  End
-
-  Behavior = CommandSetUpgrade ModuleTag_19
-    TriggeredBy = Upgrade_GLAWorkerRealCommandSet
-    RemovesUpgrades = Upgrade_GLAWorkerFakeCommandSet Upgrade_GLAWorkerRealCommandSet
-    CommandSet = Demo_GLAWorkerCommandSet
   End
 
   Geometry            = BOX


### PR DESCRIPTION
This change removes the obsolete Worker command sets from the GLA Demo Barracks.