### PR TITLE
Fix: Set correct object strings for Partisan01, Partisan02

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8823,7 +8823,7 @@ Object Partisan01
     DamageFX        = None
   End
   VisionRange = 150
-  DisplayName = OBJECT:MogadishuFemaleCivilian
+  DisplayName = OBJECT:MogadishuMaleCivilian ; Patch104p @fix from MogadishuFemaleCivilian (#2080)
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
   ; *** AUDIO Parameters ***
@@ -8906,7 +8906,7 @@ Object Partisan02
     DamageFX        = None
   End
   VisionRange = 150
-  DisplayName = OBJECT:MogadishuFemaleCivilian
+  DisplayName = OBJECT:MogadishuMaleCivilian ; Patch104p @fix from MogadishuFemaleCivilian (#2080)
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
   ; *** AUDIO Parameters ***


### PR DESCRIPTION
This change sets the correct object string for Partisan01, Partisan02, because they look male. Only Partisan03 looks female. In game nothing changes, because the OBJECT:MogadishuMaleCivilian and OBJECT:MogadishuFemaleCivilian strings read the same.