### PR TITLE
Decrease damage dealt by GLA Terrorist when killed by USA Laser Crusader

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2067_laser_weapons_infantry_burn.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2067_laser_weapons_infantry_burn.yaml
@@ -4,9 +4,9 @@ date: 2023-07-08
 title: Enables Laser weapons to burn killed infantry units
 
 changes:
-  - tweak: The USA Laser Turret now burns infantry on kill. It does not change gameplay.
-  - tweak: The USA Laser Crusader now burns infantry on kill. The burned death now triggers the suicide explosion of the GLA Terrorist.
-  - tweak: The Point Defense Laser of the USA Paladin now burns infantry on kill. It does not change gameplay.
+  - tweak: The USA Laser Turret now burns infantry on kill. It still triggers the strong suicide explosion of the GLA Terrorist as per original design.
+  - tweak: The USA Laser Crusader now burns infantry on kill. It triggers the new weak crush explosion of the GLA Terrorist.
+  - tweak: The Point Defense Laser of the USA Paladin now burns infantry on kill. It triggers the new weak crush explosion of the GLA Terrorist.
 
 labels:
   - controversial
@@ -18,6 +18,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2067
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2071
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2081
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2081_laser_weapons_infantry_burn.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2081_laser_weapons_infantry_burn.txt
@@ -1,0 +1,1 @@
+2067_laser_weapons_infantry_burn.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -6745,7 +6745,7 @@ Weapon GC_Slth_QuadCannonSnipeGun
 End
 
 ;------------------------------------------------------------------------------
-; Patch104p @tweak xezon 08/07/2023 Changes DeathType from NORMAL to burn infantry on kill. (#2067)
+; Patch104p @tweak xezon 08/07/2023 Changes DeathType from NORMAL to burn infantry on kill. (#2067) (#2081)
 Weapon Lazr_CrusaderTankGun
   PrimaryDamage           = 80.0
   PrimaryDamageRadius     = 5.0
@@ -6754,7 +6754,7 @@ Weapon Lazr_CrusaderTankGun
   MinTargetPitch          = -15                         ; we may not target anything outside of this pitch range
   MaxTargetPitch          = 15                          ; ditto
   DamageType              = ARMOR_PIERCING
-  DeathType               = BURNED
+  DeathType               = LASERED
   WeaponSpeed             = 99999                           ; dist/sec
   WeaponRecoil            = 5                            ; angle to deflect the model when firing
   LaserName               = Lazr_CrusaderLaserBeam


### PR DESCRIPTION
* Follow up for #2067
* Follow up for #2071

This change decreases the damage dealt by the GLA Terrorist when killed by the USA Laser Crusader. It is now consistent with the USA Paladin laser death and is closer to the original behavior where no damage was taken when a Terrorist unit was killed by the tank lasers.

It takes at least 5 small Terrorist explosions to destroy the pristine Laser Crusader.

## Original

| Weapon                                | Affect on GLA Terrorist kill     |
|---------------------------------------|----------------------------------|
| Original USA Paladin laser            | No death explosion               |
| Original USA Laser Crusader           | No death explosion               |
| Original USA Laser Turret             | Strong suicide death explosion   |

## Patched

| Weapon                                | Affect on GLA Terrorist kill     |
|---------------------------------------|----------------------------------|
| Patched USA Paladin laser             | Weak crushed death explosion     |
| **Patched USA Laser Crusader (this)** | Weak crushed death explosion     |
| Patched USA Laser Turret              | Strong suicide death explosion   |