### PR TITLE
Fix: Add missing death modules to GLA Terrorists

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2074_infantry_death_module_fixes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2074_infantry_death_module_fixes.yaml
@@ -13,21 +13,18 @@ changes:
   - fix: Adds missing crushed, exploded death modules to GenericFemale01, AmericanFarmer01, AsianFarmer01, AsianFarmer02, AsianFarmer3.
   - fix: Adds missing crushed, exploded death modules to HomelessGuy.
   - fix: Adds missing crushed, exploded death modules to GenericMale02, GenericFemale02.
-  - fix: Sets correct poison death models for GC_Chem_GLAInfantryTerrorist, GC_Slth_GLAInfantryTerrorist.
 
 labels:
   - bug
   - china
   - civilian
   - design
-  - gla
   - minor
   - usa
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2074
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2085
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2231
 
 authors:

--- a/Patch104pZH/Design/Changes/v1.0/2084_terrorist_death_module_fixes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2084_terrorist_death_module_fixes.yaml
@@ -1,0 +1,24 @@
+---
+date: 2023-07-08
+
+title: Fixes death modules of GLA Terrorists
+
+changes:
+  - fix: GLA Terrorists now fling in air when exploded.
+  - fix: GLA Terrorists now burn when burned and lasered.
+  - fix: GLA Terrorists now play the crush death sound when crushed and splatted.
+  - fix: Sets correct poison death models for GC_Chem_GLAInfantryTerrorist, GC_Slth_GLAInfantryTerrorist.
+
+labels:
+  - bug
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2084
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2085
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2084_terrorist_death_module_fixes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2084_terrorist_death_module_fixes.yaml
@@ -4,14 +4,12 @@ date: 2023-07-08
 title: Fixes death modules of GLA Terrorists
 
 changes:
-  - fix: GLA Terrorists now fling in air when exploded.
-  - fix: GLA Terrorists now burn when burned and lasered.
+  - fix: GLA Terrorists now fling in air when burned and exploded.
   - fix: GLA Terrorists now play the crush death sound when crushed and splatted.
   - fix: Sets correct poison death models for GC_Chem_GLAInfantryTerrorist, GC_Slth_GLAInfantryTerrorist.
 
 labels:
   - bug
-  - design
   - gla
   - minor
   - v1.0

--- a/Patch104pZH/Design/Changes/v1.0/2085_terrorist_poison_death_models.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2085_terrorist_poison_death_models.txt
@@ -1,1 +1,1 @@
-2074_infantry_death_module_fixes.yaml
+2084_terrorist_death_module_fixes.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -14071,7 +14071,7 @@ Object Chem_GLAInfantryTerrorist
 
 ; --- begin Death modules --- Chem_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14086,13 +14086,13 @@ Object Chem_GLAInfantryTerrorist
     DestructionDelay    = 8000
     FX                  = INITIAL FX_GIDieCrushed
   End
-  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
-  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
+  ; Flaming infantry is disabled, because the Barrel in the German version is no human.
+  ;Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+  ;  DeathTypes          = NONE +BURNED +LASERED
+  ;  DestructionDelay    = 0
+  ;  FX                  = INITIAL FX_DieByFireGLA
+  ;  OCL                 = INITIAL OCL_FlamingInfantry
+  ;End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
     Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -14118,9 +14118,9 @@ Object Chem_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
+  ; Patch104p @fix xezon 09/07/2023 Adds BURNED, EXPLODED death types. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14130,7 +14130,7 @@ Object Chem_GLAInfantryTerrorist
     FlingPitch          = 60
     FlingPitchVariance  = 10
   End
-  
+
   ; Patch104p @bugfix xezon 16/07/2022 Paste death types from other Terrorists to avoid Toxin Terrorists exploding by all kinds of deaths.
   ; Patch104p @bugfix hanfield 27/07/2022 Exempt MASKED status to postpone death explosion until after passenger exit, if ever.
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -14069,15 +14069,30 @@ Object Chem_GLAInfantryTerrorist
     ;nothing
   End
 
-; --- begin Death modules ---
+; --- begin Death modules --- Chem_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL  -SUICIDED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
     FX                  = INITIAL FX_TerroristDie
   End
 
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_CrushedDeath
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
     Behavior = SlowDeathBehavior ModuleTag_Death05
@@ -14103,8 +14118,9 @@ Object Chem_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
+  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+    DeathTypes          = NONE +SUICIDED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14544,7 +14544,7 @@ Object Demo_GLAInfantryTerrorist
 
 ; --- begin Death modules --- Demo_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -14559,13 +14559,13 @@ Object Demo_GLAInfantryTerrorist
     DestructionDelay    = 8000
     FX                  = INITIAL FX_GIDieCrushed
   End
-  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
-  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
+  ; Flaming infantry is disabled, because the Barrel in the German version is no human.
+  ;Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+  ;  DeathTypes          = NONE +BURNED +LASERED
+  ;  DestructionDelay    = 0
+  ;  FX                  = INITIAL FX_DieByFireGLA
+  ;  OCL                 = INITIAL OCL_FlamingInfantry
+  ;End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -14590,9 +14590,9 @@ Object Demo_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
+  ; Patch104p @fix xezon 09/07/2023 Adds BURNED, EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death07
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14542,15 +14542,30 @@ Object Demo_GLAInfantryTerrorist
     ;nothing
   End
 
-; --- begin Death modules ---
+; --- begin Death modules --- Demo_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL  -SUICIDED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
     FX                  = INITIAL FX_TerroristDie
   End
 
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_CrushedDeath
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -14575,8 +14590,9 @@ Object Demo_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
+  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death07
-    DeathTypes          = NONE +SUICIDED
+    DeathTypes          = NONE +SUICIDED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -4112,15 +4112,30 @@ Object GC_Chem_GLAInfantryTerrorist
     ;nothing
   End
 
-; --- begin Death modules ---
+; --- begin Death modules --- GC_Chem_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL  -SUICIDED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
     FX                  = INITIAL FX_TerroristDie
   End
 
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_CrushedDeath
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -4146,8 +4161,9 @@ Object GC_Chem_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
+  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+    DeathTypes          = NONE +SUICIDED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -4114,7 +4114,7 @@ Object GC_Chem_GLAInfantryTerrorist
 
 ; --- begin Death modules --- GC_Chem_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -4129,13 +4129,13 @@ Object GC_Chem_GLAInfantryTerrorist
     DestructionDelay    = 8000
     FX                  = INITIAL FX_GIDieCrushed
   End
-  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
-  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
+  ; Flaming infantry is disabled, because the Barrel in the German version is no human.
+  ;Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+  ;  DeathTypes          = NONE +BURNED +LASERED
+  ;  DestructionDelay    = 0
+  ;  FX                  = INITIAL FX_DieByFireGLA
+  ;  OCL                 = INITIAL OCL_FlamingInfantry
+  ;End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -4161,9 +4161,9 @@ Object GC_Chem_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
+  ; Patch104p @fix xezon 09/07/2023 Adds BURNED, EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2405,7 +2405,7 @@ Object GC_Slth_GLAInfantryTerrorist
 
 ; --- begin Death modules --- GC_Slth_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -2420,13 +2420,13 @@ Object GC_Slth_GLAInfantryTerrorist
     DestructionDelay    = 8000
     FX                  = INITIAL FX_GIDieCrushed
   End
-  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
-  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
+  ; Flaming infantry is disabled, because the Barrel in the German version is no human.
+  ;Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+  ;  DeathTypes          = NONE +BURNED +LASERED
+  ;  DestructionDelay    = 0
+  ;  FX                  = INITIAL FX_DieByFireGLA
+  ;  OCL                 = INITIAL OCL_FlamingInfantry
+  ;End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -2452,9 +2452,9 @@ Object GC_Slth_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
+  ; Patch104p @fix xezon 09/07/2023 Adds BURNED, EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2403,15 +2403,30 @@ Object GC_Slth_GLAInfantryTerrorist
     ;nothing
   End
 
-; --- begin Death modules ---
+; --- begin Death modules --- GC_Slth_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL  -SUICIDED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
     FX                  = INITIAL FX_TerroristDie
   End
 
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_CrushedDeath
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -2437,8 +2452,9 @@ Object GC_Slth_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
+  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+    DeathTypes          = NONE +SUICIDED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1531,7 +1531,7 @@ Object GLAInfantryTerrorist
 
 ; --- begin Death modules --- GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -1546,13 +1546,13 @@ Object GLAInfantryTerrorist
     DestructionDelay    = 8000
     FX                  = INITIAL FX_GIDieCrushed
   End
-  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
-  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
+  ; Flaming infantry is disabled, because the Barrel in the German version is no human.
+  ;Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+  ;  DeathTypes          = NONE +BURNED +LASERED
+  ;  DestructionDelay    = 0
+  ;  FX                  = INITIAL FX_DieByFireGLA
+  ;  OCL                 = INITIAL OCL_FlamingInfantry
+  ;End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -1578,9 +1578,9 @@ Object GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
+  ; Patch104p @fix xezon 09/07/2023 Adds BURNED, EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1529,15 +1529,30 @@ Object GLAInfantryTerrorist
     ;nothing
   End
 
-; --- begin Death modules ---
+; --- begin Death modules --- GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL  -SUICIDED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
     FX                  = INITIAL FX_TerroristDie
   End
 
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_CrushedDeath
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -1563,8 +1578,9 @@ Object GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
+  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+    DeathTypes          = NONE +SUICIDED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -15086,15 +15086,30 @@ Object Slth_GLAInfantryTerrorist
     ;nothing
   End
 
-; --- begin Death modules ---
+; --- begin Death modules --- Slth_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL  -SUICIDED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
     FX                  = INITIAL FX_TerroristDie
   End
 
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_CrushedDeath
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
+  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireGLA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -15119,8 +15134,9 @@ Object Slth_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
+  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED
+    DeathTypes          = NONE +SUICIDED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -15088,7 +15088,7 @@ Object Slth_GLAInfantryTerrorist
 
 ; --- begin Death modules --- Slth_GLAInfantryTerrorist
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -LASERED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -BURNED -SUICIDED -EXPLODED -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -15103,13 +15103,13 @@ Object Slth_GLAInfantryTerrorist
     DestructionDelay    = 8000
     FX                  = INITIAL FX_GIDieCrushed
   End
-  ; Patch104p @fix xezon 09/07/2023 Adds specialized death module. (#2084)
-  Behavior = SlowDeathBehavior DeathTag_BurnedDeath
-    DeathTypes          = NONE +BURNED +LASERED
-    DestructionDelay    = 0
-    FX                  = INITIAL FX_DieByFireGLA
-    OCL                 = INITIAL OCL_FlamingInfantry
-  End
+  ; Flaming infantry is disabled, because the Barrel in the German version is no human.
+  ;Behavior = SlowDeathBehavior DeathTag_BurnedDeath
+  ;  DeathTypes          = NONE +BURNED +LASERED
+  ;  DestructionDelay    = 0
+  ;  FX                  = INITIAL FX_DieByFireGLA
+  ;  OCL                 = INITIAL OCL_FlamingInfantry
+  ;End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS
   Behavior = SlowDeathBehavior ModuleTag_Death02
@@ -15134,9 +15134,9 @@ Object Slth_GLAInfantryTerrorist
 
 
   ; I have just pulled my ripcord, and this ain't no parachute!
-  ; Patch104p @fix xezon 09/07/2023 Adds EXPLODED death type. (#2084)
+  ; Patch104p @fix xezon 09/07/2023 Adds BURNED, EXPLODED death type. (#2084)
   Behavior = SlowDeathBehavior ModuleTag_Death03
-    DeathTypes          = NONE +SUICIDED +EXPLODED
+    DeathTypes          = NONE +SUICIDED +BURNED +EXPLODED
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000


### PR DESCRIPTION
This change adds the missing death modules to GLA Terrorists. They now behave identical to other infantry units. The gameplay is unchanged.

* ~~Terrorists burn when burned and lasered~~
* Terrorists fling in air when burned and exploded
* Terrorists play crush sound when crushed and splatted

## Patched

Burned death is no longer representative.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/ba8094fc-864f-497e-83c8-41942cdec8ef