### PR TITLE
Fix: Use correct model for poison deaths of GC Terrorists

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2074_infantry_death_module_fixes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2074_infantry_death_module_fixes.yaml
@@ -13,18 +13,21 @@ changes:
   - fix: Adds missing crushed, exploded death modules to GenericFemale01, AmericanFarmer01, AsianFarmer01, AsianFarmer02, AsianFarmer3.
   - fix: Adds missing crushed, exploded death modules to HomelessGuy.
   - fix: Adds missing crushed, exploded death modules to GenericMale02, GenericFemale02.
+  - fix: Sets correct poison death models for GC_Chem_GLAInfantryTerrorist, GC_Slth_GLAInfantryTerrorist.
 
 labels:
   - bug
   - china
   - civilian
   - design
+  - gla
   - minor
   - usa
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2074
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2085
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2231
 
 authors:

--- a/Patch104pZH/Design/Changes/v1.0/2085_terrorist_poison_death_models.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2085_terrorist_poison_death_models.txt
@@ -1,0 +1,1 @@
+2074_infantry_death_module_fixes.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -4127,19 +4127,19 @@ Object GC_Chem_GLAInfantryTerrorist
     DeathTypes          = NONE +POISONED
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantry
+    OCL                 = INITIAL OCL_ToxicInfantry_TerroristOnly ; Patch104p @fix from OCL_ToxicInfantry (#2085)
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06 ; don't forget to give it a new, unique module tag
     DeathTypes          = NONE +POISONED_BETA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantryBeta ;you'll have to create this OCL and make it use the blue guys instead of green ones
+    OCL                 = INITIAL OCL_ToxicInfantryBeta_TerroristOnly ; Patch104p @fix from OCL_ToxicInfantryBeta (#2085)
   End
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantryGamma
+    OCL                 = INITIAL OCL_ToxicInfantryGamma_TerroristOnly ; Patch104p @fix from OCL_ToxicInfantryGamma (#2085)
   End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2418,19 +2418,19 @@ Object GC_Slth_GLAInfantryTerrorist
     DeathTypes          = NONE +POISONED
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantry
+    OCL                 = INITIAL OCL_ToxicInfantry_TerroristOnly ; Patch104p @fix from OCL_ToxicInfantry (#2085)
   End
   Behavior = SlowDeathBehavior ModuleTag_Death06 ; don't forget to give it a new, unique module tag
     DeathTypes          = NONE +POISONED_BETA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantryBeta ;you'll have to create this OCL and make it use the blue guys instead of green ones
+    OCL                 = INITIAL OCL_ToxicInfantryBeta_TerroristOnly ; Patch104p @fix from OCL_ToxicInfantryBeta (#2085)
   End
   Behavior = SlowDeathBehavior ModuleTag_Death07
     DeathTypes          = NONE +POISONED_GAMMA
     DestructionDelay    = 0
     FX                  = INITIAL FX_DieByToxinGLA
-    OCL                 = INITIAL OCL_ToxicInfantryGamma
+    OCL                 = INITIAL OCL_ToxicInfantryGamma_TerroristOnly ; Patch104p @fix from OCL_ToxicInfantryGamma (#2085)
   End
 
   ;POISON_DEATHS POISON_DEATHS POISON_DEATHS POISON_DEATHS


### PR DESCRIPTION
This changes adds correct model for poison deaths of GC Terrorists. For the GC Chemical Terrorist it makes no difference however, because it takes no poison damage.

![shot_20230709_112031_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/5b56b0e2-4576-4fc0-b59c-6b3218114622)
