### PR TITLE
Fix: Add name variants to GLA Stealth infantry units

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2086_stealth_infantry_unit_names.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2086_stealth_infantry_unit_names.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-07-09
 
-title: Adds specialized names for GLA Stealth infantry unit variants in all languages
+title: Adds name variants to GLA Stealth infantry units for all languages
 
 changes:
   - fix: All GLA Stealth infantry unit variants now have their own unique names in all languages.
@@ -17,7 +17,6 @@ subchanges:
 labels:
   - gla
   - minor
-  - optional
   - text
   - v1.0
 

--- a/Patch104pZH/Design/Changes/v1.0/2086_stealth_infantry_unit_names.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2086_stealth_infantry_unit_names.yaml
@@ -1,0 +1,28 @@
+---
+date: 2023-07-09
+
+title: Adds specialized names for GLA Stealth infantry unit variants in all languages
+
+changes:
+  - fix: All GLA Stealth infantry unit variants now have their own unique names in all languages.
+
+subchanges:
+  - fix: The GLA Stealth Rebel is now called "Stealth Rebel".
+  - fix: The GLA Stealth Hijacker is now called "Stealth Hijacker".
+  - fix: The GLA Stealth (Campaign) Tunnel Defender is now called "Stealth RPG Trooper".
+  - fix: The GLA Stealth (Campaign) Rebel is now called "Stealth Rebel".
+  - fix: The GLA Stealth (Campaign) Terrorist is now called "Stealth Terrorist".
+  - fix: The GLA Stealth (Campaign) Hijacker is now called "Stealth Hijacker".
+
+labels:
+  - gla
+  - minor
+  - optional
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2086
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -4735,16 +4735,10 @@ CommandButton GC_Slth_Command_ConstructGLAWorker
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildWorker
 End
 
-; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryRPGTrooper
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryTunnelDefender
-;patch104p-core-begin
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryRPGTrooper
-;patch104p-core-end
-;patch104p-optional-begin
-  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryRPGTrooper
-;patch104p-optional-end
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryRPGTrooper ; Patch104p @tweak from CONTROLBAR:ConstructGLAInfantryRPGTrooper. (#2086)
   ButtonImage   = SURPG
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRPGTrooper
@@ -4768,46 +4762,28 @@ CommandButton GC_Slth_Command_ConstructGLAInfantrySniper
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildSniper
 End
 
-; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryTerrorist
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryTerrorist
-;patch104p-core-begin
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryTerrorist
-;patch104p-core-end
-;patch104p-optional-begin
-  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryTerrorist
-;patch104p-optional-end
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryTerrorist ; Patch104p @tweak from CONTROLBAR:ConstructGLAInfantryTerrorist. (#2086)
   ButtonImage   = SUTerrorist
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildTerrorist
 End
 
-; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryRebel
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryRebel
-;patch104p-core-begin
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryRebel
-;patch104p-core-end
-;patch104p-optional-begin
-  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryRebel
-;patch104p-optional-end
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryRebel ; Patch104p @fix from CONTROLBAR:ConstructGLAInfantryRebel. (#2086)
   ButtonImage   = SURebel
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRebel
 End
 
-; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryHijacker
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryHijacker
-;patch104p-core-begin
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryHijacker
-;patch104p-core-end
-;patch104p-optional-begin
-  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryHijacker
-;patch104p-optional-end
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryHijacker ; Patch104p @tweak from CONTROLBAR:ConstructGLAInfantryHijacker. (#2086)
   ButtonImage   = SUHijacker
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildHijacker
@@ -5942,16 +5918,10 @@ CommandButton Slth_Command_ConstructGLADemoTrap
   DescriptLabel           = CONTROLBAR:ToolTipGLABUildDemoTrap
 End
 
-; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton Slth_Command_ConstructGLAInfantryHijacker
   Command       = UNIT_BUILD
   Object        = Slth_GLAInfantryHijacker
-;patch104p-core-begin
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryHijacker
-;patch104p-core-end
-;patch104p-optional-begin
-  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryHijacker
-;patch104p-optional-end
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryHijacker ; Patch104p @tweak from CONTROLBAR:ConstructGLAInfantryHijacker. (#2086)
   ButtonImage   = SUHijacker
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildHijacker

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -4735,10 +4735,16 @@ CommandButton GC_Slth_Command_ConstructGLAWorker
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildWorker
 End
 
+; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryRPGTrooper
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryTunnelDefender
+;patch104p-core-begin
   TextLabel     = CONTROLBAR:ConstructGLAInfantryRPGTrooper
+;patch104p-core-end
+;patch104p-optional-begin
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryRPGTrooper
+;patch104p-optional-end
   ButtonImage   = SURPG
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRPGTrooper
@@ -4762,28 +4768,46 @@ CommandButton GC_Slth_Command_ConstructGLAInfantrySniper
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildSniper
 End
 
+; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryTerrorist
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryTerrorist
+;patch104p-core-begin
   TextLabel     = CONTROLBAR:ConstructGLAInfantryTerrorist
+;patch104p-core-end
+;patch104p-optional-begin
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryTerrorist
+;patch104p-optional-end
   ButtonImage   = SUTerrorist
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildTerrorist
 End
 
+; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryRebel
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryRebel
+;patch104p-core-begin
   TextLabel     = CONTROLBAR:ConstructGLAInfantryRebel
+;patch104p-core-end
+;patch104p-optional-begin
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryRebel
+;patch104p-optional-end
   ButtonImage   = SURebel
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRebel
 End
 
+; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton GC_Slth_Command_ConstructGLAInfantryHijacker
   Command       = UNIT_BUILD
   Object        = GC_Slth_GLAInfantryHijacker
+;patch104p-core-begin
   TextLabel     = CONTROLBAR:ConstructGLAInfantryHijacker
+;patch104p-core-end
+;patch104p-optional-begin
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryHijacker
+;patch104p-optional-end
   ButtonImage   = SUHijacker
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildHijacker
@@ -5918,10 +5942,16 @@ CommandButton Slth_Command_ConstructGLADemoTrap
   DescriptLabel           = CONTROLBAR:ToolTipGLABUildDemoTrap
 End
 
+; Patch104p @fix xezon 09/07/2023 Optionally specializes the text label for this stealth unit variant. (#2086)
 CommandButton Slth_Command_ConstructGLAInfantryHijacker
   Command       = UNIT_BUILD
   Object        = Slth_GLAInfantryHijacker
+;patch104p-core-begin
   TextLabel     = CONTROLBAR:ConstructGLAInfantryHijacker
+;patch104p-core-end
+;patch104p-optional-begin
+  TextLabel     = CONTROLBAR:Slth_ConstructGLAInfantryHijacker
+;patch104p-optional-end
   ButtonImage   = SUHijacker
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildHijacker

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -843,7 +843,7 @@ Object GC_Slth_GLAInfantryTunnelDefender
   End
 
   ; ***DESIGN parameters ***
-  DisplayName = OBJECT:Slth_TunnelDefender ; Patch104p @fix from OBJECT:TunnelDefender
+  DisplayName = OBJECT:Slth_TunnelDefender ; Patch104p @tweak from OBJECT:TunnelDefender (#2086)
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -1987,7 +1987,7 @@ Object GC_Slth_GLAInfantryRebel
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Slth_Rebel ; Patch104p @fix from OBJECT:Rebel
+  DisplayName         = OBJECT:Slth_Rebel ; Patch104p @fix from OBJECT:Rebel (#2086)
   Side                = GLAStealthGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -2333,7 +2333,7 @@ Object GC_Slth_GLAInfantryTerrorist
   End
 
   ; ***DESIGN parameters ***
-  DisplayName = OBJECT:Slth_Terrorist ; Patch104p @fix from OBJECT:Terrorist
+  DisplayName = OBJECT:Slth_Terrorist ; Patch104p @tweak from OBJECT:Terrorist (#2086)
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -2607,7 +2607,7 @@ Object GC_Slth_GLAInfantryHijacker
   End
 
   ; ***DESIGN parameters ***
-  DisplayName = OBJECT:Slth_Hijacker ; Patch104p @fix from OBJECT:Hijacker
+  DisplayName = OBJECT:Slth_Hijacker ; Patch104p @tweak from OBJECT:Hijacker (#2086)
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -843,7 +843,7 @@ Object GC_Slth_GLAInfantryTunnelDefender
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:TunnelDefender
+  DisplayName = OBJECT:Slth_TunnelDefender ; Patch104p @fix from OBJECT:TunnelDefender
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -1987,7 +1987,7 @@ Object GC_Slth_GLAInfantryRebel
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Rebel
+  DisplayName         = OBJECT:Slth_Rebel ; Patch104p @fix from OBJECT:Rebel
   Side                = GLAStealthGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -2333,7 +2333,7 @@ Object GC_Slth_GLAInfantryTerrorist
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Terrorist
+  DisplayName = OBJECT:Slth_Terrorist ; Patch104p @fix from OBJECT:Terrorist
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -2607,7 +2607,7 @@ Object GC_Slth_GLAInfantryHijacker
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Hijacker
+  DisplayName = OBJECT:Slth_Hijacker ; Patch104p @fix from OBJECT:Hijacker
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13733,7 +13733,7 @@ Object Slth_GLAInfantryRebel
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Slth_Rebel ; Patch104p @fix from OBJECT:Rebel
+  DisplayName         = OBJECT:Slth_Rebel ; Patch104p @fix from OBJECT:Rebel (#2086)
   Side                = GLAStealthGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -17025,7 +17025,7 @@ Object Slth_GLAInfantryHijacker
   End
 
   ; ***DESIGN parameters ***
-  DisplayName = OBJECT:Slth_Hijacker ; Patch104p @fix from OBJECT:Hijacker
+  DisplayName = OBJECT:Slth_Hijacker ; Patch104p @tweak from OBJECT:Hijacker (#2086)
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13733,7 +13733,7 @@ Object Slth_GLAInfantryRebel
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Rebel
+  DisplayName         = OBJECT:Slth_Rebel ; Patch104p @fix from OBJECT:Rebel
   Side                = GLAStealthGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -17025,7 +17025,7 @@ Object Slth_GLAInfantryHijacker
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Hijacker
+  DisplayName = OBJECT:Slth_Hijacker ; Patch104p @fix from OBJECT:Hijacker
   Side = GLAStealthGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)

--- a/Patch104pZH/ModBundleItems.json
+++ b/Patch104pZH/ModBundleItems.json
@@ -375,7 +375,6 @@
                     {
                         "parent": "GameFilesEdited",
                         "sourceList": [
-                            "Data/INI/CommandButton.ini",
                             "Data/INI/CommandSet.ini",
                             "Data/INI/Voice.ini"
                         ],

--- a/Patch104pZH/ModBundleItems.json
+++ b/Patch104pZH/ModBundleItems.json
@@ -375,6 +375,7 @@
                     {
                         "parent": "GameFilesEdited",
                         "sourceList": [
+                            "Data/INI/CommandButton.ini",
                             "Data/INI/CommandSet.ini",
                             "Data/INI/Voice.ini"
                         ],


### PR DESCRIPTION
This change adds specialized text for stealth GLA infantry units. This way the stealth behavior difference is reflected in the unit text.

~~Demo_GLAInfantrySaboteur is now "Stealth Saboteur"~~
GC_Slth_GLAInfantryTunnelDefender "Stealth RPG Trooper"
~~GC_Slth_GLAInfantrySniper is now "Stealth Sniper"~~
GC_Slth_GLAInfantryRebel is now "Stealth Rebel"
GC_Slth_GLAInfantryTerrorist is now "Stealth Terrorist"
GC_Slth_GLAInfantryHijacker is now "Stealth Hijacker"
~~GLAInfantrySaboteur is now "Stealth Saboteur"~~
Slth_GLAInfantryRebel  is now "Stealth Rebel"
Slth_GLAInfantryHijacker is now "Stealth Hijacker"
~~Slth_GLAInfantrySaboteur is now "Stealth Saboteur"~~

This fix is demoted to Optional bundle. It is not clear why. See comments below.