### PR TITLE
Fix: Add specialized names for GLA Demolition infantry unit variants

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5033,7 +5033,7 @@ End
 CommandButton Demo_Command_ConstructGLAInfantryRebel
   Command       = UNIT_BUILD
   Object        = Demo_GLAInfantryRebel
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryRebel
+  TextLabel     = CONTROLBAR:Demo_ConstructGLAInfantryRebel ; Patch104p @fix from CONTROLBAR:ConstructGLAInfantryRebel
   ButtonImage   = SURebel
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRebel
@@ -5051,7 +5051,7 @@ End
 CommandButton Demo_Command_ConstructGLAInfantryRPGTrooper
   Command       = UNIT_BUILD
   Object        = Demo_GLAInfantryTunnelDefender
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryRPGTrooper
+  TextLabel     = CONTROLBAR:Demo_ConstructGLAInfantryRPGTrooper ; Patch104p @fix from CONTROLBAR:ConstructGLAInfantryRPGTrooper
   ButtonImage   = SURPG
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRPGTrooper
@@ -5060,7 +5060,7 @@ End
 CommandButton Demo_Command_ConstructGLAInfantryTerrorist
   Command       = UNIT_BUILD
   Object        = Demo_GLAInfantryTerrorist
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryTerrorist
+  TextLabel     = CONTROLBAR:Demo_ConstructGLAInfantryTerrorist ; Patch104p @fix from CONTROLBAR:ConstructGLAInfantryTerrorist
   ButtonImage   = SUTerrorist
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildTerrorist
@@ -5078,7 +5078,7 @@ End
 CommandButton Demo_Command_ConstructGLAInfantryJarmenKell
   Command       = UNIT_BUILD
   Object        = Demo_GLAInfantryJarmenKell
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryJarmenKell
+  TextLabel     = CONTROLBAR:Demo_ConstructGLAInfantryJarmenKell ; Patch104p @fix from CONTROLBAR:ConstructGLAInfantryJarmenKell
   ButtonImage   = SUJermanKell1    ;NOTE: Asset spelling mistake
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildJarmenKell

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -12878,7 +12878,7 @@ Object Demo_GLAInfantryRebel
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Rebel
+  DisplayName         = OBJECT:Demo_Rebel ; Patch104p @fix from OBJECT:Rebel
   Side                = GLADemolitionGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -13338,7 +13338,7 @@ Object Demo_GLAInfantryJarmenKell
   End
 
   ; ***DESIGN parameters ***
-  DisplayName           = OBJECT:JarmenKell
+  DisplayName           = OBJECT:Demo_JarmenKell ; Patch104p @fix from OBJECT:JarmenKell
   Side                  = GLADemolitionGeneral
   EditorSorting         = INFANTRY
   TransportSlotCount    = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -13712,7 +13712,7 @@ Object Demo_GLAInfantryTunnelDefender
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:TunnelDefender
+  DisplayName = OBJECT:Demo_TunnelDefender ; Patch104p @fix from OBJECT:TunnelDefender
   Side = GLADemolitionGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)
@@ -14288,7 +14288,7 @@ Object Demo_GLAInfantryTerrorist
   End
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:Terrorist
+  DisplayName = OBJECT:Demo_Terrorist ; Patch104p @fix from OBJECT:Terrorist
   Side = GLADemolitionGeneral
   EditorSorting = INFANTRY
   TransportSlotCount = 1                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
This change adds specialized text for demolition GLA infantry units. This way the demolition ability differences are reflected in the unit text.

Demo_GLAInfantryRebel is now "Demolition Rebel"
Demo_GLAInfantryJarmenKell is now "Demolition Jarmen Kell"
Demo_GLAInfantryTunnelDefender is now "Demolition RPG Trooper"
Demo_GLAInfantryTerrorist is now "Demolition Terrorist"