### PR TITLE
Fix: Add missing Assault Troop Transport, Attack Outpost and Assault Helix name specializations to German localization

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2088_german_infa_transports_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2088_german_infa_transports_text.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-07-09
+
+title: Adds missing Assault Troop Transport, Attack Outpost and Assault Helix name specializations to German localization
+
+changes:
+  - fix: The China Infantry "Truppentransporter" is now called "Sturm-Truppentransporter".
+  - fix: The China Infantry "Horchposten" is now called "Angriffs-Horchposten".
+  - fix: The China Infantry "Helix" is now called "Sturm-Helix".
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2088
+
+authors:
+  - xezon


### PR DESCRIPTION
This change adds the missing Assault Helix, Assault Outpost and Assault Troopcrawler name specializations for German language.