### PR TITLE
Fix: Removes unnecessary line breaks in object labels of German and French localizations

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2089_german_french_object_name_line_breaks.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2089_german_french_object_name_line_breaks.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-07-09
+
+title: Removes unnecessary line breaks in object labels of German and French localizations
+
+changes:
+  - fix: Removes unnecessary line breaks in 6 object labels of German and French localizations. All object labels are now setup consistently.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2089
+
+authors:
+  - xezon


### PR DESCRIPTION
This change removes unnecessary line breaks in German and French object labels. I reviewed all OBJECT labels and these are the only ones I found. 5 in DE, 1 in FR.