### PR TITLE
Fix: Key conflict of Satellite Hack I & II with STOP (S)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2092_satellite_hack_i_ii_key_conflict.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2092_satellite_hack_i_ii_key_conflict.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-07-12
+
+title: Fixes key conflict of China Satellite Hack I and II with STOP (E)
+
+changes:
+  - fix: The China Satellite Hack I and II upgrades in the Internet Center can now be purchased and selected with key A and no longer conflict with STOP (S). Affects all languages.
+
+labels:
+  - bug
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2106
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2106_neutron_shells_key_conflict.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2106_neutron_shells_key_conflict.yaml
@@ -4,7 +4,7 @@ date: 2023-07-12
 title: Fixes key conflict of China Neutron Shells warhead with SELECT_MATCHING_UNITS (E)
 
 changes:
-  - fix: The China Neutron Shells warhead of the Nuke Cannon can now be selected with A key and no longer conflicts with SELECT_MATCHING_UNITS (E). Affects all languages.
+  - fix: The China Neutron Shells warhead of the Nuke Cannon can now be selected with key A and no longer conflicts with SELECT_MATCHING_UNITS (E). Affects all languages.
 
 labels:
   - bug


### PR DESCRIPTION
* Relates to TheSuperHackers/GeneralsGameCode#136
* Relates to TheSuperHackers/GeneralsGamePatch#2091

This change fixes the key conflict of Satellite Hack I & II with Stop on China Internet Center.

The new button mapping is A instead of S.