### PR TITLE
Change: Move Stop button of USA Strategy Center to common position

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2094_strategy_center_stop_button_placement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2094_strategy_center_stop_button_placement.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-07-10
+
+title: Swaps position of Stop and Supply Lines buttons in command set of USA Strategy Center
+
+changes:
+  - tweak: The Stop button is now positioned at its regular place in the command set of the USA Strategy Center.
+
+labels:
+  - design
+  - gui
+  - minor
+  - optional
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2094
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -940,6 +940,7 @@ CommandSet AmericaPowerPlantCommandSet
  14 = Command_Sell
 End
 
+; Patch104p @tweak xezon 10/07/2023 Optionally swaps Stop and SupplyLines buttons to put Stop into its common place. (#2094)
 CommandSet AmericaStrategyCenterCommandSet
   1 = Command_InitiateBattlePlanBombardment
   2 = Command_CIAIntelligence
@@ -951,8 +952,14 @@ CommandSet AmericaStrategyCenterCommandSet
   8 = Command_UpgradeAmericaCompositeArmor
   9 = Command_UpgradeAmericaAdvancedTraining
  10 = Command_UpgradeAmericaDroneArmor
+;patch104p-core-begin
  11 = Command_StrategyCenter_Stop
  13 = Command_UpgradeAmericaSupplyLines
+;patch104p-core-end
+;patch104p-optional-begin
+ 11 = Command_UpgradeAmericaSupplyLines
+ 13 = Command_StrategyCenter_Stop
+;patch104p-optional-end
  14 = Command_Sell
 End
 
@@ -2060,6 +2067,7 @@ CommandSet AirF_AmericaPowerPlantCommandSet
  14 = Command_Sell
 End
 
+; Patch104p @tweak xezon 10/07/2023 Optionally swaps Stop and SupplyLines buttons to put Stop into its common place. (#2094)
 CommandSet AirF_AmericaStrategyCenterCommandSet
   1 = Command_InitiateBattlePlanBombardment
   2 = Command_CIAIntelligence
@@ -2071,9 +2079,16 @@ CommandSet AirF_AmericaStrategyCenterCommandSet
 ; 8 = Command_UpgradeAmericaCompositeArmor
   9 = Command_UpgradeAmericaAdvancedTraining
  10 = Command_UpgradeAmericaDroneArmor
+;patch104p-core-begin
  11 = Command_StrategyCenter_Stop
  12 = AirF_Command_CarpetBomb
  13 = Command_UpgradeAmericaSupplyLines
+;patch104p-core-end
+;patch104p-optional-begin
+ 11 = Command_UpgradeAmericaSupplyLines
+ 12 = AirF_Command_CarpetBomb
+ 13 = Command_StrategyCenter_Stop
+;patch104p-optional-end
  14 = Command_Sell
 End
 
@@ -4015,6 +4030,7 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   14 = Command_Sell
 End
 
+; Patch104p @tweak xezon 10/07/2023 Optionally swaps Stop and SupplyLines buttons to put Stop into its common place. (#2094)
 CommandSet SupW_AmericaStrategyCenterCommandSet
   1 = Command_InitiateBattlePlanBombardment
   2 = Command_CIAIntelligence
@@ -4026,8 +4042,14 @@ CommandSet SupW_AmericaStrategyCenterCommandSet
 ; 8 = Command_UpgradeAmericaCompositeArmor
   9 = Command_UpgradeAmericaAdvancedTraining
  10 = Command_UpgradeAmericaDroneArmor
+;patch104p-core-begin
  11 = Command_StrategyCenter_Stop
  13 = Command_UpgradeAmericaSupplyLines
+;patch104p-core-end
+;patch104p-optional-begin
+ 11 = Command_UpgradeAmericaSupplyLines
+ 13 = Command_StrategyCenter_Stop
+;patch104p-optional-end
  14 = Command_Sell
 End
 
@@ -4898,6 +4920,7 @@ End
 ; 14  = Command_Sell
 ;End
 
+; Patch104p @tweak xezon 10/07/2023 Optionally swaps Stop and SupplyLines buttons to put Stop into its common place. (#2094)
 CommandSet Lazr_AmericaStrategyCenterCommandSet
   1 = Command_InitiateBattlePlanBombardment
   2 = Command_CIAIntelligence
@@ -4909,8 +4932,14 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
   8 = Command_UpgradeAmericaCompositeArmor
   9 = Command_UpgradeAmericaAdvancedTraining
  10 = Command_UpgradeAmericaDroneArmor
+;patch104p-core-begin
  11 = Command_StrategyCenter_Stop
  13 = Command_UpgradeAmericaSupplyLines
+;patch104p-core-end
+;patch104p-optional-begin
+ 11 = Command_UpgradeAmericaSupplyLines
+ 13 = Command_StrategyCenter_Stop
+;patch104p-optional-end
  14 = Command_Sell
 End
 


### PR DESCRIPTION
This change moves the Stop button of the USA Strategy Center to the common position. Optional, to not confuse legacy players.

## Original

![shot_20230710_163050_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/37f4d327-a829-4cc6-b80b-fe119343558c)

## Patched

![shot_20230710_174112_3](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/49175836-4642-4cec-a729-c33ce54cfc49)
