### PR TITLE
Fix: Misspelled and invalid string references in CommandButton.ini

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2100_remove_duplicate_camo_netting_button.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2100_remove_duplicate_camo_netting_button.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-07-12
+
+title: Removes duplicate Command_UpgradeCamoNetting definition from ini files
+
+changes:
+  - fix: Removes the duplicate Command_UpgradeCamoNetting definition from ini files. Command_UpgradeGLACamoNetting should be used.
+
+labels:
+  - minor
+  - v1.0
+  - worldbuilder
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2100
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -729,7 +729,7 @@ CommandButton Command_DetonateFakeBuilding
   TextLabel         = CONTROLBAR:DetonateFakeBuilding
   ButtonImage       = SSTerroristCarBomb
   ButtonBorderType  = ACTION
-  DescriptLabel     = CONTROLBAR:TooltipDetonateFakeBuilding
+  DescriptLabel     = CONTROLBAR:TooltipDetonateFakebuilding
 End
 
 CommandButton Command_BecomeRealGLACommandCenter
@@ -783,7 +783,7 @@ CommandButton Command_TerrorCell
   Command                 = SPECIAL_POWER
   SpecialPower            = SuperweaponTerrorCell
   Options                 = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
-  TextLabel               = CONTROLBAR:TerrorCell
+  TextLabel               = GUI:SuperweaponTerrorCell
   ButtonImage             = SCTempDefaultCommand
   ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TempDescription
@@ -1194,7 +1194,7 @@ CommandButton Command_UpgradeAmericaRangerCaptureBuilding
   TextLabel     = CONTROLBAR:UpgradeAmericaRangerCaptureBuilding
   ButtonImage   = SSCaptureBuilding
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeRangerCaptureBuilding
+  DescriptLabel           = CONTROLBAR:ToolTipUSAUpgradeRangerCaptureBuilding
 End
 
 CommandButton Command_UpgradeAmericaTOWMissile
@@ -1259,7 +1259,7 @@ CommandButton Command_UpgradeChinaRedguardCaptureBuilding
   TextLabel     = CONTROLBAR:UpgradeChinaRedguardCaptureBuilding
   ButtonImage   = SSCaptureBuilding
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeRedguardCaptureBuilding
+  DescriptLabel           = CONTROLBAR:ToolTipChinaUpgradeRedGuardCaptureBuilding
 End
 
 CommandButton Command_UpgradeChinaMines
@@ -1566,7 +1566,6 @@ CommandButton Command_UpgradeGLACamoNetting
   ButtonImage       = SUcamo
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLACamoNetting
-;  UnitSpecificSound = BombTruckVoiceModeHiEx
 End
 
 CommandButton Command_UpgradeGLARadarVanScan
@@ -1713,7 +1712,7 @@ CommandButton Command_UpgradeGLARebelCaptureBuilding
   TextLabel     = CONTROLBAR:UpgradeGLARebelCaptureBuilding
   ButtonImage   = SSCaptureBuilding
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:TooltipGLAUpgradeRebelCaptureBuilding
+  DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeRebelCaptureBuilding
 End
 
 
@@ -4176,16 +4175,6 @@ CommandButton GC_Slth_Command_ConstructGLASupplyStash
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildSupplyStash
 End
 
-CommandButton Command_UpgradeCamoNetting
-  Command       = OBJECT_UPGRADE
-  Upgrade       = Upgrade_GLACamoNetting
-  TextLabel     = CONTROLBAR:UpgradeGLACamoNetting
-  ButtonImage   = SSControlRods
-  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:CONTROLBAR:ToolTipGLACamoNetting
-End
-
-
 CommandButton GC_Slth_Command_ConstructGLABarracks
   Command       = DOZER_CONSTRUCT
   Object        = GC_Slth_GLABarracks
@@ -4646,10 +4635,10 @@ CommandButton AirF_Command_ConstructAmericaSupplyCenter
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildSupplyCenter
 End
 
-CommandButton AirF_Command_ConstructAmericaVehicleBattleDrone
+CommandButton AirF_Command_ConstructAmericaVehicleBattleDrone ; unused
   Command       = UNIT_BUILD
   Object       = AirF_AmericaVehicleBattleDrone
-  TextLabel     = CONTROLBAR:AirF_ConstructAmericaVehicleBattleDrone
+  TextLabel     = CONTROLBAR:ConstructAmericaVehicleBattleDrone
   ButtonImage   = SASoloDrone
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildBattleDrone
@@ -5550,15 +5539,14 @@ CommandButton Slth_Command_ConstructGLAVehicleRocketBuggy
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRocketBuggy
 End
 
-
-CommandButton Slth_Command_BattleBusBuildSlthTrap
+CommandButton Slth_Command_BattleBusBuildSlthTrap ; unused
   Command           = FIRE_WEAPON
   WeaponSlot        = PRIMARY
   Options           = OK_FOR_MULTI_SELECT
-  TextLabel         = CONTROLBAR:ConstructGLASlthTrap
+  TextLabel         = CONTROLBAR:TempDescription
   ButtonImage       = SSHideBomb
   ButtonBorderType  = BUILD
-  DescriptLabel     = CONTROLBAR:ToolTipGLABUildSlthTrap
+  DescriptLabel     = CONTROLBAR:TempDescription
 End
 
 CommandButton Slth_Command_ConstructGLAVehicleScudLauncher
@@ -7155,7 +7143,7 @@ CommandButton Infa_Command_UpgradeChinaRedguardCaptureBuilding
   TextLabel     = CONTROLBAR:UpgradeChinaRedguardCaptureBuilding
   ButtonImage   = SSCaptureBuilding
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:Infa_TooltipChinaUpgradeRedguardCaptureBuilding
+  DescriptLabel           = CONTROLBAR:Infa_ToolTipChinaUpgradeRedGuardCaptureBuilding
 End
 
 CommandButton Infa_Command_ConstructChinaVehicleNukeLauncher


### PR DESCRIPTION
This change fixes misspelled and invalid string references in CommandButton.ini. It does not fix bugs, because string id's are case tolerant. User facing nothing changes. Requires no special documentation.