### PR TITLE
Fix: Remove hidden Terrorist Bike button from GLA Stealth Arms Dealer

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -3053,6 +3053,7 @@ CommandSet Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell
 End
 
+; Patch104p @bugfix xezon 12/07/2023 Removes hidden button 15.
 CommandSet Slth_GLAArmsDealerCommandSet
   2  = Slth_Command_ConstructGLAVehicleTechnical
   3  = Slth_Command_ConstructGLAVehicleRadarVan
@@ -3065,7 +3066,7 @@ CommandSet Slth_GLAArmsDealerCommandSet
   12 = Command_UpgradeGLACamoNetting
   13 = Command_SetRallyPoint
   14 = Command_Sell
-  15 = Command_ConstructGLAVehicleCombatBikeTerrorist ;??? is this for script then?
+  ;15 = Command_ConstructGLAVehicleCombatBikeTerrorist ;??? is this for script then?
 End
 
 CommandSet Slth_GLADemoTrapCommandSet


### PR DESCRIPTION
This change removes the hidden Terrorist Bike button from GLA Stealth Arms Dealer.