### PR TITLE
Fix: Add complete ECM Tank name in construction tool tip

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2113_ecm_tank_tooltip_name.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2113_ecm_tank_tooltip_name.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-07-15
+
+title: Adds complete ECM Tank name in construction tool tip
+
+changes:
+  - fix: Adds complete ECM Tank name in construction tool tip of all latin languages.
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2113
+
+authors:
+  - xezon


### PR DESCRIPTION
This change fixes the incomplete ECM Tank name in the construction tool tip.

For reference, the object labels are

```
OBJECT:ECMTank
US: "ECM Tank"
DE: "ECM-Panzer"
FR: "Char CME"
ES: "Tanque CME"
IT: "Carro ECM"
KO: "ECM 탱크"
ZH: "電子干擾坦克"
BP: "Tanque ECM"
PL: "Czołg ECM"
RU: "Электромагнитный танк"
AR: "ﺔﻛﺮﺘﺸﻤﻟا ﺔﯿﺑروﻷا قﻮﺴﻟا ﺔﺑﺎﺑد"
END
```