### PR TITLE
Fix: Paradrop Missile Defender has wrong animation transition between PARACHUTING and DYING

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -3970,6 +3970,12 @@ Object AirF_AmericaInfantryMissileDefender
       AnimationMode     = ONCE
     End
 
+    ; Patch104p @bugfix commy2 15/07/2023 Fix transition PARACHUTING -> DYING
+    TransitionState     = TRANS_Chute TRANS_Dying
+      Animation         = NITHNT_SKL.NITHNT_PTD
+      AnimationMode     = ONCE
+    End
+
   End
 
   ; ***DESIGN parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1212,6 +1212,12 @@ Object AmericaInfantryMissileDefender
       AnimationMode     = ONCE
     End
 
+    ; Patch104p @bugfix commy2 15/07/2023 Fix transition PARACHUTING -> DYING
+    TransitionState     = TRANS_Chute TRANS_Dying
+      Animation         = NITHNT_SKL.NITHNT_PTD
+      AnimationMode     = ONCE
+    End
+
   End
 
   ; ***DESIGN parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -3509,6 +3509,12 @@ Object Lazr_AmericaInfantryMissileDefender
       AnimationMode     = ONCE
     End
 
+    ; Patch104p @bugfix commy2 15/07/2023 Fix transition PARACHUTING -> DYING
+    TransitionState     = TRANS_Chute TRANS_Dying
+      Animation         = NITHNT_SKL.NITHNT_PTD
+      AnimationMode     = ONCE
+    End
+
   End
 
   ; ***DESIGN parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -3995,6 +3995,12 @@ Object SupW_AmericaInfantryMissileDefender
       AnimationMode     = ONCE
     End
 
+    ; Patch104p @bugfix commy2 15/07/2023 Fix transition PARACHUTING -> DYING
+    TransitionState     = TRANS_Chute TRANS_Dying
+      Animation         = NITHNT_SKL.NITHNT_PTD
+      AnimationMode     = ONCE
+    End
+
   End
 
   ; ***DESIGN parameters ***


### PR DESCRIPTION
- fix TheSuperHackers/GeneralsGameCode#235