### PR TITLE
Add separate buttons and labels to all major Boss commands

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2119_add_boss_commands_and_labels.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2119_add_boss_commands_and_labels.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-07-16
+
+title: Adds separate buttons and labels to all major Boss commands
+
+changes:
+  - feature: Adds separate buttons and labels for all major Boss commands. This allows to setup custom key mappings that do not conflict with the setups for other factions.
+
+labels:
+  - boss
+  - enhancement
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2102
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2119
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -124,6 +124,19 @@ CommandButton Command_FireParticleUplinkCannon
   InvalidCursorName = GenericInvalid
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_FireParticleUplinkCannon
+  Command           = SPECIAL_POWER
+  SpecialPower      = SuperweaponParticleUplinkCannon
+  Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND CAN_USE_WAYPOINTS
+  TextLabel         = CONTROLBAR:Boss_FireParticleUplinkCannon
+  ButtonImage       = SSParticleFire
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel     = CONTROLBAR:TooltipFireParticleUplinkCannon
+  CursorName        = ParticleUplinkCannon
+  InvalidCursorName = GenericInvalid
+End
+
 ; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_FireParticleUplinkCannonFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
@@ -221,6 +234,19 @@ CommandButton Command_ClusterMines
   InvalidCursorName     = GenericInvalid
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_ClusterMines
+  Command           = SPECIAL_POWER
+  SpecialPower      = SuperweaponClusterMines
+  Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
+  TextLabel         = CONTROLBAR:Boss_ClusterMines
+  ButtonImage       = SSClusterMines
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel     = CONTROLBAR:TooltipClusterMines
+  RadiusCursorType  = CLUSTERMINES
+  InvalidCursorName     = GenericInvalid
+End
+
 CommandButton Command_ClusterMinesFromShortcut
   Command           = SPECIAL_POWER_FROM_SHORTCUT
   SpecialPower      = SuperweaponClusterMines
@@ -238,6 +264,19 @@ CommandButton Command_EMPPulse
   SpecialPower      = SuperweaponEMPPulse
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   TextLabel         = CONTROLBAR:EMPPulse
+  ButtonImage       = SSEMP
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel     = CONTROLBAR:TooltipEMPPulse
+  RadiusCursorType  = EMPPULSE
+  InvalidCursorName     = GenericInvalid
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_EMPPulse
+  Command           = SPECIAL_POWER
+  SpecialPower      = SuperweaponEMPPulse
+  Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
+  TextLabel         = CONTROLBAR:Boss_EMPPulse
   ButtonImage       = SSEMP
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipEMPPulse
@@ -292,6 +331,20 @@ CommandButton Command_SpectreGunship
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   Science           = SCIENCE_SpectreGunshipSolo ;These will cause the buttons to change icons, nothing more
   TextLabel         = CONTROLBAR:SpectreGunship
+  ButtonImage       = SASpGunship2; until Samm makes a new cameo for this...
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel     = CONTROLBAR:TooltipSpectreGunship
+  RadiusCursorType  = SPECTREGUNSHIP
+  InvalidCursorName     = GenericInvalid
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_SpectreGunship
+  Command           = SPECIAL_POWER
+  SpecialPower      = SuperweaponSpectreGunship
+  Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
+  Science           = SCIENCE_SpectreGunshipSolo ;These will cause the buttons to change icons, nothing more
+  TextLabel         = CONTROLBAR:Boss_SpectreGunship
   ButtonImage       = SASpGunship2; until Samm makes a new cameo for this...
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipSpectreGunship
@@ -372,6 +425,19 @@ CommandButton Command_ChinaCarpetBomb
   SpecialPower  = SuperweaponChinaCarpetBomb
   Options       = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   TextLabel     = CONTROLBAR:CarpetBomb
+  ButtonImage   = SNCBomber
+  RadiusCursorType  = CARPETBOMB
+  InvalidCursorName = GenericInvalid
+  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipCarpetBomb
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_ChinaCarpetBomb
+  Command       = SPECIAL_POWER
+  SpecialPower  = SuperweaponChinaCarpetBomb
+  Options       = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
+  TextLabel     = CONTROLBAR:Boss_CarpetBomb
   ButtonImage   = SNCBomber
   RadiusCursorType  = CARPETBOMB
   InvalidCursorName = GenericInvalid
@@ -462,7 +528,7 @@ CommandButton Command_NeutronMissile
   InvalidCursorName = GenericInvalid
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Adds extra button for Boss to avoid key conflicts. (#2102)
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2102) (#2119)
 CommandButton Boss_Command_NeutronMissile
   Command           = SPECIAL_POWER
   SpecialPower      = SuperweaponNeutronMissile
@@ -500,6 +566,19 @@ CommandButton Command_ScudStorm
   InvalidCursorName       = GenericInvalid
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_ScudStorm
+  Command                 = SPECIAL_POWER
+  SpecialPower            = SuperweaponScudStorm
+  Options                 = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
+  TextLabel               = CONTROLBAR:Boss_ScudStorm
+  ButtonImage             = SSScudStorm
+  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipFireSCUDStorm
+  RadiusCursorType        = SCUDSTORM
+  InvalidCursorName       = GenericInvalid
+End
+
 ; Patch104p @fix Disable ButtonBorderType on all Generals Powers Shortcuts.
 CommandButton Command_ScudStormFromShortcut
   Command                 = SPECIAL_POWER_FROM_SHORTCUT
@@ -520,6 +599,20 @@ CommandButton Command_ArtilleryBarrage
   Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
   Science           = SCIENCE_ArtilleryBarrage1 SCIENCE_ArtilleryBarrage2 SCIENCE_ArtilleryBarrage3 ;These will cause the buttons to change icons, nothing more
   TextLabel         = CONTROLBAR:ArtilleryBarrage
+  ButtonImage       = SSBarrage
+  ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel     = CONTROLBAR:TooltipFireArtilleryBarrage
+  RadiusCursorType  = ARTILLERYBARRAGE
+  InvalidCursorName     = GenericInvalid
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_ArtilleryBarrage
+  Command           = SPECIAL_POWER
+  SpecialPower      = SuperweaponArtilleryBarrage
+  Options           = NEED_SPECIAL_POWER_SCIENCE NEED_TARGET_POS CONTEXTMODE_COMMAND
+  Science           = SCIENCE_ArtilleryBarrage1 SCIENCE_ArtilleryBarrage2 SCIENCE_ArtilleryBarrage3 ;These will cause the buttons to change icons, nothing more
+  TextLabel         = CONTROLBAR:Boss_ArtilleryBarrage
   ButtonImage       = SSBarrage
   ButtonBorderType  = ACTION ; Identifier for the User as to what kind of button this is
   DescriptLabel     = CONTROLBAR:TooltipFireArtilleryBarrage
@@ -1121,6 +1214,15 @@ CommandButton Command_UpgradeAmericaSentryDroneGun
   DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeSentryDroneGun
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaSentryDroneGun
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_AmericaSentryDroneGun
+  TextLabel     = CONTROLBAR:Boss_UpgradeAmericaSentryDroneGun
+  ButtonImage   = SASentryUpgr
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeSentryDroneGun
+End
 
 CommandButton Command_UpgradeAmericaAdvancedTraining
   Command       = PLAYER_UPGRADE
@@ -1131,11 +1233,32 @@ CommandButton Command_UpgradeAmericaAdvancedTraining
   DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeAdvancedTraining
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaAdvancedTraining
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_AmericaAdvancedTraining
+  TextLabel     = CONTROLBAR:Boss_UpgradeAmericaAdvancedTraining
+  ButtonImage   = SSAdvancedTraining
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeAdvancedTraining
+End
+
 CommandButton Command_UpgradeAmericaDroneArmor
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_AmericaDroneArmor
   Options       = OK_FOR_MULTI_SELECT
   TextLabel     = CONTROLBAR:UpgradeAmericaDroneArmor
+  ButtonImage   = SSScoutArmor
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeDroneARmor
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaDroneArmor
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_AmericaDroneArmor
+  Options       = OK_FOR_MULTI_SELECT
+  TextLabel     = CONTROLBAR:Boss_UpgradeAmericaDroneArmor
   ButtonImage   = SSScoutArmor
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeDroneARmor
@@ -1159,6 +1282,16 @@ CommandButton Command_UpgradeAmericaRangerFlashBangGrenade
   DescriptLabel     = CONTROLBAR:TooltipUSAUpgradeFlashBangGrenades
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaRangerFlashBangGrenade
+  Command           = PLAYER_UPGRADE
+  Upgrade           = Upgrade_AmericaRangerFlashBangGrenade
+  TextLabel         = CONTROLBAR:Boss_UpgradeAmericaFlashBangGrenade
+  ButtonImage       = SSFlashbang
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel     = CONTROLBAR:TooltipUSAUpgradeFlashBangGrenades
+End
+
 CommandButton Command_UpgradeAmericaCompositeArmor
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_AmericaCompositeArmor
@@ -1168,7 +1301,7 @@ CommandButton Command_UpgradeAmericaCompositeArmor
   DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeCompositeArmor
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Adds extra button for Boss to avoid key conflicts. (#2102)
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2102) (#2119)
 CommandButton Boss_Command_UpgradeAmericaCompositeArmor
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_AmericaCompositeArmor
@@ -1187,11 +1320,30 @@ CommandButton Command_UpgradeAmericaChemicalSuits
   DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeChemicalSuits
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaChemicalSuits
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_AmericaChemicalSuits
+  TextLabel     = CONTROLBAR:Boss_UpgradeAmericaChemicalSuits
+  ButtonImage   = SAChemsuit
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeChemicalSuits
+End
 
 CommandButton Command_UpgradeAmericaRangerCaptureBuilding
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_InfantryCaptureBuilding
   TextLabel     = CONTROLBAR:UpgradeAmericaRangerCaptureBuilding
+  ButtonImage   = SSCaptureBuilding
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipUSAUpgradeRangerCaptureBuilding
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaRangerCaptureBuilding
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_InfantryCaptureBuilding
+  TextLabel     = CONTROLBAR:Boss_UpgradeAmericaRangerCaptureBuilding
   ButtonImage   = SSCaptureBuilding
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSAUpgradeRangerCaptureBuilding
@@ -1219,6 +1371,16 @@ CommandButton Command_UpgradeAmericaLaserMissiles
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_AmericaLaserMissiles
   TextLabel     = CONTROLBAR:UpgradeAmericaLaserMissiles
+  ButtonImage   = SSPlaneLaserMissiles
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeLaserMissiles
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaLaserMissiles
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_AmericaLaserMissiles
+  TextLabel     = CONTROLBAR:Boss_UpgradeAmericaLaserMissiles
   ButtonImage   = SSPlaneLaserMissiles
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeLaserMissiles
@@ -1252,6 +1414,16 @@ CommandButton Command_UpgradeAmericaCountermeasures
   DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeCountermeasures
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeAmericaCountermeasures
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_AmericaCountermeasures
+  TextLabel     = CONTROLBAR:Boss_UpgradeAmericaCountermeasures
+  ButtonImage   = SAFlares
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUSAUpgradeCountermeasures
+End
+
 ; China upgrades --------------------------------------------------------------
 CommandButton Command_UpgradeChinaRedguardCaptureBuilding
   Command       = PLAYER_UPGRADE
@@ -1271,7 +1443,7 @@ CommandButton Command_UpgradeChinaMines
   DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeMines
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Adds extra button for Boss to avoid key conflicts. (#2102)
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2102) (#2119)
 CommandButton Boss_Command_UpgradeChinaMines
   Command       = OBJECT_UPGRADE
   Upgrade       = Upgrade_ChinaMines
@@ -1331,6 +1503,16 @@ CommandButton Command_UpgradeChinaRadar
   Command       = OBJECT_UPGRADE
   Upgrade       = Upgrade_ChinaRadar
   TextLabel     = CONTROLBAR:UpgradeChinaRadar
+  ButtonImage   = SARadarUpgrade
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeRadar
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeChinaRadar
+  Command       = OBJECT_UPGRADE
+  Upgrade       = Upgrade_ChinaRadar
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaRadar
   ButtonImage   = SARadarUpgrade
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeRadar
@@ -1406,10 +1588,30 @@ CommandButton Command_UpgradeChinaAircraftArmor
   DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeAircraftArmor
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeChinaAircraftArmor
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_ChinaAircraftArmor
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaAircraftArmor
+  ButtonImage   = SSMigArmor
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeAircraftArmor
+End
+
 CommandButton Command_UpgradeChinaBlackNapalm
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_ChinaBlackNapalm
   TextLabel     = CONTROLBAR:UpgradeChinaBlackNapalm
+  ButtonImage   = SSBlackNapalm
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeBlackNapalm
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeChinaBlackNapalm
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_ChinaBlackNapalm
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaBlackNapalm
   ButtonImage   = SSBlackNapalm
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeBlackNapalm
@@ -1424,10 +1626,30 @@ CommandButton Command_UpgradeChinaChainGuns
   DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeChainGuns
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeChinaChainGuns
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_ChinaChainGuns
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaChainGuns
+  ButtonImage   = SSGattling
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipChinaUpgradeChainGuns
+End
+
 CommandButton Command_UpgradeChinaSubliminalMessaging
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_ChinaSubliminalMessaging
   TextLabel     = CONTROLBAR:UpgradeChinaSubliminalMessaging
+  ButtonImage   = SSSobMsge
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaSubliminal
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeChinaSubliminalMessaging
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_ChinaSubliminalMessaging
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaSubliminalMessaging
   ButtonImage   = SSSobMsge
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaSubliminal
@@ -1438,6 +1660,17 @@ CommandButton Command_UpgradeChinaUraniumShells
   Upgrade       = Upgrade_ChinaUraniumShells
   Options       = IGNORES_UNDERPOWERED
   TextLabel     = CONTROLBAR:UpgradeChinaUraniumShells
+  ButtonImage   = SSDepletedU_Shell
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaUraniumShells
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeChinaUraniumShells
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_ChinaUraniumShells
+  Options       = IGNORES_UNDERPOWERED
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaUraniumShells
   ButtonImage   = SSDepletedU_Shell
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaUraniumShells
@@ -1462,12 +1695,32 @@ CommandButton Command_UpgradeEMPMines
   DescriptLabel           = CONTROLBAR:ToolTipUpgradeChinaEMPMines
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeEMPMines
+  Command       = OBJECT_UPGRADE
+  Upgrade       = Upgrade_ChinaEMPMines
+  TextLabel     = CONTROLBAR:Boss_UpgradeEMPMines
+  ButtonImage   = SNEMPMine
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipUpgradeChinaEMPMines
+End
 
 CommandButton Command_UpgradeChinaNuclearTanks
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_ChinaNuclearTanks
   Options       = IGNORES_UNDERPOWERED
   TextLabel     = CONTROLBAR:UpgradeChinaNuclearTanks
+  ButtonImage   = SSNukeTank
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaNuclearTanks
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeChinaNuclearTanks
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_ChinaNuclearTanks
+  Options       = IGNORES_UNDERPOWERED
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaNuclearTanks
   ButtonImage   = SSNukeTank
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:TooltipUpgradeChinaNuclearTanks
@@ -1613,10 +1866,30 @@ CommandButton Command_UpgradeGLABuggyAmmo
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeBuggyAmmo
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeGLABuggyAmmo
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_GLABuggyAmmo
+  TextLabel     = CONTROLBAR:Boss_UpgradeGLABuggyAmmo
+  ButtonImage   = SSBuggyRockets
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeBuggyAmmo
+End
+
 CommandButton Command_UpgradeGLAAPRockets
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_GLAAPRockets
   TextLabel     = CONTROLBAR:UpgradeGLAAPRockets
+  ButtonImage   = SSAPRockets
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeAPRockets
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeGLAAPRockets
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_GLAAPRockets
+  TextLabel     = CONTROLBAR:Boss_UpgradeGLAAPRockets
   ButtonImage   = SSAPRockets
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeAPRockets
@@ -1650,7 +1923,7 @@ CommandButton Command_UpgradeGLAAnthraxBeta
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeAnthraxBeta
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Adds extra button for Boss to avoid key conflicts. (#2102)
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2102) (#2119)
 CommandButton Boss_Command_UpgradeGLAAnthraxBeta
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_GLAAnthraxBeta
@@ -1669,10 +1942,30 @@ CommandButton Command_UpgradeGLAAPBullets
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeAPBullets
 End
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeGLAAPBullets
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_GLAAPBullets
+  TextLabel     = CONTROLBAR:Boss_UpgradeGLAAPBullets
+  ButtonImage   = SSAPShells
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeAPBullets
+End
+
 CommandButton Command_UpgradeGLAJunkRepair
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_GLAJunkRepair
   TextLabel     = CONTROLBAR:UpgradeGLAJunkRepair
+  ButtonImage   = SSJunkRepair
+  ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeJunkRepair
+End
+
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2119)
+CommandButton Boss_Command_UpgradeGLAJunkRepair
+  Command       = PLAYER_UPGRADE
+  Upgrade       = Upgrade_GLAJunkRepair
+  TextLabel     = CONTROLBAR:Boss_UpgradeGLAJunkRepair
   ButtonImage   = SSJunkRepair
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeJunkRepair
@@ -1696,7 +1989,7 @@ CommandButton Command_UpgradeGLAArmTheMob
   DescriptLabel           = CONTROLBAR:ToolTipGLAUpgradeArmTheMob
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Adds extra button for Boss to avoid key conflicts. (#2102)
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2102) (#2119)
 CommandButton Boss_Command_UpgradeGLAArmTheMob
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_GLAArmTheMob
@@ -3846,7 +4139,7 @@ CommandButton Command_SneakAttack
   DescriptLabel     = CONTROLBAR:ToolTipGLASneakAttack
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Adds extra button for Boss to avoid key conflicts. (#2102)
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific command to allow customize key mapping. (#2102) (#2119)
 CommandButton Boss_Command_SneakAttack
   Command           = SPECIAL_POWER_CONSTRUCT
   SpecialPower      = SuperweaponSneakAttack
@@ -8079,11 +8372,12 @@ End
 ;; BOSS command buttons
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; Patch104p @feature xezon 16/07/2023 Adds Boss specific labels to all commands to allow customize their keys. (#2102) (#2119)
 
 CommandButton Boss_Command_UpgradeChinaNationalism
   Command       = PLAYER_UPGRADE
   Upgrade       = Upgrade_Nationalism
-  TextLabel     = CONTROLBAR:UpgradeChinaNationalism
+  TextLabel     = CONTROLBAR:Boss_UpgradeChinaNationalism
   ButtonImage   = SSNationalism
   ButtonBorderType        = UPGRADE ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Boss_TooltipChinaUpgradeNationalism
@@ -8092,7 +8386,7 @@ End
 CommandButton Boss_Command_ConstructChinaCommandCenter
   Command       = DOZER_CONSTRUCT
   Object        = Boss_CommandCenter
-  TextLabel     = CONTROLBAR:ConstructChinaCommandCenter
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaCommandCenter
   ButtonImage   = SNComCentr
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildCommandCenter
@@ -8102,7 +8396,7 @@ End
 CommandButton Boss_Command_ConstructAmericaPowerPlant
   Command       = DOZER_CONSTRUCT
   Object        = Boss_PowerPlant
-  TextLabel     = CONTROLBAR:ConstructAmericaPowerPlant
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaPowerPlant
   ButtonImage   = SAPowerPlant
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Boss_ToolTipUSABuildPowerPlant
@@ -8111,7 +8405,7 @@ End
 CommandButton Boss_Command_ConstructAmericaParticleCannonUplink
   Command       = DOZER_CONSTRUCT
   Object        = Boss_ParticleCannonUplink
-  TextLabel     = CONTROLBAR:ConstructAmericaParticleCannonUplink
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaParticleCannonUplink
   ButtonImage   = SAUplink
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildParticleCannonBoss
@@ -8120,7 +8414,7 @@ End
 CommandButton Boss_Command_ConstructChinaAirfield
   Command       = DOZER_CONSTRUCT
   Object        = Boss_Airfield
-  TextLabel     = CONTROLBAR:ConstructChinaAirfield
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaAirfield
   ButtonImage   = SNAirfield
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Boss_ToolTipChinaBuildAirField
@@ -8129,13 +8423,12 @@ End
 CommandButton Boss_Command_ConstructGLAScudStorm
   Command       = DOZER_CONSTRUCT
   Object        = Boss_ScudStorm
-  TextLabel     = CONTROLBAR:ConstructGLAScudStorm
+  TextLabel     = CONTROLBAR:Boss_ConstructGLAScudStorm
   ButtonImage   = SUScudStorm
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildScudStorm
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Changes TextLabel from CONTROLBAR:ConstructChinaNuclearMissileLauncher. (#2102)
 CommandButton Boss_Command_ConstructChinaNuclearMissileLauncher
   Command       = DOZER_CONSTRUCT
   Object        = Boss_NuclearMissileLauncher
@@ -8148,7 +8441,7 @@ End
 CommandButton Boss_Command_ConstructChinaSpeakerTower
   Command       = DOZER_CONSTRUCT
   Object        = Boss_SpeakerTower
-  TextLabel     = CONTROLBAR:ConstructChinaSpeakerTower
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaSpeakerTower
   ButtonImage   = SNPropSpeaker
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildSpeakerTower
@@ -8157,7 +8450,7 @@ End
 CommandButton Boss_Command_ConstructGLATunnelNetwork
   Command       = DOZER_CONSTRUCT
   Object        = Boss_TunnelNetwork
-  TextLabel     = CONTROLBAR:ConstructGLATunnelNetwork
+  TextLabel     = CONTROLBAR:Boss_ConstructGLATunnelNetwork
   ButtonImage   = SUTunnel
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildTunnelNetwork
@@ -8166,7 +8459,7 @@ End
 CommandButton Boss_Command_ConstructChinaSupplyCenter
   Command       = DOZER_CONSTRUCT
   Object        = Boss_SupplyCenter
-  TextLabel     = CONTROLBAR:ConstructChinaSupplyCenter
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaSupplyCenter
   ButtonImage   = SNSupplyCenter
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Boss_ToolTipChinaBuildSupplyCenter
@@ -8175,7 +8468,7 @@ End
 CommandButton Boss_Command_ConstructChinaBarracks
   Command       = DOZER_CONSTRUCT
   Object        = Boss_Barracks
-  TextLabel     = CONTROLBAR:ConstructChinaBarracks
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaBarracks
   ButtonImage   = SNBarracks
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Boss_ToolTipChinaBuildBarracks
@@ -8184,7 +8477,7 @@ End
 CommandButton Boss_Command_ConstructChinaWarFactory
   Command       = DOZER_CONSTRUCT
   Object        = Boss_WarFactory
-  TextLabel     = CONTROLBAR:ConstructChinaWarFactory
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaWarFactory
   ButtonImage   = SNWarFact
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Boss_ToolTipChinaBuildWarFactory
@@ -8193,7 +8486,7 @@ End
 CommandButton Boss_Command_ConstructAmericaPatriotBattery
   Command       = DOZER_CONSTRUCT
   Object        = Boss_PatriotBattery
-  TextLabel     = CONTROLBAR:ConstructAmericaPatriotBattery
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaPatriotBattery
   ButtonImage   = SAPatriot
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildPatriotBattery
@@ -8202,7 +8495,7 @@ End
 CommandButton Boss_Command_ConstructChinaBunker
   Command       = DOZER_CONSTRUCT
   Object        = Boss_Bunker
-  TextLabel     = CONTROLBAR:ConstructChinaBunker
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaBunker
   ButtonImage   = SNBunker
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Boss_ToolTipChinaBuildBunker
@@ -8211,7 +8504,7 @@ End
 CommandButton Boss_Command_ConstructChinaGattlingCannon
   Command       = DOZER_CONSTRUCT
   Object        = Boss_GattlingCannon
-  TextLabel     = CONTROLBAR:ConstructChinaGattlingCannon
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaGattlingCannon
   ButtonImage   = SNGatTower
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildGattlingCannon
@@ -8223,16 +8516,16 @@ End
 CommandButton Boss_Command_ConstructChinaDozer
   Command       = UNIT_BUILD
   Object        = Boss_VehicleDozer
-  TextLabel     = CONTROLBAR:ConstructBossDozer
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaDozer
   ButtonImage   = SACDozer
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipBossBuildDozer
+  DescriptLabel           = CONTROLBAR:Boss_ToolTipAmericaBuildDozer
 End
 
 CommandButton Boss_Command_ConstructChinaVehicleSupplyTruck
   Command       = UNIT_BUILD
   Object        = Boss_VehicleSupplyTruck
-  TextLabel     = CONTROLBAR:ConstructChinaVehicleSupplyTruck
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaVehicleSupplyTruck
   ButtonImage   = SNSupplyTruck
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildSupplyTruck
@@ -8241,7 +8534,7 @@ End
 CommandButton Boss_Command_ConstructAmericaJetAurora
   Command       = UNIT_BUILD
   Object        = Boss_JetAurora
-  TextLabel     = CONTROLBAR:ConstructAmericaJetAurora
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaJetAurora
   ButtonImage   = SAAurora
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildAurora
@@ -8250,7 +8543,7 @@ End
 CommandButton Boss_Command_ConstructChinaVehicleHelix
   Command       = UNIT_BUILD
   Object        = Boss_VehicleHelix
-  TextLabel     = CONTROLBAR:ConstructChinaVehicleHelix
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaVehicleHelix
   ButtonImage   = SNHelix
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildHelix
@@ -8259,7 +8552,7 @@ End
 CommandButton Boss_Command_ConstructChinaJetMIG
   Command       = UNIT_BUILD
   Object        = Boss_JetMIG
-  TextLabel     = CONTROLBAR:ConstructChinaJetMIG
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaJetMIG
   ButtonImage   = SNMig
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildMIG
@@ -8268,7 +8561,7 @@ End
 CommandButton Boss_Command_ConstructAmericaJetRaptor
   Command       = UNIT_BUILD
   Object        = Boss_JetRaptor
-  TextLabel     = CONTROLBAR:ConstructAmericaJetKingRaptor
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaJetKingRaptor
   ButtonImage   = SAKingRap
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildKingRaptor
@@ -8277,7 +8570,7 @@ End
 CommandButton Boss_Command_ConstructAmericaInfantryColonelBurton
   Command       = UNIT_BUILD
   Object        = Boss_InfantryColonelBurton
-  TextLabel     = CONTROLBAR:ConstructAmericaInfantryColonelBurton
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaInfantryColonelBurton
   ButtonImage   = SABurton
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildColonelBurton
@@ -8287,7 +8580,7 @@ End
 CommandButton Boss_Command_ConstructAmericaInfantryRanger
   Command       = UNIT_BUILD
   Object        = Boss_InfantryRanger
-  TextLabel     = CONTROLBAR:ConstructAmericaInfantryRanger
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaInfantryRanger
   ButtonImage   = SARanger
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildRanger
@@ -8297,7 +8590,7 @@ End
 CommandButton Boss_Command_ConstructAmericaInfantryPathfinder
   Command       = UNIT_BUILD
   Object        = Boss_InfantryPathfinder
-  TextLabel     = CONTROLBAR:ConstructAmericaInfantryPathfinder
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaInfantryPathfinder
   ButtonImage   = SAPathfinder1
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildPathFinder
@@ -8306,7 +8599,7 @@ End
 CommandButton Boss_Command_ConstructChinaInfantryBlackLotus
   Command       = UNIT_BUILD
   Object        = Boss_InfantryBlackLotus
-  TextLabel     = CONTROLBAR:ConstructChinaInfantryBlackLotus
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaInfantryBlackLotus
   ButtonImage   = SNBLKLotus2
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this i
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildBlackLotus
@@ -8315,7 +8608,7 @@ End
 CommandButton Boss_Command_ConstructChinaInfantryTankHunter
   Command       = UNIT_BUILD
   Object        = Boss_InfantryTankHunter
-  TextLabel     = CONTROLBAR:ConstructChinaInfantryTankHunter
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaInfantryTankHunter
   ButtonImage   = SNTankHunter
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildTankHunter
@@ -8324,7 +8617,7 @@ End
 CommandButton Boss_Command_ConstructChinaInfantryHacker
   Command       = UNIT_BUILD
   Object        = Boss_InfantryHacker
-  TextLabel     = CONTROLBAR:ConstructChinaInfantryHacker
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaInfantryHacker
   ButtonImage   = SNHacker2
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildHacker
@@ -8333,7 +8626,7 @@ End
 CommandButton Boss_Command_ConstructGLAInfantryJarmenKell
   Command       = UNIT_BUILD
   Object        = Boss_InfantryJarmenKell
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryJarmenKell
+  TextLabel     = CONTROLBAR:Boss_ConstructGLAInfantryJarmenKell
   ButtonImage   = SUJermanKell1    ;NOTE: Asset spelling mistake
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildJarmenKell
@@ -8342,7 +8635,7 @@ End
 CommandButton Boss_Command_ConstructGLAInfantryAngryMob
   Command       = UNIT_BUILD
   Object        = Boss_InfantryAngryMobNexus
-  TextLabel     = CONTROLBAR:ConstructGLAInfantryAngryMob
+  TextLabel     = CONTROLBAR:Boss_ConstructGLAInfantryAngryMob
   ButtonImage   = SUAngryMob
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildAngryMob
@@ -8352,7 +8645,7 @@ End
 CommandButton Boss_Command_ConstructAmericaVehicleTomahawk
   Command       = UNIT_BUILD
   Object        = Boss_VehicleTomahawk
-  TextLabel     = CONTROLBAR:ConstructAmericaVehicleTomahawk
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaVehicleTomahawk
   ButtonImage   = SACTomahawk
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildTomahawk
@@ -8361,7 +8654,7 @@ End
 CommandButton Boss_Command_ConstructAmericaVehiclePaladin
   Command       = UNIT_BUILD
   Object        = Boss_TankPaladin
-  TextLabel     = CONTROLBAR:ConstructAmericaTankPaladin
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaTankPaladin
   ButtonImage   = SAPaladin
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildPaladin
@@ -8370,7 +8663,7 @@ End
 CommandButton Boss_Command_ConstructAmericaVehicleSentryDrone
   Command       = UNIT_BUILD
   Object        = Boss_VehicleSentryDrone
-  TextLabel     = CONTROLBAR:ConstructAmericaVehicleSentryDrone
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaVehicleSentryDrone
   ButtonImage   = SAsentry
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildSentryDrone
@@ -8379,7 +8672,7 @@ End
 CommandButton Boss_Command_ConstructAmericaVehicleAvenger
   Command       = UNIT_BUILD
   Object        = Boss_TankAvenger
-  TextLabel     = CONTROLBAR:ConstructAmericaTankAvenger
+  TextLabel     = CONTROLBAR:Boss_ConstructAmericaTankAvenger
   ButtonImage   = SAAvnger
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildAvenger
@@ -8389,7 +8682,7 @@ End
 CommandButton Boss_Command_ConstructChinaTankOverlord
   Command       = UNIT_BUILD
   Object        = Boss_TankOverlord
-  TextLabel     = CONTROLBAR:ConstructChinaTankOverlord
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaTankOverlord
   ButtonImage   = SNOverlord
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildOverlord
@@ -8398,13 +8691,12 @@ End
 CommandButton Boss_Command_ConstructChinaTankDragon
   Command       = UNIT_BUILD
   Object        = Boss_TankDragon
-  TextLabel     = CONTROLBAR:ConstructChinaTankDragon
+  TextLabel     = CONTROLBAR:Boss_ConstructChinaTankDragon
   ButtonImage   = SNDragonTank
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipChinaBuildDragonTank
 End
 
-; Patch104p @bugfix xezon 12/07/2023 Changes TextLabel from CONTROLBAR:ConstructChinaTankGattling. (#2102)
 CommandButton Boss_Command_ConstructChinaTankGattling
   Command       = UNIT_BUILD
   Object        = Boss_TankGattling
@@ -8417,7 +8709,7 @@ End
 CommandButton Boss_Command_ConstructGLAVehicleRocketBuggy
   Command       = UNIT_BUILD
   Object        = Boss_VehicleRocketBuggy
-  TextLabel     = CONTROLBAR:ConstructGLAVehicleRocketBuggy
+  TextLabel     = CONTROLBAR:Boss_ConstructGLAVehicleRocketBuggy
   ButtonImage   = SURocketBuggy
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildRocketBuggy
@@ -8426,7 +8718,7 @@ End
 CommandButton Boss_Command_ConstructGLAVehicleCombatBikeTerrorist
   Command       = UNIT_BUILD
   Object        = Boss_VehicleCombatBikeTerrorist
-  TextLabel     = CONTROLBAR:ConstructGLAVehicleCombatBike
+  TextLabel     = CONTROLBAR:Boss_ConstructGLAVehicleCombatBike
   ButtonImage   = SUComBike
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildCombatBike

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5481,6 +5481,42 @@ End
 ;  Who's the BOSS ?  Ohhh yeah!
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; Patch104p @feature xezon 16/07/2023 Uses new Boss command buttons to allow key customizations and avoid potential key conflicts with other faction setups. (#2102) (#2119)
+
+; Boss_Command_UpgradeChinaMines
+; Boss_Command_UpgradeEMPMines
+; Boss_Command_ChinaCarpetBomb
+; Boss_Command_ClusterMines
+; Boss_Command_SpectreGunship
+; Boss_Command_ArtilleryBarrage
+; Boss_Command_SneakAttack
+; Boss_Command_EMPPulse
+; Boss_Command_UpgradeChinaRadar
+; Boss_Command_UpgradeChinaAircraftArmor
+; Boss_Command_UpgradeAmericaLaserMissiles
+; Boss_Command_UpgradeAmericaCountermeasures
+; Boss_Command_UpgradeAmericaRangerCaptureBuilding
+; Boss_Command_UpgradeAmericaChemicalSuits
+; Boss_Command_UpgradeAmericaRangerFlashBangGrenade
+; Boss_Command_UpgradeChinaChainGuns
+; Boss_Command_UpgradeChinaBlackNapalm
+; Boss_Command_FireParticleUplinkCannon
+; Boss_Command_UpgradeAmericaSentryDroneGun
+; Boss_Command_UpgradeAmericaCompositeArmor
+; Boss_Command_UpgradeAmericaDroneArmor
+; Boss_Command_UpgradeAmericaAdvancedTraining
+; Boss_Command_ScudStorm
+; Boss_Command_UpgradeGLAAPBullets
+; Boss_Command_UpgradeGLAAPRockets
+; Boss_Command_UpgradeGLAJunkRepair
+; Boss_Command_UpgradeGLABuggyAmmo
+; Boss_Command_UpgradeGLAAnthraxBeta
+; Boss_Command_UpgradeGLAArmTheMob
+; Boss_Command_NeutronMissile
+; Boss_Command_UpgradeChinaSubliminalMessaging
+; Boss_Command_UpgradeChinaUraniumShells
+; Boss_Command_UpgradeChinaNuclearTanks
+
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank1
   1 = Command_PurchaseSciencePaladinTank
@@ -5511,7 +5547,6 @@ END
 
 
 ; Patch104p @tweak commy 20/09/2021 Adds stop button. (#386)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_GLATunnelNetworkCommandSet
   1  = Command_StructureExit
   2  = Command_StructureExit
@@ -5542,14 +5577,13 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
   9  = Command_StructureExit
   10 = Command_StructureExit
   11 = Command_TunnelEvacuate
-  12 = Command_UpgradeEMPMines
+  12 = Boss_Command_UpgradeEMPMines
   13 = Command_Stop
   14 = Command_Sell
 End
 
 
 
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_AmericaPowerPlantCommandSet
   1 = Command_UpgradeAmericaAdvancedControlRods
  12 = Boss_Command_UpgradeChinaMines
@@ -5558,12 +5592,11 @@ End
 
 CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
   1 = Command_UpgradeAmericaAdvancedControlRods
- 12 = Command_UpgradeEMPMines
+ 12 = Boss_Command_UpgradeEMPMines
  14 = Command_Sell
 End
 
 ; Patch104p @bugfix commy2 18/09/2021 Fix position of Stop command.
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_AmericaPatriotBatteryCommandSet
   12 = Boss_Command_UpgradeChinaMines
   13 = Command_Stop
@@ -5571,7 +5604,7 @@ CommandSet Boss_AmericaPatriotBatteryCommandSet
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
-  12 = Command_UpgradeEMPMines
+  12 = Boss_Command_UpgradeEMPMines
   13 = Command_Stop
   14 = Command_Sell
 End
@@ -5595,21 +5628,19 @@ CommandSet Boss_AmericaDozerCommandSet
 End
 
 ; Patch104p @tweak xezon 19/04/2023 Moves buttons into more familiar China button positions. (#1859)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_SneakAttack to avoid key conflict(s). (#2102)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaCommandCenterCommandSet
   1  = Boss_Command_ConstructChinaDozer
-  2  = Command_ChinaCarpetBomb ; Patch104p @tweak from 10
-  4  = Command_ClusterMines ; Patch104p @tweak from 7
-  5  = Command_SpectreGunship ; Patch104p @tweak from 8
-  6  = Command_ArtilleryBarrage ; Patch104p @tweak from 5
+  2  = Boss_Command_ChinaCarpetBomb ; Patch104p @tweak from 10
+  4  = Boss_Command_ClusterMines ; Patch104p @tweak from 7
+  5  = Boss_Command_SpectreGunship ; Patch104p @tweak from 8
+  6  = Boss_Command_ArtilleryBarrage ; Patch104p @tweak from 5
   7  = Boss_Command_SneakAttack ; Patch104p @tweak from 9
-  8  = Command_EMPPulse ; Patch104p @tweak from 6
+  8  = Boss_Command_EMPPulse ; Patch104p @tweak from 6
 ;patch104p-core-begin
-  9  = Command_UpgradeChinaRadar ; Patch104p @tweak from 11
+  9  = Boss_Command_UpgradeChinaRadar ; Patch104p @tweak from 11
 ;patch104p-core-end
 ;patch104p-optional-begin
-  11 = Command_UpgradeChinaRadar
+  11 = Boss_Command_UpgradeChinaRadar
 ;patch104p-optional-end
   12 = Boss_Command_UpgradeChinaMines
   13 = Command_SetRallyPoint
@@ -5617,22 +5648,21 @@ CommandSet Boss_ChinaCommandCenterCommandSet
 End
 
 ; Patch104p @tweak xezon 19/04/2023 Moves buttons into more familiar China button positions. (#1859)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_SneakAttack to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   1  = Boss_Command_ConstructChinaDozer
-  2  = Command_ChinaCarpetBomb ; Patch104p @tweak from 10
-  4  = Command_ClusterMines ; Patch104p @tweak from 7
-  5  = Command_SpectreGunship ; Patch104p @tweak from 8
-  6  = Command_ArtilleryBarrage ; Patch104p @tweak from 5
+  2  = Boss_Command_ChinaCarpetBomb ; Patch104p @tweak from 10
+  4  = Boss_Command_ClusterMines ; Patch104p @tweak from 7
+  5  = Boss_Command_SpectreGunship ; Patch104p @tweak from 8
+  6  = Boss_Command_ArtilleryBarrage ; Patch104p @tweak from 5
   7  = Boss_Command_SneakAttack ; Patch104p @tweak from 9
-  8  = Command_EMPPulse ; Patch104p @tweak from 6
+  8  = Boss_Command_EMPPulse ; Patch104p @tweak from 6
 ;patch104p-core-begin
-  9  = Command_UpgradeChinaRadar ; Patch104p @tweak from 11
+  9  = Boss_Command_UpgradeChinaRadar ; Patch104p @tweak from 11
 ;patch104p-core-end
 ;patch104p-optional-begin
-  11 = Command_UpgradeChinaRadar
+  11 = Boss_Command_UpgradeChinaRadar
 ;patch104p-optional-end
-  12 = Command_UpgradeEMPMines
+  12 = Boss_Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
@@ -5640,15 +5670,14 @@ End
 ; Patch104p @bugfix xezon 16/04/2023 Adds missing rally point button to Boss Airfield.
 ; Patch104p @bugfix xezon 16/04/2023 Moves Mig Armor upgrade button into top row to make room for other upgrades below. (#1892)
 ; Patch104p @bugfix xezon 16/04/2023 Adds missing Counter Measures and Laser Missiles upgrade buttons. (#1892)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaAirfieldCommandSet
  1  = Boss_Command_ConstructChinaJetMIG
  2  = Boss_Command_ConstructAmericaJetRaptor ; AirF version
  3  = Boss_Command_ConstructChinaVehicleHelix
  4  = Boss_Command_ConstructAmericaJetAurora
- 7  = Command_UpgradeChinaAircraftArmor ; Patch @tweak from 8
- 8  = Command_UpgradeAmericaLaserMissiles
- 10 = Command_UpgradeAmericaCountermeasures
+ 7  = Boss_Command_UpgradeChinaAircraftArmor ; Patch @tweak from 8
+ 8  = Boss_Command_UpgradeAmericaLaserMissiles
+ 10 = Boss_Command_UpgradeAmericaCountermeasures
  12 = Boss_Command_UpgradeChinaMines
  13 = Command_SetRallyPoint
  14 = Command_Sell
@@ -5662,15 +5691,14 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
  2  = Boss_Command_ConstructAmericaJetRaptor ; AirF version
  3  = Boss_Command_ConstructChinaVehicleHelix
  4  = Boss_Command_ConstructAmericaJetAurora
- 7  = Command_UpgradeChinaAircraftArmor ; Patch @tweak from 8
- 8  = Command_UpgradeAmericaLaserMissiles
- 10 = Command_UpgradeAmericaCountermeasures
- 12 = Command_UpgradeEMPMines
+ 7  = Boss_Command_UpgradeChinaAircraftArmor ; Patch @tweak from 8
+ 8  = Boss_Command_UpgradeAmericaLaserMissiles
+ 10 = Boss_Command_UpgradeAmericaCountermeasures
+ 12 = Boss_Command_UpgradeEMPMines
  13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaSupplyCenterCommandSet
   1 = Boss_Command_ConstructChinaVehicleSupplyTruck
  12 = Boss_Command_UpgradeChinaMines
@@ -5680,13 +5708,12 @@ End
 
 CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
   1 = Boss_Command_ConstructChinaVehicleSupplyTruck
- 12 = Command_UpgradeEMPMines
+ 12 = Boss_Command_UpgradeEMPMines
  13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaBarracksCommandSet
   1 = Boss_Command_ConstructAmericaInfantryRanger
   2 = Boss_Command_ConstructChinaInfantryBlackLotus
@@ -5696,9 +5723,9 @@ CommandSet Boss_ChinaBarracksCommandSet
   6 = Boss_Command_ConstructAmericaInfantryColonelBurton
   7 = Boss_Command_ConstructAmericaInfantryPathfinder
   8 = Boss_Command_ConstructGLAInfantryAngryMob
-  9 = Command_UpgradeAmericaRangerCaptureBuilding
- 10 = Command_UpgradeAmericaChemicalSuits
- 11 = Command_UpgradeAmericaRangerFlashBangGrenade
+  9 = Boss_Command_UpgradeAmericaRangerCaptureBuilding
+ 10 = Boss_Command_UpgradeAmericaChemicalSuits
+ 11 = Boss_Command_UpgradeAmericaRangerFlashBangGrenade
  12 = Boss_Command_UpgradeChinaMines
  13 = Command_SetRallyPoint
  14 = Command_Sell
@@ -5713,25 +5740,24 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   6 = Boss_Command_ConstructAmericaInfantryColonelBurton
   7 = Boss_Command_ConstructAmericaInfantryPathfinder
   8 = Boss_Command_ConstructGLAInfantryAngryMob
-  9 = Command_UpgradeChinaRedguardCaptureBuilding
- 10 = Command_UpgradeAmericaChemicalSuits
- 11 = Command_UpgradeAmericaRangerFlashBangGrenade
- 12 = Command_UpgradeEMPMines
+  9 = Boss_Command_UpgradeAmericaRangerCaptureBuilding
+ 10 = Boss_Command_UpgradeAmericaChemicalSuits
+ 11 = Boss_Command_UpgradeAmericaRangerFlashBangGrenade
+ 12 = Boss_Command_UpgradeEMPMines
  13 = Command_SetRallyPoint
  14 = Command_Sell
 End
 
 ; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar faction button positions. (#1865)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaWarFactoryCommandSet
   1 = Boss_Command_ConstructAmericaVehiclePaladin
   2 = Boss_Command_ConstructChinaTankOverlord ; Patch104p @tweak from 5
   3 = Boss_Command_ConstructAmericaVehicleAvenger ; Patch104p @tweak from 4
   4 = Boss_Command_ConstructAmericaVehicleSentryDrone ; Patch104p @tweak from 9
   5 = Boss_Command_ConstructChinaTankGattling ; Patch104p @tweak from 2
-  6 = Command_UpgradeChinaChainGuns ; Patch104p @tweak from 11
+  6 = Boss_Command_UpgradeChinaChainGuns ; Patch104p @tweak from 11
   7 = Boss_Command_ConstructChinaTankDragon ; Patch104p @tweak from 3
-  8 = Command_UpgradeChinaBlackNapalm ; Patch104p @tweak from 10
+  8 = Boss_Command_UpgradeChinaBlackNapalm ; Patch104p @tweak from 10
   9 = Boss_Command_ConstructAmericaVehicleTomahawk ; Patch104p @tweak from 6
   10 = Boss_Command_ConstructGLAVehicleRocketBuggy ; Patch104p @tweak from 8
   11 = Boss_Command_ConstructGLAVehicleCombatBikeTerrorist ; Patch104p @tweak from 7
@@ -5747,54 +5773,48 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   3 = Boss_Command_ConstructAmericaVehicleAvenger ; Patch104p @tweak from 4
   4 = Boss_Command_ConstructAmericaVehicleSentryDrone ; Patch104p @tweak from 9
   5 = Boss_Command_ConstructChinaTankGattling ; Patch104p @tweak from 2
-  6 = Command_UpgradeChinaChainGuns ; Patch104p @tweak from 11
+  6 = Boss_Command_UpgradeChinaChainGuns ; Patch104p @tweak from 11
   7 = Boss_Command_ConstructChinaTankDragon ; Patch104p @tweak from 3
-  8 = Command_UpgradeChinaBlackNapalm ; Patch104p @tweak from 10
+  8 = Boss_Command_UpgradeChinaBlackNapalm ; Patch104p @tweak from 10
   9 = Boss_Command_ConstructAmericaVehicleTomahawk ; Patch104p @tweak from 6
   10 = Boss_Command_ConstructGLAVehicleRocketBuggy ; Patch104p @tweak from 8
   11 = Boss_Command_ConstructGLAVehicleCombatBikeTerrorist ; Patch104p @tweak from 7
-  12 = Command_UpgradeEMPMines
+  12 = Boss_Command_UpgradeEMPMines
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
 
 ; Patch104p @bugfix xezon 30/04/2023 Adds missing Drone Armor upgrade button. (#1892)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeAmericaCompositeArmor to avoid key conflict(s). (#2102)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_AmericaParticleUplinkCannonCommandSet
-  1 = Command_FireParticleUplinkCannon
-  4 = Command_UpgradeAmericaSentryDroneGun
+  1 = Boss_Command_FireParticleUplinkCannon
+  4 = Boss_Command_UpgradeAmericaSentryDroneGun
   6 = Boss_Command_UpgradeAmericaCompositeArmor
-  7 = Command_UpgradeAmericaDroneArmor
-  8 = Command_UpgradeAmericaAdvancedTraining
+  7 = Boss_Command_UpgradeAmericaDroneArmor
+  8 = Boss_Command_UpgradeAmericaAdvancedTraining
  12 = Boss_Command_UpgradeChinaMines
  14 = Command_Sell
 End
 
 ; Patch104p @bugfix xezon 30/04/2023 Adds missing Drone Armor upgrade button. (#1892)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeAmericaCompositeArmor to avoid key conflict(s). (#2102)
 CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
-  1 = Command_FireParticleUplinkCannon
-  4 = Command_UpgradeAmericaSentryDroneGun
+  1 = Boss_Command_FireParticleUplinkCannon
+  4 = Boss_Command_UpgradeAmericaSentryDroneGun
   6 = Boss_Command_UpgradeAmericaCompositeArmor
-  7 = Command_UpgradeAmericaDroneArmor
-  8 = Command_UpgradeAmericaAdvancedTraining
- 12 = Command_UpgradeEMPMines
+  7 = Boss_Command_UpgradeAmericaDroneArmor
+  8 = Boss_Command_UpgradeAmericaAdvancedTraining
+ 12 = Boss_Command_UpgradeEMPMines
  14 = Command_Sell
 End
 
 ; Patch104p @tweak xezon 30/04/2023 Sorts Buggy Ammo and AP Rockets upgrade buttons to some order as in GLA Black Market. (#1892)
 ; Patch104p @bugfix xezon 30/04/2023 Adds missing AP Bullets, JunkRepair, Anthrax Beta upgrade button. (#1892)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeGLAAnthraxBeta to avoid key conflict(s). (#2102)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeGLAArmTheMob to avoid key conflict(s). (#2102)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_GLAScudStormCommandSet
-  1  = Command_ScudStorm
-  3  = Command_UpgradeGLAAPBullets
-  4  = Command_UpgradeGLAAPRockets ; Patch104p @tweak from 6
-  5  = Command_UpgradeGLAJunkRepair
-  6  = Command_UpgradeGLABuggyAmmo ; Patch104p @tweak from 4
+  1  = Boss_Command_ScudStorm
+  3  = Boss_Command_UpgradeGLAAPBullets
+  4  = Boss_Command_UpgradeGLAAPRockets ; Patch104p @tweak from 6
+  5  = Boss_Command_UpgradeGLAJunkRepair
+  6  = Boss_Command_UpgradeGLABuggyAmmo ; Patch104p @tweak from 4
   7  = Boss_Command_UpgradeGLAAnthraxBeta
   8  = Boss_Command_UpgradeGLAArmTheMob
   12 = Boss_Command_UpgradeChinaMines
@@ -5803,30 +5823,26 @@ End
 
 ; Patch104p @tweak xezon 30/04/2023 Sorts Buggy Ammo and AP Rockets upgrade buttons to some order as in GLA Black Market. (#1892)
 ; Patch104p @bugfix xezon 30/04/2023 Adds missing AP Bullets, JunkRepair, Anthrax Beta upgrade button. (#1892)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeGLAAnthraxBeta to avoid key conflict(s). (#2102)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeGLAArmTheMob to avoid key conflict(s). (#2102)
 CommandSet Boss_GLAScudStormCommandSetUpgrade
-  1  = Command_ScudStorm
-  3  = Command_UpgradeGLAAPBullets
-  4  = Command_UpgradeGLAAPRockets ; Patch104p @tweak from 6
-  5  = Command_UpgradeGLAJunkRepair
-  6  = Command_UpgradeGLABuggyAmmo ; Patch104p @tweak from 4
+  1  = Boss_Command_ScudStorm
+  3  = Boss_Command_UpgradeGLAAPBullets
+  4  = Boss_Command_UpgradeGLAAPRockets ; Patch104p @tweak from 6
+  5  = Boss_Command_UpgradeGLAJunkRepair
+  6  = Boss_Command_UpgradeGLABuggyAmmo ; Patch104p @tweak from 4
   7  = Boss_Command_UpgradeGLAAnthraxBeta
   8  = Boss_Command_UpgradeGLAArmTheMob
-  12 = Command_UpgradeEMPMines
+  12 = Boss_Command_UpgradeEMPMines
   14 = Command_Sell
 End
 
 ; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions. (#1866)
 ; Patch104p @bugfix xezon 22/04/2023 Removes Neutron Shells upgrade button because Boss cannot build Nuke Cannon. (#1866)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_NeutronMissile to avoid key conflict(s). (#2102)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_UpgradeChinaMines to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaNuclearMissileCommandSet
   1 = Boss_Command_NeutronMissile
   4 = Boss_Command_UpgradeChinaNationalism ; Patch104p @tweak from 6
-  6 = Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
-  7 = Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
-  8 = Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
+  6 = Boss_Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
+  7 = Boss_Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
+  8 = Boss_Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
 ; 10 = Command_UpgradeChinaNeutronShells
  12 = Boss_Command_UpgradeChinaMines
  14 = Command_Sell
@@ -5835,14 +5851,13 @@ End
 ; Patch104p @bugfix commy2 18/09/2021 Fix Nationalism upgrade changing description after Landmines upgrade.
 ; Patch104p @tweak xezon 22/04/2023 Moves buttons into more familiar China button positions. (#1866)
 ; Patch104p @bugfix xezon 22/04/2023 Removes Neutron Shells upgrade button because Boss cannot build Nuke Cannon. (#1866)
-; Patch104p @bugfix xezon 12/07/2023 No longer uses Command_NeutronMissile to avoid key conflict(s). (#2102)
 CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   1 = Boss_Command_NeutronMissile
   4 = Boss_Command_UpgradeChinaNationalism ; Patch104p @tweak from 6
-  6 = Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
-  7 = Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
-  8 = Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
+  6 = Boss_Command_UpgradeChinaSubliminalMessaging ; Patch104p @tweak from 4
+  7 = Boss_Command_UpgradeChinaUraniumShells ; Patch104p @tweak from 9
+  8 = Boss_Command_UpgradeChinaNuclearTanks ; Patch104p @tweak from 7
 ; 10 = Command_UpgradeChinaNeutronShells
- 12 = Command_UpgradeEMPMines
+ 12 = Boss_Command_UpgradeEMPMines
  14 = Command_Sell
 End


### PR DESCRIPTION
* Follow up for #2102

This changes adds new dedicated buttons and labels for all major Boss commands. This allows full key mapping customization independent of the three factions it borrows features from.

User facing nothing changes as is.

The downside is a lot of new code redundancy - the usual.