### PR TITLE
Fix: Worker Has Wrong Death Animation When Carrying Boxes

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2120_worker_death_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2120_worker_death_animation.yaml
@@ -14,7 +14,6 @@ labels:
   - v1.0
 
 links:
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1528
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2120
 
 authors:

--- a/Patch104pZH/Design/Changes/v1.0/2120_worker_death_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2120_worker_death_animation.yaml
@@ -1,5 +1,5 @@
 ---
-date: 2023-01-08
+date: 2023-07-16
 
 title: Fixes wrong exploded death animation of GLA Worker
 
@@ -15,7 +15,9 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1528
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2120
 
 authors:
   - RedMeow2
   - xezon
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -15888,6 +15888,7 @@ Object Chem_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -15899,12 +15900,14 @@ Object Chem_GLAInfantryWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
 
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16702,6 +16702,7 @@ Object Demo_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -16713,12 +16714,14 @@ Object Demo_GLAInfantryWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
 
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1235,6 +1235,7 @@ Object GC_Chem_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
       AnimationMode = ONCE
@@ -1244,11 +1245,13 @@ Object GC_Chem_GLAInfantryWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA
       AnimationMode = ONCE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -176,6 +176,7 @@ Object GC_Slth_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -187,12 +188,14 @@ Object GC_Slth_GLAInfantryWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
 
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -6044,6 +6044,7 @@ Object CINE_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -6055,12 +6056,14 @@ Object CINE_GLAInfantryWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
 
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA
@@ -8024,6 +8027,7 @@ Object CINE_CheeringWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -8035,12 +8039,14 @@ Object CINE_CheeringWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
 
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -3700,6 +3700,7 @@ Object GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -3711,12 +3712,14 @@ Object GLAInfantryWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
 
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17102,6 +17102,7 @@ Object Slth_GLAInfantryWorker
       AnimationMode = ONCE
       TransitionKey = TRANS_Dying
     End
+    AliasConditionState = DYING CARRYING
 
     TransitionState = TRANS_Dying TRANS_Flailing
       Animation = UIWRKR_SKL.UIWRKR_ADTE1
@@ -17113,12 +17114,14 @@ Object Slth_GLAInfantryWorker
       AnimationMode = LOOP
       TransitionKey = TRANS_Flailing
     End
+    AliasConditionState = DYING EXPLODED_FLAILING CARRYING
 
     ConditionState = DYING EXPLODED_BOUNCING
       Animation = UIWRKR_SKL.UIWRKR_ADTE3
       AnimationMode = ONCE
       TransitionKey = None
     End
+    AliasConditionState = DYING EXPLODED_BOUNCING CARRYING
 
     ConditionState  = SPECIAL_CHEERING
       Animation     = UIWRKR_SKL.UIWRKR_CHA


### PR DESCRIPTION
#### Situation in 1.04:

- Worker displays wrong death animation when blown up while carrying a box as described here: #1468

#### Situation in current patch main branch

- After the change in #1528, the Worker displays the correct death animation when blown up, but the wrong animation when shot while carrying a box. This worked previously in 1.04

Repro:

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/059f4bc9-88df-4d7d-87b3-4c63d655b986

#### Situation with this fix

- The correct death animation is played in all cases:

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/72cfde48-5247-4050-a180-746d035db4af

- close #1468

