### PR TITLE
Fix: Stinger Trooper Upgrade Icons

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2121_stinger_soldier_upgrade_cameos.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2121_stinger_soldier_upgrade_cameos.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-07-16
+
+title: Adds missing upgrade icons to Stinger Soldiers
+
+changes:
+  - fix: All Stinger Soldiers are missing AP Rockets upgrade icon.
+  - fix: Toxin General Stinger Soldier is missing Anthrax Gamma upgrade icon.
+  - fix: Unused Demo General Stinger Soldier is missing Demolitions upgrade icon.
+  - fix: Single player only GLA02 Stinger Soldier has inapplicable Camo Netting upgrade icon.
+
+labels:
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2121
+
+authors:
+  - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2121_stinger_soldier_upgrade_cameos.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2121_stinger_soldier_upgrade_cameos.yaml
@@ -4,10 +4,10 @@ date: 2023-07-16
 title: Adds missing upgrade icons to Stinger Soldiers
 
 changes:
-  - fix: All Stinger Soldiers are missing AP Rockets upgrade icon.
-  - fix: Toxin General Stinger Soldier is missing Anthrax Gamma upgrade icon.
-  - fix: Unused Demo General Stinger Soldier is missing Demolitions upgrade icon.
-  - fix: Single player only GLA02 Stinger Soldier has inapplicable Camo Netting upgrade icon.
+  - fix: All GLA Stinger Soldiers now show the AP Rockets upgrade icon.
+  - fix: Toxin General Stinger Soldiers now show the Anthrax Gamma upgrade icon.
+  - fix: Demo General Stinger Soldiers (unused) now show the Demolitions upgrade icon.
+  - fix: Enemy Stinger Soldiers from the GLA02 single player campaign no longer show the inapplicable Camo Netting upgrade icon.
 
 labels:
   - gla

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13402,8 +13402,8 @@ Object Chem_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for Anthrax Gamma.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets. (#2121)
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for Anthrax Gamma. (#2121)
   UpgradeCameo1           = Upgrade_GLAAPRockets
   UpgradeCameo2           = Chem_Upgrade_GLAAnthraxGamma
   ;UpgradeCameo3           = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13402,6 +13402,14 @@ Object Chem_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for Anthrax Gamma.
+  UpgradeCameo1           = Upgrade_GLAAPRockets
+  UpgradeCameo2           = Chem_Upgrade_GLAAnthraxGamma
+  ;UpgradeCameo3           = NONE
+  ;UpgradeCameo4           = NONE
+  ;UpgradeCameo5           = NONE
+
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13869,8 +13869,8 @@ Object Demo_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for Demolitions upgrade.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets. (#2121)
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for Demolitions upgrade. (#2121)
   UpgradeCameo1           = Upgrade_GLAAPRockets
   UpgradeCameo2           = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo3           = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13869,6 +13869,14 @@ Object Demo_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for Demolitions upgrade.
+  UpgradeCameo1           = Upgrade_GLAAPRockets
+  UpgradeCameo2           = Demo_Upgrade_SuicideBomb
+  ;UpgradeCameo3           = NONE
+  ;UpgradeCameo4           = NONE
+  ;UpgradeCameo5           = NONE
+
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -120,7 +120,7 @@ Object GC_Chem_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets. (#2121)
   UpgradeCameo1           = Upgrade_GLAAPRockets
   UpgradeCameo2           = Chem_Upgrade_GLAAnthraxGamma
   ;UpgradeCameo3           = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -116,10 +116,16 @@ End
 ;-------------------------------------------------------------------------
 Object GC_Chem_GLAInfantryStingerSoldier
 
-  UpgradeCameo1 = Chem_Upgrade_GLAAnthraxGamma
   ; *** ART Parameters ***
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
+
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  UpgradeCameo1           = Upgrade_GLAAPRockets
+  UpgradeCameo2           = Chem_Upgrade_GLAAnthraxGamma
+  ;UpgradeCameo3           = NONE
+  ;UpgradeCameo4           = NONE
+  ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -440,8 +440,8 @@ Object GC_Slth_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
-  ; Patch104p @bugfix commy2 16/07/2023 Remove wrong upgrade icon for Camo Netting.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets. (#2121)
+  ; Patch104p @bugfix commy2 16/07/2023 Remove wrong upgrade icon for Camo Netting. (#2121)
   UpgradeCameo1           = Upgrade_GLAAPRockets
   ;UpgradeCameo2           = NONE
   ;UpgradeCameo3           = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -440,7 +440,9 @@ Object GC_Slth_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
-  UpgradeCameo1           = Upgrade_GLACamoNetting
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  ; Patch104p @bugfix commy2 16/07/2023 Remove wrong upgrade icon for Camo Netting.
+  UpgradeCameo1           = Upgrade_GLAAPRockets
   ;UpgradeCameo2           = NONE
   ;UpgradeCameo3           = NONE
   ;UpgradeCameo4           = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -973,6 +973,13 @@ Object GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  UpgradeCameo1           = Upgrade_GLAAPRockets
+  ;UpgradeCameo2           = NONE
+  ;UpgradeCameo3           = NONE
+  ;UpgradeCameo4           = NONE
+  ;UpgradeCameo5           = NONE
+
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -973,7 +973,7 @@ Object GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets. (#2121)
   UpgradeCameo1           = Upgrade_GLAAPRockets
   ;UpgradeCameo2           = NONE
   ;UpgradeCameo3           = NONE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14414,6 +14414,13 @@ Object Slth_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  UpgradeCameo1           = Upgrade_GLAAPRockets
+  ;UpgradeCameo2           = NONE
+  ;UpgradeCameo3           = NONE
+  ;UpgradeCameo4           = NONE
+  ;UpgradeCameo5           = NONE
+
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
 
   Draw = W3DModelDraw ModuleTag_01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14414,7 +14414,7 @@ Object Slth_GLAInfantryStingerSoldier
   SelectPortrait         = SUStinger_L
   ButtonImage            = SUStinger
 
-  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets.
+  ; Patch104p @bugfix commy2 16/07/2023 Add missing upgrade icon for AP Rockets. (#2121)
   UpgradeCameo1           = Upgrade_GLAAPRockets
   ;UpgradeCameo2           = NONE
   ;UpgradeCameo3           = NONE


### PR DESCRIPTION
- In the Generals Challenge vs Stealthgen / Kassad, there are a few Stinger Troopers placed outside of the Stinger Site.
- https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1086 makes them selectable, which makes them way less annoying to kill
- However, with them being selectable it becomes apparent that they are missing upgrade icons for AP Rockets.

With this PR:

- AP Rockets icon will be added to all Stinger Troopers. 
- Suicide icon will be added to the unused Demogen Stinger Troopers (the Demo Stinger Site uses vGLA Troopers). 
- Anthrax Gamma icon will be added to the Toxgen Stinger Troopers.
- Camo Netting icon will be removed from the single player only GLA02 Stinger Troopers. That upgrade does not transfer from the Site to the Troopers anyway, so it would always be greyed out.

This has essentially no effect in multiplayer as these units are mot buildable outside of Stinger Sites and are not selectable on any map by default.