### PR TITLE
Reduce key mapping changes

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2108_german_key_conflicts.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2108_german_key_conflicts.yaml
@@ -7,10 +7,11 @@ changes:
   - fix: All 99 German specific key conflicts are now fixed.
 
 subchanges:
+  - fix: The Boss Patriot System can now be constructed with key M and no longer conflicts with Bunker (B).
+  - fix: The Boss Supply Center can now be constructed with key U and no longer conflicts with Tunnel Network (N).
   - fix: The Boss Arm the Mob can now be researched with key O and no longer conflicts with Buggy Ammo (B).
   - fix: The Boss Gattling Tank can now be produced with key A and no longer conflicts with Avenger (G).
   - fix: The Boss Land Mines can now be researched with key M and no longer conflicts with Laser Missiles (L).
-  - fix: The China Supply Center can now be constructed with key U and no longer conflicts with Tunnel Network (N).
   - fix: The China Black Napalm can now be researched with key N and no longer conflicts with Listening Outpost (S).
   - fix: The China Subliminal Messaging can now be researched with key B and no longer conflicts with Uranium Shells (U).
   - fix: The China Nuclear Tanks can now be researched with key P and no longer conflicts with Nationalism (N).
@@ -33,7 +34,6 @@ subchanges:
   - fix: The USA Combat Drop can now be triggered with key N and no longer conflicts with Attack Move (A).
   - fix: The USA Hold The Line plan can now be set with key N and no longer conflicts with Stop (S).
   - fix: The USA Search and Destroy plan can now be set with key G and no longer conflicts with Carpet Bomb (T).
-  - fix: The USA Patriot System can now be constructed with key M and no longer conflicts with Bunker (B).
   - fix: The USA Strategy Center can now be constructed with key T and no longer conflicts with Stop (S).
   - fix: The USA Burton can now be produced with key O and no longer conflicts with Missile Defender (B).
   - fix: The USA Nuke Cannon can now be produced with key K and no longer conflicts with Black Napalm (N).
@@ -55,6 +55,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2102
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2123
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2112_french_key_conflicts.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2112_french_key_conflicts.yaml
@@ -14,9 +14,8 @@ subchanges:
   - fix: The Boss Composite Armor can now be researched with key C and no longer conflicts with Particle Cannon (P).
   - fix: The Boss Nuke Missile can now be launched with key I and no longer conflicts with Mines (M).
   - fix: The Boss Sneak Attack can now be placed with key F and no longer conflicts with Carpet Bomb (T).
-  - fix: The China Overlord can now be produced with key O and no longer conflicts with Paladin (P).
-  - fix: The China Inferno Cannon can now be produced with key P.
-  - fix: The China Black Lotus can now be produced with key L and no longer conflicts with Burton (N).
+  - fix: The Boss Overlord can now be produced with key O and no longer conflicts with Paladin (P).
+  - fix: The China Black Lotus can now be produced with key S and no longer conflicts with Burton (N).
   - fix: The China EMP Pulse can now be placed with key E and no longer conflicts with Mines (P).
   - fix: The China Helix Nuke Bomb can now be researched with key N and no longer conflicts with Attack Move (A).
   - fix: The China Infantry Outpost can now be produced with key S and no longer conflicts with Inferno Cannon (O).
@@ -46,6 +45,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2112
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2123
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2117_spanish_key_conflicts.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2117_spanish_key_conflicts.yaml
@@ -12,8 +12,7 @@ subchanges:
   - fix: The Boss Gattling Tank can now be produced with key A and no longer conflicts with Avenger (G).
   - fix: The Boss Nuke Missile can now be constructed with key I and no longer conflicts with Pariot Missile (M).
   - fix: The Boss Nuke Missile can now be launched with key I and no longer conflicts with Nationalism (N).
-  - fix: The China War Factory can now be constructed with key A.
-  - fix: The China Gattling Cannon can now be placed with key G and no longer conflicts with Tunnel Network (N).
+  - fix: The China Gattling Cannon can now be placed with key A and no longer conflicts with Tunnel Network (N).
   - fix: The China Subliminal Messaging can now be researched with key B and no longer conflicts with Uranium Shells (U).
   - fix: The China Cash Hack can now be used with key C and no longer conflicts with Paradrop (P).
   - fix: The China Cluster Mines can now be placed with key I and no longer conflicts with Mines (M).
@@ -40,7 +39,7 @@ subchanges:
   - fix: The USA MOAB can now be researched with key M and no longer conflicts with Stop (S).
   - fix: The USA Spectre can now be placed with key G and no longer conflicts with View Command Center (H).
   - fix: The USA Combat Chinook can now be produced with key T and no longer conflicts with View Command Center (H).
-  - fix: The USA Laser Tank can now be produced with key T.
+  - fix: The USA Laser Tank can now be produced with key C.
 
 labels:
   - boss
@@ -54,6 +53,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2117
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2123
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2118_italian_key_conflicts.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2118_italian_key_conflicts.yaml
@@ -34,7 +34,7 @@ subchanges:
   - fix: The USA Composite Armor can now be researched with key P and no longer conflicts with Intelligence (C).
   - fix: The USA Sentry Drone can now be produced with key S and no longer conflicts with Dragon Tank (D).
   - fix: The USA Laser Turret can now be constructed with key M.
-  - fix: The USA Laser Tank can now be produced with key T.
+  - fix: The USA Laser Tank can now be produced with key C.
 
 labels:
   - boss
@@ -48,6 +48,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2118
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2123
 
 authors:
   - xezon


### PR DESCRIPTION
**Merge with Rebase**

* Follow up for #2108
* Follow up for #2112
* Follow up for #2117
* Follow up for #2118

This change walks back and improves a few of the key changes to resolve Boss conflicts with. Plus improves resolved mappings of French Lotus, Spanish Laser Tank and Italian Laser Tank to fit better to faction variant mappings (Super Lotus, Crusader Tank).

Also the "Patriot Batterie" change for German was reverted for now.

### German

* The Boss Patriot System can now be constructed with key M and no longer conflicts with Bunker (B).
* The Boss Supply Center can now be constructed with key U and no longer conflicts with Tunnel Network (N).
* ~~The China Supply Center can now be constructed with key U and no longer conflicts with Tunnel Network (N).~~
* ~~The USA Patriot System can now be constructed with key M and no longer conflicts with Bunker (B).~~

### French
* The Boss Overlord can now be produced with key O and no longer conflicts with Paladin (P).
* The China Black Lotus can now be produced with key S and no longer conflicts with Burton (N).
* ~~The China Overlord can now be produced with key O and no longer conflicts with Paladin (P).~~
* ~~The China Inferno Cannon can now be produced with key P.~~
* ~~The China Black Lotus can now be produced with key L and no longer conflicts with Burton (N).~~

### Spanish

* The China Gattling Cannon can now be placed with key A and no longer conflicts with Tunnel Network (N).
* The USA Laser Tank can now be produced with key C.
* ~~The China War Factory can now be constructed with key A.~~
* ~~The China Gattling Cannon can now be placed with key G and no longer conflicts with Tunnel Network (N).~~
* ~~The USA Laser Tank can now be produced with key T.~~

### Italian

* The USA Laser Tank can now be produced with key C.
* ~~The USA Laser Tank can now be produced with key T.~~
