### PR TITLE
Fix: Set consistent name for EMP Patriot Battery in German language

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2124_german_emp_patriot_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2124_german_emp_patriot_text.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-07-17
+
+title: Sets consistent name for EMP Patriot Battery in German language
+
+changes:
+  - fix: The EMP version of the "Patriot-Batterie" is now called "EMP Patriot-Batterie".
+
+labels:
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2124
+
+authors:
+  - xezon


### PR DESCRIPTION
This change sets the correct name of the EMP Patriot Battery in the German language. It is now consistent with "Patriot-Batterie". In voice lines it is also described as "Patriot Batterie".