### PR TITLE
Fix: Boss General key conflicts in Korean localization

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2125_korean_boss_key_conflicts.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2125_korean_boss_key_conflicts.yaml
@@ -1,0 +1,30 @@
+---
+date: 2023-07-17
+
+title: Fixes Boss General key conflicts in Korean localization
+
+changes:
+  - fix: All 13 Korean specific key conflicts are now fixed.
+
+subchanges:
+  - fix: The Boss Nuke Missile can now be constructed with key I and no longer conflicts with Patriot Missile (M).
+  - fix: The Boss Nuke Missile can now be launched with key I and no longer conflicts with Nationalism (N).
+  - fix: The Boss Sneak Attack can now be placed with key S and no longer conflicts with Carpet Bomb (T).
+  - fix: The Boss Gattling Tank can now be produced with key A and no longer conflicts with Avenger (G).
+  - fix: The Boss Land Mines can now be researched with key M and no longer conflicts with Laser Missiles (L).
+  - fix: The Boss Arm the Mob can now be researched with key O and no longer conflicts with Neutron Mines (M).
+  - fix: The Boss Composite Armor can now be researched with key C and no longer conflicts with Particle Cannon (P).
+  - fix: The Boss Anthrax Beta can now be researched with key X and no longer conflicts with Buggy Ammo (A).
+
+labels:
+  - boss
+  - bug
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2125
+
+authors:
+  - xezon


### PR DESCRIPTION
* Relates to #2091

This change fixes 13 key conflicts in Korean localization.

* The Boss Nuke Missile can now be constructed with key I and no longer conflicts with Patriot Missile (M).
* The Boss Nuke Missile can now be launched with key I and no longer conflicts with Nationalism (N).
* The Boss Sneak Attack can now be placed with key S and no longer conflicts with Carpet Bomb (T).
* The Boss Gattling Tank can now be produced with key A and no longer conflicts with Avenger (G).
* The Boss Land Mines can now be researched with key M and no longer conflicts with Laser Missiles (L).
* The Boss Arm the Mob can now be researched with key O and no longer conflicts with Neutron Mines (M).
* The Boss Composite Armor can now be researched with key C and no longer conflicts with Particle Cannon (P).
* The Boss Anthrax Beta can now be researched with key X and no longer conflicts with Buggy Ammo (A).

## Issue log

```
Boss_AmericaDozerCommandSet has key conflict with
  Boss_Command_ConstructAmericaPatriotBattery : CONTROLBAR:ConstructAmericaPatriotBattery "패트리엇 미사일 시스템(&M)"
  Boss_Command_ConstructChinaNuclearMissileLauncher : CONTROLBAR:ConstructChinaNuclearMissileLauncher "핵 미사일(&M)"

Boss_ChinaCommandCenterCommandSet has key conflict with
  Command_ChinaCarpetBomb : CONTROLBAR:CarpetBomb "융단 폭격(&T)"
  Command_SneakAttack : CONTROLBAR:SneakAttack "잠입 공격(&T)"

Boss_ChinaCommandCenterCommandSetUpgrade has key conflict with
  Command_ChinaCarpetBomb : CONTROLBAR:CarpetBomb "융단 폭격(&T)"
  Command_SneakAttack : CONTROLBAR:SneakAttack "잠입 공격(&T)"

Boss_ChinaAirfieldCommandSet has key conflict with
  Command_UpgradeAmericaLaserMissiles : CONTROLBAR:UpgradeAmericaLaserMissiles "레이저 미사일(&L)"
  Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰(&L)"

Boss_ChinaWarFactoryCommandSet has key conflict with
  Boss_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "어벤져(&G)"
  Boss_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "개틀링 탱크(&G)"

Boss_ChinaWarFactoryCommandSetUpgrade has key conflict with
  Boss_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "어벤져(&G)"
  Boss_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "개틀링 탱크(&G)"

Boss_AmericaParticleUplinkCannonCommandSet has key conflict with
  Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "파티클 캐논 발사(&P)"
  Command_UpgradeAmericaCompositeArmor : CONTROLBAR:UpgradeAmericaCompositeArmor "합성장갑(&P)"

Boss_AmericaParticleUplinkCannonCommandSetUpgrade has key conflict with
  Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "파티클 캐논 발사(&P)"
  Command_UpgradeAmericaCompositeArmor : CONTROLBAR:UpgradeAmericaCompositeArmor "합성장갑(&P)"

Boss_GLAScudStormCommandSet has key conflict with
  Command_UpgradeGLABuggyAmmo : CONTROLBAR:UpgradeGLABuggyAmmo "버기 공격력(&A)"
  Command_UpgradeGLAAnthraxBeta : CONTROLBAR:UpgradeGLAAnthraxBeta "탄저병 베타(&A)"

Boss_GLAScudStormCommandSetUpgrade has key conflict with
  Command_UpgradeGLABuggyAmmo : CONTROLBAR:UpgradeGLABuggyAmmo "버기 공격력(&A)"
  Command_UpgradeGLAAnthraxBeta : CONTROLBAR:UpgradeGLAAnthraxBeta "탄저병 베타(&A)"

Boss_GLAScudStormCommandSetUpgrade has key conflict with
  Command_UpgradeGLAArmTheMob : CONTROLBAR:UpgradeGLAArmTheMob "성난 군중 무장(&M)"
  Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰(&M)"

Boss_ChinaNuclearMissileCommandSet has key conflict with
  Command_NeutronMissile : CONTROLBAR:NeutronMissile "핵 미사일(&N)"
  Boss_Command_UpgradeChinaNationalism : CONTROLBAR:UpgradeChinaNationalism "민족주의(&N)"

Boss_ChinaNuclearMissileCommandSetUpgrade has key conflict with
  Command_NeutronMissile : CONTROLBAR:NeutronMissile "핵 미사일(&N)"
  Boss_Command_UpgradeChinaNationalism : CONTROLBAR:UpgradeChinaNationalism "민족주의(&N)"
```