### PR TITLE
Fix: Boss General key conflicts in Chinese localization

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2128_chinese_boss_key_conflicts.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2128_chinese_boss_key_conflicts.yaml
@@ -1,0 +1,30 @@
+---
+date: 2023-07-18
+
+title: Fixes Boss General key conflicts in Chinese localization
+
+changes:
+  - fix: All 13 Chinese specific key conflicts are now fixed.
+
+subchanges:
+  - fix: The Boss Nuke Missile can now be constructed with key I and no longer conflicts with Patriot Missile (M).
+  - fix: The Boss Nuke Missile can now be launched with key I and no longer conflicts with Nationalism (N).
+  - fix: The Boss Sneak Attack can now be placed with key S and no longer conflicts with Carpet Bomb (T).
+  - fix: The Boss Gattling Tank can now be produced with key A and no longer conflicts with Avenger (G).
+  - fix: The Boss Land Mines can now be researched with key M and no longer conflicts with Laser Missiles (L).
+  - fix: The Boss Arm the Mob can now be researched with key O and no longer conflicts with Neutron Mines (M).
+  - fix: The Boss Composite Armor can now be researched with key C and no longer conflicts with Particle Cannon (P).
+  - fix: The Boss Anthrax Beta can now be researched with key X and no longer conflicts with Buggy Ammo (A).
+
+labels:
+  - boss
+  - bug
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2128
+
+authors:
+  - xezon


### PR DESCRIPTION
* Relates to #2091

This change fixes 13 key conflicts in Chinese localization.

* The Boss Nuke Missile can now be constructed with key I and no longer conflicts with Patriot Missile (M).
* The Boss Nuke Missile can now be launched with key I and no longer conflicts with Nationalism (N).
* The Boss Sneak Attack can now be placed with key S and no longer conflicts with Carpet Bomb (T).
* The Boss Gattling Tank can now be produced with key A and no longer conflicts with Avenger (G).
* The Boss Land Mines can now be researched with key M and no longer conflicts with Laser Missiles (L).
* The Boss Arm the Mob can now be researched with key O and no longer conflicts with Neutron Mines (M).
* The Boss Composite Armor can now be researched with key C and no longer conflicts with Particle Cannon (P).
* The Boss Anthrax Beta can now be researched with key X and no longer conflicts with Buggy Ammo (A).

## Issue log

```
Boss_AmericaDozerCommandSet has key conflict with
  Boss_Command_ConstructAmericaPatriotBattery : CONTROLBAR:ConstructAmericaPatriotBattery "愛國者飛彈系統（&M）"
  Boss_Command_ConstructChinaNuclearMissileLauncher : CONTROLBAR:ConstructChinaNuclearMissileLauncher "核彈（&M）"

Boss_ChinaCommandCenterCommandSet has key conflict with
  Command_ChinaCarpetBomb : CONTROLBAR:CarpetBomb "地毯式炸彈轟炸（&T）"
  Command_SneakAttack : CONTROLBAR:SneakAttack "偷襲（&T）"

Boss_ChinaCommandCenterCommandSetUpgrade has key conflict with
  Command_ChinaCarpetBomb : CONTROLBAR:CarpetBomb "地毯式炸彈轟炸（&T）"
  Command_SneakAttack : CONTROLBAR:SneakAttack "偷襲（&T）"

Boss_ChinaAirfieldCommandSet has key conflict with
  Command_UpgradeAmericaLaserMissiles : CONTROLBAR:UpgradeAmericaLaserMissiles "雷射飛彈（&L）"
  Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "埋放地雷（&L）"

Boss_ChinaWarFactoryCommandSet has key conflict with
  Boss_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "復仇者支援車（&G）"
  Boss_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "蓋特坦克（&G）"

Boss_ChinaWarFactoryCommandSetUpgrade has key conflict with
  Boss_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "復仇者支援車（&G）"
  Boss_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "蓋特坦克（&G）"

Boss_AmericaParticleUplinkCannonCommandSet has key conflict with
  Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "發射離子砲（&P）"
  Command_UpgradeAmericaCompositeArmor : CONTROLBAR:UpgradeAmericaCompositeArmor "複合式裝甲（&P）"

Boss_AmericaParticleUplinkCannonCommandSetUpgrade has key conflict with
  Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "發射離子砲（&P）"
  Command_UpgradeAmericaCompositeArmor : CONTROLBAR:UpgradeAmericaCompositeArmor "複合式裝甲（&P）"

Boss_GLAScudStormCommandSet has key conflict with
  Command_UpgradeGLABuggyAmmo : CONTROLBAR:UpgradeGLABuggyAmmo "吉普車彈藥（&A）"
  Command_UpgradeGLAAnthraxBeta : CONTROLBAR:UpgradeGLAAnthraxBeta "炭疽菌試驗（&A）"

Boss_GLAScudStormCommandSetUpgrade has key conflict with
  Command_UpgradeGLABuggyAmmo : CONTROLBAR:UpgradeGLABuggyAmmo "吉普車彈藥（&A）"
  Command_UpgradeGLAAnthraxBeta : CONTROLBAR:UpgradeGLAAnthraxBeta "炭疽菌試驗（&A）"

Boss_GLAScudStormCommandSetUpgrade has key conflict with
  Command_UpgradeGLAArmTheMob : CONTROLBAR:UpgradeGLAArmTheMob "武裝暴民（&M）"
  Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "中子地雷（&M）"

Boss_ChinaNuclearMissileCommandSet has key conflict with
  Command_NeutronMissile : CONTROLBAR:NeutronMissile "核彈（&N）"
  Boss_Command_UpgradeChinaNationalism : CONTROLBAR:UpgradeChinaNationalism "民族精神（&N）"

Boss_ChinaNuclearMissileCommandSetUpgrade has key conflict with
  Command_NeutronMissile : CONTROLBAR:NeutronMissile "核彈（&N）"
  Boss_Command_UpgradeChinaNationalism : CONTROLBAR:UpgradeChinaNationalism "民族精神（&N）"
```