### PR TITLE
Fix: Streamline key mappings of GLA fake structures with regular GLA structures

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2142_fake_structures_key_mismatch.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2142_fake_structures_key_mismatch.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-07-23
+
+title: Streamlines key mappings of GLA fake structures with regular GLA structures
+
+changes:
+  - fix: All GLA fake structures now have the same key mapping as regular GLA structures in French, Spanish, Italian and Polish languages.
+  - tweak: The GLA worker can now toggle to real structures with key F in Spanish, Italian and Polish languages.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2142
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
@@ -73,10 +73,10 @@ End
 CommandSet GLAWorkerFakeBuildingsCommandSet
   1 = Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Centro de mando falso: &C"
   2 = Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Barracones falsos: &B"
-  3 = Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &U"
+  3 = Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &R"
   4 = Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Tienda de armas falsa: &A"
   5 = Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Mercado negro falso: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Despejar minas"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -84,7 +84,7 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, L, N, O, P, T, V, Y, Z, 
+    Available keys: D, G, I, J, K, L, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -2818,10 +2818,10 @@ End
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   1 = Demo_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Centro de mando falso: &C"
   2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Barracones falsos: &B"
-  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &U"
+  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &R"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Tienda de armas falsa: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Mercado negro falso: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Despejar minas"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -2829,7 +2829,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, L, N, O, P, T, V, Y, Z, 
+    Available keys: D, G, I, J, K, L, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -3339,11 +3339,11 @@ End
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   1 = Demo_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Centro de mando falso: &C"
   2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Barracones falsos: &B"
-  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &U"
+  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &R"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Tienda de armas falsa: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Mercado negro falso: &M"
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Despejar minas"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3351,7 +3351,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, L, N, O, P, T, V, Y, Z, 
+    Available keys: D, G, I, J, K, L, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3722,10 +3722,10 @@ End
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   1 = Slth_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Centro de mando falso: &C"
   2 = Slth_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Barracones falsos: &B"
-  3 = Slth_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &U"
+  3 = Slth_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &R"
   4 = Slth_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Tienda de armas falsa: &A"
   5 = Slth_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Mercado negro falso: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Despejar minas"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3733,7 +3733,7 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, L, N, O, P, T, V, Y, Z, 
+    Available keys: D, G, I, J, K, L, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -4101,10 +4101,10 @@ End
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   1 = Chem_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Centro de mando falso: &C"
   2 = Chem_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Barracones falsos: &B"
-  3 = Chem_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &U"
+  3 = Chem_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &R"
   4 = Chem_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Tienda de armas falsa: &A"
   5 = Chem_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Mercado negro falso: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Despejar minas"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -4112,7 +4112,7 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, L, N, O, P, T, V, Y, Z, 
+    Available keys: D, G, I, J, K, L, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLABarracksCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
@@ -67,8 +67,8 @@ End
 
 CommandSet GLAWorkerFakeBuildingsCommandSet
   1 = Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Décor Poste de commandement: &C"
-  2 = Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &D"
-  3 = Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &R"
+  2 = Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &R"
+  3 = Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &I"
   4 = Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Décor Trafiquant d'armes: &A"
   5 = Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Décor Marché noir: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Vraies structures: &V"
@@ -78,7 +78,7 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, J, K, L, N, O, P, T, U, W, Y, Z, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -2616,8 +2616,8 @@ End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   1 = Demo_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Décor Poste de commandement: &C"
-  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &D"
-  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &R"
+  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &R"
+  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &I"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Décor Trafiquant d'armes: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Décor Marché noir: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Vraies structures: &V"
@@ -2627,7 +2627,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, J, K, L, N, O, P, T, U, W, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -3102,8 +3102,8 @@ End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   1 = Demo_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Décor Poste de commandement: &C"
-  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &D"
-  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &R"
+  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &R"
+  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &I"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Décor Trafiquant d'armes: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Décor Marché noir: &M"
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
@@ -3114,7 +3114,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, J, K, L, N, O, P, T, U, W, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3459,8 +3459,8 @@ End
 
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   1 = Slth_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Décor Poste de commandement: &C"
-  2 = Slth_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &D"
-  3 = Slth_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &R"
+  2 = Slth_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &R"
+  3 = Slth_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &I"
   4 = Slth_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Décor Trafiquant d'armes: &A"
   5 = Slth_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Décor Marché noir: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Vraies structures: &V"
@@ -3470,7 +3470,7 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, J, K, L, N, O, P, T, U, W, Y, Z, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -3811,8 +3811,8 @@ End
 
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   1 = Chem_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Décor Poste de commandement: &C"
-  2 = Chem_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &D"
-  3 = Chem_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &R"
+  2 = Chem_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Décor Caserne: &R"
+  3 = Chem_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &I"
   4 = Chem_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Décor Trafiquant d'armes: &A"
   5 = Chem_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Décor Marché noir: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Vraies structures: &V"
@@ -3822,7 +3822,7 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, J, K, L, N, O, P, T, U, W, Y, Z, 
 End
 
 CommandSet Chem_GLABarracksCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
@@ -67,18 +67,18 @@ End
 
 CommandSet GLAWorkerFakeBuildingsCommandSet
   1 = Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Falso Centro comando: &C"
-  2 = Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &A"
-  3 = Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &N"
-  4 = Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &T"
+  2 = Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &R"
+  3 = Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &U"
+  4 = Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &A"
   5 = Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Falso Mercato nero: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Disinnesca mine: &L"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, U, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -2616,18 +2616,18 @@ End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   1 = Demo_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Falso Centro comando: &C"
-  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &A"
-  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &N"
-  4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &T"
+  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &R"
+  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &U"
+  4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Falso Mercato nero: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Disinnesca mine: &L"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, U, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -3102,19 +3102,19 @@ End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   1 = Demo_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Falso Centro comando: &C"
-  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &A"
-  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &N"
-  4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &T"
+  2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &R"
+  3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &U"
+  4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Falso Mercato nero: &M"
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio: &I"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Disinnesca mine: &L"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, J, K, O, P, U, V, W, Y, Z, 
+    Available keys: B, D, G, J, K, N, O, P, T, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3459,18 +3459,18 @@ End
 
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   1 = Slth_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Falso Centro comando: &C"
-  2 = Slth_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &A"
-  3 = Slth_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &N"
-  4 = Slth_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &T"
+  2 = Slth_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &R"
+  3 = Slth_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &U"
+  4 = Slth_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &A"
   5 = Slth_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Falso Mercato nero: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Disinnesca mine: &L"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, U, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -3811,18 +3811,18 @@ End
 
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   1 = Chem_Command_ConstructFakeGLACommandCenter : CONTROLBAR:ConstructFakeGLACommandCenter "Falso Centro comando: &C"
-  2 = Chem_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &A"
-  3 = Chem_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &N"
-  4 = Chem_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &T"
+  2 = Chem_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Falsa Caserma: &R"
+  3 = Chem_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Falso Nucleo rifornimenti: &U"
+  4 = Chem_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Falso Trafficante d'armi: &A"
   5 = Chem_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Falso Mercato nero: &M"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Passa alle strutture reali: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Disinnesca mine: &L"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, U, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLABarracksCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
@@ -70,15 +70,15 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   2 = Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Fałszywe koszary: &K"
   3 = Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Fałszywy skład zaopatrzenia: &D"
   4 = Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Fałszywy handlarz bronią: &A"
-  5 = Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &C"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &R"
+  5 = Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Rozminowanie"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
+    Available keys: B, C, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -2619,15 +2619,15 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Fałszywe koszary: &K"
   3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Fałszywy skład zaopatrzenia: &D"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Fałszywy handlarz bronią: &A"
-  5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &C"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &R"
+  5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Rozminowanie"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
+    Available keys: B, C, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -3105,16 +3105,16 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   2 = Demo_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Fałszywe koszary: &K"
   3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Fałszywy skład zaopatrzenia: &D"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Fałszywy handlarz bronią: &A"
-  5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &C"
+  5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &R"
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonuj: &J"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Rozminowanie"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, L, M, N, O, P, T, U, V, W, Y, 
+    Available keys: B, C, G, I, L, M, N, O, P, T, U, V, W, Y, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3462,15 +3462,15 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   2 = Slth_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Fałszywe koszary: &K"
   3 = Slth_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Fałszywy skład zaopatrzenia: &D"
   4 = Slth_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Fałszywy handlarz bronią: &A"
-  5 = Slth_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &C"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &R"
+  5 = Slth_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Rozminowanie"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
+    Available keys: B, C, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -3814,15 +3814,15 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   2 = Chem_Command_ConstructFakeGLABarracks : CONTROLBAR:ConstructFakeGLABarracks "Fałszywe koszary: &K"
   3 = Chem_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Fałszywy skład zaopatrzenia: &D"
   4 = Chem_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Fałszywy handlarz bronią: &A"
-  5 = Chem_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &C"
-  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &R"
+  5 = Chem_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Fałszywy czarny rynek: &R"
+  13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Przełączenie na prawdziwe budynki: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Rozminowanie"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
+    Available keys: B, C, G, I, J, L, M, N, O, P, T, U, V, W, Y, 
 End
 
 CommandSet Chem_GLABarracksCommandSet


### PR DESCRIPTION
* Relates to #2095

This change fixes all key mapping mismatches between Fake GLA buildings and regular GLA buildings.

Affected languages are French, Spanish, Italian, Polish.