### PR TITLE
Fix: Key mapping mismatches between faction unit variations

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2143_faction_variant_key_mismatches.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2143_faction_variant_key_mismatches.yaml
@@ -1,0 +1,40 @@
+---
+date: 2023-07-23
+
+title: Fixes key mapping mismatches between faction unit variants in all languages
+
+changes:
+  - fix: Key mapping mismatches between faction unit variants are now fixed in all languages.
+
+subchanges:
+  - fix: The China Hacker can now be produced with the same key as for the Super Hacker in German language.
+  - fix: The China Emperor can now be produced with the same key as for the Overlord in French, Polish languages.
+  - fix: The China Minigunner can now be produced with the same key as for the regular Red Guard in all languages.
+  - fix: The China Super Lotus can now be produced with the same key as for the regular Black Lotus in all language.
+  - fix: The China Attack Outpost can now be produced with the same key as for the regular Outpost in English, Spanish, Italian, Korean, Chinese, Brazilian, Polish languages.
+  - fix: The China Assault Troop Crawler can now be produced with the same key as for the regular Troop Crawler in English, French, Spanish, Italian, Korean, Chinese, Brazilian, Polish languages.
+  - fix: The China Fortified Bunker can now be constructed with the same key as for the regular Bunker in Polish language.
+  - fix: The China Nuke Bomber can now be placed with the same key as for the regular Bomber in English, Korean, Chinese languages.
+  - fix: The GLA Toxin Rebel can now be produced with the same key as for the regular Rebel in German language.
+  - fix: The GLA Toxin Terrorist can now be produced with the same key as for the regular Terrorist in Spanish language.
+  - fix: The USA Control Rods can now be researched with the same key as for the Advanced Control Rods in Polish language.
+  - fix: The USA Aurora Alpha can now be produced with the same key as for the regular Aurora in Spanish, Italian languages.
+  - fix: The USA King Raptor can now be produced with the same key as for the regular Raptor in Brazilian language.
+  - fix: The USA Laser Turret can now be constructed with the same key as for the regular Patriot Battery in English, Spanish, Korean, Chinese, Brazilian, Polish languages.
+  - fix: The USA Laser Crusader can now be produced with the same key as for the regular Crusader in English, Korean, Chinese, Brazilian, Polish languages.
+
+labels:
+  - china
+  - design
+  - gla
+  - gui
+  - major
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2143
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
@@ -2464,7 +2464,7 @@ CommandSet AirF_AmericaFireBaseCommandSet
 End
 
 CommandSet AirF_AmericaAirfieldCommandSet
-  1 = AirF_Command_ConstructAmericaJetRaptor : CONTROLBAR:ConstructAmericaJetKingRaptor "King Raptor: &T"
+  1 = AirF_Command_ConstructAmericaJetRaptor : CONTROLBAR:ConstructAmericaJetKingRaptor "King Raptor: &R"
   2 = AirF_Command_ConstructAmericaVehicleComanche : CONTROLBAR:ConstructAmericaVehicleComanche "Comanche: &C"
   3 = AirF_Command_ConstructAmericaJetAurora : CONTROLBAR:ConstructAmericaJetAurora "Bombardeiro Aurora: &A"
   4 = AirF_Command_ConstructAmericaJetStealthFighter : CONTROLBAR:ConstructAmericaJetStealthFighter "Bombardeiro Invisível: &I"
@@ -2477,7 +2477,7 @@ CommandSet AirF_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, G, J, K, M, N, R, S, U, V, W, X, Y, Z, 
+    Available keys: D, E, G, J, K, M, N, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaParticleUplinkCannonCommandSet
@@ -4957,31 +4957,31 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minicanhão: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minicanhão: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Caçador de Tanques: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super Hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &B"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Capturar Estrutura: &C"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Campo Minado: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, J, K, L, N, O, R, U, V, W, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minicanhão: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minicanhão: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Caçador de Tanques: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super Hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Capturar Estrutura: &C"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Minas de Nêutron: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, J, K, L, N, O, R, U, V, W, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5008,8 +5008,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de Tropa de Assalto: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Postos Avançados de Ataque: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de Tropa de Assalto: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Postos Avançados de Ataque: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Correia de Balas: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Tanque Dragon: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Napalm Negro: &N"
@@ -5021,12 +5021,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, L, R, S, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, R, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de Tropa de Assalto: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Postos Avançados de Ataque: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de Tropa de Assalto: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Postos Avançados de Ataque: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Correia de Balas: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Tanque Dragon: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Napalm Negro: &N"
@@ -5038,7 +5038,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, L, R, S, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, R, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5411,7 +5411,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   4 = Lazr_Command_ConstructAmericaSupplyDropZone : CONTROLBAR:ConstructAmericaSupplyDropZone "Zona de Abastecimento Aéreo: &Z"
   5 = Lazr_Command_ConstructAmericaSupplyCenter : CONTROLBAR:ConstructAmericaSupplyCenter "Central de Suprimentos: &U"
   6 = Lazr_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:ConstructAmericaParticleCannonUplink "Canhão de Partículas: &P"
-  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Torres de Defesa com Laser: &D"
+  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Torres de Defesa com Laser: &M"
   8 = Lazr_Command_ConstructAmericaCommandCenter : CONTROLBAR:ConstructAmericaCommandCenter "Centro de Comando: &C"
   9 = Lazr_Command_ConstructAmericaFireBase : CONTROLBAR:ConstructAmericaFireBase "Base de Foguetes: &O"
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "Fábrica de Armamentos: &A"
@@ -5422,7 +5422,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, M, V, W, Y, 
+    Available keys: D, F, G, I, J, K, V, W, Y, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5470,7 +5470,7 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
-  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Tanque Laser: &T"
+  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Tanque Laser: &C"
   3 = Lazr_Command_ConstructAmericaVehicleHumvee : CONTROLBAR:ConstructAmericaVehicleHumvee "Jipe: &J"
   4 = Lazr_Command_ConstructAmericaVehicleMedic : CONTROLBAR:ConstructAmericaVehicleMedic "Ambulância: &A"
   6 = Lazr_Command_ConstructAmericaVehicleSentryDrone : CONTROLBAR:ConstructAmericaVehicleSentryDrone "Drone Sentinela: &S"
@@ -5482,7 +5482,7 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, K, L, O, R, U, V, X, Y, Z, 
+    Available keys: B, D, E, F, I, K, L, O, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet
@@ -6257,7 +6257,7 @@ End
 
 CommandSet Boss_ChinaAirfieldCommandSet
   1 = Boss_Command_ConstructChinaJetMIG : CONTROLBAR:Boss_ConstructChinaJetMIG "MiG: &G"
-  2 = Boss_Command_ConstructAmericaJetRaptor : CONTROLBAR:Boss_ConstructAmericaJetKingRaptor "King Raptor: &T"
+  2 = Boss_Command_ConstructAmericaJetRaptor : CONTROLBAR:Boss_ConstructAmericaJetKingRaptor "King Raptor: &R"
   3 = Boss_Command_ConstructChinaVehicleHelix : CONTROLBAR:Boss_ConstructChinaVehicleHelix "Hélix: &X"
   4 = Boss_Command_ConstructAmericaJetAurora : CONTROLBAR:Boss_ConstructAmericaJetAurora "Bombardeiro Aurora: &A"
   7 = Boss_Command_UpgradeChinaAircraftArmor : CONTROLBAR:Boss_UpgradeChinaAircraftArmor "Blindagem MiG: &D"
@@ -6268,12 +6268,12 @@ CommandSet Boss_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, E, F, I, J, K, N, R, S, U, V, W, Y, Z, 
+    Available keys: B, C, E, F, I, J, K, N, S, T, U, V, W, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSetUpgrade
   1 = Boss_Command_ConstructChinaJetMIG : CONTROLBAR:Boss_ConstructChinaJetMIG "MiG: &G"
-  2 = Boss_Command_ConstructAmericaJetRaptor : CONTROLBAR:Boss_ConstructAmericaJetKingRaptor "King Raptor: &T"
+  2 = Boss_Command_ConstructAmericaJetRaptor : CONTROLBAR:Boss_ConstructAmericaJetKingRaptor "King Raptor: &R"
   3 = Boss_Command_ConstructChinaVehicleHelix : CONTROLBAR:Boss_ConstructChinaVehicleHelix "Hélix: &X"
   4 = Boss_Command_ConstructAmericaJetAurora : CONTROLBAR:Boss_ConstructAmericaJetAurora "Bombardeiro Aurora: &A"
   7 = Boss_Command_UpgradeChinaAircraftArmor : CONTROLBAR:Boss_UpgradeChinaAircraftArmor "Blindagem MiG: &D"
@@ -6284,7 +6284,7 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, E, F, I, J, K, N, R, S, U, V, W, Y, Z, 
+    Available keys: B, C, E, F, I, J, K, N, S, T, U, V, W, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/de_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/de_commandsets.txt
@@ -1483,7 +1483,7 @@ End
 CommandSet ChinaBarracksCommandSet
   1 = Command_ConstructChinaInfantryRedguard : CONTROLBAR:ConstructChinaInfantryRedguard "Standard-Cyborg: &R"
   2 = Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
-  3 = Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  3 = Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   4 = Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:ConstructChinaInfantryBlackLotus "Black Bot: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Landminen: &L"
@@ -1491,13 +1491,13 @@ CommandSet ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, J, K, M, N, O, S, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, M, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSetUpgrade
   1 = Command_ConstructChinaInfantryRedguard : CONTROLBAR:ConstructChinaInfantryRedguard "Standard-Cyborg: &R"
   2 = Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
-  3 = Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  3 = Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   4 = Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:ConstructChinaInfantryBlackLotus "Black Bot: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Neutronenminen: &M"
@@ -1505,7 +1505,7 @@ CommandSet ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, J, K, L, N, O, S, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, L, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSet
@@ -2032,7 +2032,7 @@ CommandSet GC_Chem_GLAWorkerCommandSet
 End
 
 CommandSet GC_Chem_GLABarracksCommandSet
-  1 = GC_Chem_Command_ConstructGLAInfantryRebel : CONTROLBAR:Chem_ConstructGLAInfantryRebel "Säure-Cyborg: &S"
+  1 = GC_Chem_Command_ConstructGLAInfantryRebel : CONTROLBAR:Chem_ConstructGLAInfantryRebel "Säure-Cyborg: &R"
   2 = GC_Chem_Command_ConstructGLAInfantryRPGTrooper : CONTROLBAR:ConstructGLAInfantryRPGTrooper "RPG-Einheit: &P"
   3 = GC_Chem_Command_ConstructGLAInfantryTerrorist : CONTROLBAR:Chem_ConstructGLAInfantryTerrorist "Säure-Bombe: &B"
   5 = GC_Chem_Command_ConstructGLAInfantryHijacker : CONTROLBAR:ConstructGLAInfantryHijacker "Entführer: &F"
@@ -2043,7 +2043,7 @@ CommandSet GC_Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, J, K, L, M, N, O, R, T, V, W, X, Y, Z, 
+    Available keys: A, C, D, E, J, K, L, M, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAPalaceCommandSet
@@ -3826,7 +3826,7 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
 End
 
 CommandSet Chem_GLABarracksCommandSet
-  1 = Chem_Command_ConstructGLAInfantryRebel : CONTROLBAR:Chem_ConstructGLAInfantryRebel "Säure-Cyborg: &S"
+  1 = Chem_Command_ConstructGLAInfantryRebel : CONTROLBAR:Chem_ConstructGLAInfantryRebel "Säure-Cyborg: &R"
   2 = Chem_Command_ConstructGLAInfantryRPGTrooper : CONTROLBAR:ConstructGLAInfantryRPGTrooper "RPG-Einheit: &P"
   3 = Chem_Command_ConstructGLAInfantryTerrorist : CONTROLBAR:Chem_ConstructGLAInfantryTerrorist "Säure-Bombe: &B"
   4 = Chem_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Cyborg-Trupp: &T"
@@ -3836,7 +3836,7 @@ CommandSet Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, J, K, L, M, N, O, R, V, W, X, Y, Z, 
+    Available keys: A, C, D, E, F, J, K, L, M, N, O, S, V, W, X, Y, Z, 
 End
 
 CommandSet Chem_GLATunnelNetworkCommandSet
@@ -4102,7 +4102,7 @@ End
 CommandSet Nuke_ChinaBarracksCommandSet
   1 = Nuke_Command_ConstructChinaInfantryRedguard : CONTROLBAR:ConstructChinaInfantryRedguard "Standard-Cyborg: &R"
   2 = Nuke_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
-  3 = Nuke_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  3 = Nuke_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   4 = Nuke_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:ConstructChinaInfantryBlackLotus "Black Bot: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Landminen: &L"
@@ -4110,13 +4110,13 @@ CommandSet Nuke_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, J, K, M, N, O, S, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, M, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaInfantryRedguard : CONTROLBAR:ConstructChinaInfantryRedguard "Standard-Cyborg: &R"
   2 = Nuke_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
-  3 = Nuke_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  3 = Nuke_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   4 = Nuke_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:ConstructChinaInfantryBlackLotus "Black Bot: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Neutronenminen: &M"
@@ -4124,7 +4124,7 @@ CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, J, K, L, N, O, S, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, L, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
@@ -4957,31 +4957,31 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minigun-Cyborg: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minigun-Cyborg: &R"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super-Hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super-Bot: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super-Bot: &B"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Landminen: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Sammelpunkt: &U"
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, J, K, M, N, O, R, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, M, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minigun-Cyborg: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Minigun-Cyborg: &R"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super-Hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super-Bot: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super-Bot: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Neutronenminen: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Sammelpunkt: &U"
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, J, K, L, N, O, R, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, L, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -6021,7 +6021,7 @@ End
 CommandSet Tank_ChinaBarracksCommandSet
   1 = Tank_Command_ConstructChinaInfantryRedguard : CONTROLBAR:ConstructChinaInfantryRedguard "Standard-Cyborg: &R"
   2 = Tank_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
-  3 = Tank_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  3 = Tank_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   4 = Tank_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:ConstructChinaInfantryBlackLotus "Black Bot: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Landminen: &L"
@@ -6029,13 +6029,13 @@ CommandSet Tank_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, J, K, M, N, O, S, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, M, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSetUpgrade
   1 = Tank_Command_ConstructChinaInfantryRedguard : CONTROLBAR:ConstructChinaInfantryRedguard "Standard-Cyborg: &R"
   2 = Tank_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Panzerjäger: &P"
-  3 = Tank_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  3 = Tank_Command_ConstructChinaInfantryHacker : CONTROLBAR:ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   4 = Tank_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:ConstructChinaInfantryBlackLotus "Black Bot: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Gebäude besetzen: &G"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Neutronenminen: &M"
@@ -6043,7 +6043,7 @@ CommandSet Tank_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, J, K, L, N, O, S, T, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, I, J, K, L, N, O, S, T, V, W, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryHackerCommandSet
@@ -6312,7 +6312,7 @@ CommandSet Boss_ChinaBarracksCommandSet
   2 = Boss_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Boss_ConstructChinaInfantryBlackLotus "Black Bot: &B"
   3 = Boss_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:Boss_ConstructChinaInfantryTankHunter "Panzerjäger: &P"
   4 = Boss_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:Boss_ConstructGLAInfantryJarmenKell "Infiltrator: &I"
-  5 = Boss_Command_ConstructChinaInfantryHacker : CONTROLBAR:Boss_ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  5 = Boss_Command_ConstructChinaInfantryHacker : CONTROLBAR:Boss_ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   6 = Boss_Command_ConstructAmericaInfantryColonelBurton : CONTROLBAR:Boss_ConstructAmericaInfantryColonelBurton "Kommandobot: &O"
   7 = Boss_Command_ConstructAmericaInfantryPathfinder : CONTROLBAR:Boss_ConstructAmericaInfantryPathfinder "Kundschafter: &K"
   8 = Boss_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:Boss_ConstructGLAInfantryAngryMob "Cyborg-Trupp: &T"
@@ -6324,7 +6324,7 @@ CommandSet Boss_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, J, N, S, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, J, N, S, V, W, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSetUpgrade
@@ -6332,7 +6332,7 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   2 = Boss_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Boss_ConstructChinaInfantryBlackLotus "Black Bot: &B"
   3 = Boss_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:Boss_ConstructChinaInfantryTankHunter "Panzerjäger: &P"
   4 = Boss_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:Boss_ConstructGLAInfantryJarmenKell "Infiltrator: &I"
-  5 = Boss_Command_ConstructChinaInfantryHacker : CONTROLBAR:Boss_ConstructChinaInfantryHacker "Cyborg-Hacker: &C"
+  5 = Boss_Command_ConstructChinaInfantryHacker : CONTROLBAR:Boss_ConstructChinaInfantryHacker "Cyborg-Hacker: &A"
   6 = Boss_Command_ConstructAmericaInfantryColonelBurton : CONTROLBAR:Boss_ConstructAmericaInfantryColonelBurton "Kommandobot: &O"
   7 = Boss_Command_ConstructAmericaInfantryPathfinder : CONTROLBAR:Boss_ConstructAmericaInfantryPathfinder "Kundschafter: &K"
   8 = Boss_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:Boss_ConstructGLAInfantryAngryMob "Cyborg-Trupp: &T"
@@ -6344,7 +6344,7 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, J, N, S, V, W, X, Y, Z, 
+    Available keys: C, D, E, F, J, N, S, V, W, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
@@ -2189,7 +2189,7 @@ End
 CommandSet GC_Chem_GLABarracksCommandSet
   1 = GC_Chem_Command_ConstructGLAInfantryRebel : CONTROLBAR:Chem_ConstructGLAInfantryRebel "Rebelde de la toxina: &B"
   2 = GC_Chem_Command_ConstructGLAInfantryRPGTrooper : CONTROLBAR:ConstructGLAInfantryRPGTrooper "Soldado RPG: &G"
-  3 = GC_Chem_Command_ConstructGLAInfantryTerrorist : CONTROLBAR:Chem_ConstructGLAInfantryTerrorist "Terrorista de la toxina: &X"
+  3 = GC_Chem_Command_ConstructGLAInfantryTerrorist : CONTROLBAR:Chem_ConstructGLAInfantryTerrorist "Terrorista de la toxina: &I"
   5 = GC_Chem_Command_ConstructGLAInfantryHijacker : CONTROLBAR:ConstructGLAInfantryHijacker "Secuestrador: &S"
   6 = GC_Chem_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   8 = Command_UpgradeGLAInfantryRebelBoobyTrapAttack : CONTROLBAR:UpgradeGLABoobyTrap "Trampa explosiva: &O"
@@ -2199,7 +2199,7 @@ CommandSet GC_Chem_GLABarracksCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, I, K, L, M, N, P, U, V, Y, Z, 
+    Available keys: A, C, D, E, F, K, L, M, N, P, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAPalaceCommandSet
@@ -4118,7 +4118,7 @@ End
 CommandSet Chem_GLABarracksCommandSet
   1 = Chem_Command_ConstructGLAInfantryRebel : CONTROLBAR:Chem_ConstructGLAInfantryRebel "Rebelde de la toxina: &B"
   2 = Chem_Command_ConstructGLAInfantryRPGTrooper : CONTROLBAR:ConstructGLAInfantryRPGTrooper "Soldado RPG: &G"
-  3 = Chem_Command_ConstructGLAInfantryTerrorist : CONTROLBAR:Chem_ConstructGLAInfantryTerrorist "Terrorista de la toxina: &X"
+  3 = Chem_Command_ConstructGLAInfantryTerrorist : CONTROLBAR:Chem_ConstructGLAInfantryTerrorist "Terrorista de la toxina: &I"
   4 = Chem_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Turba: &U"
   6 = Chem_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Tomar edificio: &T"
@@ -4127,7 +4127,7 @@ CommandSet Chem_GLABarracksCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, I, K, L, M, N, O, P, S, V, Y, Z, 
+    Available keys: A, C, D, E, F, K, L, M, N, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLATunnelNetworkCommandSet
@@ -4922,7 +4922,7 @@ End
 CommandSet SupW_AmericaAirfieldCommandSet
   1 = SupW_Command_ConstructAmericaJetRaptor : CONTROLBAR:ConstructAmericaJetRaptor "Raptor: &T"
   2 = SupW_Command_ConstructAmericaVehicleComanche : CONTROLBAR:ConstructAmericaVehicleComanche "Comanche: &C"
-  3 = SupW_Command_ConstructAmericaJetAurora : CONTROLBAR:ConstructAmericaJetFuelAirAurora "Aurora Alpha: &U"
+  3 = SupW_Command_ConstructAmericaJetAurora : CONTROLBAR:ConstructAmericaJetFuelAirAurora "Aurora Alpha: &A"
   4 = SupW_Command_ConstructAmericaJetStealthFighter : CONTROLBAR:ConstructAmericaJetStealthFighter "Caza Stealth: &Z"
   7 = Command_UpgradeComancheRocketPods : CONTROLBAR:UpgradeComancheRocketPods "Compartimentos para cohetes: &P"
   8 = Command_UpgradeAmericaLaserMissiles : CONTROLBAR:UpgradeAmericaLaserMissiles "Misiles Láser: &L"
@@ -4933,7 +4933,7 @@ CommandSet SupW_AmericaAirfieldCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, D, E, F, G, I, J, M, N, S, V, X, Y, 
+    Available keys: B, D, E, F, G, I, J, M, N, S, U, V, X, Y, 
 End
 
 CommandSet SupW_AmericaNuclearMissileCommandSet
@@ -5331,10 +5331,10 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Artillero minigun: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Artillero minigun: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Cazatanques: &Z"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Súper-hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Súper-Loto: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Súper-Loto: &N"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Tomar edificio: &T"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Minas terrestres: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto de concentración: &R"
@@ -5342,14 +5342,14 @@ CommandSet Infa_ChinaBarracksCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, C, D, E, F, G, J, K, L, N, O, P, U, V, X, Y, 
+    Available keys: B, C, D, E, F, I, J, K, L, O, P, S, U, V, X, Y, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Artillero minigun: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Artillero minigun: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Cazatanques: &Z"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Súper-hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Súper-Loto: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Súper-Loto: &N"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Tomar edificio: &T"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Minas de neutrones: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto de concentración: &R"
@@ -5357,7 +5357,7 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, C, D, E, F, G, J, K, L, N, O, P, U, V, X, Y, 
+    Available keys: B, C, D, E, F, I, J, K, L, O, P, S, U, V, X, Y, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5386,8 +5386,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de asalto: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Puesto de ataque: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de asalto: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Puesto de ataque: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cañón repetidor: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Tanque Dragon: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Napalm negro: &N"
@@ -5400,12 +5400,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, F, G, J, K, L, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de asalto: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Puesto de ataque: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporte de asalto: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Puesto de ataque: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cañón repetidor: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Tanque Dragon: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Napalm negro: &N"
@@ -5418,7 +5418,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, F, G, J, K, L, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5815,7 +5815,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   4 = Lazr_Command_ConstructAmericaSupplyDropZone : CONTROLBAR:ConstructAmericaSupplyDropZone "Zona de lanzamiento de suministros: &Z"
   5 = Lazr_Command_ConstructAmericaSupplyCenter : CONTROLBAR:ConstructAmericaSupplyCenter "Centro de suministro: &U"
   6 = Lazr_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:ConstructAmericaParticleCannonUplink "Cañón de partículas: &P"
-  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Torreta láser de defensa: &L"
+  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Torreta láser de defensa: &M"
   8 = Lazr_Command_ConstructAmericaCommandCenter : CONTROLBAR:ConstructAmericaCommandCenter "Centro de mando: &C"
   9 = Lazr_Command_ConstructAmericaFireBase : CONTROLBAR:ConstructAmericaFireBase "Base de disparo: &I"
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "Fábrica de guerra: &G"
@@ -5827,7 +5827,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, F, J, K, M, O, T, V, Y, 
+    Available keys: A, F, J, K, L, O, T, V, Y, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
@@ -4957,7 +4957,7 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mitrailleur: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mitrailleur: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Tueur de char: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super technopirate: &A"
   4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &S"
@@ -4967,11 +4967,11 @@ CommandSet Infa_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, J, K, L, N, O, U, V, W, X, Y, Z, 
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mitrailleur: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mitrailleur: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Tueur de char: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super technopirate: &A"
   4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &S"
@@ -4981,7 +4981,7 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, J, K, L, N, O, U, V, W, X, Y, Z, 
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5008,7 +5008,7 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporteur d'assaut: &A"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporteur d'assaut: &T"
   4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Poste d'écoute amélioré: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cadences rapides: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Char Dragon: &D"
@@ -5021,11 +5021,11 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, I, J, K, L, P, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, I, J, K, L, P, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporteur d'assaut: &A"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporteur d'assaut: &T"
   4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Poste d'écoute amélioré: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cadences rapides: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Char Dragon: &D"
@@ -5038,7 +5038,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, I, J, K, L, P, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, I, J, K, L, P, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5857,7 +5857,7 @@ End
 
 CommandSet Tank_ChinaWarFactoryCommandSet
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Maître de guerre: &A"
-  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Char Despote: &O"
+  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Char Despote: &P"
   3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Transporteur: &T"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Poste mobile d'écoute: &S"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Char Gattling: &G"
@@ -5870,12 +5870,12 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, P, U, V, W, X, Y, Z, 
+    Available keys: B, F, I, J, K, L, O, U, V, W, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Maître de guerre: &A"
-  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Char Despote: &O"
+  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Char Despote: &P"
   3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Transporteur: &T"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Poste mobile d'écoute: &S"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Char Gattling: &G"
@@ -5888,7 +5888,7 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, P, U, V, W, X, Y, Z, 
+    Available keys: B, F, I, J, K, L, O, U, V, W, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
@@ -1511,7 +1511,7 @@ End
 CommandSet ChinaWarFactoryCommandSet
   1 = Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Command_ConstructChinaTankOverlord : CONTROLBAR:ConstructChinaTankOverlord "Overlord: &O"
-  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Crawler: &W"
+  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
   4 = Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -1531,7 +1531,7 @@ End
 CommandSet ChinaWarFactoryCommandSetUpgrade
   1 = Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Command_ConstructChinaTankOverlord : CONTROLBAR:ConstructChinaTankOverlord "Overlord: &O"
-  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Crawler: &W"
+  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
   4 = Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -4153,7 +4153,7 @@ End
 CommandSet Nuke_ChinaWarFactoryCommandSet
   1 = Nuke_Command_ConstructChinaTankBattleMaster : CONTROLBAR:Nuke_ConstructChinaTankBattleMaster "Battlemaster nucleare: &B"
   2 = Nuke_Command_ConstructChinaTankOverlord : CONTROLBAR:Nuke_ConstructChinaTankOverlord "Overlord nucleare: &O"
-  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Crawler: &W"
+  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
   4 = Nuke_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Nuke_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -4173,7 +4173,7 @@ End
 CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaTankBattleMaster : CONTROLBAR:Nuke_ConstructChinaTankBattleMaster "Battlemaster nucleare: &B"
   2 = Nuke_Command_ConstructChinaTankOverlord : CONTROLBAR:Nuke_ConstructChinaTankOverlord "Overlord nucleare: &O"
-  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Crawler: &W"
+  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
   4 = Nuke_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Nuke_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -4577,7 +4577,7 @@ End
 CommandSet SupW_AmericaAirfieldCommandSet
   1 = SupW_Command_ConstructAmericaJetRaptor : CONTROLBAR:ConstructAmericaJetRaptor "Raptor: &T"
   2 = SupW_Command_ConstructAmericaVehicleComanche : CONTROLBAR:ConstructAmericaVehicleComanche "Comanche: &C"
-  3 = SupW_Command_ConstructAmericaJetAurora : CONTROLBAR:ConstructAmericaJetFuelAirAurora "Bombardiere Aurora Alfa: &B"
+  3 = SupW_Command_ConstructAmericaJetAurora : CONTROLBAR:ConstructAmericaJetFuelAirAurora "Bombardiere Aurora Alfa: &A"
   4 = SupW_Command_ConstructAmericaJetStealthFighter : CONTROLBAR:ConstructAmericaJetStealthFighter "Caccia stealth: &F"
   7 = Command_UpgradeComancheRocketPods : CONTROLBAR:UpgradeComancheRocketPods "Lanciarazzi: &N"
   8 = Command_UpgradeAmericaLaserMissiles : CONTROLBAR:UpgradeAmericaLaserMissiles "Missili a guida laser: &L"
@@ -4587,7 +4587,7 @@ CommandSet SupW_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, P, S, V, W, X, Y, Z, 
+    Available keys: B, D, E, G, I, J, K, M, P, S, V, W, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaNuclearMissileCommandSet
@@ -4957,31 +4957,31 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Commando: &N"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Commando: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Cacciatore di carri: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Loto: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Loto: &L"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Conquista struttura: &C"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Mine terrestri: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, I, J, K, L, O, P, U, V, W, X, Y, Z, 
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Commando: &N"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Commando: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Cacciatore di carri: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Loto: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Loto: &L"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Conquista struttura: &C"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Mine a neutroni: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, I, J, K, L, O, P, U, V, W, X, Y, Z, 
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5008,8 +5008,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Avamposto d'assalto: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &W"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Avamposto d'assalto: &T"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Carro Dragon: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Napalm nero: &N"
@@ -5021,12 +5021,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, L, P, S, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Avamposto d'assalto: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &W"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Avamposto d'assalto: &T"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Carro Dragon: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Napalm nero: &N"
@@ -5038,7 +5038,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, L, P, S, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5858,7 +5858,7 @@ End
 CommandSet Tank_ChinaWarFactoryCommandSet
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Emperor: &O"
-  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Crawler: &W"
+  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -5876,7 +5876,7 @@ End
 CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Emperor: &O"
-  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Crawler: &W"
+  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"

--- a/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
@@ -4372,7 +4372,7 @@ End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "건설 불도저: &D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "핵 폭격기: &K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "핵 폭격기: &T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "네이팜 공습: &N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "산탄형 지뢰: &I"
   5 = Command_CashHack : CONTROLBAR:CashHack "자금 해킹: &C"
@@ -4387,12 +4387,12 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, M, O, P, S, T, V, X, Z, 
+    Available keys: F, G, J, K, M, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "건설 불도저: &D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "핵 폭격기: &K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "핵 폭격기: &T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "네이팜 공습: &N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "산탄형 지뢰: &I"
   5 = Command_CashHack : CONTROLBAR:CashHack "자금 해킹: &C"
@@ -4407,7 +4407,7 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, L, O, P, S, T, V, X, Z, 
+    Available keys: F, G, J, K, L, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -5331,10 +5331,10 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "미니 거너: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "미니 거너: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "탱크 헌터: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "슈퍼 해커: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "슈퍼 흑수선: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "슈퍼 흑수선: &B"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "건물 점령: &C"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
@@ -5342,14 +5342,14 @@ CommandSet Infa_ChinaBarracksCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, J, K, M, N, O, P, U, V, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "미니 거너: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "미니 거너: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "탱크 헌터: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "슈퍼 해커: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "슈퍼 흑수선: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "슈퍼 흑수선: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "건물 점령: &C"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
@@ -5357,7 +5357,7 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, J, K, L, N, O, P, U, V, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5386,8 +5386,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "공격 부대 수송 차량: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "공격 아웃포스트: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "공격 부대 수송 차량: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "공격 아웃포스트: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "체인건: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "드래곤 탱크: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "블랙 네이팜: &N"
@@ -5400,12 +5400,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, M, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "공격 부대 수송 차량: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "공격 아웃포스트: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "공격 부대 수송 차량: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "공격 아웃포스트: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "체인건: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "드래곤 탱크: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "블랙 네이팜: &N"
@@ -5418,7 +5418,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, L, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5815,7 +5815,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   4 = Lazr_Command_ConstructAmericaSupplyDropZone : CONTROLBAR:ConstructAmericaSupplyDropZone "투하지역: &Z"
   5 = Lazr_Command_ConstructAmericaSupplyCenter : CONTROLBAR:ConstructAmericaSupplyCenter "서플라이 센터: &U"
   6 = Lazr_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:ConstructAmericaParticleCannonUplink "파티클 캐논 발사: &P"
-  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "레이저 방어 포탑: &T"
+  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "레이저 방어 포탑: &M"
   8 = Lazr_Command_ConstructAmericaCommandCenter : CONTROLBAR:ConstructAmericaCommandCenter "커맨드 센터: &C"
   9 = Lazr_Command_ConstructAmericaFireBase : CONTROLBAR:ConstructAmericaFireBase "파이어 베이스: &I"
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "군수공장: &A"
@@ -5827,7 +5827,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, M, N, O, V, 
+    Available keys: D, G, J, K, N, O, T, V, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5878,7 +5878,7 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
-  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "레이저 탱크: &T"
+  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "레이저 탱크: &C"
   3 = Lazr_Command_ConstructAmericaVehicleHumvee : CONTROLBAR:ConstructAmericaVehicleHumvee "험비: &V"
   4 = Lazr_Command_ConstructAmericaVehicleMedic : CONTROLBAR:ConstructAmericaVehicleMedic "앰뷸런스: &A"
   6 = Lazr_Command_ConstructAmericaVehicleSentryDrone : CONTROLBAR:ConstructAmericaVehicleSentryDrone "센트리 드론: &S"
@@ -5891,7 +5891,7 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
+    Available keys: B, D, E, F, J, K, L, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
@@ -1190,11 +1190,11 @@ CommandSet AmericaSupplyCenterCommandSet
 End
 
 CommandSet AmericaPowerPlantCommandSet
-  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &P"
+  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaStrategyCenterCommandSet
@@ -2411,11 +2411,11 @@ CommandSet AirF_AmericaCommandCenterCommandSet
 End
 
 CommandSet AirF_AmericaPowerPlantCommandSet
-  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &P"
+  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaStrategyCenterCommandSet
@@ -4876,7 +4876,7 @@ CommandSet Infa_ChinaDozerCommandSet
   4 = Infa_Command_ConstructChinaAirfield : CONTROLBAR:ConstructChinaAirfield "Lotnisko: &L"
   5 = Infa_Command_ConstructChinaSupplyCenter : CONTROLBAR:ConstructChinaSupplyCenter "Ośrodek zaopatrzeniowy: &O"
   6 = Infa_Command_ConstructChinaPropagandaCenter : CONTROLBAR:ConstructChinaPropagandaCenter "Ośrodek propagandowy: &P"
-  7 = Infa_Command_ConstructChinaBunker : CONTROLBAR:Infa_ConstructChinaBunker "Wzmocniony bunkier: &U"
+  7 = Infa_Command_ConstructChinaBunker : CONTROLBAR:Infa_ConstructChinaBunker "Wzmocniony bunkier: &B"
   8 = Infa_Command_ConstructChinaSpeakerTower : CONTROLBAR:ConstructChinaSpeakerTower "Megafon: &F"
   9 = Infa_Command_ConstructChinaGattlingCannon : CONTROLBAR:ConstructChinaGattlingCannon "Działko Gattling: &G"
   10 = Infa_Command_ConstructChinaNuclearMissileLauncher : CONTROLBAR:ConstructChinaNuclearMissileLauncher "Rakieta atomowa: &M"
@@ -4888,7 +4888,7 @@ CommandSet Infa_ChinaDozerCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, J, N, T, V, W, Y, 
+    Available keys: C, D, J, N, T, U, V, W, Y, 
 End
 
 CommandSet Infa_ChinaPowerPlantCommandSet
@@ -4957,31 +4957,31 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Komandos: &O"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Komandos: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Tropiciel czołgów: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Superhaker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Superlotos: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Superlotos: &L"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Zajmij budynek: &Z"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Miny: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punkt zborny: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, P, U, V, W, X, Y, 
+    Available keys: B, C, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Komandos: &O"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Komandos: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Tropiciel czołgów: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Superhaker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Superlotos: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Superlotos: &L"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Zajmij budynek: &Z"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Miny neutronowe: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punkt zborny: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, P, U, V, W, X, Y, 
+    Available keys: B, C, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5008,8 +5008,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporter szturmowy: &Z"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Posterunek szturmowy: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporter szturmowy: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Posterunek szturmowy: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "CKM-y: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Czołg Smok: &K"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Czarny napalm: &N"
@@ -5021,12 +5021,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, F, G, J, L, P, S, T, U, V, W, X, Y, 
+    Available keys: B, D, F, G, J, L, O, P, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporter szturmowy: &Z"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Posterunek szturmowy: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Transporter szturmowy: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Posterunek szturmowy: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "CKM-y: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Czołg Smok: &K"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Czarny napalm: &N"
@@ -5038,7 +5038,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, F, G, J, L, P, S, T, U, V, W, X, Y, 
+    Available keys: B, D, F, G, J, L, O, P, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5411,7 +5411,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   4 = Lazr_Command_ConstructAmericaSupplyDropZone : CONTROLBAR:ConstructAmericaSupplyDropZone "Strefa zrzutu: &U"
   5 = Lazr_Command_ConstructAmericaSupplyCenter : CONTROLBAR:ConstructAmericaSupplyCenter "Ośrodek zaopatrzeniowy: &O"
   6 = Lazr_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:ConstructAmericaParticleCannonUplink "Miotacz cząstek: &M"
-  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Wieżyczka laserowa: &W"
+  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Wieżyczka laserowa: &T"
   8 = Lazr_Command_ConstructAmericaCommandCenter : CONTROLBAR:ConstructAmericaCommandCenter "Sztab: &Z"
   9 = Lazr_Command_ConstructAmericaFireBase : CONTROLBAR:ConstructAmericaFireBase "Baza ogniowa: &G"
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "Fabryka wojenna: &A"
@@ -5422,7 +5422,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, N, P, T, V, 
+    Available keys: B, C, D, F, I, J, N, P, V, W, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5470,7 +5470,7 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
-  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Czołg laserowy: &C"
+  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Czołg laserowy: &K"
   3 = Lazr_Command_ConstructAmericaVehicleHumvee : CONTROLBAR:ConstructAmericaVehicleHumvee "Humvee: &V"
   4 = Lazr_Command_ConstructAmericaVehicleMedic : CONTROLBAR:ConstructAmericaVehicleMedic "Ambulans: &A"
   6 = Lazr_Command_ConstructAmericaVehicleSentryDrone : CONTROLBAR:ConstructAmericaVehicleSentryDrone "Robot strażniczy: &S"
@@ -5482,7 +5482,7 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, G, J, K, L, N, O, P, T, U, W, X, Y, Z, 
+    Available keys: B, C, E, G, J, L, N, O, P, T, U, W, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet
@@ -5513,11 +5513,11 @@ CommandSet Lazr_AmericaFireBaseCommandSet
 End
 
 CommandSet Lazr_AmericaPowerPlantCommandSet
-  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &P"
+  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaAirfieldCommandSet
@@ -5857,7 +5857,7 @@ End
 
 CommandSet Tank_ChinaWarFactoryCommandSet
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Pancerna Pięść: &P"
-  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Cesarz: &Z"
+  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Cesarz: &O"
   3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Transporter opancerzony: &T"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Posterunek nasłuchowy: &S"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Czołg gattling: &G"
@@ -5870,12 +5870,12 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, F, I, J, L, O, U, V, W, X, Y, 
+    Available keys: A, B, D, F, I, J, L, U, V, W, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Pancerna Pięść: &P"
-  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Cesarz: &Z"
+  2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Cesarz: &O"
   3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Transporter opancerzony: &T"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Posterunek nasłuchowy: &S"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Czołg gattling: &G"
@@ -5888,7 +5888,7 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, F, I, J, L, O, U, V, W, X, Y, 
+    Available keys: A, B, D, F, I, J, L, U, V, W, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSet
@@ -6163,21 +6163,21 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSet
-  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &P"
+  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &C"
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "Miny: &M"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
-  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &P"
+  1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "Pręty sterujące: &C"
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "Miny neutronowe: &M"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/ru_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ru_commandsets.txt
@@ -4372,7 +4372,7 @@ End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "Строительный бульдозер: &D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Ядерный бомбардировщик: &K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Ядерный бомбардировщик: &T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "Удар напалмом: &N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "Осколочные бомбы: &L"
   5 = Command_CashHack : CONTROLBAR:CashHack "Взлом денег: &C"
@@ -4387,12 +4387,12 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: F, G, I, J, O, P, S, T, V, X, Z, 
+    Available keys: F, G, I, J, K, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "Строительный бульдозер: &D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Ядерный бомбардировщик: &K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Ядерный бомбардировщик: &T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "Удар напалмом: &N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "Осколочные бомбы: &L"
   5 = Command_CashHack : CONTROLBAR:CashHack "Взлом денег: &C"
@@ -4407,7 +4407,7 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: F, G, I, J, O, P, S, T, V, X, Z, 
+    Available keys: F, G, I, J, K, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -5331,10 +5331,10 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Пулемётчик: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Пулемётчик: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Охотник за танками: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Супер хакер: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Супер лотос: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Супер лотос: &B"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Захват здания: &C"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Заминировать: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Точка сбора: &R"
@@ -5342,14 +5342,14 @@ CommandSet Infa_ChinaBarracksCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, D, E, F, G, J, K, L, N, O, P, U, V, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Пулемётчик: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Пулемётчик: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Охотник за танками: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Супер хакер: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Супер лотос: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Супер лотос: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Захват здания: &C"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Нейтронные мины: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Точка сбора: &R"
@@ -5357,7 +5357,7 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, D, E, F, G, J, K, L, N, O, P, U, V, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5386,8 +5386,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Штурмовой бронетранспортёр: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Боевой передвижной радар: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Штурмовой бронетранспортёр: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Боевой передвижной радар: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Пулемёты: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Танк Дракон: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Чёрный напалм: &N"
@@ -5400,12 +5400,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, F, G, J, K, L, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Штурмовой бронетранспортёр: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Боевой передвижной радар: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Штурмовой бронетранспортёр: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Боевой передвижной радар: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Пулемёты: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Танк Дракон: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Чёрный напалм: &N"
@@ -5418,7 +5418,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, F, G, J, K, L, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5815,7 +5815,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   4 = Lazr_Command_ConstructAmericaSupplyDropZone : CONTROLBAR:ConstructAmericaSupplyDropZone "Зона доставки снабжения: &Z"
   5 = Lazr_Command_ConstructAmericaSupplyCenter : CONTROLBAR:ConstructAmericaSupplyCenter "Центр снабжения: &U"
   6 = Lazr_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:ConstructAmericaParticleCannonUplink "Молекулярная пушка: &P"
-  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Лазерная пушка: &T"
+  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Лазерная пушка: &M"
   8 = Lazr_Command_ConstructAmericaCommandCenter : CONTROLBAR:ConstructAmericaCommandCenter "Командный центр: &C"
   9 = Lazr_Command_ConstructAmericaFireBase : CONTROLBAR:ConstructAmericaFireBase "Защитная пушка: &I"
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "Военный завод: &A"
@@ -5827,7 +5827,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, M, N, O, V, 
+    Available keys: D, G, J, K, N, O, T, V, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5878,7 +5878,7 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
-  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Лазерный танк: &T"
+  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Лазерный танк: &C"
   3 = Lazr_Command_ConstructAmericaVehicleHumvee : CONTROLBAR:ConstructAmericaVehicleHumvee "Джип Хаммер: &V"
   4 = Lazr_Command_ConstructAmericaVehicleMedic : CONTROLBAR:ConstructAmericaVehicleMedic "Скорая помощь: &A"
   6 = Lazr_Command_ConstructAmericaVehicleSentryDrone : CONTROLBAR:ConstructAmericaVehicleSentryDrone "Сторожевой беспилотный аппарат: &S"
@@ -5891,7 +5891,7 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
+    Available keys: B, D, E, F, J, K, L, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/us_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/us_commandsets.txt
@@ -4372,7 +4372,7 @@ End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "Construction Dozer: &D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Nuke Bomber: &K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Nuke Bomber: &T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "Napalm Strike: &N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "Cluster Mines: &I"
   5 = Command_CashHack : CONTROLBAR:CashHack "Cash Hack: &C"
@@ -4387,12 +4387,12 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: F, G, J, M, O, P, S, T, V, X, Z, 
+    Available keys: F, G, J, K, M, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "Construction Dozer: &D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Nuke Bomber: &K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "Nuke Bomber: &T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "Napalm Strike: &N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "Cluster Mines: &I"
   5 = Command_CashHack : CONTROLBAR:CashHack "Cash Hack: &C"
@@ -4407,7 +4407,7 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: F, G, J, L, O, P, S, T, V, X, Z, 
+    Available keys: F, G, J, K, L, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -5331,10 +5331,10 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mini-Gunner: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mini-Gunner: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Tank Hunter: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super Hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &B"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Capture Building: &C"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "Land Mines: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Rally Point: &R"
@@ -5342,14 +5342,14 @@ CommandSet Infa_ChinaBarracksCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, D, E, F, G, J, K, M, N, O, P, U, V, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mini-Gunner: &I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "Mini-Gunner: &G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "Tank Hunter: &T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "Super Hacker: &A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "Super Lotus: &B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "Capture Building: &C"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "Neutron Mines: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Rally Point: &R"
@@ -5357,7 +5357,7 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, D, E, F, G, J, K, L, N, O, P, U, V, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5386,8 +5386,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Assault Troop Transport: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Attack Outpost: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Assault Troop Crawler: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Attack Outpost: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Chain Guns: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Dragon Tank: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Black Napalm: &N"
@@ -5400,12 +5400,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, F, G, J, K, M, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, M, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Assault Troop Transport: &A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Attack Outpost: &O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Assault Troop Crawler: &T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Attack Outpost: &S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Chain Guns: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Dragon Tank: &D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "Black Napalm: &N"
@@ -5418,7 +5418,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, F, G, J, K, L, P, S, T, V, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5815,7 +5815,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   4 = Lazr_Command_ConstructAmericaSupplyDropZone : CONTROLBAR:ConstructAmericaSupplyDropZone "Supply Drop Zone: &Z"
   5 = Lazr_Command_ConstructAmericaSupplyCenter : CONTROLBAR:ConstructAmericaSupplyCenter "Supply Center: &U"
   6 = Lazr_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:ConstructAmericaParticleCannonUplink "Particle Cannon: &P"
-  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Laser Defense Turret: &T"
+  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "Laser Defense Turret: &M"
   8 = Lazr_Command_ConstructAmericaCommandCenter : CONTROLBAR:ConstructAmericaCommandCenter "Command Center: &C"
   9 = Lazr_Command_ConstructAmericaFireBase : CONTROLBAR:ConstructAmericaFireBase "Fire Base: &I"
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "War Factory: &A"
@@ -5827,7 +5827,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, M, N, O, V, 
+    Available keys: D, G, J, K, N, O, T, V, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5878,7 +5878,7 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
-  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Laser Tank: &T"
+  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "Laser Tank: &C"
   3 = Lazr_Command_ConstructAmericaVehicleHumvee : CONTROLBAR:ConstructAmericaVehicleHumvee "Humvee: &V"
   4 = Lazr_Command_ConstructAmericaVehicleMedic : CONTROLBAR:ConstructAmericaVehicleMedic "Ambulance: &A"
   6 = Lazr_Command_ConstructAmericaVehicleSentryDrone : CONTROLBAR:ConstructAmericaVehicleSentryDrone "Sentry Drone: &S"
@@ -5891,7 +5891,7 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
+    Available keys: B, D, E, F, J, K, L, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
@@ -4063,7 +4063,7 @@ End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "建築推土機：&D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "核子炸彈：&K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "核子炸彈：&T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "汽油彈攻擊：&N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "集束地雷：&I"
   5 = Command_CashHack : CONTROLBAR:CashHack "金牌駭客：&C"
@@ -4077,12 +4077,12 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, M, O, P, S, T, V, W, X, Z, 
+    Available keys: F, G, J, K, M, O, P, S, V, W, X, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaDozer : CONTROLBAR:ConstructChinaDozer "建築推土機：&D"
-  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "核子炸彈：&K"
+  2 = Nuke_Command_ChinaCarpetBomb : CONTROLBAR:Nuke_CarpetBomb "核子炸彈：&T"
   3 = Command_NapalmStrike : CONTROLBAR:NapalmStrike "汽油彈攻擊：&N"
   4 = Command_ClusterMines : CONTROLBAR:ClusterMines "集束地雷：&I"
   5 = Command_CashHack : CONTROLBAR:CashHack "金牌駭客：&C"
@@ -4096,7 +4096,7 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, L, O, P, S, T, V, W, X, Z, 
+    Available keys: F, G, J, K, L, O, P, S, V, W, X, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -4957,31 +4957,31 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "蓋特機槍兵：&I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "蓋特機槍兵：&G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "坦克獵人：&T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "超級駭客：&A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "超級黑蓮花：&S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "超級黑蓮花：&B"
   7 = Infa_Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "佔領建築物：&C"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "埋放地雷：&L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "集合點：&R"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, J, K, M, N, O, P, U, V, W, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
-  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "蓋特機槍兵：&I"
+  1 = Infa_Command_ConstructChinaInfantryMiniGunner : CONTROLBAR:ConstructChinaInfantryMiniGunner "蓋特機槍兵：&G"
   2 = Infa_Command_ConstructChinaInfantryTankHunter : CONTROLBAR:ConstructChinaInfantryTankHunter "坦克獵人：&T"
   3 = Infa_Command_ConstructChinaInfantryHacker : CONTROLBAR:Infa_ConstructChinaInfantryHacker "超級駭客：&A"
-  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "超級黑蓮花：&S"
+  4 = Infa_Command_ConstructChinaInfantryBlackLotus : CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus "超級黑蓮花：&B"
   7 = Command_UpgradeChinaRedguardCaptureBuilding : CONTROLBAR:UpgradeChinaRedguardCaptureBuilding "佔領建築物：&C"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "中子地雷：&M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "集合點：&R"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, J, K, L, N, O, P, U, V, W, X, Y, Z, 
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -5008,8 +5008,8 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "突擊運輸機：&A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "攻擊前哨車：&O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "突擊運輸機：&T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "攻擊前哨車：&S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "鍊砲：&C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "火龍坦克：&D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "黑色汽油彈：&N"
@@ -5021,12 +5021,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, P, S, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, M, O, P, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "突擊運輸機：&A"
-  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "攻擊前哨車：&O"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "突擊運輸機：&T"
+  4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "攻擊前哨車：&S"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "鍊砲：&C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "火龍坦克：&D"
   8 = Command_UpgradeChinaBlackNapalm : CONTROLBAR:UpgradeChinaBlackNapalm "黑色汽油彈：&N"
@@ -5038,7 +5038,7 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, L, P, S, T, V, W, X, Y, Z, 
+    Available keys: A, B, F, G, J, K, L, O, P, V, W, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5411,7 +5411,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   4 = Lazr_Command_ConstructAmericaSupplyDropZone : CONTROLBAR:ConstructAmericaSupplyDropZone "補給空投區：&Z"
   5 = Lazr_Command_ConstructAmericaSupplyCenter : CONTROLBAR:ConstructAmericaSupplyCenter "補給中心：&U"
   6 = Lazr_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:ConstructAmericaParticleCannonUplink "離子砲：&P"
-  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "雷射防禦炮塔：&T"
+  7 = Lazr_Command_ConstructAmericaPatriotBattery : CONTROLBAR:Lazr_ConstructAmericaPatriotBattery "雷射防禦炮塔：&M"
   8 = Lazr_Command_ConstructAmericaCommandCenter : CONTROLBAR:ConstructAmericaCommandCenter "指揮中心：&C"
   9 = Lazr_Command_ConstructAmericaFireBase : CONTROLBAR:ConstructAmericaFireBase "火力基地：&I"
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "戰車工廠：&A"
@@ -5422,7 +5422,7 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, M, N, O, V, W, 
+    Available keys: D, G, J, K, N, O, T, V, W, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5470,7 +5470,7 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
-  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "雷射坦克：&T"
+  1 = Lazr_Command_ConstructAmericaTankCrusader : CONTROLBAR:Lazr_ConstructAmericaTankCrusader "雷射坦克：&C"
   3 = Lazr_Command_ConstructAmericaVehicleHumvee : CONTROLBAR:ConstructAmericaVehicleHumvee "汗馬車：&V"
   4 = Lazr_Command_ConstructAmericaVehicleMedic : CONTROLBAR:ConstructAmericaVehicleMedic "救護車：&A"
   6 = Lazr_Command_ConstructAmericaVehicleSentryDrone : CONTROLBAR:ConstructAmericaVehicleSentryDrone "無人哨兵機：&S"
@@ -5482,7 +5482,7 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, J, K, L, O, P, U, W, X, Y, Z, 
+    Available keys: B, D, E, F, J, K, L, O, P, T, U, W, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet


### PR DESCRIPTION
* Relates to #2095

This change fixes all key mapping mismatches between faction unit variations. This greatly reduces the complexity of key mappings one has to remember. The key mapping of the regular faction unit typically takes precedence.

* The China Hacker can now be produced with the same key as for the Super Hacker in German language.
* The China Emperor can now be produced with the same key as for the Overlord in French, Polish languages.
* The China Minigunner can now be produced with the same key as for the regular Red Guard in all languages.
* The China Super Lotus can now be produced with the same key as for the regular Black Lotus in all language.
* The China Attack Outpost can now be produced with the same key as for the regular Outpost in English, Spanish, Italian, Korean, Chinese, Brazilian, Polish languages.
* The China Assault Troop Crawler can now be produced with the same key as for the regular Troop Crawler in English, French, Spanish, Italian, Korean, Chinese, Brazilian, Polish languages.
* The China Fortified Bunker can now be constructed with the same key as for the regular Bunker in Polish language.
* The China Nuke Bomber can now be placed with the same key as for the regular Bomber in English, Korean, Chinese languages.
* The GLA Toxin Rebel can now be produced with the same key as for the regular Rebel in German language.
* The GLA Toxin Terrorist can now be produced with the same key as for the regular Terrorist in Spanish language.
* The USA Control Rods can now be researched with the same key as for the Advanced Control Rods in Polish language.
* The USA Aurora Alpha can now be produced with the same key as for the regular Aurora in Spanish, Italian languages.
* The USA King Raptor can now be produced with the same key as for the regular Raptor in Brazilian language.
* The USA Laser Turret can now be constructed with the same key as for the regular Patriot Battery in English, Spanish, Korean, Chinese, Brazilian, Polish languages.
* The USA Laser Crusader can now be produced with the same key as for the regular Crusader in English, Korean, Chinese, Brazilian, Polish languages.

## Inspected button texts

### SWG

CONTROLBAR:UpgradeAmericaAdvancedControlRods **[FIXED]**
CONTROLBAR:SupW_UpgradeAmericaAdvancedControlRods **[GOOD]**
CONTROLBAR:SupW_ConstructAmericaPatriotBattery **[GOOD]**
CONTROLBAR:ConstructAmericaJetFuelAirAurora **[FIXED]**

### LASER

CONTROLBAR:Lazr_ConstructAmericaPatriotBattery **[FIXED]**
CONTROLBAR:Lazr_ConstructAmericaTankCrusader **[FIXED]**

### AIRFORCE

CONTROLBAR:AirF_ConstructAmericaVehicleChinook **[GOOD]**
CONTROLBAR:ConstructAmericaJetKingRaptor **[FIXED]**

### DEMO

CONTROLBAR:Demo_ConstructGLADemoTrap **[GOOD]**

### CHEMICAL

CONTROLBAR:Chem_ConstructGLAInfantryRebel **[FIXED]**
CONTROLBAR:Chem_ConstructGLAInfantryTerrorist **[FIXED]**
CONTROLBAR:Chem_ConstructGLATunnelNetwork **[GOOD]**

### STEALTH

CONTROLBAR:Slth_ConstructGLAInfantryRebel **[GOOD]**

### TANK

CONTROLBAR:ConstructChinaTankEmperor **[FIXED]**

### NUKE

CONTROLBAR:Nuke_ConstructChinaTankOverlord **[GOOD]**
CONTROLBAR:Nuke_ConstructChinaTankBattleMaster **[GOOD]**
CONTROLBAR:Nuke_ConstructChinaVehicleListeningOutpost **[FIXED]**
CONTROLBAR:Nuke_ConstructChinaPowerPlant **[GOOD]**
CONTROLBAR:Nuke_CarpetBomb **[FIXED]**
CONTROLBAR:ConstructChinaInfantryNukeHunter **[FIXED]**

### INFANTRY

CONTROLBAR:ConstructChinaInfantryHacker **[FIXED]**
CONTROLBAR:Infa_ConstructChinaInfantryHacker **[GOOD]**
CONTROLBAR:Infa_ConstructChinaInfantryBlackLotus **[FIXED]**
CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost **[FIXED]**
CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler **[FIXED]**
CONTROLBAR:Infa_ConstructChinaVehicleHelix **[GOOD]**
CONTROLBAR:Infa_ConstructChinaBunker **[FIXED]**
CONTROLBAR:ConstructChinaInfantryMiniGunner **[FIXED]**