### PR TITLE
Fix: Remove incorrect text from USA MOAB tool tip

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2146_moab_tooltip_text.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2146_moab_tooltip_text.txt
@@ -1,0 +1,1 @@
+2156_misc_errors_in_strings.yaml

--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
@@ -8,6 +8,7 @@ changes:
   - fix: Removes superfluous sentences from Scud Launcher promotion tool tip strings.
   - fix: Adds missing sentences to various tool tip strings.
   - fix: Removes superfluous mention of 'enemy' in tool tip strings of USA Stealth Figher, Tomahawk and China Inferno Cannon for all languages.
+  - fix: Removes incorrect sentence in MOAB tooltip for all languages.
 
 labels:
   - minor
@@ -17,6 +18,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2156
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2167
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2146
 
 authors:
   - xezon


### PR DESCRIPTION
This change removes the incorrect text from the USA MOAB tool tip for all languages. It no longer says "Will shock units in the blast radius".