### PR TITLE
Fix: Add consistent wording in Polish tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-07-26
+
+title: Fixes inconsistent wording in Polish tool tip strings
+
+changes:
+  - fix: The wording in Polish tool tip strings is more consistent now.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2148
+
+authors:
+  - xezon


### PR DESCRIPTION
This change fixes polish tool tip texts. They now no longer say "Good against" or "Strong against" or "Effective against" but always "Strong against" like English does.