### PR TITLE
Fix: Set correct strengths and weaknesses in China Listening Outpost tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
@@ -9,7 +9,8 @@ changes:
   - fix: Adds missing sentences to various tool tip strings.
   - fix: Removes superfluous mention of 'enemy' in tool tip strings of USA Stealth Figher, Tomahawk and China Inferno Cannon for all languages.
   - fix: Removes incorrect sentence in MOAB tooltip for all languages.
-  - fix: The China Infantry Assault Transport tool tip now shows correct strengths and weaknesses for all languages.
+  - fix: The China Assault Transport tool tip strings now show correct strengths and weaknesses for all languages.
+  - fix: The China Listening Outpost tool tip strings now show correct strengths and weaknesses for all languages.
 
 labels:
   - minor
@@ -20,6 +21,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2156
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2167
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2146
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2149
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
 
 authors:


### PR DESCRIPTION
This change adds the missing strength sentences to the China Outpost tool tip. Affects English, German, French, Spanish, Italian, Russian.