### PR TITLE
Fix: English tool tip texts

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-07-26
+
+title: Fixes inconsistent wording and capitalization of words in English tool tip strings
+
+changes:
+  - fix: The wording in English tool tip strings is more consistent now.
+  - fix: The capitalization of words in English tool tip strings is more consistent now.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2150
+
+authors:
+  - xezon


### PR DESCRIPTION
**Merge with Rebase**

This change fixes English tool tip texts. The capitalization of words is now consistent. And it always says "Strong vs. ..." instead of "Strong against ..." (1).