### PR TITLE
Fix: Add consistent wording in Spanish tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-07-26
+
+title: Fixes inconsistent wording in Spanish tool tip strings
+
+changes:
+  - fix: The wording in Spanish tool tip strings is more consistent now.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2151
+
+authors:
+  - xezon


### PR DESCRIPTION
This change fixes Spanish tool tip texts. They now no longer say "Strong against" or "Powerful against" but always "Powerful against".