### PR TITLE
Add Range And Damage Bonus To Infantry Inside Overlord Bunkers

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -899,7 +899,7 @@ Object ChinaTankOverlordBattleBunker
     InitialHealth   = 100.0
   End
 
-  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#XXXX)
+  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#2152)
   Behavior = HelixContain ModuleTag_03
     Slots                 = 5
     PassengersAllowedToFire = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -899,7 +899,8 @@ Object ChinaTankOverlordBattleBunker
     InitialHealth   = 100.0
   End
 
-  Behavior = TransportContain ModuleTag_03
+  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#XXXX)
+  Behavior = HelixContain ModuleTag_03
     Slots                 = 5
     PassengersAllowedToFire = Yes
     AllowInsideKindOf  = INFANTRY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17795,7 +17795,8 @@ Object Nuke_ChinaTankOverlordBattleBunker
     InitialHealth   = 100.0
   End
 
-  Behavior = TransportContain ModuleTag_03
+  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#XXXX)
+  Behavior = HelixContain ModuleTag_03
     Slots                 = 5
     PassengersAllowedToFire = Yes
     AllowInsideKindOf  = INFANTRY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17795,7 +17795,7 @@ Object Nuke_ChinaTankOverlordBattleBunker
     InitialHealth   = 100.0
   End
 
-  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#XXXX)
+  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#2152)
   Behavior = HelixContain ModuleTag_03
     Slots                 = 5
     PassengersAllowedToFire = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3623,7 +3623,8 @@ Object Tank_ChinaTankOverlordBattleBunker
   End
 
 
-  Behavior = TransportContain ModuleTag_03
+  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#XXXX)
+  Behavior = HelixContain ModuleTag_03
     Slots                 = 5
     PassengersAllowedToFire = Yes
     AllowInsideKindOf  = INFANTRY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -3623,7 +3623,7 @@ Object Tank_ChinaTankOverlordBattleBunker
   End
 
 
-  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#XXXX)
+  ; Patch104p @balance commy2 21/07/2023 Change from Transport to HelixContain to grant GARRISON bonus. (#2152)
   Behavior = HelixContain ModuleTag_03
     Slots                 = 5
     PassengersAllowedToFire = Yes


### PR DESCRIPTION
- close https://github.com/TheSuperHackers/GeneralsGamePatch/issues/2131

This change grants GARRISON bonus (133% range, 125% damage) to infantry inside Overlord Bunkers. They already gain this bonus in regular and Helix Bunkers in 1.04, but not inside Overlord Bunkers.

![shot_20230721_102229_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/c46a7a56-c3e4-4283-8b28-dd7ed549a8de)
