### PR TITLE
Fix: Battle Bus with Demolitions upgrade does explode when killed

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/102_demo_battle_bus_suicide_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/102_demo_battle_bus_suicide_damage.yaml
@@ -16,6 +16,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/102
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1504
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2164
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2164_demo_battle_bus_suicide_damage.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2164_demo_battle_bus_suicide_damage.txt
@@ -1,0 +1,1 @@
+102_demo_battle_bus_suicide_damage.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -22436,7 +22436,7 @@ Object Demo_GLAVehicleBattleBus
   ;  DeathTypes = NONE +SUICIDED
   ;End;
 
-  ; Patch104p @bugfix commy2 29/07/2023 Restore explosion when killed with Demolitions upgrade. (xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Restore explosion when killed with Demolitions upgrade. (#2164)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag999
     DeathWeapon   = Demo_DestroyedWeapon
     StartsActive  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -22428,6 +22428,22 @@ Object Demo_GLAVehicleBattleBus
     DeathTypes = NONE +CRUSHED +SPLATTED
   End
 
+  ; Patch104p @bugfix commy2 29/08/2021 Doesn't trigger with Bus. Handled by SlowDeathBehavior OCL below. (#102)
+  ;Behavior = FireWeaponWhenDeadBehavior ModuleTag998
+  ;  DeathWeapon   = Demo_SuicideDynamitePackPlusFire
+  ;  StartsActive  = No
+  ;  TriggeredBy   = Demo_Upgrade_SuicideBomb
+  ;  DeathTypes = NONE +SUICIDED
+  ;End;
+
+  ; Patch104p @bugfix commy2 29/07/2023 Restore explosion when killed with Demolitions upgrade. (xxxx)
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag999
+    DeathWeapon   = Demo_DestroyedWeapon
+    StartsActive  = No
+    TriggeredBy   = Demo_Upgrade_SuicideBomb
+    DeathTypes = ALL -SUICIDED
+  End
+
   Behavior = CommandSetUpgrade ModuleTag_33
     CommandSet = Demo_GLAVehicleBattleBusCommandSetUpgrade
     TriggeredBy = Demo_Upgrade_SuicideBomb
@@ -22447,7 +22463,7 @@ Object Demo_GLAVehicleBattleBus
 
   Behavior = SlowDeathBehavior ModuleTag_35 ; Sorry, because the terrorist does Suicide damage to others, we cannot tell if it is a legit suicide (us killing self)
     DeathTypes          = NONE +SUICIDED
-    OCL                 = INITIAL Demo_OCL_BattleBusSuicideWeaponDummy ; Patch104p @bugfix commy2 29/08/2021 Spawns dummy object to let Battle Bus deal damage by suicide.
+    OCL                 = INITIAL Demo_OCL_BattleBusSuicideWeaponDummy ; Patch104p @bugfix commy2 29/08/2021 Spawns dummy object to let Battle Bus deal damage by suicide. (#102)
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_BattleBusDeath
     ;FX                  = FINAL   FX_BattleBusDeathExplosion
@@ -22474,7 +22490,7 @@ End
 
 
 
-; Patch104p @bugfix commy2 29/08/2021 Dummies used to fire regular Demolitions upgrade explosion weapons after "suicide death" and "passive death".
+; Patch104p @bugfix commy2 29/08/2021 Dummy used to trigger explosion weapon after "suicide death". (#102)
 ; Patch104p @bugfix commy2 15/08/2022 Do not use HighlanderBody for these dummies: It will cause unexpected resistance to particle beams.
 ; Patch104p @bugfix commy2 20/08/2022 Use DeletionUpdate for ImmortalBody, because immortals cannot die.
 ; Patch104p @bugfix xezon 15/12/2022 Use ActiveBody + DestroyDie instead of ImmortalBody + DeletionUpdate,


### PR DESCRIPTION
- fix #2161 

Should work now. Damage appears to be correct in all cases. Much simpler than previous implementation. Clarified some comments.

With this, Bus Demolitions interaction can be described as:

- no boom before Demolitions upgrade
- big damage when suicided
- bunker mode disables suicide button
- small damage when bunker mode is destroyed or abandoned (only with upgrade).

I don't see any double explosions.