### PR TITLE
Add missing sentences and remove superfluous sentences in various tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-07-29
+
+title: Fixes various errors in text strings
+
+changes:
+  - fix: Removes superfluous sentences from Korean strings.
+  - fix: Removes superfluous sentences from Scud Launcher promotion tool tip strings.
+  - fix: Adds missing sentences to various tool tip strings.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2156
+
+authors:
+  - xezon


### PR DESCRIPTION
**Merge with Rebase**

This change adds missing sentences and removes obsolete sentences in various tool tip strings.

* Removes superfluous sentences from Korean language strings
* Removes superfluous sentences from Scud Launcher promotion tool tip
* Adds missing sentences to various tool tip strings