### PR TITLE
Fix: Unlockable vehicles display wrong requirements in Generals Promotion screen of sub-factions

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2166_unlockable_units_on_promotion_screen.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2166_unlockable_units_on_promotion_screen.yaml
@@ -1,0 +1,30 @@
+---
+date: 2023-07-29
+
+title: Shows correct dynamic requirements for unlockable units on promotion screen of sub-factions
+
+changes:
+  - fix: Paladin promotion for USA sub-factions and Boss General no longer displays "Requires: War Factory" despite having built a War Factory.
+  - fix: Stealth Fighter promotion for USA sub-factions no longer displays "Requires: Airfield" despite having built an Airfield.
+  - fix: Pathfinder promotion for USA sub-factions and Boss General no longer displays "Requires: Barracks" despite having built a Barracks.
+  - fix: Nuke Cannon promotion now displays "Requires: War Factory, General's Promotion".
+  - fix: Nuke Cannon promotion for China sub-factions no longer displays "Requires: Propaganda Center".
+  - fix: Marauder promotion for GLA sub-factions no longer displays "Requires: Arms Dealer" despite having built an Arms Dealer.
+  - fix: Scud Launcher promotion for GLA sub-factions no longer displays "Requires: Arms Dealer, Palace" despite having built an Arms Dealer and/or Palace.
+  - fix: Hijacker promotion for GLA sub-factions no longer displays "Requires: Barracks" despite having built a Barracks.
+
+labels:
+  - boss
+  - bug
+  - china
+  - gla
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2166
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3758,7 +3758,25 @@ End
 ; begin Chinese PurchaseScience buttons
 CommandButton Command_PurchaseScienceNukeLauncher
   Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_NukeLauncher ; Patch104p @bugfix commy2 29/07/2023 Add object to dynamically display requirements. (#xxxx)
+  Object            = ChinaVehicleNukeLauncher
+  ButtonImage       = SNNukeCannon
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+CommandButton Infa_Command_PurchaseScienceNukeLauncher
+  Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_NukeLauncher
+  Object            = Infa_ChinaVehicleNukeLauncher
+  ButtonImage       = SNNukeCannon
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Tank_Command_PurchaseScienceNukeLauncher ; unused
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_NukeLauncher
+  Object            = Tank_ChinaVehicleNukeLauncher
   ButtonImage       = SNNukeCannon
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3634,6 +3634,23 @@ CommandButton Command_PurchaseSciencePaladinTank
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+CommandButton Lazr_Command_PurchaseSciencePaladinTank ; unused
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_PaladinTank
+  Object            = Lazr_AmericaTankPaladin
+  ButtonImage       = SAPaladin
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton SupW_Command_PurchaseSciencePaladinTank ; unused
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_PaladinTank
+  Object            = SupW_AmericaTankPaladin
+  ButtonImage       = SAPaladin
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
 CommandButton Command_PurchaseSciencePathfinder
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_Pathfinder
@@ -3642,10 +3659,52 @@ CommandButton Command_PurchaseSciencePathfinder
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+CommandButton AirF_Command_PurchaseSciencePathfinder
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_Pathfinder
+  Object            = AirF_AmericaInfantryPathfinder
+  ButtonImage       = SAPathfinder1
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Lazr_Command_PurchaseSciencePathfinder
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_Pathfinder
+  Object            = Lazr_AmericaInfantryPathfinder
+  ButtonImage       = SAPathfinder1
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton SupW_Command_PurchaseSciencePathfinder
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_Pathfinder
+  Object            = SupW_AmericaInfantryPathfinder
+  ButtonImage       = SAPathfinder1
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
 CommandButton Command_PurchaseScienceStealthFighter
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_StealthFighter
   Object            = AmericaJetStealthFighter
+  ButtonImage       = SAStealth
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+CommandButton Lazr_Command_PurchaseScienceStealthFighter
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_StealthFighter
+  Object            = Lazr_AmericaJetStealthFighter
+  ButtonImage       = SAStealth
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton SupW_Command_PurchaseScienceStealthFighter
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_StealthFighter
+  Object            = SupW_AmericaJetStealthFighter
   ButtonImage       = SAStealth
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3833,8 +3833,8 @@ End
 ; begin Chinese PurchaseScience buttons
 CommandButton Command_PurchaseScienceNukeLauncher
   Command           = PURCHASE_SCIENCE
-  Science           = SCIENCE_NukeLauncher ; Patch104p @bugfix commy2 29/07/2023 Add object to dynamically display requirements. (#2166)
-  Object            = ChinaVehicleNukeLauncher
+  Science           = SCIENCE_NukeLauncher
+  Object            = ChinaVehicleNukeLauncher ; Patch104p @bugfix commy2 29/07/2023 Add object to dynamically display requirements. (#2166)
   ButtonImage       = SNNukeCannon
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
@@ -6143,7 +6143,7 @@ End
 CommandButton Chem_Command_PurchaseScienceMarauderTank
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_MarauderTank
-  Object            = Chem_GLATankMarauder ; Patch104p @bugfix commy2 29/07/2023 Use right object for tooltip. (#2166)
+  Object            = Chem_GLATankMarauder ; Patch104p @bugfix commy2 29/07/2023 Use correct object for tooltip. (#2166)
   ButtonImage       = SUMarauder
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -4055,6 +4055,14 @@ CommandButton Slth_Command_PurchaseScienceScudLauncher ; unused
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
+CommandButton GC_Chem_Command_PurchaseScienceScudLauncher
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_ScudLauncher
+  Object            = GC_Chem_GLAVehicleScudLauncher
+  ButtonImage       = SUScudLauncher
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
 CommandButton Command_PurchaseScienceMarauderTank
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_MarauderTank

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3920,6 +3920,15 @@ CommandButton Command_PurchaseScienceHijacker
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+CommandButton Demo_Command_PurchaseScienceHijacker ; unused
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_Hijacker
+  Object            = Demo_GLAInfantryHijacker
+  ButtonImage       = SUHijacker
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
 CommandButton Command_PurchaseScienceScudLauncher
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_ScudLauncher
@@ -3928,10 +3937,52 @@ CommandButton Command_PurchaseScienceScudLauncher
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+CommandButton Chem_Command_PurchaseScienceScudLauncher
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_ScudLauncher
+  Object            = Chem_GLAVehicleScudLauncher
+  ButtonImage       = SUScudLauncher
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Demo_Command_PurchaseScienceScudLauncher
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_ScudLauncher
+  Object            = Demo_GLAVehicleScudLauncher
+  ButtonImage       = SUScudLauncher
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Slth_Command_PurchaseScienceScudLauncher ; unused
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_ScudLauncher
+  Object            = Slth_GLAVehicleScudLauncher
+  ButtonImage       = SUScudLauncher
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
 CommandButton Command_PurchaseScienceMarauderTank
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_MarauderTank
   Object            = GLATankMarauder
+  ButtonImage       = SUMarauder
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+CommandButton Demo_Command_PurchaseScienceMarauderTank
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_MarauderTank
+  Object            = Demo_GLATankMarauder
+  ButtonImage       = SUMarauder
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Slth_Command_PurchaseScienceMarauderTank ; unused
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_MarauderTank
+  Object            = Slth_GLATankMarauder
   ButtonImage       = SUMarauder
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
@@ -5991,7 +6042,7 @@ End
 CommandButton Chem_Command_PurchaseScienceMarauderTank
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_MarauderTank
-  Object            = GLATankMarauder
+  Object            = Chem_GLATankMarauder ; Patch104p @bugfix commy2 29/07/2023 Use right object for tooltip. (#xxxx)
   ButtonImage       = SUMarauder
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3651,6 +3651,14 @@ CommandButton SupW_Command_PurchaseSciencePaladinTank ; unused
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
+CommandButton Boss_Command_PurchaseSciencePaladinTank
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_PaladinTank
+  Object            = Boss_TankPaladin
+  ButtonImage       = SAPaladin
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
 CommandButton Command_PurchaseSciencePathfinder
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_Pathfinder
@@ -3680,6 +3688,14 @@ CommandButton SupW_Command_PurchaseSciencePathfinder
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_Pathfinder
   Object            = SupW_AmericaInfantryPathfinder
+  ButtonImage       = SAPathfinder1
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Boss_Command_PurchaseSciencePathfinder
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_Pathfinder
+  Object            = Boss_InfantryPathfinder
   ButtonImage       = SAPathfinder1
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -3634,7 +3634,7 @@ CommandButton Command_PurchaseSciencePaladinTank
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
-; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#2166)
 CommandButton Lazr_Command_PurchaseSciencePaladinTank ; unused
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_PaladinTank
@@ -3667,7 +3667,7 @@ CommandButton Command_PurchaseSciencePathfinder
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
-; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#2166)
 CommandButton AirF_Command_PurchaseSciencePathfinder
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_Pathfinder
@@ -3708,7 +3708,7 @@ CommandButton Command_PurchaseScienceStealthFighter
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
-; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#2166)
 CommandButton Lazr_Command_PurchaseScienceStealthFighter
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_StealthFighter
@@ -3833,13 +3833,13 @@ End
 ; begin Chinese PurchaseScience buttons
 CommandButton Command_PurchaseScienceNukeLauncher
   Command           = PURCHASE_SCIENCE
-  Science           = SCIENCE_NukeLauncher ; Patch104p @bugfix commy2 29/07/2023 Add object to dynamically display requirements. (#xxxx)
+  Science           = SCIENCE_NukeLauncher ; Patch104p @bugfix commy2 29/07/2023 Add object to dynamically display requirements. (#2166)
   Object            = ChinaVehicleNukeLauncher
   ButtonImage       = SNNukeCannon
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
-; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#2166)
 CommandButton Infa_Command_PurchaseScienceNukeLauncher
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_NukeLauncher
@@ -4013,7 +4013,7 @@ CommandButton Command_PurchaseScienceHijacker
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
-; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#2166)
 CommandButton Demo_Command_PurchaseScienceHijacker ; unused
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_Hijacker
@@ -4030,7 +4030,7 @@ CommandButton Command_PurchaseScienceScudLauncher
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
-; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#2166)
 CommandButton Chem_Command_PurchaseScienceScudLauncher
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_ScudLauncher
@@ -4071,7 +4071,7 @@ CommandButton Command_PurchaseScienceMarauderTank
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
 
-; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#xxxx)
+; Patch104p @bugfix commy2 29/07/2023 Add sub-faction specific variants to display correct requirements in tooltip. (#2166)
 CommandButton Demo_Command_PurchaseScienceMarauderTank
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_MarauderTank
@@ -6143,7 +6143,7 @@ End
 CommandButton Chem_Command_PurchaseScienceMarauderTank
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_MarauderTank
-  Object            = Chem_GLATankMarauder ; Patch104p @bugfix commy2 29/07/2023 Use right object for tooltip. (#xxxx)
+  Object            = Chem_GLATankMarauder ; Patch104p @bugfix commy2 29/07/2023 Use right object for tooltip. (#2166)
   ButtonImage       = SUMarauder
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -4242,7 +4242,7 @@ End
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank1
   1 = Infa_Command_PurchaseScienceRedGuardTraining
   2 = Command_PurchaseScienceArtilleryTraining
-  3 = Command_PurchaseScienceNukeLauncher
+  3 = Infa_Command_PurchaseScienceNukeLauncher
   4 = Early_Command_PurchaseScienceFrenzy1
 END
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1608,7 +1608,7 @@ End
 ; GENERALS CHALLENGE COMMAND SETS
 ;--------------------------------------------------------------------------------
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank1
-  1 = Command_PurchaseScienceScudLauncher
+  1 = GC_Chem_Command_PurchaseScienceScudLauncher
 END
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank3

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1946,7 +1946,7 @@ CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
 END
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank3
-  1 = Command_PurchaseSciencePathfinder
+  1 = AirF_Command_PurchaseSciencePathfinder
   4 = Command_PurchaseScienceParadrop1
   5 = Command_PurchaseScienceParadrop2
   6 = Command_PurchaseScienceParadrop3
@@ -3864,11 +3864,11 @@ End
 ;--------------------------------------------------------------------------------
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank1
   1 = Command_PurchaseScienceSpyDrone
-  2 = Command_PurchaseScienceStealthFighter
+  2 = SupW_Command_PurchaseScienceStealthFighter
 END
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank3
-   1 = Command_PurchaseSciencePathfinder
+   1 = SupW_Command_PurchaseSciencePathfinder
    3 = Early_Command_PurchaseScienceLeafletDrop
    4 = Command_PurchaseScienceParadrop1
    5 = Command_PurchaseScienceParadrop2
@@ -4779,11 +4779,11 @@ End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank1
   1 = Command_PurchaseScienceSpyDrone
-  2 = Command_PurchaseScienceStealthFighter
+  2 = Lazr_Command_PurchaseScienceStealthFighter
 END
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank3
-  1 = Command_PurchaseSciencePathfinder
+  1 = Lazr_Command_PurchaseSciencePathfinder
   4 = Command_PurchaseScienceParadrop1
   5 = Command_PurchaseScienceParadrop2
   6 = Command_PurchaseScienceParadrop3

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2204,8 +2204,8 @@ End
 ;Demolitions General
 ;---
 CommandSet Demo_SCIENCE_GLA_CommandSetRank1
-  1 = Command_PurchaseScienceScudLauncher
-  2 = Command_PurchaseScienceMarauderTank
+  1 = Demo_Command_PurchaseScienceScudLauncher
+  2 = Demo_Command_PurchaseScienceMarauderTank
   3 = Command_PurchaseScienceTechnicalTraining
 END
 
@@ -3194,7 +3194,7 @@ End
 
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank1
-  1 = Command_PurchaseScienceScudLauncher
+  1 = Chem_Command_PurchaseScienceScudLauncher
   2 = Chem_Command_PurchaseScienceMarauderTank
   3 = Chem_Command_PurchaseScienceTechnicalTraining
 END

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -5519,8 +5519,8 @@ End
 
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank1
-  1 = Command_PurchaseSciencePaladinTank
-  2 = Command_PurchaseSciencePathfinder
+  1 = Boss_Command_PurchaseSciencePaladinTank
+  2 = Boss_Command_PurchaseSciencePathfinder
   3 = Command_PurchaseScienceClusterMines
 ;  4 = Command_PurchaseScienceEmergencyRepair1
 END


### PR DESCRIPTION
### 1.04

- Paladin Promotion displays "Requires: War Factory" despite having built a War Factory as Boss.
- Stealth Fighter Promotion displays "Requires: Airfield" for Lasergen and SWG despite having built an Airfield
- Pathfinder Promotion displays "Requires: Barracks" for Lasergen, AFG, SWG and Boss despite having built a Barracks
- Nuke Cannon Promotion always displays "Requires: Propaganda Center", despite missing a War Factory and/or having built a Propaganda Center
- Marauder Promotion displays "Requires: Arms Dealer" for Toxgen and Demogen despite having built an Arms Dealer.
- Scud Launcher Promotion displays "Requires: Arms Dealer, Palace" for Toxgen and Demogen despite having  built an Arms Dealer and/or Palace.

This bug does not apply to vUSA, vChina and vGLA, because the buttons used on the General's Promotion screen refer to those faction units.

Working example, expected behaviour:

<details><summary>vGLA missing everything</summary>

![shot_20230729_141446_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/c7f2710b-3dee-4cac-8cae-eb74c4a11b14)

</details>

<details><summary>vGLA all requirements met</summary>

![shot_20230729_141705_4](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/f5417f82-45fa-4243-9417-d37aae3bc282)

</details>

Broken example:

<details><summary>Demo all requirements met, tooltip wrong</summary>

![shot_20230729_142314_7](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/2d17b622-48e3-4c77-b485-c30382430887)

</details>

### patch

- all requirements are displayed dynamically specfic to every sub-faction