### PR TITLE
Fix: Remove superfluous mentions of 'enemy' in tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
@@ -7,6 +7,7 @@ changes:
   - fix: Removes superfluous sentences from Korean strings.
   - fix: Removes superfluous sentences from Scud Launcher promotion tool tip strings.
   - fix: Adds missing sentences to various tool tip strings.
+  - fix: Removes superfluous mention of 'enemy' in tool tip strings of USA Stealth Figher, Tomahawk and China Inferno Cannon for all languages.
 
 labels:
   - minor
@@ -15,6 +16,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2156
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2167
 
 authors:
   - xezon


### PR DESCRIPTION
This change removes superfluous mentions of 'enemy' in tool tip strings.

Affected tool tips are

* CONTROLBAR:ToolTipUSABuildStealthFighter
* CONTROLBAR:ToolTipUSABuildTomahawk
* CONTROLBAR:ToolTipChinaBuildInfernoCannon
* CONTROLBAR:AirF_ToolTipUSABuildStealthFighter

Unaffected tool tip is

* CONTROLBAR:ToolTipGLABuildSaboteur

Most tool tips do not mention enemy forces, because the associated unit could be used against any forces, including allies and civilians. Only the GLA Saboteur can attack enemy buildings only, and therefore the mention of "enemy" is ok.