### PR TITLE
Fix: Boss Aurora Countermeasures Evasion Rate

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2170_boss_aurora_countermeasures_missile_evasion_rate.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2170_boss_aurora_countermeasures_missile_evasion_rate.yaml
@@ -11,7 +11,6 @@ labels:
   - bug
   - minor
   - v1.0
-  - worldbuilder
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2170

--- a/Patch104pZH/Design/Changes/v1.0/2170_boss_aurora_countermeasures_missile_evasion_rate.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2170_boss_aurora_countermeasures_missile_evasion_rate.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-07-29
+
+title: Fixes Boss General's Aurora Countermeasures missile evasion rate
+
+changes:
+  - fix: Reduces the Boss General's Aurora missile evasion rate after Countermeasures upgrade from 50% to 30%.
+
+labels:
+  - boss
+  - bug
+  - minor
+  - v1.0
+  - worldbuilder
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2170
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15545,6 +15545,7 @@ Object Boss_JetAurora
     TriggeredBy           = Upgrade_AmericaCountermeasures
   End
 
+  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#xxxx)
   Behavior                = CountermeasuresBehavior ModuleTag_10
     TriggeredBy           = Upgrade_AmericaCountermeasures
     FlareTemplateName     = CountermeasureFlare
@@ -15555,7 +15556,7 @@ Object Boss_JetAurora
     DelayBetweenVolleys   = 1000  ; Time between flare volleys
     NumberOfVolleys       = 3     ; Number of times the volleys will fire before reloading
     ReloadTime            = 0     ; After all volleys launched, then reloading must occur. If 0, then reloading occurs at airstrip only.
-    EvasionRate           = 50%   ; With active flares, the specified percentage will be diverted.
+    EvasionRate           = 30%   ; With active flares, the specified percentage will be diverted.
     ReactionLaunchLatency = 0     ; Reaction between getting shot at and the firing of the first volley of countermeasures.
     MissileDecoyDelay     = 200   ; A reported missile that has been determined to hit a decoy will wait this long before acquiring countermeasures.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15545,7 +15545,7 @@ Object Boss_JetAurora
     TriggeredBy           = Upgrade_AmericaCountermeasures
   End
 
-  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#2170)
   Behavior                = CountermeasuresBehavior ModuleTag_10
     TriggeredBy           = Upgrade_AmericaCountermeasures
     FlareTemplateName     = CountermeasureFlare


### PR DESCRIPTION
### 1.04

- Almost all airplanes, including all Aurora variants except the Boss General's have a 30% missile evasion rate after Countermeasures upgrade
- Boss Aurora has 50% for whatever reason. This seems to be an oversight, because missile evasion rate was nerfed from 50% in 1.02.

### this change

- All Aurora have the same 30% missile evasion rate as almost all other planes.