### PR TITLE
Fix: Unused Boss Spectre Countermeasures Evasion Rate

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2171_spectre_countermeasures_missile_evasion_rate.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2171_spectre_countermeasures_missile_evasion_rate.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-07-29
+
+title: Fixes unused Boss General's Spectre Countermeasures missile evasion rate
+
+changes:
+  - fix: Reduces the unused Boss General's Spectre missile evasion rate after Countermeasures upgrade from 50% to 30%.
+
+labels:
+  - boss
+  - bug
+  - minor
+  - v1.0
+  - worldbuilder
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2171
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15270,7 +15270,7 @@ Object Boss_JetSpectreGunship
     TriggeredBy           = Upgrade_AmericaCountermeasures
   End
 
-  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#2171)
   Behavior                = CountermeasuresBehavior ModuleTag_11
     TriggeredBy           = Upgrade_AmericaCountermeasures
     FlareTemplateName     = CountermeasureFlare

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15270,6 +15270,7 @@ Object Boss_JetSpectreGunship
     TriggeredBy           = Upgrade_AmericaCountermeasures
   End
 
+  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#xxxx)
   Behavior                = CountermeasuresBehavior ModuleTag_11
     TriggeredBy           = Upgrade_AmericaCountermeasures
     FlareTemplateName     = CountermeasureFlare
@@ -15280,7 +15281,7 @@ Object Boss_JetSpectreGunship
     DelayBetweenVolleys   = 1000  ; Time between flare volleys
     NumberOfVolleys       = 5     ; Number of times the volleys will fire before reloading
     ReloadTime            = 0     ; After all volleys launched, then reloading must occur. If 0, then reloading occurs at airstrip only.
-    EvasionRate           = 50%   ; With active flares, the specified percentage will be diverted.
+    EvasionRate           = 30%   ; With active flares, the specified percentage will be diverted.
     ReactionLaunchLatency = 0     ; Reaction between getting shot at and the firing of the first volley of countermeasures.
     MissileDecoyDelay     = 200   ; A reported missile that has been determined to hit a decoy will wait this long before acquiring countermeasures.
   End


### PR DESCRIPTION
### 1.04

- Almost all airplanes, including all Spectre variants except the Boss General's have a 30% missile evasion rate after Countermeasures upgrade
- Boss Spectre has 50% for whatever reason. This seems to be an oversight, because missile evasion rate was nerfed from 50% in 1.02.
- This Spectre unit is not actually used by the Boss General's Spectre ability. This makes this unit a pretty much useless world builder only unit.

### this change

- All Spectre variants have the same 30% missile evasion rate as almost all other planes.