### PR TITLE
Fix: MOAB B2 Bomber Countermeasures Evasion Rate

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2172_moab_countermeasures_missile_evasion_rate.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2172_moab_countermeasures_missile_evasion_rate.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-07-29
+
+title: Fixes MOAB B2 Bomber Countermeasures missile evasion rate
+
+changes:
+  - fix: Reduces MOAB B2 Bomber missile evasion rate after Countermeasures upgrade from 50% to 30%.
+
+labels:
+  - bug
+  - minor
+  - nerf
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2172
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
@@ -163,6 +163,7 @@ Object AmericaJetB3
     TriggeredBy           = Upgrade_AmericaCountermeasures
   End
 
+  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#xxxx)
   Behavior                = CountermeasuresBehavior ModuleTag_12
     TriggeredBy           = Upgrade_AmericaCountermeasures
     FlareTemplateName     = CountermeasureFlare
@@ -173,7 +174,7 @@ Object AmericaJetB3
     DelayBetweenVolleys   = 1000  ; Time between flare volleys
     NumberOfVolleys       = 5     ; Number of times the volleys will fire before reloading
     ReloadTime            = 0  ; After all volleys launched, then reloading must occur. If 0, then reloading occurs at airstrip only.
-    EvasionRate           = 50%   ; With active flares, the specified percentage will be diverted.
+    EvasionRate           = 30%   ; With active flares, the specified percentage will be diverted.
     ReactionLaunchLatency = 100   ; Reaction between getting shot at and the firing of the first volley of countermeasures.
     MissileDecoyDelay     = 200   ; A reported missile that has been determined to hit a decoy will wait this long before acquiring countermeasures.
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SpecialPowerObjects.ini
@@ -163,7 +163,7 @@ Object AmericaJetB3
     TriggeredBy           = Upgrade_AmericaCountermeasures
   End
 
-  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Change EvasionRate from 50% to 30% in line with other units. (#2172)
   Behavior                = CountermeasuresBehavior ModuleTag_12
     TriggeredBy           = Upgrade_AmericaCountermeasures
     FlareTemplateName     = CountermeasureFlare


### PR DESCRIPTION
### 1.04

- Almost all airplanes, including the Airforce General B2 Carpet Bomber have a 30% missile evasion rate after Countermeasures upgrade
- The MOAB Bomber has 50% for whatever reason. This seems to be an oversight, because missile evasion rate was nerfed from 50% in 1.02.
- This error likely happened, because the object is placed in a strange file that only contains the B2 and a Chinese Bomber that has no Countermeasures.

### this change

- All B2 Bomber variants have the same 30% missile evasion rate as almost all other planes.

This is technically a nerf I suppose, but I do not think the MOAB Bomber even needs the extra missile evasion, considering that will not be shot down by Stingers or Patriots unless there are MASSIVE amounts of them. The only real impact I see is trying to MOAB massive blobs of TOW vees.

It outruns Rocketeer missiles.