### PR TITLE
Fix: Lone Stinger Soldiers float above ground when moving while reloading

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2173_stinger_trooper_reload_animation_while_moving.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2173_stinger_trooper_reload_animation_while_moving.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-07-29
+
+title: Fixes lone Stinger Trooper movement animation while reloading
+
+changes:
+  - fix: Lone Stinger Trooper no longer floats over ground when moving while reloading
+
+labels:
+  - boss
+  - bug
+  - gla
+  - minor
+  - v1.0
+  - worldbuilder
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2173
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13411,7 +13411,7 @@ Object Chem_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -13443,6 +13443,10 @@ Object Chem_GLAInfantryStingerSoldier
       AnimationMode = LOOP
       WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState = DYING
       Animation = UISmsd_SKL.UISmsd_DTA
@@ -13487,8 +13491,6 @@ Object Chem_GLAInfantryStingerSoldier
     AliasConditionState = FIRING_B
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING FIRING_B
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING RELOADING_B
 
 
     ConditionState = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13411,7 +13411,7 @@ Object Chem_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#2173)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13878,7 +13878,7 @@ Object Demo_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#2173)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13878,7 +13878,7 @@ Object Demo_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -13910,6 +13910,10 @@ Object Demo_GLAInfantryStingerSoldier
       AnimationMode = LOOP
       WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState = DYING
       Animation = UISmsd_SKL.UISmsd_DTA
@@ -13954,8 +13958,6 @@ Object Demo_GLAInfantryStingerSoldier
     AliasConditionState = FIRING_B
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING FIRING_B
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING RELOADING_B
 
 
     ConditionState = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -128,7 +128,7 @@ Object GC_Chem_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#2173)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -128,7 +128,7 @@ Object GC_Chem_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -160,6 +160,10 @@ Object GC_Chem_GLAInfantryStingerSoldier
       AnimationMode = LOOP
       WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState = DYING
       Animation = UISmsd_SKL.UISmsd_DTA
@@ -204,8 +208,6 @@ Object GC_Chem_GLAInfantryStingerSoldier
     AliasConditionState = FIRING_B
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING FIRING_B
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING RELOADING_B
 
 
     ConditionState = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -452,7 +452,7 @@ Object GC_Slth_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -484,6 +484,10 @@ Object GC_Slth_GLAInfantryStingerSoldier
       AnimationMode = LOOP
       WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState = DYING
       Animation = UISmsd_SKL.UISmsd_DTA
@@ -528,8 +532,6 @@ Object GC_Slth_GLAInfantryStingerSoldier
     AliasConditionState = FIRING_B
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING FIRING_B
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING RELOADING_B
 
 
     ConditionState = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -452,7 +452,7 @@ Object GC_Slth_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#2173)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -981,7 +981,7 @@ Object GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -1013,6 +1013,10 @@ Object GLAInfantryStingerSoldier
       AnimationMode = LOOP
       WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState = DYING
       Animation = UISmsd_SKL.UISmsd_DTA
@@ -1057,8 +1061,6 @@ Object GLAInfantryStingerSoldier
     AliasConditionState = FIRING_B
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING FIRING_B
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING RELOADING_B
 
 
     ConditionState = SPECIAL_CHEERING

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -981,7 +981,7 @@ Object GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#2173)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14422,7 +14422,7 @@ Object Slth_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#2173)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -14422,7 +14422,7 @@ Object Slth_GLAInfantryStingerSoldier
   ;UpgradeCameo5           = NONE
 
   ; Patch104p @bugfix commy2 11/09/2021 Fix animation and muzzle flash against air targets.
-
+  ; Patch104p @bugfix commy2 29/07/2023 Fix floating over ground when moving while reloading. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -14454,6 +14454,10 @@ Object Slth_GLAInfantryStingerSoldier
       AnimationMode = LOOP
       WaitForStateToFinishIfPossible = NONE ; Patch104p @bugfix commy2 03/09/2022 Fix walk animation right after firing.
     End
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState = MOVING RELOADING_A
+    AliasConditionState = MOVING BETWEEN_FIRING_SHOTS_B
+    AliasConditionState = MOVING RELOADING_B
 
     ConditionState = DYING
       Animation = UISmsd_SKL.UISmsd_DTA
@@ -14498,8 +14502,6 @@ Object Slth_GLAInfantryStingerSoldier
     AliasConditionState = FIRING_B
     AliasConditionState = MOVING FIRING_A
     AliasConditionState = MOVING FIRING_B
-    AliasConditionState = MOVING RELOADING_A
-    AliasConditionState = MOVING RELOADING_B
 
 
     ConditionState = SPECIAL_CHEERING


### PR DESCRIPTION
### 1.04

Lone Stinger Troopers float over the ground when moving while reloading.


### patch

Lone Stinger Troopers use move animation while moving and reloading

Notes:

Lone Stinger Troopers only appear in the Generals Challenge vs Kassad, or on custom maps.