### PR TITLE
Fix: Streamline Nuke Missile and Scud Storm tool tip strings for all languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2176_nuke_missile_scud_storm_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2176_nuke_missile_scud_storm_tool_tip_text.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-07-30
+
+title: Streamlines Nuke Missile and Scud Storm tool tip strings for all languages
+
+changes:
+  - fix: All native game languages now say "Strong against everything" or similar in the tool tip strings for Nuke Missile and Scud Storm.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2176
+
+authors:
+  - xezon


### PR DESCRIPTION
This change streamlines Nuke Missile and Scud Storm tool tip strings for all languages (except Arabic). They now say "Strong against everything" like English does.