### PR TITLE
Fix: Add status requirement to GLA Demolition death weapons

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/764_terrorist_crash.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/764_terrorist_crash.yaml
@@ -1,11 +1,12 @@
 ---
 date: 2022-07-27
 
-title: Fixes game crash upon the use of a GLA Terrorist
+title: Fixes game crash upon the use of a GLA Terrorist or Demo General infantry unit
 
 changes:
   - fix: Game no longer crashes when using Toxin GLA Terrorist (1)
   - fix: Game no longer crashes when using any GLA Terrorist (2)
+  - fix: Game no longer crashes when using any Demo General infantry unit (3)
 
 labels:
   - bug
@@ -16,7 +17,9 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/699
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/764
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2177
 
 authors:
   - hanfield
   - xezon
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13830,11 +13830,13 @@ Object Demo_GLAInfantryTunnelDefender
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = NONE +SUICIDED
+    ExemptStatus  = MASKED
   End;
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag999
@@ -13842,6 +13844,7 @@ Object Demo_GLAInfantryTunnelDefender
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = ALL -SUICIDED
+    ExemptStatus  = MASKED
   End
 
   Behavior = CommandSetUpgrade ModuleTag_15

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13089,11 +13089,13 @@ Object Demo_GLAInfantryRebel
 ;    DeathTypes = NONE +SUICIDED
 ;  End
 
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = NONE +SUICIDED
+    ExemptStatus  = MASKED
   End;
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag999
@@ -13101,6 +13103,7 @@ Object Demo_GLAInfantryRebel
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = ALL -SUICIDED
+    ExemptStatus  = MASKED
   End
 
   Behavior = CommandSetUpgrade ModuleTag_25

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14130,11 +14130,13 @@ Object Demo_GLAInfantryStingerSoldier
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = NONE +SUICIDED
+    ExemptStatus  = MASKED
   End;
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag999
@@ -14142,6 +14144,7 @@ Object Demo_GLAInfantryStingerSoldier
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = ALL -SUICIDED
+    ExemptStatus  = MASKED
   End
 
   Behavior = CommandSetUpgrade ModuleTag_17

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13510,11 +13510,13 @@ Object Demo_GLAInfantryJarmenKell
 ;    DeathTypes = NONE +SUICIDED
 ;  End
 
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = NONE +SUICIDED
+    ExemptStatus  = MASKED
   End;
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag999
@@ -13522,6 +13524,7 @@ Object Demo_GLAInfantryJarmenKell
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = ALL -SUICIDED
+    ExemptStatus  = MASKED
   End
 
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13089,7 +13089,7 @@ Object Demo_GLAInfantryRebel
 ;    DeathTypes = NONE +SUICIDED
 ;  End
 
-  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#2177)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
@@ -13510,7 +13510,7 @@ Object Demo_GLAInfantryJarmenKell
 ;    DeathTypes = NONE +SUICIDED
 ;  End
 
-  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#2177)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
@@ -13833,7 +13833,7 @@ Object Demo_GLAInfantryTunnelDefender
     FlingPitchVariance  = 10
   End
 
-  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#2177)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
@@ -14133,7 +14133,7 @@ Object Demo_GLAInfantryStingerSoldier
     FlingPitchVariance  = 10
   End
 
-  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#2177)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
@@ -16540,7 +16540,7 @@ Object Demo_GLAInfantryHijacker
     FlingPitchVariance  = 10
   End
 
-  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#2177)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
@@ -17000,7 +17000,7 @@ Object Demo_GLAInfantryWorker
     FlingPitchVariance  = 10
   End
 
-  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#2177)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16997,11 +16997,13 @@ Object Demo_GLAInfantryWorker
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = NONE +SUICIDED
+    ExemptStatus  = MASKED
   End;
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag999
@@ -17009,6 +17011,7 @@ Object Demo_GLAInfantryWorker
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = ALL -SUICIDED
+    ExemptStatus  = MASKED
   End
 
   Behavior = WeaponSetUpgrade ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -16537,11 +16537,13 @@ Object Demo_GLAInfantryHijacker
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#xxxx)
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998
     DeathWeapon   = Demo_SuicideDynamitePackPlusFire
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = NONE +SUICIDED
+    ExemptStatus  = MASKED
   End;
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag999
@@ -16549,6 +16551,7 @@ Object Demo_GLAInfantryHijacker
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     DeathTypes = ALL -SUICIDED
+    ExemptStatus  = MASKED
   End
 
   Behavior = CommandSetUpgrade ModuleTag_19


### PR DESCRIPTION
Same as https://github.com/TheSuperHackers/GeneralsGamePatch/pull/764, but for Demogen.
May also fix https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2164#issuecomment-1656742863