### PR TITLE
Fix: Stinger Soldiers can fire while Stinger Site is being sold (bad fix)

### DIFF
--- a/Patch104pZH/Design/Tasks/nproject_tasks.txt
+++ b/Patch104pZH/Design/Tasks/nproject_tasks.txt
@@ -1254,7 +1254,7 @@ the list of known bugs and how to prevent them. If you encounter bugs that not l
  - [NOTRELEVANT] Stinger Site no longer block unit sights, allowing other units to attack enemies behind
  - [MAYBE] Stinger Soldiers now can properly take damage from radiations like the other normal infantry
  - [MAYBE] Individual Stinger Soldier can't be targeted by Burton knife attacks anymore
- - [IMPROVEMENT][MAJOR] Stinger Soldiers no longer able to attack when the building is being sold, like the other defense buildings
+ - [DONE][MAJOR] Stinger Soldiers no longer able to attack when the building is being sold, like the other defense buildings
  - [MAYBE] Fixed the Stinger Soldier anti-air weapon that didn't get benefit from AP Rockets upgrade
 
  DEMO TRAPS:

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -6424,6 +6424,12 @@ Object Chem_GLAStingerSite
     StartsActive  = Yes
   End
 
+  ; Patch104p @bugfix 02/08/2023 Kill troopers when sold to stop them from firing immediately. (#xxxx)
+  Behavior = FireWeaponCollide ModuleTag_12Sold
+    CollideWeapon = StingerSiteDeathConcussion
+    RequiredStatus = SOLD
+  End
+
   ;Kris: Cut camo-netting from Chem General
   ;Behavior = StealthUpdate ModuleTag_13
   ;  StealthDelay                = 2500 ; msec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -6310,6 +6310,12 @@ Object Demo_GLAStingerSite
     StartsActive  = Yes
   End
 
+  ; Patch104p @bugfix 02/08/2023 Kill troopers when sold to stop them from firing immediately. (#xxxx)
+  Behavior = FireWeaponCollide ModuleTag_12Sold
+    CollideWeapon = StingerSiteDeathConcussion
+    RequiredStatus = SOLD
+  End
+
   ;Kris: Cut camo-netting from Demo General
   ;Behavior = StealthUpdate ModuleTag_13
   ;  StealthDelay                = 2500 ; msec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -17452,6 +17452,13 @@ Object GLAStingerSite
     DeathWeapon   = StingerSiteDeathConcussion
     StartsActive  = Yes
   End
+
+  ; Patch104p @bugfix 02/08/2023 Kill troopers when sold to stop them from firing immediately. (#xxxx)
+  Behavior = FireWeaponCollide ModuleTag_12Sold
+    CollideWeapon = StingerSiteDeathConcussion
+    RequiredStatus = SOLD
+  End
+
   Behavior = StealthUpdate ModuleTag_13
     StealthDelay                = 2500 ; msec
     StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE
@@ -34636,6 +34643,12 @@ Object GLAStingerSiteNoHole
   Behavior        = FireWeaponWhenDeadBehavior ModuleTag_12
     DeathWeapon   = StingerSiteDeathConcussion
     StartsActive  = Yes
+  End
+
+  ; Patch104p @bugfix 02/08/2023 Kill troopers when sold to stop them from firing immediately. (#xxxx)
+  Behavior = FireWeaponCollide ModuleTag_12Sold
+    CollideWeapon = StingerSiteDeathConcussion
+    RequiredStatus = SOLD
   End
 
   Behavior                = FlammableUpdate ModuleTag_15

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -999,6 +999,12 @@ Object GC_Chem_GLAStingerSite
     StartsActive  = Yes
   End
 
+  ; Patch104p @bugfix 02/08/2023 Kill troopers when sold to stop them from firing immediately. (#xxxx)
+  Behavior = FireWeaponCollide ModuleTag_12Sold
+    CollideWeapon = StingerSiteDeathConcussion
+    RequiredStatus = SOLD
+  End
+
   ;Kris: Cut camo-netting from Demo General
   ;Behavior = StealthUpdate ModuleTag_13
   ;  StealthDelay                = 2500 ; msec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -2974,6 +2974,13 @@ Object GC_Slth_GLAStingerSite
     DeathWeapon   = StingerSiteDeathConcussion
     StartsActive  = Yes
   End
+
+  ; Patch104p @bugfix 02/08/2023 Kill troopers when sold to stop them from firing immediately. (#xxxx)
+  Behavior = FireWeaponCollide ModuleTag_12Sold
+    CollideWeapon = StingerSiteDeathConcussion
+    RequiredStatus = SOLD
+  End
+
   Behavior = StealthUpdate ModuleTag_13
     StealthDelay                = 2000 ; msec
     StealthForbiddenConditions  = FIRING_PRIMARY FIRING_SECONDARY

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -7005,6 +7005,13 @@ Object Slth_GLAStingerSite
     DeathWeapon   = StingerSiteDeathConcussion
     StartsActive  = Yes
   End
+
+  ; Patch104p @bugfix 02/08/2023 Kill troopers when sold to stop them from firing immediately. (#xxxx)
+  Behavior = FireWeaponCollide ModuleTag_12Sold
+    CollideWeapon = StingerSiteDeathConcussion
+    RequiredStatus = SOLD
+  End
+
   Behavior = StealthUpdate ModuleStealth_09
     StealthDelay                = 2500 ; msec
     StealthForbiddenConditions  = ATTACKING USING_ABILITY TAKING_DAMAGE


### PR DESCRIPTION
Taken from NPM.

The point is to kill the Troopers when model state switches to SOLD.

This is a bad idea for several reasons:

- they can still fire for a variable amount of time due to how FireWeaponCollide works
- this will kill or injure other units near the Stinger Site when it is sold, which makes no sense at all
- EVA noise "unit lost" will be played when Stinger Site is sold

In conclusion, the Stinger Site is weirder with this than without this. A proper fix would need engine support. I advice to close this.