### PR TITLE
Fix: Add implementation of Partisans and Militia Man

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2192_militia_man.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2192_militia_man.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-07
+
+title: Adds Militia Man
+
+changes:
+  - feature: Adds armed Milita guy to worldbuilder.
+
+labels:
+  - civilian
+  - enhancement
+  - minor
+  - v1.0
+  - worldbuilder
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2192
+
+authors:
+  - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2192_partisans.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2192_partisans.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-07
+
+title: Implements Partisans
+
+changes:
+  - feature: The armed Partisans are now fully functional worldbuilder units.
+
+labels:
+  - civilian
+  - enhancement
+  - minor
+  - v1.0
+  - worldbuilder
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2192
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/MappedImages/TextureSize_512/SAUserInterface512.INI
+++ b/Patch104pZH/GameFilesEdited/Data/INI/MappedImages/TextureSize_512/SAUserInterface512.INI
@@ -1410,3 +1410,11 @@ MappedImage SAWarFactory
   Coords = Left:1 Top:1 Right:61 Bottom:49
   Status = NONE
 End
+
+MappedImage SCGeneric
+  Texture = SCShellUserInterface512_009.tga
+  TextureWidth = 512
+  TextureHeight = 512
+  Coords = Left:7 Top:169 Right:155 Bottom:317
+  Status = NONE
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8854,8 +8854,8 @@ End
 Object Partisan01
 
     ; *** ART Parameters ***
-  SelectPortrait         = SULeadGLA01_L
-  ButtonImage            = SULeadGLA01
+  SelectPortrait         = SCGeneric
+  ButtonImage            = SCGeneric
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -9081,8 +9081,8 @@ End
 Object Partisan02
 
     ; *** ART Parameters ***
-  SelectPortrait         = SULeadGLA01_L
-  ButtonImage            = SULeadGLA01
+  SelectPortrait         = SCGeneric
+  ButtonImage            = SCGeneric
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -9308,8 +9308,8 @@ End
 Object Partisan03
 
     ; *** ART Parameters ***
-  SelectPortrait         = SULeadGLA01_L
-  ButtonImage            = SULeadGLA01
+  SelectPortrait         = SCGeneric
+  ButtonImage            = SCGeneric
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
@@ -9536,6 +9536,9 @@ End
 Object MilitiaMan
 
     ; *** ART Parameters ***
+  SelectPortrait         = SCGeneric
+  ButtonImage            = SCGeneric
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8849,7 +8849,7 @@ Object ConvoyTruck04
 
 End
 
-; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#xxxx)
+; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#2192)
 ;------------------------------------------------------------------------------
 Object Partisan01
 
@@ -9072,7 +9072,7 @@ Object Partisan01
 
 End
 
-; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#xxxx)
+; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#2192)
 ;------------------------------------------------------------------------------
 Object Partisan02
 
@@ -9295,7 +9295,7 @@ Object Partisan02
 
 End
 
-; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#xxxx)
+; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#2192)
 ;------------------------------------------------------------------------------
 Object Partisan03
 
@@ -9519,7 +9519,7 @@ Object Partisan03
 
 End
 
-; Patch104p @feature commy2 02/08/2023 Implement MilitiaMan. (#xxxx)
+; Patch104p @feature commy2 02/08/2023 Implement MilitiaMan. (#2192)
 ;------------------------------------------------------------------------------
 Object MilitiaMan
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8980,6 +8980,7 @@ Object Partisan01
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet
+  ExperienceValue = 20 20 40 60    ;Experience point value at each level
 
   ; *** AUDIO Parameters ***
 
@@ -9208,6 +9209,7 @@ Object Partisan02
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet
+  ExperienceValue = 20 20 40 60    ;Experience point value at each level
 
   ; *** AUDIO Parameters ***
 
@@ -9436,6 +9438,7 @@ Object Partisan03
   DisplayName = OBJECT:PartisanFemale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet
+  ExperienceValue = 20 20 40 60    ;Experience point value at each level
 
   ; *** AUDIO Parameters ***
 
@@ -9665,6 +9668,7 @@ Object MilitiaMan
   DisplayName = OBJECT:Militia
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet
+  ExperienceValue = 20 20 40 60    ;Experience point value at each level
 
   ; *** AUDIO Parameters ***
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8849,38 +8849,139 @@ Object ConvoyTruck04
 
 End
 
+; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#xxxx)
 ;------------------------------------------------------------------------------
 Object Partisan01
 
     ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
+    IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
 
+    ; ---- standing
     DefaultConditionState
-      Model = UIPART_SKN
-      Animation = UIPART_SKL.UIPART_STA
-      AnimationMode = LOOP
+      Model               = UIPart_SKN
+      IdleAnimation       = UIPart_SKL.UIPart_STA 0 35
+      IdleAnimation       = UIPart_SKL.UIPart_IDA
+      IdleAnimation       = UIPart_SKL.UIPart_IDB
+      AnimationMode       = ONCE
+      WeaponFireFXBone    = PRIMARY Muzzle
+      WeaponMuzzleFlash   = PRIMARY MuzzleFX
+      TransitionKey       = TRANS_Standing
     End
+    AliasConditionState   = REALLYDAMAGED
+
+    ; ---- moving
+    ConditionState        = MOVING
+      Animation           = UIPart_SKL.UIPart_RNA 30
+      AnimationMode       = LOOP
+      TransitionKey       = TRANS_Walking
+      ParticleSysBone     = None InfantryDustTrails
+    End
+    AliasConditionState   = MOVING ATTACKING
+    AliasConditionState   = MOVING REALLYDAMAGED
+    AliasConditionState   = MOVING ATTACKING REALLYDAMAGED
+
+    ; ---- dying
+    ; Patch104p @bugfix commy2 30/07/2023 Fix units stuck in walk animation when dying. (#2175)
+    ConditionState        = DYING
+      Animation           = UIPart_SKL.UIPart_DTA
+      Animation           = UIPart_SKL.UIPart_DTB
+      AnimationMode       = ONCE
+      TransitionKey       = TRANS_Dying
+    End
+    AliasConditionState = DYING MOVING
+
+    TransitionState = TRANS_Dying TRANS_Flailing
+      Animation = UIPart_SKL.UIPart_ADTD1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING
+      Animation = UIPart_SKL.UIPart_ADTD2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING
+      Animation = UIPart_SKL.UIPart_ADTD3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIPart_SKL.UIPart_CHA
+    End
+    AliasConditionState = SPECIAL_CHEERING REALLYDAMAGED
+
+    ; ---- firing
+    ConditionState = USING_WEAPON_A
+      Animation = UIPart_SKL.UIPart_ATA
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Firing
+    End
+    AliasConditionState = USING_WEAPON_A REALLYDAMAGED
+
+    ; ---- parachuting
+    ConditionState      = FREEFALL
+      Animation         = UIPart_SKL.UIPart_PFL
+      AnimationMode     = LOOP
+      TransitionKey     = TRANS_Falling
+    End
+    AliasConditionState = FREEFALL REALLYDAMAGED
+    AliasConditionState = FREEFALL DYING
+
+    ConditionState      = PARACHUTING
+      Animation         = UIPart_SKL.UIPart_PHG
+      AnimationMode     = LOOP
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+      TransitionKey     = TRANS_Chute
+    End
+    AliasConditionState = PARACHUTING REALLYDAMAGED
+    AliasConditionState = PARACHUTING DYING
+
+    TransitionState     = TRANS_Falling TRANS_Chute
+      Animation         = UIPart_SKL.UIPart_POP
+      AnimationMode     = ONCE
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+    End
+
+    TransitionState     = TRANS_Chute TRANS_Stand
+      Animation         = UIPart_SKL.UIPart_PTD
+      AnimationMode     = ONCE
+    End
+
+    ; ---- surrendering
+    ;UIPart_SUR
+    ;UIPart_SST
   End
 
   ; ***DESIGN parameters ***
   Side = Civilian
   EditorSorting = INFANTRY
   TransportSlotCount = 1
+
+  WeaponSet
+    Conditions = None
+    Weapon = PRIMARY GLAAngryMobAK47Weapon
+  End
+
   ArmorSet
     Conditions      = None
     Armor           = HumanArmor
-    DamageFX        = None
+    DamageFX        = InfantryDamageFX
   End
+
   VisionRange = 150
-  DisplayName = OBJECT:MogadishuMaleCivilian ; Patch104p @fix from MogadishuFemaleCivilian (#2080)
+  ShroudClearingRange = 150
+  DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
   ; *** AUDIO Parameters ***
 
   ; *** ENGINEERING Parameters ***
-  RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY SELECTABLE
+  RadarPriority = UNIT
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0
@@ -8971,38 +9072,139 @@ Object Partisan01
 
 End
 
+; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#xxxx)
 ;------------------------------------------------------------------------------
 Object Partisan02
 
     ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
+    IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
 
+    ; ---- standing
     DefaultConditionState
-      Model = UIPART2_SKN
-      Animation = UIPART2_SKL.UIPART2_STA
-      AnimationMode = LOOP
+      Model               = UIPart2_SKN
+      IdleAnimation       = UIPart2_SKL.UIPart2_STA 0 35
+      IdleAnimation       = UIPart2_SKL.UIPart2_IDA
+      IdleAnimation       = UIPart2_SKL.UIPart2_IDB
+      AnimationMode       = ONCE
+      WeaponFireFXBone    = PRIMARY Muzzle
+      WeaponMuzzleFlash   = PRIMARY MuzzleFX
+      TransitionKey       = TRANS_Standing
     End
+    AliasConditionState   = REALLYDAMAGED
+
+    ; ---- moving
+    ConditionState        = MOVING
+      Animation           = UIPart2_SKL.UIPart2_RNA 30
+      AnimationMode       = LOOP
+      TransitionKey       = TRANS_Walking
+      ParticleSysBone     = None InfantryDustTrails
+    End
+    AliasConditionState   = MOVING ATTACKING
+    AliasConditionState   = MOVING REALLYDAMAGED
+    AliasConditionState   = MOVING ATTACKING REALLYDAMAGED
+
+    ; ---- dying
+    ; Patch104p @bugfix commy2 30/07/2023 Fix units stuck in walk animation when dying. (#2175)
+    ConditionState        = DYING
+      Animation           = UIPart2_SKL.UIPart2_DTA
+      Animation           = UIPart2_SKL.UIPart2_DTB
+      AnimationMode       = ONCE
+      TransitionKey       = TRANS_Dying
+    End
+    AliasConditionState = DYING MOVING
+
+    TransitionState = TRANS_Dying TRANS_Flailing
+      Animation = UIPart2_SKL.UIPart2_ADTC1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING
+      Animation = UIPart2_SKL.UIPart2_ADTC2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING
+      Animation = UIPart2_SKL.UIPart2_ADTC3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIPart2_SKL.UIPart2_CHA
+    End
+    AliasConditionState = SPECIAL_CHEERING REALLYDAMAGED
+
+    ; ---- firing
+    ConditionState = USING_WEAPON_A
+      Animation = UIPart2_SKL.UIPart2_ATA
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Firing
+    End
+    AliasConditionState = USING_WEAPON_A REALLYDAMAGED
+
+    ; ---- parachuting
+    ConditionState      = FREEFALL
+      Animation         = UIPart2_SKL.UIPart2_PFL
+      AnimationMode     = LOOP
+      TransitionKey     = TRANS_Falling
+    End
+    AliasConditionState = FREEFALL REALLYDAMAGED
+    AliasConditionState = FREEFALL DYING
+
+    ConditionState      = PARACHUTING
+      Animation         = UIPart2_SKL.UIPart2_PHG
+      AnimationMode     = LOOP
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+      TransitionKey     = TRANS_Chute
+    End
+    AliasConditionState = PARACHUTING REALLYDAMAGED
+    AliasConditionState = PARACHUTING DYING
+
+    TransitionState     = TRANS_Falling TRANS_Chute
+      Animation         = UIPart2_SKL.UIPart2_POP
+      AnimationMode     = ONCE
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+    End
+
+    TransitionState     = TRANS_Chute TRANS_Stand
+      Animation         = UIPart2_SKL.UIPart2_PTD
+      AnimationMode     = ONCE
+    End
+
+    ; ---- surrendering
+    ;UIPart2_SUR
+    ;UIPart2_SST
   End
 
   ; ***DESIGN parameters ***
   Side = Civilian
   EditorSorting = INFANTRY
   TransportSlotCount = 1
+
+  WeaponSet
+    Conditions = None
+    Weapon = PRIMARY GLAAngryMobAK47Weapon
+  End
+
   ArmorSet
     Conditions      = None
     Armor           = HumanArmor
-    DamageFX        = None
+    DamageFX        = InfantryDamageFX
   End
+
   VisionRange = 150
-  DisplayName = OBJECT:MogadishuMaleCivilian ; Patch104p @fix from MogadishuFemaleCivilian (#2080)
+  ShroudClearingRange = 150
+  DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
   ; *** AUDIO Parameters ***
 
   ; *** ENGINEERING Parameters ***
-  RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY SELECTABLE
+  RadarPriority = UNIT
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0
@@ -9093,38 +9295,139 @@ Object Partisan02
 
 End
 
+; Patch104p @feature commy2 02/08/2023 Implement Partisans. (#xxxx)
 ;------------------------------------------------------------------------------
 Object Partisan03
 
     ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
+    IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
 
+    ; ---- standing
     DefaultConditionState
-      Model = UIPRTSN3_SKN
-      Animation = UIPRTSN3_SKL.UIPRTSN3_STA
-      AnimationMode = LOOP
+      Model               = UIPrtsn3_SKN
+      IdleAnimation       = UIPrtsn3_SKL.UIPrtsn3_STA 0 35
+      IdleAnimation       = UIPrtsn3_SKL.UIPrtsn3_IDA
+      IdleAnimation       = UIPrtsn3_SKL.UIPrtsn3_IDB
+      AnimationMode       = ONCE
+      WeaponFireFXBone    = PRIMARY Muzzle
+      WeaponMuzzleFlash   = PRIMARY MuzzleFX
+      TransitionKey       = TRANS_Standing
     End
+    AliasConditionState   = REALLYDAMAGED
+
+    ; ---- moving
+    ConditionState        = MOVING
+      Animation           = UIPrtsn3_SKL.UIPrtsn3_RNA 15
+      AnimationMode       = LOOP
+      TransitionKey       = TRANS_Walking
+      ParticleSysBone     = None InfantryDustTrails
+    End
+    AliasConditionState   = MOVING ATTACKING
+    AliasConditionState   = MOVING REALLYDAMAGED
+    AliasConditionState   = MOVING ATTACKING REALLYDAMAGED
+
+    ; ---- dying
+    ; Patch104p @bugfix commy2 30/07/2023 Fix units stuck in walk animation when dying. (#2175)
+    ConditionState        = DYING
+      Animation           = UIPrtsn3_SKL.UIPrtsn3_DTA
+      Animation           = UIPrtsn3_SKL.UIPrtsn3_DTB
+      AnimationMode       = ONCE
+      TransitionKey       = TRANS_Dying
+    End
+    AliasConditionState = DYING MOVING
+
+    TransitionState = TRANS_Dying TRANS_Flailing
+      Animation = UIPrtsn3_SKL.UIPrtsn3_ADTA1
+      AnimationMode = ONCE
+    End
+
+    ConditionState = DYING EXPLODED_FLAILING
+      Animation = UIPrtsn3_SKL.UIPrtsn3_ADTA2
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Flailing
+    End
+
+    ConditionState = DYING EXPLODED_BOUNCING
+      Animation = UIPrtsn3_SKL.UIPrtsn3_ADTA3
+      AnimationMode = ONCE
+      TransitionKey = None
+    End
+
+    ConditionState = SPECIAL_CHEERING
+      Animation = UIPrtsn3_SKL.UIPrtsn3_CHA
+    End
+    AliasConditionState = SPECIAL_CHEERING REALLYDAMAGED
+
+    ; ---- firing
+    ConditionState = USING_WEAPON_A
+      Animation = UIPrtsn3_SKL.UIPrtsn3_ATA
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Firing
+    End
+    AliasConditionState = USING_WEAPON_A REALLYDAMAGED
+
+    ; ---- parachuting
+    ConditionState      = FREEFALL
+      Animation         = UIPrtsn3_SKL.UIPrtsn3_PFL
+      AnimationMode     = LOOP
+      TransitionKey     = TRANS_Falling
+    End
+    AliasConditionState = FREEFALL REALLYDAMAGED
+    AliasConditionState = FREEFALL DYING
+
+    ConditionState      = PARACHUTING
+      Animation         = UIPrtsn3_SKL.UIPrtsn3_PHG
+      AnimationMode     = LOOP
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+      TransitionKey     = TRANS_Chute
+    End
+    AliasConditionState = PARACHUTING REALLYDAMAGED
+    AliasConditionState = PARACHUTING DYING
+
+    TransitionState     = TRANS_Falling TRANS_Chute
+      Animation         = UIPrtsn3_SKL.UIPrtsn3_POP
+      AnimationMode     = ONCE
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+    End
+
+    TransitionState     = TRANS_Chute TRANS_Stand
+      Animation         = UIPrtsn3_SKL.UIPrtsn3_PTD
+      AnimationMode     = ONCE
+    End
+
+    ; ---- surrendering
+    ;UIPrtsn3_SUR
+    ;UIPrtsn3_SST
   End
 
   ; ***DESIGN parameters ***
   Side = Civilian
   EditorSorting = INFANTRY
   TransportSlotCount = 1
+
+  WeaponSet
+    Conditions = None
+    Weapon = PRIMARY GLAAngryMobAK47Weapon
+  End
+
   ArmorSet
     Conditions      = None
     Armor           = HumanArmor
-    DamageFX        = None
+    DamageFX        = InfantryDamageFX
   End
+
   VisionRange = 150
-  DisplayName = OBJECT:MogadishuFemaleCivilian
+  ShroudClearingRange = 150
+  DisplayName = OBJECT:PartisanFemale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
 
   ; *** AUDIO Parameters ***
 
   ; *** ENGINEERING Parameters ***
-  RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY SELECTABLE
+  RadarPriority = UNIT
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8993,6 +8993,7 @@ Object Partisan01
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
+    AutoAcquireEnemiesWhenIdle = Yes
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor
   Locomotor = SET_WANDER WanderHumanLocomotor
@@ -9220,6 +9221,7 @@ Object Partisan02
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
+    AutoAcquireEnemiesWhenIdle = Yes
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor
   Locomotor = SET_WANDER WanderHumanLocomotor
@@ -9447,6 +9449,7 @@ Object Partisan03
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
+    AutoAcquireEnemiesWhenIdle = Yes
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor
   Locomotor = SET_WANDER WanderHumanLocomotor
@@ -9675,6 +9678,7 @@ Object MilitiaMan
   End
 
   Behavior = AIUpdateInterface ModuleTag_03
+    AutoAcquireEnemiesWhenIdle = Yes
   End
   Locomotor = SET_NORMAL BasicHumanLocomotor
   Locomotor = SET_WANDER WanderHumanLocomotor

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8966,7 +8966,7 @@ Object Partisan01
 
   WeaponSet
     Conditions = None
-    Weapon = PRIMARY GLAAngryMobAK47Weapon
+    Weapon = PRIMARY ArmedCivilianUziAkimboWeapon
   End
 
   ArmorSet
@@ -9088,7 +9088,7 @@ Object Partisan02
 
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
-    IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
+    IgnoreConditionStates = PREATTACK_A
 
     ; ---- standing
     DefaultConditionState
@@ -9110,9 +9110,13 @@ Object Partisan02
       TransitionKey       = TRANS_Walking
       ParticleSysBone     = None InfantryDustTrails
     End
-    AliasConditionState   = MOVING ATTACKING
+    AliasConditionState   = MOVING FIRING_A
+    AliasConditionState   = MOVING BETWEEN_FIRING_SHOTS_A
+    AliasConditionState   = MOVING RELOADING_A
     AliasConditionState   = MOVING REALLYDAMAGED
-    AliasConditionState   = MOVING ATTACKING REALLYDAMAGED
+    AliasConditionState   = MOVING FIRING_A REALLYDAMAGED
+    AliasConditionState   = MOVING BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState   = MOVING RELOADING_A REALLYDAMAGED
 
     ; ---- dying
     ; Patch104p @bugfix commy2 30/07/2023 Fix units stuck in walk animation when dying. (#2175)
@@ -9147,12 +9151,21 @@ Object Partisan02
     AliasConditionState = SPECIAL_CHEERING REALLYDAMAGED
 
     ; ---- firing
-    ConditionState = USING_WEAPON_A
+    ConditionState = FIRING_A
       Animation = UIPart2_SKL.UIPart2_ATA
       AnimationMode = LOOP
       TransitionKey = TRANS_Firing
     End
-    AliasConditionState = USING_WEAPON_A REALLYDAMAGED
+    AliasConditionState = FIRING_A REALLYDAMAGED
+
+    ConditionState      = BETWEEN_FIRING_SHOTS_A
+      Animation         = UIPart2_SKL.UIPart2_STA
+      AnimationMode     = ONCE
+      WaitForStateToFinishIfPossible = TRANS_Firing
+    End
+    AliasConditionState = RELOADING_A
+    AliasConditionState = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
+    AliasConditionState = RELOADING_A REALLYDAMAGED
 
     ; ---- parachuting
     ConditionState      = FREEFALL
@@ -9195,7 +9208,7 @@ Object Partisan02
 
   WeaponSet
     Conditions = None
-    Weapon = PRIMARY GLAAngryMobAK47Weapon
+    Weapon = PRIMARY ArmedCivilianShotgunWeapon
   End
 
   ArmorSet
@@ -9424,7 +9437,7 @@ Object Partisan03
 
   WeaponSet
     Conditions = None
-    Weapon = PRIMARY GLAAngryMobAK47Weapon
+    Weapon = PRIMARY ArmedCivilianAssaultRifleWeapon
   End
 
   ArmorSet
@@ -9654,7 +9667,7 @@ Object MilitiaMan
 
   WeaponSet
     Conditions = None
-    Weapon = PRIMARY GLAAngryMobAK47Weapon
+    Weapon = PRIMARY ArmedCivilianAK47Weapon
   End
 
   ArmorSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8854,6 +8854,9 @@ End
 Object Partisan01
 
     ; *** ART Parameters ***
+  SelectPortrait         = SULeadGLA01_L
+  ButtonImage            = SULeadGLA01
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
@@ -8976,6 +8979,7 @@ Object Partisan01
   ShroudClearingRange = 150
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CommandSet = GenericCommandSet
 
   ; *** AUDIO Parameters ***
 
@@ -9077,6 +9081,9 @@ End
 Object Partisan02
 
     ; *** ART Parameters ***
+  SelectPortrait         = SULeadGLA01_L
+  ButtonImage            = SULeadGLA01
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
@@ -9199,6 +9206,7 @@ Object Partisan02
   ShroudClearingRange = 150
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CommandSet = GenericCommandSet
 
   ; *** AUDIO Parameters ***
 
@@ -9300,6 +9308,9 @@ End
 Object Partisan03
 
     ; *** ART Parameters ***
+  SelectPortrait         = SULeadGLA01_L
+  ButtonImage            = SULeadGLA01
+
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
     IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
@@ -9422,6 +9433,7 @@ Object Partisan03
   ShroudClearingRange = 150
   DisplayName = OBJECT:PartisanFemale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CommandSet = GenericCommandSet
 
   ; *** AUDIO Parameters ***
 
@@ -9646,6 +9658,7 @@ Object MilitiaMan
   ShroudClearingRange = 150
   DisplayName = OBJECT:Militia
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CommandSet = GenericCommandSet
 
   ; *** AUDIO Parameters ***
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8867,7 +8867,7 @@ Object Partisan01
       AnimationMode       = ONCE
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      TransitionKey       = TRANS_Standing
+      TransitionKey       = TRANS_Stand
     End
     AliasConditionState   = REALLYDAMAGED
 
@@ -9061,8 +9061,8 @@ Object Partisan01
   End
 
   Geometry = CYLINDER
-  GeometryMajorRadius = 3.0
-  GeometryMinorRadius = 3.0
+  GeometryMajorRadius = 10.0
+  GeometryMinorRadius = 10.0
   GeometryHeight = 12.0
   GeometryIsSmall = Yes
   Shadow = SHADOW_DECAL
@@ -9090,7 +9090,7 @@ Object Partisan02
       AnimationMode       = ONCE
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      TransitionKey       = TRANS_Standing
+      TransitionKey       = TRANS_Stand
     End
     AliasConditionState   = REALLYDAMAGED
 
@@ -9284,8 +9284,8 @@ Object Partisan02
   End
 
   Geometry = CYLINDER
-  GeometryMajorRadius = 3.0
-  GeometryMinorRadius = 3.0
+  GeometryMajorRadius = 10.0
+  GeometryMinorRadius = 10.0
   GeometryHeight = 12.0
   GeometryIsSmall = Yes
   Shadow = SHADOW_DECAL
@@ -9313,7 +9313,7 @@ Object Partisan03
       AnimationMode       = ONCE
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponMuzzleFlash   = PRIMARY MuzzleFX
-      TransitionKey       = TRANS_Standing
+      TransitionKey       = TRANS_Stand
     End
     AliasConditionState   = REALLYDAMAGED
 
@@ -9508,8 +9508,8 @@ Object Partisan03
   End
 
   Geometry = CYLINDER
-  GeometryMajorRadius = 3.0
-  GeometryMinorRadius = 3.0
+  GeometryMajorRadius = 10.0
+  GeometryMinorRadius = 10.0
   GeometryHeight = 12.0
   GeometryIsSmall = Yes
   Shadow = SHADOW_DECAL
@@ -9518,6 +9518,231 @@ Object Partisan03
   ShadowTexture = ShadowI;
 
 End
+
+; Patch104p @feature commy2 02/08/2023 Implement MilitiaMan. (#xxxx)
+;------------------------------------------------------------------------------
+Object MilitiaMan
+
+    ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    OkToChangeModelColor = Yes
+    IgnoreConditionStates = PREATTACK_A FIRING_A BETWEEN_FIRING_SHOTS_A RELOADING_A
+
+    ; ---- standing
+    DefaultConditionState
+      Model               = CIMilt1_SKN
+      IdleAnimation       = CIMilt1_SKL.CIMilt1_STA 0 35
+      IdleAnimation       = CIMilt1_SKL.CIMilt1_IDA
+      IdleAnimation       = CIMilt1_SKL.CIMilt1_IDB
+      AnimationMode       = ONCE
+      WeaponFireFXBone    = PRIMARY Muzzle
+      WeaponMuzzleFlash   = PRIMARY MuzzleFX
+      TransitionKey       = TRANS_Stand
+    End
+    AliasConditionState   = REALLYDAMAGED
+
+    ; ---- moving
+    ConditionState        = MOVING
+      Animation           = CIMilt1_SKL.CIMilt1_RNA 30
+      AnimationMode       = LOOP
+      TransitionKey       = TRANS_Walking
+      ParticleSysBone     = None InfantryDustTrails
+    End
+    AliasConditionState   = MOVING ATTACKING
+    AliasConditionState   = MOVING REALLYDAMAGED
+    AliasConditionState   = MOVING ATTACKING REALLYDAMAGED
+
+    ; ---- dying
+    ; Patch104p @bugfix commy2 30/07/2023 Fix units stuck in walk animation when dying. (#2175)
+    ConditionState        = DYING
+      Animation           = CIMilt1_SKL.CIMilt1_DTA
+      Animation           = CIMilt1_SKL.CIMilt1_DTB
+      AnimationMode       = ONCE
+      TransitionKey       = TRANS_Dying
+    End
+    AliasConditionState = DYING MOVING
+
+    ;TransitionState = TRANS_Dying TRANS_Flailing
+    ;  Animation = CIMilt1_SKL.CIMilt1_XXX1
+    ;  AnimationMode = ONCE
+    ;End
+
+    ;ConditionState = DYING EXPLODED_FLAILING
+    ;  Animation = CIMilt1_SKL.CIMilt1_XXX2
+    ;  AnimationMode = LOOP
+    ;  TransitionKey = TRANS_Flailing
+    ;End
+
+    ;ConditionState = DYING EXPLODED_BOUNCING
+    ;  Animation = CIMilt1_SKL.CIMilt1_XXX3
+    ;  AnimationMode = ONCE
+    ;  TransitionKey = None
+    ;End
+
+    ConditionState = SPECIAL_CHEERING
+      Animation = CIMilt1_SKL.CIMilt1_CHA
+    End
+    AliasConditionState = SPECIAL_CHEERING REALLYDAMAGED
+
+    ; ---- firing
+    ConditionState = USING_WEAPON_A
+      Animation = CIMilt1_SKL.CIMilt1_ATA
+      AnimationMode = LOOP
+      TransitionKey = TRANS_Firing
+    End
+    AliasConditionState = USING_WEAPON_A REALLYDAMAGED
+
+    ; ---- parachuting
+    ConditionState      = FREEFALL
+      Animation         = CIMilt1_SKL.CIMilt1_PFL
+      AnimationMode     = LOOP
+      TransitionKey     = TRANS_Falling
+    End
+    AliasConditionState = FREEFALL REALLYDAMAGED
+    AliasConditionState = FREEFALL DYING
+
+    ConditionState      = PARACHUTING
+      Animation         = CIMilt1_SKL.CIMilt1_PHG
+      AnimationMode     = LOOP
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+      TransitionKey     = TRANS_Chute
+    End
+    AliasConditionState = PARACHUTING REALLYDAMAGED
+    AliasConditionState = PARACHUTING DYING
+
+    TransitionState     = TRANS_Falling TRANS_Chute
+      Animation         = CIMilt1_SKL.CIMilt1_POP
+      AnimationMode     = ONCE
+      Flags             = PRISTINE_BONE_POS_IN_FINAL_FRAME  ; our bone positions should come from the last frame, rather than the first
+    End
+
+    TransitionState     = TRANS_Chute TRANS_Stand
+      Animation         = CIMilt1_SKL.CIMilt1_PTD
+      AnimationMode     = ONCE
+    End
+
+    ; ---- surrendering
+    ;CIMilt1_SUR
+    ;CIMilt1_SST
+  End
+
+  ; ***DESIGN parameters ***
+  Side = Civilian
+  EditorSorting = INFANTRY
+  TransportSlotCount = 1
+
+  WeaponSet
+    Conditions = None
+    Weapon = PRIMARY GLAAngryMobAK47Weapon
+  End
+
+  ArmorSet
+    Conditions      = None
+    Armor           = HumanArmor
+    DamageFX        = InfantryDamageFX
+  End
+
+  VisionRange = 150
+  ShroudClearingRange = 150
+  DisplayName = OBJECT:Militia
+  CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+
+  ; *** AUDIO Parameters ***
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = UNIT
+  KindOf = PRELOAD SELECTABLE CAN_ATTACK ATTACK_NEEDS_LINE_OF_SIGHT CAN_CAST_REFLECTIONS INFANTRY
+
+  Body = ActiveBody ModuleTag_02
+    MaxHealth       = 50.0
+    InitialHealth   = 50.0
+  End
+
+  Behavior = AIUpdateInterface ModuleTag_03
+  End
+  Locomotor = SET_NORMAL BasicHumanLocomotor
+  Locomotor = SET_WANDER WanderHumanLocomotor
+  Locomotor = SET_PANIC PanicHumanLocomotor
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 5.0
+  End
+
+  Behavior = SquishCollide ModuleTag_06
+    ;nothing
+  End
+
+; Patch104p @bugfix xezon 08/07/2023 Adds proper death modules. (#2074)
+
+; --- begin Death modules --- Partisan03
+  Behavior = SlowDeathBehavior ModuleTag_Death01
+    DeathTypes          = ALL -CRUSHED -SPLATTED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death02
+    DeathTypes          = NONE +CRUSHED +SPLATTED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_GIDieCrushed
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death03
+    DeathTypes          = NONE +EXPLODED
+    SinkDelay           = 3000
+    SinkRate            = 0.5     ; in Dist/Sec
+    DestructionDelay    = 8000
+    FX                  = INITIAL FX_CivilianArabMaleDie
+    FlingForce          = 8
+    FlingForceVariance  = 3
+    FlingPitch          = 60
+    FlingPitchVariance  = 10
+  End
+  Behavior = SlowDeathBehavior ModuleTag_DeathBurned
+    DeathTypes          = NONE +BURNED +LASERED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByFireUSA
+    OCL                 = INITIAL OCL_FlamingInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death05
+    DeathTypes          = NONE +POISONED
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinUSA
+    OCL                 = INITIAL OCL_ToxicInfantry
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death06
+    DeathTypes          = NONE +POISONED_BETA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinUSA
+    OCL                 = INITIAL OCL_ToxicInfantryBeta
+  End
+  Behavior = SlowDeathBehavior ModuleTag_Death07
+    DeathTypes          = NONE +POISONED_GAMMA
+    DestructionDelay    = 0
+    FX                  = INITIAL FX_DieByToxinUSA
+    OCL                 = INITIAL OCL_ToxicInfantryGamma
+  End
+; --- end Death modules ---
+
+  Behavior = PoisonedBehavior ModuleTag_09
+    PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
+    PoisonDuration = 3000       ; ... for this long after last hit by poison damage
+  End
+
+  Geometry = CYLINDER
+  GeometryMajorRadius = 10.0
+  GeometryMinorRadius = 10.0
+  GeometryHeight = 12.0
+  GeometryIsSmall = Yes
+  Shadow = SHADOW_DECAL
+  ShadowSizeX = 14;
+  ShadowSizeY = 14;
+  ShadowTexture = ShadowI;
+
+End
+
 ;------------------------------------------------------------------------------
 Object UNSoldier
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8976,7 +8976,7 @@ Object Partisan01
   End
 
   VisionRange = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 200
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet
@@ -9218,7 +9218,7 @@ Object Partisan02
   End
 
   VisionRange = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 200
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet
@@ -9447,7 +9447,7 @@ Object Partisan03
   End
 
   VisionRange = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 200
   DisplayName = OBJECT:PartisanFemale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet
@@ -9677,7 +9677,7 @@ Object MilitiaMan
   End
 
   VisionRange = 150
-  ShroudClearingRange = 150
+  ShroudClearingRange = 200
   DisplayName = OBJECT:Militia
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
   CommandSet = GenericCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -9732,10 +9732,11 @@ Object MilitiaMan
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
     FX                  = INITIAL FX_CivilianArabMaleDie
-    FlingForce          = 8
-    FlingForceVariance  = 3
-    FlingPitch          = 60
-    FlingPitchVariance  = 10
+    ; no animation
+    ;FlingForce          = 8
+    ;FlingForceVariance  = 3
+    ;FlingPitch          = 60
+    ;FlingPitchVariance  = 10
   End
   Behavior = SlowDeathBehavior ModuleTag_DeathBurned
     DeathTypes          = NONE +BURNED +LASERED

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6193,8 +6193,10 @@ ObjectCreationList SUPERWEAPON_Paradrop1
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = AmericaInfantryRanger 3
-    Payload = AmericaInfantryMissileDefender 2
+    Payload = Partisan01 5
+    Payload = Partisan02 5
+    Payload = Partisan03 5
+    Payload = MilitiaMan 5
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -10209,6 +10211,54 @@ ObjectCreationList OCL_AmericaVehicleDozer
     Disposition = ON_GROUND_ALIGNED
     Offset = X:0 Y:0 Z:0
   End
+
+  CreateObject
+    ObjectNames = MogadishuFemaleCivilian01
+    Count = 10
+    Disposition = ON_GROUND_ALIGNED
+    Offset = X:0 Y:0 Z:0
+  End
+  CreateObject
+    ObjectNames = MogadishuFemaleCivilian02
+    Count = 10
+    Disposition = ON_GROUND_ALIGNED
+    Offset = X:0 Y:0 Z:0
+  End
+  CreateObject
+    ObjectNames = MogadishuMaleCivilian01
+    Count = 10
+    Disposition = ON_GROUND_ALIGNED
+    Offset = X:0 Y:0 Z:0
+  End
+  CreateObject
+    ObjectNames = MogadishuMaleCivilian02
+    Count = 10
+    Disposition = ON_GROUND_ALIGNED
+    Offset = X:0 Y:0 Z:0
+  End
+  CreateObject
+    ObjectNames = MogadishuMaleCivilian03
+    Count = 10
+    Disposition = ON_GROUND_ALIGNED
+    Offset = X:0 Y:0 Z:0
+  End
+  CreateObject
+    ObjectNames = GLAInfantryTunnelDefender
+    Count = 10
+    Disposition = ON_GROUND_ALIGNED
+    Offset = X:0 Y:0 Z:0
+  End
+  CreateObject
+    ObjectNames = MilitiaMan
+    Count = 10
+    Disposition = ON_GROUND_ALIGNED
+    Offset = X:0 Y:0 Z:0
+  End
+
+
+
+
+
 End
 
 ;-------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -6193,10 +6193,8 @@ ObjectCreationList SUPERWEAPON_Paradrop1
     DropDelay = 150         ; time in between each item dropped (if more than one)
     ParachuteDirectly = Yes ; will tell all contained parachutes to go ahead and bunch
     PutInContainer = AmericaParachute
-    Payload = Partisan01 5
-    Payload = Partisan02 5
-    Payload = Partisan03 5
-    Payload = MilitiaMan 5
+    Payload = AmericaInfantryRanger 3
+    Payload = AmericaInfantryMissileDefender 2
     DeliveryDistance = 0  ;when outbound vehicle must be this close to target to continue delivery
     PreOpenDistance = 300 ;When inbound, vehicle can be this much farther than DeliveryDistance to begin delivery
     DeliveryDecalRadius = 50
@@ -10211,54 +10209,6 @@ ObjectCreationList OCL_AmericaVehicleDozer
     Disposition = ON_GROUND_ALIGNED
     Offset = X:0 Y:0 Z:0
   End
-
-  CreateObject
-    ObjectNames = MogadishuFemaleCivilian01
-    Count = 10
-    Disposition = ON_GROUND_ALIGNED
-    Offset = X:0 Y:0 Z:0
-  End
-  CreateObject
-    ObjectNames = MogadishuFemaleCivilian02
-    Count = 10
-    Disposition = ON_GROUND_ALIGNED
-    Offset = X:0 Y:0 Z:0
-  End
-  CreateObject
-    ObjectNames = MogadishuMaleCivilian01
-    Count = 10
-    Disposition = ON_GROUND_ALIGNED
-    Offset = X:0 Y:0 Z:0
-  End
-  CreateObject
-    ObjectNames = MogadishuMaleCivilian02
-    Count = 10
-    Disposition = ON_GROUND_ALIGNED
-    Offset = X:0 Y:0 Z:0
-  End
-  CreateObject
-    ObjectNames = MogadishuMaleCivilian03
-    Count = 10
-    Disposition = ON_GROUND_ALIGNED
-    Offset = X:0 Y:0 Z:0
-  End
-  CreateObject
-    ObjectNames = GLAInfantryTunnelDefender
-    Count = 10
-    Disposition = ON_GROUND_ALIGNED
-    Offset = X:0 Y:0 Z:0
-  End
-  CreateObject
-    ObjectNames = MilitiaMan
-    Count = 10
-    Disposition = ON_GROUND_ALIGNED
-    Offset = X:0 Y:0 Z:0
-  End
-
-
-
-
-
 End
 
 ;-------------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -49,7 +49,7 @@ PlayerTemplate FactionAmerica
   PlayableSide      = Yes
   StartMoney        = 0
   PreferredColor    = R:0 G:0 B:255
-  IntrinsicSciences = SCIENCE_AMERICA SCIENCE_Paradrop1
+  IntrinsicSciences = SCIENCE_AMERICA
   PurchaseScienceCommandSetRank1  = SCIENCE_AMERICA_CommandSetRank1
   PurchaseScienceCommandSetRank3  = SCIENCE_AMERICA_CommandSetRank3
   PurchaseScienceCommandSetRank8  = SCIENCE_AMERICA_CommandSetRank8

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -49,7 +49,7 @@ PlayerTemplate FactionAmerica
   PlayableSide      = Yes
   StartMoney        = 0
   PreferredColor    = R:0 G:0 B:255
-  IntrinsicSciences = SCIENCE_AMERICA
+  IntrinsicSciences = SCIENCE_AMERICA SCIENCE_Paradrop1
   PurchaseScienceCommandSetRank1  = SCIENCE_AMERICA_CommandSetRank1
   PurchaseScienceCommandSetRank3  = SCIENCE_AMERICA_CommandSetRank3
   PurchaseScienceCommandSetRank8  = SCIENCE_AMERICA_CommandSetRank8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -9087,6 +9087,83 @@ Weapon BattleBusDummyWeapon
   AcceptableAimDelta = 180  ; Patch104p @bugfix commy2 10/09/2021 Fix Bus turning when ordered to attack airborne targets.
 End
 
+; Patch104p @feature commy2 09/08/2023 Weapons for armed civilians (Partisan, Militia Man). (#2130)
+;------------------------------------------------------------------------------
+Weapon ArmedCivilianUziAkimboWeapon
+  PrimaryDamage         = 4.0
+  PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
+  AttackRange           = 120.0
+  DamageType            = SMALL_ARMS
+  DeathType             = NORMAL
+  WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
+  ProjectileObject      = NONE
+  FireFX                = WeaponFX_GenericMachineGunFire
+  VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
+  FireSound             = AngryMobWeaponPistol
+  RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots     = 50               ; time between shots, msec
+  ClipSize              = 2                    ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime        = 200              ; how long to reload a Clip, msec
+  AutoReloadsClip       = Yes
+End
+
+;------------------------------------------------------------------------------
+Weapon ArmedCivilianShotgunWeapon
+  PrimaryDamage         = 25.0
+  PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
+  AttackRange           = 120.0
+  DamageType            = SMALL_ARMS
+  DeathType             = NORMAL
+  WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
+  ProjectileObject      = NONE
+  FireFX                = WeaponFX_GenericMachineGunFire
+  VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
+  FireSound             = RedGuardWeapon
+  RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots     = 750         ; time between shots, msec
+  ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime        = 0              ; how long to reload a Clip, msec
+  WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; Armor Piercing Bullets
+End
+
+;------------------------------------------------------------------------------
+Weapon ArmedCivilianAssaultRifleWeapon
+  PrimaryDamage         = 10.0
+  PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
+  AttackRange           = 120.0
+  DamageType            = SMALL_ARMS
+  DeathType             = NORMAL
+  WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
+  ProjectileObject      = NONE
+  FireFX                = WeaponFX_GenericMachineGunFire
+  VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
+  FireSound             = RangerWeapon
+  RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots     = 100         ; time between shots, msec
+  ClipSize              = 3                    ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime        = 700              ; how long to reload a Clip, msec
+  WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; Armor Piercing Bullets
+End
+
+;------------------------------------------------------------------------------
+Weapon ArmedCivilianAK47Weapon
+  PrimaryDamage         = 8.0
+  PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
+  AttackRange           = 120.0
+  DamageType            = SMALL_ARMS
+  DeathType             = NORMAL
+  WeaponSpeed           = 999999.0          ; dist/sec (huge value == effectively instant)
+  ProjectileObject      = NONE
+  FireFX                = WeaponFX_GenericMachineGunFire
+  VeterancyFireFX       = HEROIC WeaponFX_GenericMachineGunFireWithRedTracers
+  FireSound             = AngryMobWeaponAK47
+  RadiusDamageAffects   = ALLIES ENEMIES NEUTRALS
+  DelayBetweenShots     = 250         ; time between shots, msec
+  ClipSize              = 0                    ; how many shots in a Clip (0 == infinite)
+  ClipReloadTime        = 0              ; how long to reload a Clip, msec
+  WeaponBonus           = PLAYER_UPGRADE DAMAGE 125% ; Armor Piercing Bullets
+End
+
 ; Patch104p @feature commy2 20/07/2023 Add Tomahawk Storm weapon. (#2130)
 ;------------------------------------------------------------------------------
 Weapon SupW_TomahawkStormWeapon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -9109,7 +9109,7 @@ End
 
 ;------------------------------------------------------------------------------
 Weapon ArmedCivilianShotgunWeapon
-  PrimaryDamage         = 25.0
+  PrimaryDamage         = 24.0
   PrimaryDamageRadius   = 0.0       ; 0 primary radius means "hits only intended victim"
   AttackRange           = 120.0
   DamageType            = SMALL_ARMS


### PR DESCRIPTION
This implements the unused models for the broken Partisan worldbuilder unit. Could be placed on a fun map as third ai faction that attacks all/some players, similar to The Forgotten in C&C or Goblins/Wargs/Cave Trolls in BFME. It also implements the Milita Man model.

~I gave them AK Mob weapons for spice.~

I gave them custom dual uzi, shotgun, semi-automatic rifle weapons depending on the model.

For some reason, they all have parachute animations.