### PR TITLE
Fix: Remove tiny debris pieces from exploded USA Scout Drone

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2193_scout_drone_debris.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2193_scout_drone_debris.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-02
+
+title: Removes very tiny debris pieces from exploded USA Scout Drone
+
+changes:
+  - optimization: The exploded USA Scout Drone no longer spawns very tiny debris pieces that are barely visible.
+
+labels:
+  - minor
+  - performance
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2193
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -7775,6 +7775,7 @@ ObjectCreationList OCL_AmericaDozerExplode
   End
 End
 
+; Patch104p @performance xezon 02/08/2023 Removes very tiny debris pieces, AVScoutDr_D2, AVScoutDr_D4. (#2193)
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_AmericaScoutDroneExplode
   CreateObject
@@ -7784,18 +7785,18 @@ ObjectCreationList OCL_AmericaScoutDroneExplode
     Disposition = SEND_IT_FLYING INHERIT_VELOCITY
     DispositionIntensity = 0.5
   End
-  CreateDebris
-    ModelNames  = AVScoutDr_D2    ;propellor
-    Offset      = X:-8.5 Y:0.0 Z:2.4
-    Mass        = 8
-    Count       = 1
-    Disposition       = SEND_IT_FLYING INHERIT_VELOCITY
-    MinForceMagnitude = 5
-    MaxForceMagnitude = 6
-    MinForcePitch     = 60
-    MaxForcePitch     = 90
-    SpinRate          = 100
-  End
+  ;CreateDebris
+  ;  ModelNames  = AVScoutDr_D2    ;propellor
+  ;  Offset      = X:-8.5 Y:0.0 Z:2.4
+  ;  Mass        = 8
+  ;  Count       = 1
+  ;  Disposition       = SEND_IT_FLYING INHERIT_VELOCITY
+  ;  MinForceMagnitude = 5
+  ;  MaxForceMagnitude = 6
+  ;  MinForcePitch     = 60
+  ;  MaxForcePitch     = 90
+  ;  SpinRate          = 100
+  ;End
   CreateDebris
     ModelNames  = AVScoutDr_D3    ;wing 1 of 2
     Offset      = X:0.0 Y:5.0 Z:0.0
@@ -7814,15 +7815,15 @@ ObjectCreationList OCL_AmericaScoutDroneExplode
     DispositionIntensity = 0.7
    BounceSound       = VehicleDebris
   End
-  CreateDebris
-    ModelNames  = AVScoutDr_D4    ;flat panel?
-    Offset      = X:-7.75 Y:-2.1 Z:1.16
-    Mass        = 4
-    Count       = 1
-    Disposition = SEND_IT_FLYING INHERIT_VELOCITY
-    DispositionIntensity = 0.7
-   BounceSound       = VehicleDebris
-  End
+  ;CreateDebris
+  ;  ModelNames  = AVScoutDr_D4    ;flat panel?
+  ;  Offset      = X:-7.75 Y:-2.1 Z:1.16
+  ;  Mass        = 4
+  ;  Count       = 1
+  ;  Disposition = SEND_IT_FLYING INHERIT_VELOCITY
+  ;  DispositionIntensity = 0.7
+  ; BounceSound       = VehicleDebris
+  ;End
 End
 
 ; Patch104p @bugfix commy2 02/08/2023 Spawn correct debris when Hellfire Drone is destroyed (#2189)


### PR DESCRIPTION
This change removes 2 tiny debris pieces from the exploded USA Scout Drone, which were barely visible. It now spawns 3 instead of 5 pieces on death, as much as Battle Drone.