### PR TITLE
Fix: Errors in China Infantry Mini Gunner and Troop Crawler tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
@@ -14,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2150
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
@@ -1,10 +1,11 @@
 ---
 date: 2023-07-26
 
-title: Fixes inconsistent wording in Spanish tool tip strings
+title: Fixes errors in Spanish tool tip strings
 
 changes:
   - fix: The wording in Spanish tool tip strings is more consistent now.
+  - fix: The TOOLTIP:NumberOfVotes string now has Spanish text.
 
 labels:
   - minor
@@ -13,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2151
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
@@ -9,11 +9,7 @@ changes:
   - fix: Adds missing sentences to various tool tip strings.
   - fix: Removes superfluous mention of 'enemy' in tool tip strings of USA Stealth Figher, Tomahawk and China Inferno Cannon for all languages.
   - fix: Removes incorrect sentence in MOAB tooltip for all languages.
-  - fix: Adds missing numbers to German, Chinese strings in TOOLTIP:GameInfoPlayer.
-  - fix: Adds missing numbers and correct sentences to German string in CONTROLBAR:PowerDescription.
-  - fix: Sets "D'accord" for French string in GUI:Ok, LAN:OK.
-  - fix: Sets "Complété" for French string in MapTransfer:Done.
-  - fix: Adds missing sentences to Spanish, Chinese strings in TOOLTIP:NumberOfVotes.
+  - fix: The China Infantry Assault Transport tool tip now shows correct strengths and weaknesses for all languages.
 
 labels:
   - minor
@@ -24,8 +20,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2156
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2167
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2146
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-08-02
+
+title: Fixes inconsistent wording in Brazilian tool tip strings
+
+changes:
+  - fix: The wording in Brazilian tool tip strings is more consistent now.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2216_chinese_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2216_chinese_tool_tip_text.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-07
+
+title: Fixes errors in Chinese tool tip strings
+
+changes:
+  - fix: The TOOLTIP:NumberOfVotes string now has Chinese text.
+  - fix: The TOOLTIP:GameInfoPlayer string now shows its number format in Chinese text.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2216_text_number_errors.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2216_text_number_errors.txt
@@ -1,1 +1,0 @@
-2156_misc_errors_in_strings.yaml

--- a/Patch104pZH/Design/Changes/v1.0/2217_misc_text_errors.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2217_misc_text_errors.txt
@@ -1,1 +1,0 @@
-2156_misc_errors_in_strings.yaml

--- a/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
@@ -5,6 +5,7 @@ title: Fixes errors in French tool tip strings
 
 changes:
   - fix: The French tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
+  - fix: The TOOLTIP:NumberOfVotes, GUI:Ok, LAN:OK, MapTransfer:Done strings now have French text.
 
 labels:
   - minor
@@ -12,6 +13,7 @@ labels:
   - v1.0
 
 links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
 
 authors:

--- a/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
@@ -4,8 +4,11 @@ date: 2023-08-07
 title: Fixes errors in German tool tip strings
 
 changes:
+  - fix: The wording in German tool tip strings is more consistent now.
   - fix: The German tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
   - fix: More German tool tip strings now list the correct strengths and weaknesses.
+  - fix: The TOOLTIP:GameInfoPlayer string now shows its number format in German text.
+  - fix: The CONTROLBAR:PowerDescription string now shows proper sentences and number format in German text.
 
 labels:
   - minor
@@ -13,6 +16,8 @@ labels:
   - v1.0
 
 links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
 
 authors:


### PR DESCRIPTION
This change fixes errors in Infantry Mini Gunner and Troop Crawler tool tip strings.

Mini Gunner strings no longer say "Strong vs air", but "Strong vs aircraft", like all other tool tips.

And Mini Gunner Troop Crawler strings no longer claim to be "Weak vs aircraft". Instead they are now labeled "Strong vs aircraft".