### PR TITLE
Fix: Promoted Crusaders, Laser and Microwave tanks spawn Pilots when crushed

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2196_crushed_tank_pilots.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2196_crushed_tank_pilots.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-08-03
+
+title: Fixes promoted Crusader, Laser and Microwave tanks spawn pilots when crushed.
+
+changes:
+  - fix: Crusader tanks crushed by Overlord no longer spawn Pilots, like all other USA vehicles.
+  - fix: Laser tanks crushed by Overlord no longer spawn Pilots.
+  - fix: Microwave tanks crushed by Overlord no longer spawn Pilots.
+
+labels:
+  - bug
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2196
+
+authors:
+  - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2196_crushed_tank_pilots.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2196_crushed_tank_pilots.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-03
 
-title: Fixes promoted Crusader, Laser and Microwave tanks spawn pilots when crushed.
+title: Fixes promoted Crusader, Laser and Microwave tanks spawn pilots when crushed
 
 changes:
   - fix: Crusader tanks crushed by Overlord no longer spawn Pilots, like all other USA vehicles.

--- a/Patch104pZH/Design/Tasks/nproject_tasks.txt
+++ b/Patch104pZH/Design/Tasks/nproject_tasks.txt
@@ -276,7 +276,7 @@ the list of known bugs and how to prevent them. If you encounter bugs that not l
 
  CRUSADER:
  - [IMPROVEMENT][MINOR] A single Crusader Tank will no longer create two chassis rubbles
- - [IMPROVEMENT][MINOR] Promoted Crusader Tank will not create Pilot if died from being crushed, like the other USA vehicles
+ - [DONE][MINOR] Promoted Crusader Tank will not create Pilot if died from being crushed, like the other USA vehicles
  - [MAYBE] Fixed the Composite Armor upgrade effect for Crusader Tanks that gives too many healthpoint bonus
  - [NOTRELEVANT] Crusader Tank turret turn speed slightly decreased
 
@@ -331,7 +331,7 @@ the list of known bugs and how to prevent them. If you encounter bugs that not l
  - [IMPROVEMENT][MINOR] Microwave Tank now have properly rotating turret so it now can attack without turning the whole tank
  - [IMPROVEMENT][MINOR] Fixed the Microwave Tank treads issue that rotating into the wrong direction while moving
  - [MAYBE][MINOR] Now Microwave Tank can rush toward enemy infantry and fry them to make better use of their emitter weapon
- - [IMPROVEMENT][MINOR] Promoted Microwave Tank will not create Pilot if died from being crushed, like the other USA vehicles
+ - [DONE][MINOR] Promoted Microwave Tank will not create Pilot if died from being crushed, like the other USA vehicles
 
  PALADIN:
  - [IMPROVEMENT][MINOR] Removed the shadow bugs on Paladin Tank model, also fixed the treads that are bit off-centered

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -7454,6 +7454,7 @@ Object AirF_AmericaTankMicrowave
   End
 
   Behavior = EjectPilotDie ModuleTag_17
+    DeathTypes = ALL -CRUSHED -SPLATTED ; Patch104p @bugfix commy2 03/08/2023 Don't spawn Pilots when crushed. (#2196)
     GroundCreationList = OCL_EjectPilotOnGround
     AirCreationList = OCL_EjectPilotViaParachute
     ExemptStatus = HIJACKED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1577,6 +1577,7 @@ Object AmericaTankCrusader
   End
 
   Behavior = EjectPilotDie ModuleTag_17
+    DeathTypes = ALL -CRUSHED -SPLATTED ; Patch104p @bugfix commy2 03/08/2023 Don't spawn Pilots when crushed. (#2196)
     GroundCreationList = OCL_EjectPilotOnGround
     AirCreationList = OCL_EjectPilotViaParachute
     ExemptStatus = HIJACKED
@@ -2823,6 +2824,7 @@ Object AmericaTankMicrowave
   End
 
   Behavior = EjectPilotDie ModuleTag_17
+    DeathTypes = ALL -CRUSHED -SPLATTED ; Patch104p @bugfix commy2 03/08/2023 Don't spawn Pilots when crushed. (#2196)
     GroundCreationList = OCL_EjectPilotOnGround
     AirCreationList = OCL_EjectPilotViaParachute
     ExemptStatus = HIJACKED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5904,6 +5904,7 @@ Object Lazr_AmericaTankCrusader
   End
 
   Behavior = EjectPilotDie ModuleTag_17
+    DeathTypes = ALL -CRUSHED -SPLATTED ; Patch104p @bugfix commy2 03/08/2023 Don't spawn Pilots when crushed. (#2196)
     GroundCreationList = OCL_EjectPilotOnGround
     AirCreationList = OCL_EjectPilotViaParachute
     ExemptStatus = HIJACKED
@@ -7148,6 +7149,7 @@ Object Lazr_AmericaTankMicrowave
   End
 
   Behavior = EjectPilotDie ModuleTag_17
+    DeathTypes = ALL -CRUSHED -SPLATTED ; Patch104p @bugfix commy2 03/08/2023 Don't spawn Pilots when crushed. (#2196)
     GroundCreationList = OCL_EjectPilotOnGround
     AirCreationList = OCL_EjectPilotViaParachute
     ExemptStatus = HIJACKED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6387,6 +6387,7 @@ Object SupW_AmericaTankCrusader
   End
 
   Behavior = EjectPilotDie ModuleTag_17
+    DeathTypes = ALL -CRUSHED -SPLATTED ; Patch104p @bugfix commy2 03/08/2023 Don't spawn Pilots when crushed. (#2196)
     GroundCreationList = OCL_EjectPilotOnGround
     AirCreationList = OCL_EjectPilotViaParachute
     ExemptStatus = HIJACKED
@@ -7620,6 +7621,7 @@ Object SupW_AmericaTankMicrowave
   End
 
   Behavior = EjectPilotDie ModuleTag_17
+    DeathTypes = ALL -CRUSHED -SPLATTED ; Patch104p @bugfix commy2 03/08/2023 Don't spawn Pilots when crushed. (#2196)
     GroundCreationList = OCL_EjectPilotOnGround
     AirCreationList = OCL_EjectPilotViaParachute
     ExemptStatus = HIJACKED


### PR DESCRIPTION
From NPM tasks. Makes sense to me. Paladin doesn't spawn pilots either when crushed. Only way to crush is an Overlord, or on fun maps, getting hit by the avalanche object.