### PR TITLE
Add: Implementation for Repair Vehicle

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -7385,6 +7385,15 @@ CommandButton SupW_Command_ConstructAmericaVehicleMedic
   DescriptLabel           = CONTROLBAR:ToolTipUSABuildMedic
 End
 
+CommandButton SupW_Command_ConstructAmericaVehicleRepair
+  Command       = UNIT_BUILD
+  Object        = SupW_AmericaVehicleRepair
+  TextLabel     = CONTROLBAR:ConstructAmericaVehicleRepair
+  ButtonImage   = SARAmblnce
+  ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipUSABuildRepair
+End
+
 CommandButton SupW_Command_ConstructAmericaStrategyCenter
   Command       = DOZER_CONSTRUCT
   Object        = SupW_AmericaStrategyCenter

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -3994,6 +3994,7 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   2  = SupW_Command_ConstructAmericaVehicleTomahawk
   3  = SupW_Command_ConstructAmericaVehicleHumvee
   4  = SupW_Command_ConstructAmericaVehicleMedic
+  5  = SupW_Command_ConstructAmericaVehicleRepair
   6  = SupW_Command_ConstructAmericaVehicleSentryDrone
   7  = SupW_Command_ConstructAmericaVehicleAvenger
   8  = SupW_Command_ConstructAmericaVehicleMicrowave

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -5574,6 +5574,231 @@ Object SupW_AmericaVehicleMedic
 End
 
 ;------------------------------------------------------------------------------
+Object SupW_AmericaVehicleRepair
+
+  ; *** ART Parameters ***
+  SelectPortrait         = SARAmblnce_L
+  ButtonImage            = SARAmblnce
+
+  UpgradeCameo1 = Upgrade_AmericaBattleDrone
+  UpgradeCameo2 = Upgrade_AmericaScoutDrone
+  UpgradeCameo3 = Upgrade_AmericaHellfireDrone
+  ;UpgradeCameo4 = NONE
+  ;UpgradeCameo5 = NONE
+
+  Draw = W3DTruckDraw ModuleTag_01
+
+    ConditionState = NONE
+      Model = AVAmbulanceSW
+      HideSubObject = TurretEL
+    End
+    ConditionState       = REALLYDAMAGED
+      Model              = AVAmbulanceSW_D
+      HideSubObject = TurretEL
+    End
+
+    ConditionState       = RUBBLE
+      Model              = AVAmbulanceSW_D
+      HideSubObject = TurretEL
+    End
+
+    TrackMarks = EXTireTrack.tga
+    OkToChangeModelColor = Yes
+
+    Dust = RocketBuggyDust
+    DirtSpray = RocketBuggyDirtSpray
+    PowerslideSpray = RocketBuggyDirtPowerSlide
+
+    ; These parameters are only used if the model has a separate suspension,
+    ; and the locomotor has HasSuspension = Yes.
+    LeftFrontTireBone = Tire01
+    RightFrontTireBone = Tire02
+    LeftRearTireBone = Tire03
+    RightRearTireBone = Tire04
+    TireRotationMultiplier = 0.2        ; this * speed = rotation.
+    PowerslideRotationAddition = 2.5    ; This speed is added to the rotation speed when powersliding.
+
+
+  End
+
+  ; ***DESIGN parameters ***
+  DisplayName      = OBJECT:RepairVehicle
+  Side = AmericaSuperWeaponGeneral
+  EditorSorting   = VEHICLE
+  TransportSlotCount = 3                 ;how many "slots" we take in a transport (0 == not transportable)
+  ArmorSet
+    Conditions      = None
+    Armor           = HumveeArmor
+    DamageFX        = TruckDamageFX
+  End
+  BuildCost       = 700
+  BuildTime       = 10.0          ;in seconds
+  VisionRange     = 100
+  ShroudClearingRange = 400
+  Prerequisites
+    Object = SupW_AmericaWarFactory
+  End
+  ExperienceValue    = 50 50 50 50 ;Experience point value at each level
+  IsTrainable     = No
+  CrusherLevel           = 2  ;What can I crush?: 1 = infantry, 2 = trees, 3 = vehicles
+  CrushableLevel         = 2  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
+  CommandSet      = SupW_AmericaVehicleHumveeCommandSet
+
+  ; *** AUDIO Parameters ***
+  VoiceSelect = RepairVehicleVoiceSelect
+  VoiceMove = RepairVehicleVoiceMove
+  VoiceGuard = RepairVehicleVoiceMove
+  VoiceAttack = RepairVehicleVoiceHeal
+  SoundMoveStart = HumveeMoveStart
+  SoundMoveStartDamaged = HumveeMoveStart
+  SoundEnter = HumveeEnter
+  SoundExit = HumveeExit
+
+  UnitSpecificSounds
+    ; These have the syntax of SomeNameSomewhereInCode = SomeNameSomewhereInLookupINIs
+    VoiceCreate          = RepairVehicleVoiceCreate
+    TurretMoveStart = NoSound
+    TurretMoveLoop = TurretMoveLoop
+    ; Required for the W3DTruckDraw module
+    TruckLandingSound = RocketBuggyLand
+    TruckPowerslideSound = RocketBuggyPowerslide
+    VoiceCrush          = AmbulanceVoiceCrush
+    VoiceEnter = RepairVehicleVoiceMove
+  End
+
+
+  ; *** ENGINEERING Parameters ***
+  RadarPriority = UNIT
+  KindOf = PRELOAD SELECTABLE CAN_CAST_REFLECTIONS VEHICLE SCORE TRANSPORT
+
+  Body = ActiveBody ModuleTag_02
+    MaxHealth       = 240.0
+    InitialHealth   = 240.0
+
+    ; Subdual damage "Subdues" you (reaction defined by BodyModule) when it passes your max health.
+    ; The cap limits how extra-subdued you can be, and the other numbers detemine how fast it drains away on its own.
+    SubdualDamageCap = 480
+    SubdualDamageHealRate = 500
+    SubdualDamageHealAmount = 50
+  End
+
+  Behavior = TransportAIUpdate ModuleTag_05
+   AutoAcquireEnemiesWhenIdle = Yes
+   Turret
+      TurretTurnRate = 180
+      TurretPitchRate = 180
+      AllowsPitch = Yes
+      MinPhysicalPitch = -20 ; If allows pitch, the lowest I can dip down to shoot.  defaults to 0 (horizontal)
+      TurretFireAngleSweep = PRIMARY 25
+      ControlledWeaponSlots = PRIMARY
+    End
+  End
+  Locomotor = SET_NORMAL HumveeLocomotor
+
+  Behavior = TransportContain ModuleTag_06
+    Slots               = 3
+    HealthRegen%PerSec  = 25
+    DamagePercentToUnits = 10%
+    AllowInsideKindOf   = INFANTRY
+    AllowAlliesInside   = Yes
+    AllowNeutralInside  = No
+    AllowEnemiesInside  = No
+    ExitDelay = 250
+    NumberOfExitPaths = 3 ; Defaults to 1.  Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn
+    GoAggressiveOnExit = Yes ; AI Will tell people to set their mood to Aggressive on exiting
+  End
+
+  Behavior = PhysicsBehavior ModuleTag_07
+    Mass = 50.0
+  End
+  Behavior = SlowDeathBehavior ModuleTag_08
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    DestructionDelay = 0
+    FX  = FINAL FX_AmericaVehicleAvengerDeathExplosion ; Patch104p @tweak from FX_GenericTankDeathExplosion
+    OCL = FINAL OCL_FinalAmbulanceDebris
+  End
+
+  Behavior = ObjectCreationUpgrade ModuleTag_09
+    UpgradeObject = OCL_AmericanBattleDrone
+    TriggeredBy   = Upgrade_AmericaBattleDrone
+    ConflictsWith = Upgrade_AmericaScoutDrone Upgrade_AmericaHellfireDrone
+  End
+  Behavior = ObjectCreationUpgrade ModuleTag_10
+    UpgradeObject = OCL_AmericanScoutDrone
+    TriggeredBy   = Upgrade_AmericaScoutDrone
+    ConflictsWith = Upgrade_AmericaBattleDrone Upgrade_AmericaHellfireDrone
+  End
+  Behavior = ObjectCreationUpgrade ModuleTag_19
+    UpgradeObject = OCL_AmericanHellfireDrone
+    TriggeredBy   = Upgrade_AmericaHellfireDrone
+    ConflictsWith = Upgrade_AmericaBattleDrone Upgrade_AmericaScoutDrone
+  End
+  Behavior = ProductionUpdate ModuleTag_11
+    MaxQueueEntries = 1; So you can't build multiple upgrades in the same frame
+  End
+
+  Behavior = DestroyDie ModuleTag_12
+    DeathTypes = NONE +CRUSHED +SPLATTED
+  End
+
+  Behavior = FXListDie ModuleTag_13
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    DeathFX = FX_CarCrush
+  End
+
+  Behavior = CreateObjectDie ModuleTag_14
+    DeathTypes = NONE +CRUSHED +SPLATTED
+    CreationList = OCL_CrusaderTank_CrushEffect
+  End
+
+  Behavior = FXListDie ModuleTag_15
+    DeathTypes = ALL -CRUSHED -SPLATTED
+    DeathFX = FX_GenericTankDeathEffect
+  End
+
+  Behavior = CreateCrateDie ModuleTag_16
+    CrateData = SalvageCrateData
+    ;CrateData = EliteTankCrateData
+    ;CrateData = HeroicTankCrateData
+  End
+
+  Behavior = ExperienceScalarUpgrade ModuleTag_17
+    TriggeredBy = Upgrade_AmericaAdvancedTraining
+    AddXPScalar = 1.0 ;Increases experience gained by an additional 100%
+  End
+
+  Behavior = TransitionDamageFX ModuleTag_18
+    ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmokeSmallContinuous01
+    ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
+
+  Behavior = FlammableUpdate ModuleTag_21
+    AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
+    AflameDamageAmount = 3       ; taking this much damage...
+    AflameDamageDelay = 500       ; this often.
+
+  End
+
+  Behavior = AutoHealBehavior ModuleTag_23
+    HealingAmount     = 5
+    HealingDelay      = 1000 ; msec
+    Radius            = 100.0
+    StartsActive      = Yes
+    KindOf            = VEHICLE
+    ForbiddenKindOf   = AIRCRAFT
+    SkipSelfForHealing = Yes
+  End
+
+  Geometry = BOX
+  GeometryMajorRadius = 14.0
+  GeometryMinorRadius = 7.0
+  GeometryHeight = 12.0  ; height set to allow clear clipping of projectile streams
+  GeometryIsSmall = Yes
+  Shadow = SHADOW_VOLUME
+
+End
+
+;------------------------------------------------------------------------------
 Object SupW_AmericaVehicleBattleDrone
 
   ; *** ART Parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -6003,3 +6003,33 @@ End
 
 
 
+;========================================================
+AudioEvent RepairVehicleVoiceSelect
+  Sounds = vambsea vambseb vamrsea vamrsec
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+AudioEvent RepairVehicleVoiceCreate
+  Sounds = vamrseb
+  Control = random
+  Volume  = 110
+  MinVolume = 100
+  Priority = high
+  Type = world global player
+End
+
+AudioEvent RepairVehicleVoiceMove
+  Sounds = vambmob vambmoc vambmod vambmof vamrmoa vamrmob
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+AudioEvent RepairVehicleVoiceHeal
+  Sounds = vambhea vambheb vambhed vamrrea vamrreb vamrrec
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End


### PR DESCRIPTION
Needs

- [ ] stringtable entries
- [ ] wreck model (currently Ambo with red cross), see https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1249
- [ ] help with voice set
- [ ] remove debug button from SWG War Factory
- [ ] doc

It's just an Ambo that can't heal infantry. Removed the gun, since goo gun makes no sense, vee gun is weird, and there is none on the portrait either.