### PR TITLE
Fix: China Command Center radar dish deploy animation is cut off early

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2201_china_command_center_radar_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2201_china_command_center_radar_animation.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-03
+
+title: Fixes cut off radar deploy animation on China Command Center
+
+changes:
+  - fix: The radar dish deploy animation on the China Command Center now plays properly.
+
+labels:
+  - bug
+  - china
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2201
+
+authors:
+  - commy2

--- a/Patch104pZH/Design/Tasks/nproject_tasks.txt
+++ b/Patch104pZH/Design/Tasks/nproject_tasks.txt
@@ -768,7 +768,7 @@ the list of known bugs and how to prevent them. If you encounter bugs that not l
 
  CHINESE COMMAND CENTER:
  - [MAYBE] Chinese Command Center door opening time reduced from 3000 to 1000 miliseconds
- - [IMPROVEMENT][MINOR] Fixed Chinese Command Center radar upgrading animation that was cut off midway
+ - [DONE][MINOR] Fixed Chinese Command Center radar upgrading animation that was cut off midway
 
  NUCLEAR REACTOR:
  - [MAYBE] All Nuclear Reactors will not die because of their Overcharge ability. Overcharge ability will automatically turned off

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1270,8 +1270,10 @@ Object Boss_CommandCenter
     UnitCreatePoint   = X:-18.0  Y: 40.0   Z:0.0
     NaturalRallyPoint = X: 60.0  Y: 40.0   Z:0.0;NaturalRallyPointX must always match GeometryMajorRadius! -ML
   End
+
+  ; Patch104p @bugfix 03/08/2023 Increase time from 4000 msec so animation is not cut off. (#2201)
   Behavior = RadarUpdate ModuleTag_10
-    RadarExtendTime   = 4000     ;in mSeconds
+    RadarExtendTime   = 5000     ;in mSeconds
   End
 
   Behavior             = DestroyDie ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -4069,8 +4069,10 @@ Object ChinaCommandCenter
     UnitCreatePoint   = X:-18.0  Y: 40.0   Z:0.0
     NaturalRallyPoint = X: 60.0  Y: 40.0   Z:0.0;NaturalRallyPointX must always match GeometryMajorRadius! -ML
   End
+
+  ; Patch104p @bugfix 03/08/2023 Increase time from 4000 msec so animation is not cut off. (#2201)
   Behavior = RadarUpdate ModuleTag_10
-    RadarExtendTime   = 4000     ;in mSeconds
+    RadarExtendTime   = 5000     ;in mSeconds
   End
 
   Behavior             = DestroyDie ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -4234,8 +4234,10 @@ Object Infa_ChinaCommandCenter
     UnitCreatePoint   = X:-18.0  Y: 40.0   Z:0.0
     NaturalRallyPoint = X: 60.0  Y: 40.0   Z:0.0;NaturalRallyPointX must always match GeometryMajorRadius! -ML
   End
+
+  ; Patch104p @bugfix 03/08/2023 Increase time from 4000 msec so animation is not cut off. (#2201)
   Behavior = RadarUpdate ModuleTag_10
-    RadarExtendTime   = 4000     ;in mSeconds
+    RadarExtendTime   = 5000     ;in mSeconds
   End
 
   Behavior             = DestroyDie ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -6017,8 +6017,10 @@ Object Nuke_ChinaCommandCenter
     UnitCreatePoint   = X:-18.0  Y: 40.0   Z:0.0
     NaturalRallyPoint = X: 60.0  Y: 40.0   Z:0.0;NaturalRallyPointX must always match GeometryMajorRadius! -ML
   End
+
+  ; Patch104p @bugfix 03/08/2023 Increase time from 4000 msec so animation is not cut off. (#2201)
   Behavior = RadarUpdate ModuleTag_10
-    RadarExtendTime   = 4000     ;in mSeconds
+    RadarExtendTime   = 5000     ;in mSeconds
   End
 
   Behavior             = DestroyDie ModuleTag_11

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17026,8 +17026,10 @@ Object Tank_ChinaCommandCenter
     UnitCreatePoint   = X:-18.0  Y: 40.0   Z:0.0
     NaturalRallyPoint = X: 60.0  Y: 40.0   Z:0.0;NaturalRallyPointX must always match GeometryMajorRadius! -ML
   End
+
+  ; Patch104p @bugfix 03/08/2023 Increase time from 4000 msec so animation is not cut off. (#2201)
   Behavior = RadarUpdate ModuleTag_10
-    RadarExtendTime   = 4000     ;in mSeconds
+    RadarExtendTime   = 5000     ;in mSeconds
   End
 
   Behavior             = DestroyDie ModuleTag_11


### PR DESCRIPTION

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/d5ffdac6-f1bf-4e8a-9b21-31ba2bcb6d8a

