### PR TITLE
Fix: Add missing number formats to language strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
@@ -9,6 +9,8 @@ changes:
   - fix: Adds missing sentences to various tool tip strings.
   - fix: Removes superfluous mention of 'enemy' in tool tip strings of USA Stealth Figher, Tomahawk and China Inferno Cannon for all languages.
   - fix: Removes incorrect sentence in MOAB tooltip for all languages.
+  - fix: Adds missing numbers to German, Chinese strings in TOOLTIP:GameInfoPlayer.
+  - fix: Adds missing numbers and correct sentences to German string in CONTROLBAR:PowerDescription.
 
 labels:
   - minor
@@ -19,6 +21,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2156
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2167
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2146
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2216_text_number_errors.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2216_text_number_errors.txt
@@ -1,0 +1,1 @@
+2156_misc_errors_in_strings.yaml


### PR DESCRIPTION
* Fixes #2214

This change adds missing number formats to language strings. And also fixes minor white space issues around numbers.

Affects

* TOOLTIP:GameInfoPlayer for German, Chinese
* CONTROLBAR:PowerDescription for German
* ~~MOTD:NumPlayersHeading for all native languages~~