### PR TITLE
Fix: Resolves miscellaneous string errors

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_errors_in_strings.yaml
@@ -11,6 +11,9 @@ changes:
   - fix: Removes incorrect sentence in MOAB tooltip for all languages.
   - fix: Adds missing numbers to German, Chinese strings in TOOLTIP:GameInfoPlayer.
   - fix: Adds missing numbers and correct sentences to German string in CONTROLBAR:PowerDescription.
+  - fix: Sets "D'accord" for French string in GUI:Ok, LAN:OK.
+  - fix: Sets "Complété" for French string in MapTransfer:Done.
+  - fix: Adds missing sentences to Spanish, Chinese strings in TOOLTIP:NumberOfVotes.
 
 labels:
   - minor
@@ -22,6 +25,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2167
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2146
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2217_misc_text_errors.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2217_misc_text_errors.txt
@@ -1,0 +1,1 @@
+2156_misc_errors_in_strings.yaml


### PR DESCRIPTION
This change fixes miscellaneous minor string errors.

Affects

* **GUI:Ok** for French
* **TOOLTIP:NumberOfVotes** for French, Spanish, Chinese
* **GUI:OverchargeExhausted** for German
* **LAN:OK** for French
* **GUI:ToggleLetterboxDescription** for German
* **CONTROLBAR:ToolTipChinaFireMIG** for German, French, Italian, Chinese
* **CONTROLBAR:ToolTipChinaDragonTankFire** for German, French, Italian, Chinese
* **MapTransfer:Done** for French