### PR TITLE
Fix: Add missing horde bonus tool tip strings for German, French languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-08-07
+
+title: Fixes errors in French tool tip strings
+
+changes:
+  - fix: The French tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-07
+
+title: Fixes errors in German tool tip strings
+
+changes:
+  - fix: The German tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
+  - fix: More German tool tip strings now list the correct strengths and weaknesses.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
+
+authors:
+  - xezon


### PR DESCRIPTION
This changes adds missing horde bonus tool tip strings for German, French languages. And fixes incorrect strength and weakness things in the same sentences.

Affects

* CONTROLBAR:ToolTipChinaBuildRedguard
* CONTROLBAR:ToolTipChinaBuildTankHunter
* CONTROLBAR:ToolTipChinaBuildBattlemaster