### PR TITLE
Fix: Add consistent wording in English, German, French, Spanish, Italian, Brazilian, Polish tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
@@ -14,6 +14,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2148
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2153
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-07-26
 
-title: Fixes inconsistent wording and capitalization of words in English tool tip strings
+title: Fixes errors in English tool tip strings
 
 changes:
   - fix: The wording in English tool tip strings is more consistent now.
@@ -15,6 +15,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2150
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
@@ -15,6 +15,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2151
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2153_korean_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2153_korean_tool_tip_text.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-07-26
 
-title: Fixes inconsistent wording in Korean tool tip strings
+title: Fixes errors in Korean tool tip strings
 
 changes:
   - fix: The wording in Korean tool tip strings is more consistent now.

--- a/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-02
 
-title: Fixes inconsistent wording in Brazilian tool tip strings
+title: Fixes errors in Brazilian tool tip strings
 
 changes:
   - fix: The wording in Brazilian tool tip strings is more consistent now.
@@ -13,6 +13,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
@@ -4,6 +4,7 @@ date: 2023-08-07
 title: Fixes errors in French tool tip strings
 
 changes:
+  - fix: The wording in French tool tip strings is more consistent now.
   - fix: The French tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
   - fix: The TOOLTIP:NumberOfVotes, GUI:Ok, LAN:OK, MapTransfer:Done strings now have French text.
 
@@ -15,6 +16,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
@@ -19,6 +19,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2219_italian_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2219_italian_tool_tip_text.yaml
@@ -1,0 +1,18 @@
+---
+date: 2023-08-07
+
+title: Fixes errors in Italian tool tip strings
+
+changes:
+  - fix: The wording in Italian tool tip strings is more consistent now.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+
+authors:
+  - xezon


### PR DESCRIPTION
**Merge with Rebase**

This change fixes a bunch of inconsistent wording in English, German, French, Spanish, Italian, Brazilian, Polish tool tip strings.

* Italian tool tip strings now omit the article for nouns more consistently
* Spanish tool tip strings now omit the article for nouns more consistently
* Brazilian tool tip strings now use Camel Case nouns more consistently
* German tool tip strings now say "Späher" instead of "Scout"
* English tool tip strings now say "rocket soldiers", "anti-air defenses" instead of various other words.
* German tool tip strings now say "Abwehreinrichtungen", "Raketen-Bots", "Flugabwehrgeschütze" more consistently instead of various other words
* French tool tip strings now say "l'infanterie armée de missiles", "défenses antiaériennes" more consistently instead of various other words
* Spanish tool tip strings now say "infantería con misiles", "defensas antiaéreas" more consistently instead of various other words
* Italian tool tip strings now say "fanteria con missili", "contraerea" more consistently instead of various other words
* Brazilian tool tip strings now say "Infantaria com Mísseis", "Defesas Antiaéreas" more consistently instead of various other words
* Polish tool tip strings now say "piechocie rakietowej", "obronie przeciwlotniczej" more consistently instead of various other words