### PR TITLE
Fix: Spectre wreck is silent when crashing on the ground

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2220_spectre_wreck_impact_sound.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2220_spectre_wreck_impact_sound.yaml
@@ -7,6 +7,7 @@ changes:
   - fix: The Spectre now uses a generic explosion sound when falling to the ground.
 
 labels:
+  - audio
   - boss
   - bug
   - minor

--- a/Patch104pZH/Design/Changes/v1.0/2220_spectre_wreck_impact_sound.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2220_spectre_wreck_impact_sound.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-07
+
+title: Fixes issue with Spectre wreck being silent when crashing onto the ground
+
+changes:
+  - fix: The Spectre now uses a generic explosion sound when falling to the ground.
+
+labels:
+  - boss
+  - bug
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2220
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8598,7 +8598,7 @@ FXList FX_spectreGunshipDeathExplosion
 
   ; Patch104p @bugfix commy2 07/08/2023 Fix Spectre silent when crashing. (#2220)
   Sound
-    Name = ExplosionScudExplosive
+    Name = SpectreCrash
   End
 
   ParticleSystem

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -8595,9 +8595,11 @@ FXList FX_spectreGunshipDeathExplosion
   ViewShake
     Type = SEVERE
   End
-;  Sound
-;    Name = ExplosionScudExplosive
-;  End
+
+  ; Patch104p @bugfix commy2 07/08/2023 Fix Spectre silent when crashing. (#2220)
+  Sound
+    Name = ExplosionScudExplosive
+  End
 
   ParticleSystem
     Name = spectreDeathExplosionArms

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -7990,3 +7990,4 @@ AudioEvent SpectreHowitzerWeapon
   Type = world shrouded everyone
 End
 
+

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -7980,3 +7980,13 @@ AudioEvent SpectreHowitzerWeapon
 End
 
 
+; Patch104p @feature commy2 09/08/2023 Adds a copy of ComancheCrash, but a bit louder and deeper.
+AudioEvent SpectreCrash
+  Sounds = vcomcraa
+  Limit = 3
+  PitchShift = -10 -10
+  Volume = 90
+  VolumeShift = -10
+  Priority = normal
+  Type = world shrouded everyone
+End

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -1895,6 +1895,17 @@ AudioEvent CarDamagedMoveLoop
   Type = world shrouded everyone
 End
 
+; Patch104p @feature commy2 09/08/2023 Adds a copy of ComancheCrash, but a bit louder and deeper.
+AudioEvent SpectreCrash
+  Sounds = vcomcraa
+  Limit = 3
+  PitchShift = -10 -10
+  Volume = 90
+  VolumeShift = -10
+  Priority = normal
+  Type = world shrouded everyone
+End
+
 AudioEvent ComancheCrash
   Sounds = vcomcraa
   Limit = 3
@@ -7979,14 +7990,3 @@ AudioEvent SpectreHowitzerWeapon
   Type = world shrouded everyone
 End
 
-
-; Patch104p @feature commy2 09/08/2023 Adds a copy of ComancheCrash, but a bit louder and deeper.
-AudioEvent SpectreCrash
-  Sounds = vcomcraa
-  Limit = 3
-  PitchShift = -10 -10
-  Volume = 90
-  VolumeShift = -10
-  Priority = normal
-  Type = world shrouded everyone
-End


### PR DESCRIPTION
### 1.04

- Spectre has no sound when impacting on the ground, unlike any other plane


### patch

- Spectre has generic explosion sound