### PR TITLE
Fix: Chemical Suits for Pilots

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1415,7 +1415,7 @@ Object AmericaInfantryPilot
   ButtonImage            = SAPilot
 
   ; Patch104p @bugfix hanfield 03/09/2021 Commented out Chemical Suit and Advanced Training cameos since it never benefited from either.
-  ;UpgradeCameo1 = Upgrade_AmericaChemicalSuits
+  UpgradeCameo1 = Upgrade_AmericaChemicalSuits
   ;UpgradeCameo2 = Upgrade_AmericaAdvancedTraining
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
@@ -1514,6 +1514,11 @@ Object AmericaInfantryPilot
   ArmorSet
     Conditions      = None
     Armor           = HumanArmor
+    DamageFX        = InfantryDamageFX
+  End
+  ArmorSet
+    Conditions      = PLAYER_UPGRADE
+    Armor           = ChemSuitHumanArmor
     DamageFX        = InfantryDamageFX
   End
 
@@ -1649,6 +1654,21 @@ Object AmericaInfantryPilot
   Behavior = PoisonedBehavior ModuleTag_14
     PoisonDamageInterval = 100  ; Every this many msec I will retake the poison damage dealt me...
     PoisonDuration = 3000       ; ... for this long after last hit by poison damage
+  End
+
+  Behavior = OverlordContain ModuleTag_ChemSuits01
+    Slots                 = 1
+    DamagePercentToUnits  = 100%
+    AllowInsideKindOf     = PORTABLE_STRUCTURE
+  End
+
+  Behavior = ObjectCreationUpgrade ModuleTag_ChemSuits02
+    UpgradeObject = OCL_ChemicalSuitsPilotDecal
+    TriggeredBy   = Upgrade_AmericaChemicalSuits
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_ChemSuits03
+    TriggeredBy = Upgrade_AmericaChemicalSuitsPilotDummyUpgrade
   End
 
   Geometry = CYLINDER

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaInfantry.ini
@@ -1518,7 +1518,7 @@ Object AmericaInfantryPilot
   End
   ArmorSet
     Conditions      = PLAYER_UPGRADE
-    Armor           = ChemSuitHumanArmor
+    Armor           = HazMatHumanArmor; ChemSuitHumanArmor
     DamageFX        = InfantryDamageFX
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -7378,6 +7378,11 @@ Object AmericaStrategyCenter
     DeathFX       = FX_StructureMediumDeath
   End
 
+  Behavior = ObjectCreationUpgrade ModuleTag_21
+    UpgradeObject = OCL_ChemicalSuitsPilotDummy
+    TriggeredBy   = Upgrade_AmericaChemicalSuits
+  End
+
   Behavior = FlammableUpdate ModuleTag_22
     AflameDuration = 5000         ; If I catch fire, I'll burn for this long...
     AflameDamageAmount = 5       ; taking this much damage...

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3146,7 +3146,29 @@ Object SatelliteHackOneDummy
   End
 End
 
-; Patch104p @bugfix commy2 11/08/2023 Pilot's Chem Suits decal, also grants replacement upgrade.
+; Patch104p @bugfix commy2 11/08/2023 Grants Chem Suits replacement upgrade for Pilots.
+;------------------------------------------------------------------------------
+Object ChemicalSuitsPilotDummy
+  EditorSorting   = SYSTEM
+  KindOf          = INERT
+
+  Body = ActiveBody ModuleTag_01
+    MaxHealth        = 1.0
+    InitialHealth    = 1.0
+  End
+
+  Behavior = DeletionUpdate ModuleTag_02
+    MinLifetime = 50
+    MaxLifetime = 50
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_03
+    UpgradeToGrant = Upgrade_AmericaChemicalSuitsPilotDummyUpgrade
+    ExemptStatus = SOLD
+  End
+End
+
+; Patch104p @bugfix commy2 11/08/2023 Chem Suits decal for Pilot.
 ;------------------------------------------------------------------------------
 Object ChemicalSuitsPilotDecal
   Draw = W3DModelDraw ModuleTag_01
@@ -3175,10 +3197,6 @@ Object ChemicalSuitsPilotDecal
 
   Behavior = ArmorUpgrade ModuleTag_04
     TriggeredBy = Upgrade_AmericaChemicalSuits
-  End
-
-  Behavior = GrantUpgradeCreate ModuleTag_05
-    UpgradeToGrant = Upgrade_AmericaChemicalSuitsPilotDummyUpgrade
   End
 
   ShadowSizeX = 14

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3146,6 +3146,45 @@ Object SatelliteHackOneDummy
   End
 End
 
+; Patch104p @bugfix commy2 11/08/2023 Pilot's Chem Suits decal, also grants replacement upgrade.
+;------------------------------------------------------------------------------
+Object ChemicalSuitsPilotDecal
+  Draw = W3DModelDraw ModuleTag_01
+    DefaultConditionState
+      Model = EXAMineGroup ; dummy model required
+    End
+  End
+
+  EditorSorting   = SYSTEM
+  KindOf          = PRELOAD PORTABLE_STRUCTURE CLICK_THROUGH IGNORED_IN_GUI INERT
+  TransportSlotCount = 1
+
+  ArmorSet
+    Conditions     = None
+    Armor          = InvulnerableAllArmor
+  End
+
+  Body = StructureBody ModuleTag_02
+    MaxHealth       = 100.0
+    InitialHealth   = 100.0
+  End
+
+  Behavior = DestroyDie ModuleTag_03
+    ;nothing
+  End
+
+  Behavior = ArmorUpgrade ModuleTag_04
+    TriggeredBy = Upgrade_AmericaChemicalSuits
+  End
+
+  Behavior = GrantUpgradeCreate ModuleTag_05
+    UpgradeToGrant = Upgrade_AmericaChemicalSuitsPilotDummyUpgrade
+  End
+
+  ShadowSizeX = 14
+  ShadowSizeY = 14
+End
+
 ; Patch104p @bugfix commy2 05/08/2022 Add faction starting unit/upgrade logic.
 ;------------------------------------------------------------------------------
 Object AmericaStartingThings

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -10209,7 +10209,17 @@ ObjectCreationList OCL_CashBountyDummy
   End
 End
 
-; Patch104p @bugfix commy2 05/08/2022 Spawns Chemical Suits decal for Pilot
+; Patch104p @bugfix commy2 11/08/2023 Grants Chem Suits replacement upgrade for Pilots.
+; -----------------------------------------------------------------------------
+ObjectCreationList OCL_ChemicalSuitsPilotDummy
+  CreateObject
+    ObjectNames = ChemicalSuitsPilotDummy
+    Count = 1
+    ContainInsideSourceObject = Yes
+  End
+End
+
+; Patch104p @bugfix commy2 11/08/2023 Spawns Chemical Suits decal for Pilot.
 ; -----------------------------------------------------------------------------
 ObjectCreationList OCL_ChemicalSuitsPilotDecal
   CreateObject

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -10209,6 +10209,16 @@ ObjectCreationList OCL_CashBountyDummy
   End
 End
 
+; Patch104p @bugfix commy2 05/08/2022 Spawns Chemical Suits decal for Pilot
+; -----------------------------------------------------------------------------
+ObjectCreationList OCL_ChemicalSuitsPilotDecal
+  CreateObject
+    ObjectNames = ChemicalSuitsPilotDecal
+    Count = 1
+    ContainInsideSourceObject = Yes
+  End
+End
+
 ; Patch104p @bugfix commy2 05/08/2022 Add faction starting unit OCLs.
 ;-------------------------------------------------------------------------------
 ObjectCreationList OCL_AmericaVehicleDozer

--- a/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Upgrade.ini
@@ -184,6 +184,11 @@ Upgrade Upgrade_AmericaChemicalSuits
   ResearchSound      = RangerVoiceUpgradeChemSuits
 End
 
+Upgrade Upgrade_AmericaChemicalSuitsPilotDummyUpgrade
+  BuildTime          = 0.0
+  BuildCost          = 0
+End
+
 Upgrade Upgrade_AmericaSentryDroneGun
   DisplayName        = UPGRADE:AmericaSentryDroneGun
   BuildTime          = 10.0 ; Patch104p @tweak from 30.0 to consolidate with usefulness of Upgrade_AmericaTOWMissile


### PR DESCRIPTION
- fix https://github.com/TheSuperHackers/GeneralsGamePatch/issues/404 chemsuits not found

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/a31aba34-1145-4c3d-86ca-b651567b92e4

This is a real decal, will be seen by the enemy.

Remaining problem is getting the replacement upgrade to work, meaning, make the armor set actually change for the Pilot.