### PR TITLE
Fix: INFANTRY KindOf on unused Toxic Infantry

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/75_dead_target_bug.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/75_dead_target_bug.yaml
@@ -15,7 +15,9 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/75
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2072
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2237
 
 authors:
   - hanfield
   - xezon
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -21832,6 +21832,7 @@ Object Chem_PoisonFieldGammaSmall ; unused
 End
 
 
+; Patch104p @bugfix commy2 16/08/2023 Removes INFANTRY flag to avoid PointDefenseLaserUpdate modules targeting this object. (#2237)
 ;------------------------------------------------------------------------------
 Object Chem_ToxicInfantryGamma ; unused
   ; *** ART Parameters ***
@@ -21862,7 +21863,7 @@ Object Chem_ToxicInfantryGamma ; unused
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY
+  KindOf = CAN_CAST_REFLECTIONS
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLASystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLASystem.ini
@@ -229,6 +229,7 @@ Object GC_Chem_PoisonFieldGammaSmall
 End
 
 
+; Patch104p @bugfix commy2 16/08/2023 Removes INFANTRY flag to avoid PointDefenseLaserUpdate modules targeting this object. (#2072)
 ;------------------------------------------------------------------------------
 Object GC_Chem_ToxicInfantryGamma
   ; *** ART Parameters ***
@@ -259,7 +260,7 @@ Object GC_Chem_ToxicInfantryGamma
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = CAN_CAST_REFLECTIONS INFANTRY
+  KindOf = CAN_CAST_REFLECTIONS
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 50.0


### PR DESCRIPTION
Follow-up on #2072. INFANTRY flag remained on two unused copies of ToxicInfantry. Remove for completeness and consistency.

Also, curiously, despite both of them being named "Gamma", they're blue dabadee dabadie