### PR TITLE
Fix: Jarmen Kell recoil animation aborted after kill shot

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
@@ -5,7 +5,6 @@ title: Fixes broken kill shot recoil animation of GLA Jarmen Kell
 
 changes:
   - fix: GLA Jarmen Kell no longer displays permanent muzzle flash in transition animations such as while paradropping.
-  - fix: GLA Jarmen Kell now has a visible muzzle fire in addition to the muzzle flash when sniping infantry.
   - fix: GLA Jarmen Kell recoil animation is no longer aborted prematurely when switching targets.
 
 labels:

--- a/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-21
 
-title: GLA Jarmen Kell recoil animation aborted after kill shot
+title: Fixes broken kill shot recoil animation of GLA Jarmen Kell
 
 changes:
   - fix: GLA Jarmen Kell no longer displays permanent muzzle flash in transition animations such as while paradropping.

--- a/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
@@ -1,0 +1,22 @@
+---
+date: 2023-08-21
+
+title: GLA Jarmen Kell recoil animation aborted after kill shot
+
+changes:
+  - fix: GLA Jarmen Kell no longer displays permanent muzzle flash in transition animations such as while paradropping.
+  - fix: GLA Jarmen Kell now has a visible muzzle fire in addition to the muzzle flash when sniping infantry.
+  - fix: GLA Jarmen Kell recoil animation is no longer aborted prematurely when switching targets.
+
+labels:
+  - boss
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2239
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2239_jarmen_kell_firing_animation.yaml
@@ -19,4 +19,4 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2239
 
 authors:
-  - xezon
+  - commy2

--- a/Patch104pZH/Design/Changes/v1.0/938_infantry_muzzle_flash.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/938_infantry_muzzle_flash.yaml
@@ -11,6 +11,7 @@ changes:
         - China Minigunner
         - GLA Rebel
         - GLA Angry Mob
+        - GLA Jarmen Kell
 
 labels:
   - bug
@@ -22,6 +23,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/938
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2239
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19440,7 +19440,7 @@ Object Boss_InfantryJarmenKell
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
   ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
-  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#938)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -19439,6 +19439,8 @@ Object Boss_InfantryJarmenKell
   ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -19451,10 +19453,9 @@ Object Boss_InfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone  = SECONDARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 21/08/2023 Manually hide muzzle flash during transitions. (#2239)
       TransitionKey     = TRANS_Stand
-      WaitForStateToFinishIfPossible = TRANS_Cheering
+      WaitForStateToFinishIfPossible = TRANS_FiringA
     End
 
     ConditionState      = REALLYDAMAGED
@@ -19463,7 +19464,7 @@ Object Boss_InfantryJarmenKell
       IdleAnimation     = UIHERO_SKL.UIHERO_IIDB
       AnimationMode     = ONCE
       TransitionKey     = TRANS_StandInjured
-      WaitForStateToFinishIfPossible = TRANS_CheeringInjured
+      WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
 
     TransitionState     = TRANS_Stand TRANS_StandInjured
@@ -19481,11 +19482,21 @@ Object Boss_InfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState      = FIRING_B
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
-      Animation         = UIHERO_SKL.UIHERO_STA
-      AnimationMode     = ONCE
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = MANUAL
+      Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
@@ -19499,7 +19510,16 @@ Object Boss_InfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B REALLYDAMAGED
+
+    ConditionState      = FIRING_B REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -19556,7 +19576,7 @@ Object Boss_InfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_Cheering
+      TransitionKey     = TRANS_FiringA ; TRANS_Cheering
       WaitForStateToFinishIfPossible = NoWait
     End
 
@@ -19565,7 +19585,7 @@ Object Boss_InfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_CheeringInjured
+      TransitionKey     = TRANS_FiringAInjured ; TRANS_CheeringInjured
       WaitForStateToFinishIfPossible = NoWait
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -12898,7 +12898,7 @@ Object Chem_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
   ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
-  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#938)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -12897,6 +12897,8 @@ Object Chem_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -12909,10 +12911,9 @@ Object Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone  = SECONDARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 21/08/2023 Manually hide muzzle flash during transitions. (#2239)
       TransitionKey     = TRANS_Stand
-      WaitForStateToFinishIfPossible = TRANS_Cheering
+      WaitForStateToFinishIfPossible = TRANS_FiringA
     End
 
     ConditionState      = REALLYDAMAGED
@@ -12921,7 +12922,7 @@ Object Chem_GLAInfantryJarmenKell
       IdleAnimation     = UIHERO_SKL.UIHERO_IIDB
       AnimationMode     = ONCE
       TransitionKey     = TRANS_StandInjured
-      WaitForStateToFinishIfPossible = TRANS_CheeringInjured
+      WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
 
     TransitionState     = TRANS_Stand TRANS_StandInjured
@@ -12938,11 +12939,21 @@ Object Chem_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState      = FIRING_B
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
-      Animation         = UIHERO_SKL.UIHERO_STA
-      AnimationMode     = ONCE
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = MANUAL
+      Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
@@ -12956,7 +12967,16 @@ Object Chem_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B REALLYDAMAGED
+
+    ConditionState      = FIRING_B REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -13010,7 +13030,7 @@ Object Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_Cheering
+      TransitionKey     = TRANS_FiringA ; TRANS_Cheering
       WaitForStateToFinishIfPossible = NoWait
     End
 
@@ -13019,7 +13039,7 @@ Object Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_CheeringInjured
+      TransitionKey     = TRANS_FiringAInjured ; TRANS_CheeringInjured
       WaitForStateToFinishIfPossible = NoWait
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13276,6 +13276,8 @@ Object Demo_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -13288,10 +13290,9 @@ Object Demo_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone  = SECONDARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 21/08/2023 Manually hide muzzle flash during transitions. (#2239)
       TransitionKey     = TRANS_Stand
-      WaitForStateToFinishIfPossible = TRANS_Cheering
+      WaitForStateToFinishIfPossible = TRANS_FiringA
     End
 
     ConditionState      = REALLYDAMAGED
@@ -13300,7 +13301,7 @@ Object Demo_GLAInfantryJarmenKell
       IdleAnimation     = UIHERO_SKL.UIHERO_IIDB
       AnimationMode     = ONCE
       TransitionKey     = TRANS_StandInjured
-      WaitForStateToFinishIfPossible = TRANS_CheeringInjured
+      WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
 
     TransitionState     = TRANS_Stand TRANS_StandInjured
@@ -13317,11 +13318,21 @@ Object Demo_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState      = FIRING_B
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
-      Animation         = UIHERO_SKL.UIHERO_STA
-      AnimationMode     = ONCE
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = MANUAL
+      Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
@@ -13335,7 +13346,16 @@ Object Demo_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B REALLYDAMAGED
+
+    ConditionState      = FIRING_B REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -13392,7 +13412,7 @@ Object Demo_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_Cheering
+      TransitionKey     = TRANS_FiringA ; TRANS_Cheering
       WaitForStateToFinishIfPossible = NoWait
     End
 
@@ -13401,7 +13421,7 @@ Object Demo_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_CheeringInjured
+      TransitionKey     = TRANS_FiringAInjured ; TRANS_CheeringInjured
       WaitForStateToFinishIfPossible = NoWait
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13277,7 +13277,7 @@ Object Demo_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
   ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
-  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#938)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -3508,6 +3508,8 @@ Object GC_Chem_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -3520,10 +3522,9 @@ Object GC_Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone  = SECONDARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 21/08/2023 Manually hide muzzle flash during transitions. (#2239)
       TransitionKey     = TRANS_Stand
-      WaitForStateToFinishIfPossible = TRANS_Cheering
+      WaitForStateToFinishIfPossible = TRANS_FiringA
     End
 
     ConditionState      = REALLYDAMAGED
@@ -3532,7 +3533,7 @@ Object GC_Chem_GLAInfantryJarmenKell
       IdleAnimation     = UIHERO_SKL.UIHERO_IIDB
       AnimationMode     = ONCE
       TransitionKey     = TRANS_StandInjured
-      WaitForStateToFinishIfPossible = TRANS_CheeringInjured
+      WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
 
     TransitionState     = TRANS_Stand TRANS_StandInjured
@@ -3549,11 +3550,21 @@ Object GC_Chem_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState      = FIRING_B
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
-      Animation         = UIHERO_SKL.UIHERO_STA
-      AnimationMode     = ONCE
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = MANUAL
+      Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
@@ -3567,7 +3578,16 @@ Object GC_Chem_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B REALLYDAMAGED
+
+    ConditionState      = FIRING_B REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -3621,7 +3641,7 @@ Object GC_Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_Cheering
+      TransitionKey     = TRANS_FiringA ; TRANS_Cheering
       WaitForStateToFinishIfPossible = NoWait
     End
 
@@ -3630,7 +3650,7 @@ Object GC_Chem_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_CheeringInjured
+      TransitionKey     = TRANS_FiringAInjured ; TRANS_CheeringInjured
       WaitForStateToFinishIfPossible = NoWait
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -3509,7 +3509,7 @@ Object GC_Chem_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
   ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
-  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#938)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -1028,6 +1028,8 @@ Object GC_Slth_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#938)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -1040,12 +1040,8 @@ Object GC_Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone  = SECONDARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX
-      WeaponFireFXBone  = TERTIARY Muzzle
-      WeaponMuzzleFlash = TERTIARY MuzzleFX
       TransitionKey     = TRANS_Stand
-      WaitForStateToFinishIfPossible = TRANS_Cheering
+      WaitForStateToFinishIfPossible = TRANS_FiringA
     End
 
     ConditionState      = REALLYDAMAGED
@@ -1054,7 +1050,7 @@ Object GC_Slth_GLAInfantryJarmenKell
       IdleAnimation     = UIHERO_SKL.UIHERO_IIDB
       AnimationMode     = ONCE
       TransitionKey     = TRANS_StandInjured
-      WaitForStateToFinishIfPossible = TRANS_CheeringInjured
+      WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
 
     TransitionState     = TRANS_Stand TRANS_StandInjured
@@ -1071,12 +1067,31 @@ Object GC_Slth_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B
-    AliasConditionState = FIRING_C
+
+    ConditionState      = FIRING_B
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
+
+    ConditionState      = FIRING_C
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = TERTIARY Muzzle
+      WeaponMuzzleFlash = TERTIARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
-      Animation         = UIHERO_SKL.UIHERO_STA
-      AnimationMode     = ONCE
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = MANUAL
+      Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
@@ -1092,8 +1107,26 @@ Object GC_Slth_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B REALLYDAMAGED
-    AliasConditionState = FIRING_C REALLYDAMAGED
+
+    ConditionState      = FIRING_B REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
+
+    ConditionState      = FIRING_C REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = TERTIARY Muzzle
+      WeaponMuzzleFlash = TERTIARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -1155,7 +1188,7 @@ Object GC_Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_Cheering
+      TransitionKey     = TRANS_FiringA ; TRANS_Cheering
       WaitForStateToFinishIfPossible = NoWait
     End
 
@@ -1164,7 +1197,7 @@ Object GC_Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_CheeringInjured
+      TransitionKey     = TRANS_FiringAInjured ; TRANS_CheeringInjured
       WaitForStateToFinishIfPossible = NoWait
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -415,7 +415,7 @@ Object GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
   ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
-  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#938)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -414,6 +414,8 @@ Object GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -426,10 +428,9 @@ Object GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone  = SECONDARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 21/08/2023 Manually hide muzzle flash during transitions. (#2239)
       TransitionKey     = TRANS_Stand
-      WaitForStateToFinishIfPossible = TRANS_Cheering
+      WaitForStateToFinishIfPossible = TRANS_FiringA
     End
 
     ConditionState      = REALLYDAMAGED
@@ -438,7 +439,7 @@ Object GLAInfantryJarmenKell
       IdleAnimation     = UIHERO_SKL.UIHERO_IIDB
       AnimationMode     = ONCE
       TransitionKey     = TRANS_StandInjured
-      WaitForStateToFinishIfPossible = TRANS_CheeringInjured
+      WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
 
     TransitionState     = TRANS_Stand TRANS_StandInjured
@@ -455,11 +456,21 @@ Object GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState      = FIRING_B
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
-      Animation         = UIHERO_SKL.UIHERO_STA
-      AnimationMode     = ONCE
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = MANUAL
+      Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
@@ -473,7 +484,16 @@ Object GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B REALLYDAMAGED
+
+    ConditionState      = FIRING_B REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -530,7 +550,7 @@ Object GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_Cheering
+      TransitionKey     = TRANS_FiringA ; TRANS_Cheering
       WaitForStateToFinishIfPossible = NoWait
     End
 
@@ -539,7 +559,7 @@ Object GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_CheeringInjured
+      TransitionKey     = TRANS_FiringAInjured ; TRANS_CheeringInjured
       WaitForStateToFinishIfPossible = NoWait
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13957,7 +13957,7 @@ Object Slth_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
   ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
-  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#938)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -13956,6 +13956,8 @@ Object Slth_GLAInfantryJarmenKell
   ; Patch104p @bugfix commy2 11/09/2021 Fix Jarmen Kell using Sniper Attack has tracer emerging below feet instead of from muzzle.
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition when injured.
   ; Patch104p @bugfix commy2 18/08/2023 Play longer cheering animation when healthy. (#2238)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix recoil animation not always being played. (#2239)
+  ; Patch104p @bugfix commy2 21/08/2023 Fix muzzle fire not shown when sniping infantry. (#2239)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -13968,10 +13970,9 @@ Object Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       WeaponFireFXBone  = PRIMARY Muzzle
       WeaponMuzzleFlash = PRIMARY MuzzleFX
-      WeaponFireFXBone  = SECONDARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      HideSubObject     = MuzzleFX01 ; Patch104p @bugfix commy2 21/08/2023 Manually hide muzzle flash during transitions. (#2239)
       TransitionKey     = TRANS_Stand
-      WaitForStateToFinishIfPossible = TRANS_Cheering
+      WaitForStateToFinishIfPossible = TRANS_FiringA
     End
 
     ConditionState      = REALLYDAMAGED
@@ -13980,7 +13981,7 @@ Object Slth_GLAInfantryJarmenKell
       IdleAnimation     = UIHERO_SKL.UIHERO_IIDB
       AnimationMode     = ONCE
       TransitionKey     = TRANS_StandInjured
-      WaitForStateToFinishIfPossible = TRANS_CheeringInjured
+      WaitForStateToFinishIfPossible = TRANS_FiringAInjured
     End
 
     TransitionState     = TRANS_Stand TRANS_StandInjured
@@ -13997,11 +13998,21 @@ Object Slth_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState      = FIRING_B
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringA
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A
-      Animation         = UIHERO_SKL.UIHERO_STA
-      AnimationMode     = ONCE
+      Animation         = UIHERO_SKL.UIHERO_ATA
+      AnimationMode     = MANUAL
+      Flags             = START_FRAME_LAST
       WaitForStateToFinishIfPossible = TRANS_FiringA
     End
     AliasConditionState = BETWEEN_FIRING_SHOTS_B
@@ -14015,7 +14026,16 @@ Object Slth_GLAInfantryJarmenKell
       WaitForStateToFinishIfPossible = NoWait
       AnimationSpeedFactorRange = 1.5 1.5
     End
-    AliasConditionState = FIRING_B REALLYDAMAGED
+
+    ConditionState      = FIRING_B REALLYDAMAGED
+      Animation         = UIHERO_SKL.UIHERO_IATA2
+      AnimationMode     = ONCE
+      TransitionKey     = TRANS_FiringAInjured
+      WaitForStateToFinishIfPossible = NoWait
+      AnimationSpeedFactorRange = 1.5 1.5
+      WeaponFireFXBone  = SECONDARY Muzzle
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+    End
 
     ConditionState      = BETWEEN_FIRING_SHOTS_A REALLYDAMAGED
       Animation         = UIHERO_SKL.UIHERO_IATA2
@@ -14072,7 +14092,7 @@ Object Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_Cheering
+      TransitionKey     = TRANS_FiringA ; TRANS_Cheering
       WaitForStateToFinishIfPossible = NoWait
     End
 
@@ -14081,7 +14101,7 @@ Object Slth_GLAInfantryJarmenKell
       AnimationMode     = ONCE
       AnimationSpeedFactorRange = 0.8 1.2
       Flags             = RESTART_ANIM_WHEN_COMPLETE
-      TransitionKey     = TRANS_CheeringInjured
+      TransitionKey     = TRANS_FiringAInjured ; TRANS_CheeringInjured
       WaitForStateToFinishIfPossible = NoWait
     End
 


### PR DESCRIPTION
This PR fixes:

- Jarmen Kell may display permanent muzzle flash in transition animations such as while paradropping (map.ini)
- Jarmen Kell has no visible muzzle fire when sniping infantry (muzzle flash however is shown, no issue when sniping vehicles)
- Jarmen Kell recoil animation is aborted prematurely (unless shooting the ground)
- Recoil animation can be cancelled by pressing S-Key (this does not make Jarmen shoot faster however)





---

Jarmen Kell has a neat recoil animation that you never see, because every shot he makes is a kill, and because everything gotta be bugged, the recoil animation is not shown after a kill.

You can still see it by shooting the ground.



https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/70cabb10-dee5-431f-b711-1f746ccc3d7e



Video above has vGLA Jarmen Kell with fix applied, and 1.04 state Demo Jarmen Kell.

All these changes are entirely cosmetical.