### PR TITLE
Change: Streamline key mappings for all detonation related buttons, except suicide

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2244_detonate_key_mapping.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2244_detonate_key_mapping.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-08-17
+
+title: Streamlines key mappings of detonate buttons in all languages
+
+changes:
+  - tweak: The detonate abilities for C4 charges, Convoy Nuke, GLA Demo Trap, GLA Bomb Truck and GLA Fake Structure can now be used with key D instead of various other keys in all languages.
+
+labels:
+  - controversial
+  - gla
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2244
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Scripts/str/generated/ar_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ar_commandsets.txt
@@ -3406,7 +3406,7 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "راﻮﺜﻟا"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "ﻦﯿﻣرﺎﺟ ﻞﺗﺎﻘﻟا"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "تﺄﺸﻨﻤﻟا ﻰﻠﻋ ءﻼﯿﺘﺳﻹا"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "! ﻥﺂﻟا ﺮﻴﺠﻔﺗ"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "رﺎﺤﺘﻧﻹا"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "ﺮﺻﺎﻨﻌﻟاو تاﺪﺣﻮﻟا عﺎﻤﺘﺟإ ﺔﻄﻘﻧ"
   14 = Command_Sell : CONTROLBAR:Sell "ةﺄﺸﻨﻤﻟا ﻊﯿﺑ"
   CommandMap VIEW_COMMAND_CENTER : "H"

--- a/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar Bomba Nuclear: &N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar Bomba Nuclear: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -525,8 +525,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bomba Biológica: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Explodir Agora! &A"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Tornar Verdadeiro o Centro de Comando: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Explodir Agora! &A"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Tornar Verdadeiro o Quartel: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Explodir Agora! &A"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Tornar Verdadeiro o Armazém de Suprimentos: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Explodir Agora! &A"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Tornar Verdadeiro o Negociante de Armas: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Explodir Agora! &A"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Tornar Verdadeiro o Mercado Negro: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2323,7 +2323,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Sair do Transporte"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Sair do Transporte"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuar: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
@@ -2332,7 +2332,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -2853,8 +2853,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3008,7 +3008,7 @@ End
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3027,7 +3027,7 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   5 = Command_TransportExit : CONTROLBAR:TransportExit "Sair do Transporte"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuar: &V"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3041,7 +3041,7 @@ End
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   1 = Command_GLAToxinTractorContaminateGround : CONTROLBAR:Contaminate "Contaminar: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3054,7 +3054,7 @@ End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3067,7 +3067,7 @@ End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3089,7 +3089,7 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   8 = Demo_Command_ConstructGLAScudStorm : CONTROLBAR:ConstructGLAScudStorm "Tempestade SCUD: &D"
   9 = Demo_Command_ConstructGLAArmsDealer : CONTROLBAR:ConstructGLAArmsDealer "Negociante de Armas: &A"
   10 = Demo_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "Centro de Comando: &C"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "Alternar para Estruturas Falsas: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Desarmar Minas: &N"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3106,7 +3106,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Armazém de Suprimentos Falso: &U"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Negociante de Armas Falso: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Mercado Negro Falso: &M"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Alternar para Estruturas de Verdade: &V"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Desarmar Minas: &N"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3124,7 +3124,7 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   6 = Command_EmergencyRepair : CONTROLBAR:EmergencyRepair "Reparos de Emergência: &E"
   7 = Command_AnthraxBomb : CONTROLBAR:AnthraxBomb "Bomba de Antraz: &B"
   8 = Command_SneakAttack : CONTROLBAR:SneakAttack "Ataque Sorrateiro: &F"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3134,7 +3134,7 @@ End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
   1 = Demo_Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "Trabalhador: &T"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3151,7 +3151,7 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   6 = Command_Evacuate : CONTROLBAR:Evacuate "Evacuar: &V"
   7 = Command_UpgradeGLAFortifiedStructure : CONTROLBAR:UpgradeGLAFortifiedStructure "Estrutura Fortificada: &E"
   8 = Command_UpgradeGLAArmTheMob : CONTROLBAR:UpgradeGLAArmTheMob "Armar a Multidão: &M"
-  11 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  11 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3166,12 +3166,12 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Multidão Revoltada: &Y"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Capturar Estrutura: &C"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Explodir Agora! &A"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, K, L, M, N, O, R, S, U, V, W, X, Z, 
+    Available keys: A, D, E, F, I, K, L, M, N, O, R, S, U, V, W, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3180,7 +3180,7 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   3 = Command_UpgradeGLAJunkRepair : CONTROLBAR:UpgradeGLAJunkRepair "Reparos de Combate: &E"
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "Varredura de Radar: &V"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "Sapatos de Trabalhador: &S"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
@@ -3188,7 +3188,7 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3198,7 +3198,7 @@ End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "Tempestade SCUD: &D"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
@@ -3217,7 +3217,7 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   9 = Command_StructureExit : CONTROLBAR:StructureExit "Abandonar Estrutura"
   10 = Command_StructureExit : CONTROLBAR:StructureExit "Abandonar Estrutura"
   11 = Command_TunnelEvacuate : CONTROLBAR:Evacuate "Evacuar: &V"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3249,7 +3249,7 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   1 = Command_GLAInfantryRebelCaptureBuilding : CONTROLBAR:CaptureBuilding "Capturar Estrutura: &C"
   2 = Command_GLAInfantryRebelBoobyTrapAttack : CONTROLBAR:BoobyTrapAttack "Ataque de Armadilha Explosiva: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3262,7 +3262,7 @@ End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3275,7 +3275,7 @@ End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3292,7 +3292,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   4 = Demo_Command_KellRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Plantar Carga Remota: &R"
   6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Detonar Explosivos: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3305,7 +3305,7 @@ End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   1 = Command_RadarVanScan : CONTROLBAR:RadarVanScan "Varredura de Radar: &V"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3318,7 +3318,7 @@ End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3330,8 +3330,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
@@ -3341,12 +3341,12 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   1 = Command_GLAInfantryHijack : CONTROLBAR:Hijack "Sequestrar: &R"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3368,7 +3368,7 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Sair do Transporte"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuar: &V"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3381,7 +3381,7 @@ End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicídio"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3698,8 +3698,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bomba Biológica: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3859,8 +3859,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bomba Biológica: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/de_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/de_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Atombombe zünden: &O"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Atombombe zünden: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Stopp: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -3166,7 +3166,7 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Cyborg-Trupp: &T"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Infiltrator: &I"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Gebäude besetzen: &G"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Jetzt zünden!"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Sprengen"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Sammelpunkt: &U"
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"

--- a/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar cabeza nuc: &N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar cabeza nuc: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -562,8 +562,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombas: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Convertir en centro de mando real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Convertir en barracones reales: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Convertir en reserva de suministros real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Convertir en tienda de armas real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Convertir en mercado negro real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2501,7 +2501,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Evacuar"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Evacuar"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuar: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
@@ -2511,7 +2511,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -3072,8 +3072,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3238,7 +3238,7 @@ End
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3258,7 +3258,7 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   5 = Command_TransportExit : CONTROLBAR:TransportExit "Evacuar"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuar: &V"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3273,7 +3273,7 @@ End
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   1 = Command_GLAToxinTractorContaminateGround : CONTROLBAR:Contaminate "Contaminar: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3287,7 +3287,7 @@ End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3301,7 +3301,7 @@ End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3324,7 +3324,7 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   8 = Demo_Command_ConstructGLAScudStorm : CONTROLBAR:ConstructGLAScudStorm "Tormenta SCUD: &O"
   9 = Demo_Command_ConstructGLAArmsDealer : CONTROLBAR:ConstructGLAArmsDealer "Tienda de armas: &A"
   10 = Demo_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "Centro de mando: &C"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "Cambiar a edificios falsos: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Despejar minas"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3342,7 +3342,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Reserva de suministros falsa: &R"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Tienda de armas falsa: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Mercado negro falso: &M"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Cambiar a edificios reales: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Despejar minas"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3361,7 +3361,7 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   6 = Command_EmergencyRepair : CONTROLBAR:EmergencyRepair "Reparación de Emergencia: &E"
   7 = Command_AnthraxBomb : CONTROLBAR:AnthraxBomb "Bomba de Ántrax: &B"
   8 = Command_SneakAttack : CONTROLBAR:SneakAttack "Ataque furtivo: &F"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto de concentración: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3372,7 +3372,7 @@ End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
   1 = Demo_Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "Trabajador: &T"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto de concentración: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3390,7 +3390,7 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   6 = Command_Evacuate : CONTROLBAR:Evacuate "Evacuar: &V"
   7 = Command_UpgradeGLAFortifiedStructure : CONTROLBAR:UpgradeGLAFortifiedStructure "Edificio fortificado: &E"
   8 = Command_UpgradeGLAArmTheMob : CONTROLBAR:UpgradeGLAArmTheMob "Armar las Turbas: &T"
-  11 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  11 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3406,13 +3406,13 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Turba: &U"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Tomar edificio: &T"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto de concentración: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, K, L, M, O, P, S, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, K, L, M, N, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3421,7 +3421,7 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   3 = Command_UpgradeGLAJunkRepair : CONTROLBAR:UpgradeGLAJunkRepair "Reparación de chapa: &P"
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "Barrido del radar: &D"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "Botas de trabajador: &S"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
@@ -3430,7 +3430,7 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3441,7 +3441,7 @@ End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "Tormenta SCUD: &U"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
@@ -3461,7 +3461,7 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   9 = Command_StructureExit : CONTROLBAR:StructureExit "Salir de estructura"
   10 = Command_StructureExit : CONTROLBAR:StructureExit "Salir de estructura"
   11 = Command_TunnelEvacuate : CONTROLBAR:Evacuate "Evacuar: &V"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3495,7 +3495,7 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   1 = Command_GLAInfantryRebelCaptureBuilding : CONTROLBAR:CaptureBuilding "Tomar edificio: &T"
   2 = Command_GLAInfantryRebelBoobyTrapAttack : CONTROLBAR:BoobyTrapAttack "Ataque trampa explosiva: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3509,7 +3509,7 @@ End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3523,7 +3523,7 @@ End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3541,7 +3541,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   4 = Demo_Command_KellRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Carga de demolición remota: &R"
   6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Detonar cargas: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3555,7 +3555,7 @@ End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   1 = Command_RadarVanScan : CONTROLBAR:RadarVanScan "Barrido del radar: &D"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3569,7 +3569,7 @@ End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3582,8 +3582,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
@@ -3594,12 +3594,12 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   1 = Command_GLAInfantryHijack : CONTROLBAR:Hijack "Secuestrar: &J"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3622,7 +3622,7 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Evacuar"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuar: &V"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3636,7 +3636,7 @@ End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonar"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3978,8 +3978,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombas: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4151,8 +4151,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombas: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Faire exploser arme nucléaire: &N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Faire exploser arme nucléaire: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -211,7 +211,7 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   1 = Command_ColonelBurtonKnifeAttack : CONTROLBAR:KnifeAttack "Attaque au couteau: &O"
   2 = Command_ColonelBurtonTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_ColonelBurtonRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
+  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -220,13 +220,13 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, P, U, V, W, Y, Z, 
 End
 
 CommandSet AmericaInfantryCIAAgentCommandSet
   2 = Command_CIAAgentTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_CIAAgentRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_CIAAgentDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
+  6 = Command_CIAAgentDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -235,7 +235,7 @@ CommandSet AmericaInfantryCIAAgentCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
 End
 
 CommandSet AmericaInfantryMissileDefenderCommandSet
@@ -525,8 +525,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Feu maintenant !"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant !"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bombes bactériologiques: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,7 +1688,7 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Déclenchez l'explosion !"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Faites exploser maintenant !"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Changer en vrai bâtiment: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -1697,7 +1697,7 @@ CommandSet FakeGLACommandCenterCommandSet
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Déclenchez l'explosion !"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Faites exploser maintenant !"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Changer en vrai bâtiment: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -1706,7 +1706,7 @@ CommandSet FakeGLABarracksCommandSet
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Déclenchez l'explosion !"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Faites exploser maintenant !"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Changer en vrai bâtiment: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -1715,7 +1715,7 @@ CommandSet FakeGLASupplyStashCommandSet
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Déclenchez l'explosion !"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Faites exploser maintenant !"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Changer en vrai bâtiment: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -1724,7 +1724,7 @@ CommandSet FakeGLAArmsDealerCommandSet
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Déclenchez l'explosion !"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Faites exploser maintenant !"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Changer en vrai bâtiment: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -1791,11 +1791,11 @@ End
 CommandSet GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Feu ! &F"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -2293,11 +2293,11 @@ End
 CommandSet GC_Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Feu ! &F"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2323,7 +2323,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Descendre"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Descendre"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuer: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -2332,7 +2332,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -2755,11 +2755,11 @@ End
 CommandSet Demo_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Feu ! &F"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2816,7 +2816,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack : CONTROLBAR:SniperAttack "Attaque de sniper: &N"
   2 = Demo_Command_KellTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Demo_Command_KellRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
+  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -2825,7 +2825,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSet
@@ -2853,8 +2853,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Feu maintenant !"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant !"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3008,7 +3008,7 @@ End
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3027,7 +3027,7 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   5 = Command_TransportExit : CONTROLBAR:TransportExit "Descendre"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuer: &V"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3041,7 +3041,7 @@ End
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   1 = Command_GLAToxinTractorContaminateGround : CONTROLBAR:Contaminate "Contaminer: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3054,7 +3054,7 @@ End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3067,7 +3067,7 @@ End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3089,7 +3089,7 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   8 = Demo_Command_ConstructGLAScudStorm : CONTROLBAR:ConstructGLAScudStorm "Scuds multiples: &L"
   9 = Demo_Command_ConstructGLAArmsDealer : CONTROLBAR:ConstructGLAArmsDealer "Trafiquant d'armes: &A"
   10 = Demo_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "Poste de commandement: &C"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "Décors: &D"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Déminer"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3106,7 +3106,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   3 = Demo_Command_ConstructFakeGLASupplyStash : CONTROLBAR:ConstructFakeGLASupplyStash "Décor Cache de ravitaillement: &I"
   4 = Demo_Command_ConstructFakeGLAArmsDealer : CONTROLBAR:ConstructFakeGLAArmsDealer "Décor Trafiquant d'armes: &A"
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "Décor Marché noir: &M"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "Vraies structures: &V"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "Déminer"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3124,7 +3124,7 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   6 = Command_EmergencyRepair : CONTROLBAR:EmergencyRepair "Réparer véhicules: &V"
   7 = Command_AnthraxBomb : CONTROLBAR:AnthraxBomb "Bombe Anthrax: &B"
   8 = Command_SneakAttack : CONTROLBAR:SneakAttack "Attaque furtive: &T"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3134,7 +3134,7 @@ End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
   1 = Demo_Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "Ouvrier: &O"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3151,7 +3151,7 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   6 = Command_Evacuate : CONTROLBAR:Evacuate "Evacuer: &V"
   7 = Command_UpgradeGLAFortifiedStructure : CONTROLBAR:UpgradeGLAFortifiedStructure "Structure fortifiée: &E"
   8 = Command_UpgradeGLAArmTheMob : CONTROLBAR:UpgradeGLAArmTheMob "Armer les émeutiers: &M"
-  11 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  11 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3166,7 +3166,7 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Emeutiers: &U"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Prendre bâtiment: &P"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Déclenchez l'explosion !"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3180,7 +3180,7 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   3 = Command_UpgradeGLAJunkRepair : CONTROLBAR:UpgradeGLAJunkRepair "Matériel de réparation: &T"
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "Scanner: &A"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "Chaussures renforcées: &S"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
@@ -3188,7 +3188,7 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3198,7 +3198,7 @@ End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "Scuds: &U"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
@@ -3217,7 +3217,7 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   9 = Command_StructureExit : CONTROLBAR:StructureExit "Quitter bâtiment"
   10 = Command_StructureExit : CONTROLBAR:StructureExit "Quitter bâtiment"
   11 = Command_TunnelEvacuate : CONTROLBAR:Evacuate "Evacuer: &V"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
@@ -3249,7 +3249,7 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   1 = Command_GLAInfantryRebelCaptureBuilding : CONTROLBAR:CaptureBuilding "Prendre bâtiment: &P"
   2 = Command_GLAInfantryRebelBoobyTrapAttack : CONTROLBAR:BoobyTrapAttack "Poser mines artisanales: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3262,7 +3262,7 @@ End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3275,7 +3275,7 @@ End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3290,9 +3290,9 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack : CONTROLBAR:SniperAttack "Attaque de sniper: &N"
   2 = Demo_Command_KellTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Demo_Command_KellRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
+  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3300,12 +3300,12 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   1 = Command_RadarVanScan : CONTROLBAR:RadarVanScan "Scanner: &C"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3318,7 +3318,7 @@ End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3330,8 +3330,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Feu maintenant !"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant !"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
@@ -3341,12 +3341,12 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   1 = Command_GLAInfantryHijack : CONTROLBAR:Hijack "Détourner: &T"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3368,7 +3368,7 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Descendre"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuer: &V"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3381,7 +3381,7 @@ End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
-  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Détonation"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap SELECT_MATCHING_UNITS : "E"
@@ -3604,11 +3604,11 @@ End
 CommandSet Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Feu ! &F"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3698,8 +3698,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Feu maintenant !"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant !"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bombes bactériologiques: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3859,8 +3859,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Feu maintenant !"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant !"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bombes bactériologiques: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet
@@ -4634,7 +4634,7 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   1 = Command_ColonelBurtonKnifeAttack : CONTROLBAR:KnifeAttack "Attaque au couteau: &O"
   2 = Command_ColonelBurtonTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_ColonelBurtonRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
+  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -4643,7 +4643,7 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, P, U, V, W, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
@@ -5588,7 +5588,7 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   1 = Command_ColonelBurtonKnifeAttack : CONTROLBAR:KnifeAttack "Attaque au couteau: &O"
   2 = Command_ColonelBurtonTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_ColonelBurtonRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
+  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -5597,7 +5597,7 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, P, U, V, W, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleChinookCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonazione nucleare: &N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonazione nucleare: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -526,7 +526,7 @@ End
 
 CommandSet GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombe: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Trasforma in vero Centro comando: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Trasforma in vera Caserma: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Trasforma in vero Nucleo rifornimenti: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Trasforma in vero Trafficante d'armi: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Trasforma in vero Mercato nero: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2854,7 +2854,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Pattuglia: &G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3166,12 +3166,12 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Folla inferocita: &Y"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Conquista struttura: &C"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicidio: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, O, P, S, U, V, W, X, Z, 
+    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, W, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3331,7 +3331,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Pattuglia: &G"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3699,7 +3699,7 @@ End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombe: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3860,7 +3860,7 @@ End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombe: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Pattuglia: &G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "핵 폭발: &N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "핵 폭발: &D"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -562,8 +562,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "바이오폭탄: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "실제 커맨드 센터로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "실제 막사로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "실제 서플라이 은닉처로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "실제 무기상으로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "실제 암시장으로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2501,7 +2501,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "나가기"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "나가기"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
@@ -2511,7 +2511,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -3072,8 +3072,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3406,13 +3406,13 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "성난 군중: &Y"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "쟈멘 켈: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "건물 점령: &C"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, O, P, S, U, V, X, Z, 
+    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3582,8 +3582,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
@@ -3594,7 +3594,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3978,8 +3978,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "바이오폭탄: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4151,8 +4151,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "바이오폭탄: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonacja bomby atomowej: &Y"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonacja bomby atomowej: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -525,8 +525,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobomby: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
+    Available keys: F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Przekształć w prawdziwy sztab: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Przekształć w prawdziwe koszary: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Przekształć w prawdziwy skład zaopatrzenia: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Przekształć w prawdziwego handlarza bronią: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Przekształć w prawdziwy czarny rynek: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -1791,11 +1791,11 @@ End
 CommandSet GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -2293,11 +2293,11 @@ End
 CommandSet GC_Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2323,7 +2323,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Wyjście z transportowca"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Wyjście z transportowca"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Ewakuacja: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Straż: &T"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
@@ -2332,7 +2332,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, G, I, J, K, L, M, N, O, P, R, U, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, U, W, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -2755,11 +2755,11 @@ End
 CommandSet Demo_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2853,8 +2853,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Straż: &T"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
+    Available keys: B, F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3166,12 +3166,12 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Wściekły tłum: &W"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Zajmij budynek: &Z"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonuj: &J"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punkt zborny: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, K, L, M, P, S, U, V, X, Y, 
+    Available keys: A, C, D, E, F, G, I, K, L, M, N, P, S, U, V, X, Y, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3330,8 +3330,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Straż: &T"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
+    Available keys: B, F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3604,11 +3604,11 @@ End
 CommandSet Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3698,8 +3698,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobomby: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
+    Available keys: F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3859,8 +3859,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobomby: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Straż: &T"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, G, I, J, K, L, M, O, P, R, U, V, W, Y, Z, 
+    Available keys: F, G, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/pl_key_conflict.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/pl_key_conflict.txt
@@ -1,5 +1,9 @@
+Demo_GLABarracksCommandSetUpgrade has key conflict with
+  6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Detonuj: &J"
+
 Slth_GLAArmsDealerCommandSet has key conflict with
   11 = Slth_Command_ConstructGLAVehicleCombatBike : CONTROLBAR:ConstructGLAVehicleCombatBike "Motor bojowy: &T"
   15 = Command_ConstructGLAVehicleCombatBikeTerrorist : CONTROLBAR:ConstructGLAVehicleCombatBike "Motor bojowy: &T"
 
-1 conflicts found
+2 conflicts found

--- a/Patch104pZH/Design/Scripts/str/generated/ru_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ru_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Взорвать ядерную бомбу: &N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Взорвать ядерную бомбу: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Стоп: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -562,7 +562,7 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
   3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать!"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Биологическая бомба: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Построить настоящий командный центр: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Построить настоящую казарму: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Построить настоящий склад снабжения: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Построить настоящего торговца оружием: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Построить настоящий чёрный рынок: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2501,7 +2501,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Выход из транспорта"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Выход из транспорта"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Эвакуация: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Охрана: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Стоп: &S"
@@ -2511,7 +2511,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -3072,7 +3072,7 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
   3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать!"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3406,13 +3406,13 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Разъярённая толпа: &Y"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Джармен Келл: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Захват здания: &C"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Самоубийство: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Точка сбора: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, D, E, F, I, K, L, M, O, P, S, U, V, X, Z, 
+    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3582,7 +3582,7 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
   3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать!"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
@@ -3594,7 +3594,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3978,7 +3978,7 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
   3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать!"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Биологическая бомба: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4151,7 +4151,7 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
   3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать!"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Биологическая бомба: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/us_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/us_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonate Nuke: &N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonate Nuke: &D"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -562,8 +562,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "BioBombs: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Become Real Command Center: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Become Real Barracks: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Become Real Supply Stash: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Become Real Arms Dealer: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Become Real Black Market: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2501,7 +2501,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Exit Transport"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Exit Transport"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuate: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
@@ -2511,7 +2511,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -3072,8 +3072,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3406,13 +3406,13 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "Angry Mob: &Y"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "Jarmen Kell: &J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "Capture Building: &C"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Rally Point: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, D, E, F, I, K, L, M, O, P, S, U, V, X, Z, 
+    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3582,8 +3582,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
@@ -3594,7 +3594,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3978,8 +3978,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "BioBombs: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4151,8 +4151,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "BioBombs: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "引爆核武：&N"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "引爆核武：&D"
   14 = Command_Stop : CONTROLBAR:Stop "停止：&S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -525,8 +525,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立刻爆炸：&N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "生化炸彈：&B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "轉變為指揮中心：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "轉變為兵營：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "轉變為補給站：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "轉變為軍火商：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "轉變為黑市：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2323,7 +2323,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "離開運輸"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "離開運輸"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "撤退：&V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&D"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
   13 = Command_Guard : CONTROLBAR:Guard "防禦：&G"
   14 = Command_Stop : CONTROLBAR:Stop "停止：&S"
@@ -2332,7 +2332,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -2853,8 +2853,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立刻爆炸：&N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
   13 = Command_Guard : CONTROLBAR:Guard "防禦：&G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3166,12 +3166,12 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   4 = Demo_Command_ConstructGLAInfantryAngryMob : CONTROLBAR:ConstructGLAInfantryAngryMob "狂暴暴民：&Y"
   6 = Demo_Command_ConstructGLAInfantryJarmenKell : CONTROLBAR:ConstructGLAInfantryJarmenKell "賈曼卡爾：&J"
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "佔領建築物：&C"
-  12 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
+  12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "自殺：&I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "集合點：&R"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, O, P, S, U, V, W, X, Z, 
+    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, W, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3330,8 +3330,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立刻爆炸：&N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
   13 = Command_Guard : CONTROLBAR:Guard "防禦：&G"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3698,8 +3698,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立刻爆炸：&N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "生化炸彈：&B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3859,8 +3859,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&D"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立刻爆炸：&N"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "生化炸彈：&B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
   13 = Command_Guard : CONTROLBAR:Guard "防禦：&G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2662,7 +2662,7 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
 ;patch104p-optional-end
 End
 
-CommandSet Demo_GLACommandCenterCommandSetUpgrade
+CommandSet Demo_GLACommandCenterCommandSetUpgrade ; unused
   1  = Demo_Command_ConstructGLAWorker
   4  = Command_GPSScrambler
   5  = Demo_Command_Ambush
@@ -2674,7 +2674,7 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   14 = Command_Sell
 End
 
-CommandSet Demo_GLASupplyStashCommandSetUpgrade
+CommandSet Demo_GLASupplyStashCommandSetUpgrade ; unused
   1  = Demo_Command_ConstructGLAWorker
   12 = Demo_Command_TertiarySuicide
   13 = Command_SetRallyPoint
@@ -2682,7 +2682,7 @@ CommandSet Demo_GLASupplyStashCommandSetUpgrade
 End
 
 ; Patch104p @tweak commy 20/09/2021 Adds stop button. (#386)
-CommandSet Demo_GLAPalaceCommandSetUpgrade
+CommandSet Demo_GLAPalaceCommandSetUpgrade ; unused
   1  = Command_StructureExit
   2  = Command_StructureExit
   3  = Command_StructureExit
@@ -2697,7 +2697,7 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   14 = Command_Sell
 End
 
-CommandSet Demo_GLABarracksCommandSetUpgrade
+CommandSet Demo_GLABarracksCommandSetUpgrade ; unused
   1  = Demo_Command_ConstructGLAInfantryRebel
   2  = Demo_Command_ConstructGLAInfantryRPGTrooper
   3  = Demo_Command_ConstructGLAInfantryTerrorist
@@ -2705,12 +2705,12 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   6  = Demo_Command_ConstructGLAInfantryJarmenKell
 ; 8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
-  12 = Command_DetonateFakeBuilding
+  12 = Demo_Command_TertiarySuicide
   13 = Command_SetRallyPoint
   14 = Command_Sell
 End
 
-CommandSet Demo_GLABlackMarketCommandSetUpgrade
+CommandSet Demo_GLABlackMarketCommandSetUpgrade ; unused
   1  = Command_UpgradeGLAAPBullets
   2  = Command_UpgradeGLAAPRockets
   3  = Command_UpgradeGLAJunkRepair
@@ -2726,7 +2726,7 @@ CommandSet Demo_GLAStingerSiteCommandSetUpgrade
   14 = Command_Sell
 End
 
-CommandSet Demo_GLAScudStormCommandSetUpgrade
+CommandSet Demo_GLAScudStormCommandSetUpgrade ; unused
   1  = Command_ScudStorm
   12 = Demo_Command_TertiarySuicide
   14 = Command_Sell
@@ -2750,7 +2750,7 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell
 End
 
-CommandSet Demo_GLAArmsDealerCommandSetUpgrade
+CommandSet Demo_GLAArmsDealerCommandSetUpgrade ; unused
   1  = Demo_Command_ConstructGLATankScorpion
   2  = Demo_Command_ConstructGLAVehicleTechnical
   3  = Demo_Command_ConstructGLAVehicleRadarVan


### PR DESCRIPTION
* Relates to #2095

This change streamlines key mappings for all detonation related buttons, except suicide. Previously mappings were all over the place. Now they are all simply bound to "D", which makes them easier to use and learn.

### Note

Changes are moved to Optional bundle with #2247

## Patched (Core)

Det. = Detonate

| Language   | Disguise | Det. Charges | Det. Nuke | Det. Demo Trap | Det. Bomb Truck | Det. Fake Building |
|------------|----------|--------------|-----------|----------------|-----------------|--------------------|
| US         | D        | D            | N         | D              | N               | N                  |
| DE         | T        | D            | O         | D              | D               | D                  |
| FR         | D        | P            | N         | F              | F               | D                  |
| ES         | D        | D            | N         | D              | N               | N                  |
| IT         | M        | D            | N         | D              | N               | N                  |
| KO         | C        | D            | N         | D              | N               | N                  |
| ZH         | C        | D            | N         | D              | N               | N                  |
| BP         | C        | D            | N         | D              | I               | A                  |
| PL         | C        | D            | Y         | J              | N               | N                  |

## Patched (Optional)

Det. = Detonate

| Language   | Disguise | Det. Charges | Det. Nuke | Det. Demo Trap | Det. Bomb Truck | Det. Fake Building |
|------------|----------|--------------|-----------|----------------|-----------------|--------------------|
| US         | C        | D            | D         | D              | D               | D                  |
| DE         | T        | D            | D         | D              | D               | D                  |
| FR         | C        | D            | D         | D              | D               | D                  |
| ES         | C        | D            | D         | D              | D               | D                  |
| IT         | M        | D            | D         | D              | D               | D                  |
| KO         | C        | D            | D         | D              | D               | D                  |
| ZH         | C        | D            | D         | D              | D               | D                  |
| BP         | C        | D            | D         | D              | D               | D                  |
| PL         | C        | D            | D         | D              | D               | D                  |
