### PR TITLE
Change: Streamline key mappings for all detonation related buttons, except suicide (2)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2244_detonate_key_mapping.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2244_detonate_key_mapping.yaml
@@ -7,15 +7,16 @@ changes:
   - tweak: The detonate abilities for C4 charges, Convoy Nuke, GLA Demo Trap, GLA Bomb Truck and GLA Fake Structure can now be used with key D instead of various other keys in all languages.
 
 labels:
-  - controversial
   - gla
   - minor
+  - optional
   - text
   - usa
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2244
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2247
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar Bomba Nuclear: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar Bomba Nuclear: &N"
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -526,7 +526,7 @@ End
 
 CommandSet GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bomba Biológica: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &A"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Tornar Verdadeiro o Centro de Comando: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &A"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Tornar Verdadeiro o Quartel: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &A"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Tornar Verdadeiro o Armazém de Suprimentos: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &A"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Tornar Verdadeiro o Negociante de Armas: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonar Agora! &A"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Tornar Verdadeiro o Mercado Negro: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2854,7 +2854,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3331,7 +3331,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3699,7 +3699,7 @@ End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bomba Biológica: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de Alto-Explosivo: &M"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3860,7 +3860,7 @@ End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disfarçar: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonar Agora! &I"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bomba Biológica: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Mover e Atacar: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Proteger: &G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/de_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/de_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Atombombe zünden: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Atombombe zünden: &O"
   14 = Command_Stop : CONTROLBAR:Stop "Stopp: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -2055,12 +2055,12 @@ CommandSet GC_Chem_GLAPalaceCommandSet
   6 = Command_Evacuate : CONTROLBAR:Evacuate "Evakuieren: &V"
   7 = Command_UpgradeGLAFortifiedStructure : CONTROLBAR:UpgradeGLAFortifiedStructure "Befestigte Struktur: &E"
   8 = Command_UpgradeGLAArmTheMob : CONTROLBAR:UpgradeGLAArmTheMob "Cyborg-Trupp bewaffnen: &B"
-  11 = GC_Chem_Command_UpgradeGLAAnthraxGamma : CONTROLBAR:UpgradeGLAAnthraxGamma "Gamma-Upgrade: &X"
+  11 = GC_Chem_Command_UpgradeGLAAnthraxGamma : CONTROLBAR:UpgradeGLAAnthraxGamma "Gamma-Upgrade: &G"
   13 = Command_Stop : CONTROLBAR:Stop "Stopp: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLACommandCenterCommandSet
@@ -3894,12 +3894,12 @@ CommandSet Chem_GLAPalaceCommandSet
   6 = Command_Evacuate : CONTROLBAR:Evacuate "Evakuieren: &V"
   7 = Command_UpgradeGLAFortifiedStructure : CONTROLBAR:UpgradeGLAFortifiedStructure "Befestigte Struktur: &E"
   8 = Command_UpgradeGLAArmTheMob : CONTROLBAR:UpgradeGLAArmTheMob "Cyborg-Trupp bewaffnen: &B"
-  11 = Chem_Command_UpgradeGLAAnthraxGamma : CONTROLBAR:UpgradeGLAAnthraxGamma "Gamma-Upgrade: &X"
+  11 = Chem_Command_UpgradeGLAAnthraxGamma : CONTROLBAR:UpgradeGLAAnthraxGamma "Gamma-Upgrade: &G"
   13 = Command_Stop : CONTROLBAR:Stop "Stopp: &S"
   14 = Command_Sell : CONTROLBAR:Sell "Verkaufen"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
 End
 
 CommandSet Chem_GLACommandCenterCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/es_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar cabeza nuc: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonar cabeza nuc: &N"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -562,8 +562,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombas: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Convertir en centro de mando real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Convertir en barracones reales: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Convertir en reserva de suministros real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Convertir en tienda de armas real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "¡Detonar ya! &N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Convertir en mercado negro real: &C"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2501,7 +2501,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Evacuar"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Evacuar"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuar: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Detener: &S"
@@ -2511,7 +2511,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -3072,8 +3072,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3582,8 +3582,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
@@ -3594,7 +3594,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3978,8 +3978,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombas: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba de alto explosivo: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4151,8 +4151,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Camuflar como vehículo: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "¡Detonar ya! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombas: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Movimiento de ataque: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Vigilar: &G"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Faire exploser arme nucléaire: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Faire exploser arme nucléaire: &N"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -211,7 +211,7 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   1 = Command_ColonelBurtonKnifeAttack : CONTROLBAR:KnifeAttack "Attaque au couteau: &O"
   2 = Command_ColonelBurtonTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_ColonelBurtonRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
+  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -220,13 +220,13 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, P, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
 End
 
 CommandSet AmericaInfantryCIAAgentCommandSet
   2 = Command_CIAAgentTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_CIAAgentRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_CIAAgentDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
+  6 = Command_CIAAgentDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -235,7 +235,7 @@ CommandSet AmericaInfantryCIAAgentCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, U, V, W, Y, Z, 
 End
 
 CommandSet AmericaInfantryMissileDefenderCommandSet
@@ -525,8 +525,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &F"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bombes bactériologiques: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1791,11 +1791,11 @@ End
 CommandSet GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &F"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -2293,11 +2293,11 @@ End
 CommandSet GC_Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &F"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2323,7 +2323,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Descendre"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Descendre"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuer: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -2332,7 +2332,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -2755,11 +2755,11 @@ End
 CommandSet Demo_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &F"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2816,7 +2816,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack : CONTROLBAR:SniperAttack "Attaque de sniper: &N"
   2 = Demo_Command_KellTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Demo_Command_KellRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
+  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -2825,7 +2825,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSet
@@ -2853,8 +2853,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &F"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3290,7 +3290,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack : CONTROLBAR:SniperAttack "Attaque de sniper: &N"
   2 = Demo_Command_KellTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Demo_Command_KellRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
+  6 = Demo_Command_KellDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "Suicide: &J"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
@@ -3300,7 +3300,7 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, O, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
@@ -3330,8 +3330,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &F"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3604,11 +3604,11 @@ End
 CommandSet Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Explosion à proximité: &P"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Commande manuelle: &M"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Faites exploser ! &F"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3698,8 +3698,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &F"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bombes bactériologiques: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Explosif C-404: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3859,8 +3859,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Se déguiser en véhicule: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Faites exploser maintenant ! &F"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Bombes bactériologiques: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet
@@ -4634,7 +4634,7 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   1 = Command_ColonelBurtonKnifeAttack : CONTROLBAR:KnifeAttack "Attaque au couteau: &O"
   2 = Command_ColonelBurtonTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_ColonelBurtonRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
+  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -4643,7 +4643,7 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, P, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
@@ -5588,7 +5588,7 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   1 = Command_ColonelBurtonKnifeAttack : CONTROLBAR:KnifeAttack "Attaque au couteau: &O"
   2 = Command_ColonelBurtonTimedDemoCharge : CONTROLBAR:TimedDemoCharge "Charge à retardement: &T"
   4 = Command_ColonelBurtonRemoteDemoCharge : CONTROLBAR:RemoteDemoCharge "Charge télécommandée: &R"
-  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &D"
+  6 = Command_ColonelBurtonDetonateCharges : CONTROLBAR:DetonateCharges "Faire exploser charges: &P"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attaquer: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Protéger: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
@@ -5597,7 +5597,7 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, P, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleChinookCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonazione nucleare: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonazione nucleare: &N"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -526,7 +526,7 @@ End
 
 CommandSet GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombe: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Trasforma in vero Centro comando: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Trasforma in vera Caserma: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Trasforma in vero Nucleo rifornimenti: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Trasforma in vero Trafficante d'armi: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Esplosione immediata! &N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Trasforma in vero Mercato nero: &T"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2854,7 +2854,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Pattuglia: &G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3331,7 +3331,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Pattuglia: &G"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3699,7 +3699,7 @@ End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombe: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba ad alto potenziale: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3860,7 +3860,7 @@ End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Mimetizza come veicolo: &M"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Esplosione immediata! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobombe: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Avanzamento ostile: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Pattuglia: &G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "핵 폭발: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "핵 폭발: &N"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -563,7 +563,7 @@ End
 
 CommandSet GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "바이오폭탄: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "실제 커맨드 센터로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "실제 막사로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "실제 서플라이 은닉처로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "실제 무기상으로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "실제 암시장으로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -3073,7 +3073,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3583,7 +3583,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
@@ -3594,7 +3594,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3979,7 +3979,7 @@ End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "바이오폭탄: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "HE 폭탄: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4152,7 +4152,7 @@ End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "차량 변장: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "지금 폭파! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "바이오폭탄: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/pl_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonacja bomby atomowej: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonacja bomby atomowej: &Y"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -526,7 +526,7 @@ End
 
 CommandSet GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobomby: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
+    Available keys: D, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Przekształć w prawdziwy sztab: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Przekształć w prawdziwe koszary: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Przekształć w prawdziwy skład zaopatrzenia: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Przekształć w prawdziwego handlarza bronią: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonuj! &N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Przekształć w prawdziwy czarny rynek: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -1791,11 +1791,11 @@ End
 CommandSet GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -2293,11 +2293,11 @@ End
 CommandSet GC_Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2755,11 +2755,11 @@ End
 CommandSet Demo_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2854,7 +2854,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Straż: &T"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3331,7 +3331,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Straż: &T"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3604,11 +3604,11 @@ End
 CommandSet Slth_GLADemoTrapCommandSet
   1 = Command_SetDemoTrapProximityDetonation : CONTROLBAR:ProximityFuse "Zapalnik zbliżeniowy: &Z"
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "Sterowanie ręczne: &W"
-  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &D"
+  5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "Detonuj! &J"
   14 = Command_Sell : CONTROLBAR:Sell "Sprzedaż"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3699,7 +3699,7 @@ End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobomby: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Bomba krusząca: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, L, M, N, P, R, U, V, W, Y, Z, 
+    Available keys: D, F, G, I, J, K, L, M, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3860,7 +3860,7 @@ End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Zamaskuj się jako pojazd: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonuj! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Biobomby: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Ruch ofensywny: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Straż: &T"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: D, F, G, I, J, K, L, M, O, P, R, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/ru_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ru_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Взорвать ядерную бомбу: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Взорвать ядерную бомбу: &N"
   14 = Command_Stop : CONTROLBAR:Stop "Стоп: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -563,7 +563,7 @@ End
 
 CommandSet GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Биологическая бомба: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Построить настоящий командный центр: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Построить настоящую казарму: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Построить настоящий склад снабжения: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Построить настоящего торговца оружием: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Взорвать сейчас! &N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Построить настоящий чёрный рынок: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Продать"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -3073,7 +3073,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Охрана: &G"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3583,7 +3583,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Охрана: &G"
@@ -3594,7 +3594,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3979,7 +3979,7 @@ End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Биологическая бомба: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "Увеличить мощность взрывчатки: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4152,7 +4152,7 @@ End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Замаскироваться под другую технику: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Немедленно взорвать! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "Биологическая бомба: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Атака в движении: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Охрана: &G"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/us_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/us_commandsets.txt
@@ -196,12 +196,12 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonate Nuke: &D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "Detonate Nuke: &N"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -562,8 +562,8 @@ CommandSet GLAVehicleToxinTruckCommandSet
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "BioBombs: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
@@ -575,7 +575,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1809,53 +1809,53 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "Become Real Command Center: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "Become Real Barracks: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "Become Real Supply Stash: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "Become Real Arms Dealer: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "Detonate Now! &N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "Become Real Black Market: &B"
   14 = Command_Sell : CONTROLBAR:Sell "Sell"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
   CommandMap SELECT_ALL_AIRCRAFT : "W"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2501,7 +2501,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   7 = Command_TransportExit : CONTROLBAR:TransportExit "Exit Transport"
   8 = Command_TransportExit : CONTROLBAR:TransportExit "Exit Transport"
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "Evacuate: &V"
-  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
+  10 = GC_Slth_Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
@@ -2511,7 +2511,7 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
@@ -3072,8 +3072,8 @@ CommandSet Demo_GLAVehicleQuadCannon
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
@@ -3084,7 +3084,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3582,8 +3582,8 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
@@ -3594,7 +3594,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3978,8 +3978,8 @@ CommandSet Slth_GLAVehicleQuadCannon
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "BioBombs: &B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "High Explosive Bomb: &O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
@@ -3991,7 +3991,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -4151,8 +4151,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
-  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &D"
+  1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "Disguise as Vehicle: &D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "Detonate Now! &N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "BioBombs: &B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "Attack Move: &A"
   13 = Command_Guard : CONTROLBAR:Guard "Guard: &G"
@@ -4163,7 +4163,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet

--- a/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
@@ -185,11 +185,11 @@ CommandSet RailedTransportCommandSet
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
-  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "引爆核武：&D"
+  1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "引爆核武：&N"
   14 = Command_Stop : CONTROLBAR:Stop "停止：&S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -526,7 +526,7 @@ End
 
 CommandSet GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "生化炸彈：&B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
@@ -537,7 +537,7 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -1688,48 +1688,48 @@ CommandSet GLABarracksCommandSet
 End
 
 CommandSet FakeGLACommandCenterCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "轉變為指揮中心：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "轉變為兵營：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "轉變為補給站：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "轉變為軍火商：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
-  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&D"
+  1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "立即引爆：&N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "轉變為黑市：&B"
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -2854,7 +2854,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
   13 = Command_Guard : CONTROLBAR:Guard "防禦：&G"
@@ -2864,7 +2864,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -3331,7 +3331,7 @@ End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&N"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
   13 = Command_Guard : CONTROLBAR:Guard "防禦：&G"
@@ -3341,7 +3341,7 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3699,7 +3699,7 @@ End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "生化炸彈：&B"
   8 = Command_UpgradeGLABombTruckHighExplosiveBomb : CONTROLBAR:UpgradeGLABombTruckHighExplosiveBomb "高爆炸彈：&O"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
@@ -3710,7 +3710,7 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3860,7 +3860,7 @@ End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
   1 = Command_DisguiseAsVehicle : CONTROLBAR:DisguiseAsVehicle "載具偽裝：&C"
-  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&D"
+  3 = Command_BombTruckDetonateNow : CONTROLBAR:DetonateBombTruck "立即引爆：&N"
   7 = Command_UpgradeGLABombTruckBioBomb : CONTROLBAR:UpgradeGLABombTruckBioBomb "生化炸彈：&B"
   11 = Command_AttackMove : CONTROLBAR:AttackMove "移動攻擊：&A"
   13 = Command_Guard : CONTROLBAR:Guard "防禦：&G"
@@ -3870,7 +3870,7 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_ALL : "Q"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet


### PR DESCRIPTION
* Relates to #2095
* Follow up for #2244

This change demotes all key mapping changes of #2244 to Optional bundle pack.

Reason being, the new key mappings could mess with legacy players. For example if a player with English localization would press D to use the disguise ability of the Bomb Truck, then it would suddenly detonate and potentially cause upset.