### PR TITLE
Fix: Issues in tool tip strings of GLA Scud Launchers for all latin languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
@@ -5,6 +5,7 @@ title: Fixes inconsistent wording in Polish tool tip strings
 
 changes:
   - fix: The wording in Polish tool tip strings is more consistent now.
+  - fix: The tool tip string of the GLA Scud Launcher now has more consistent wording.
 
 labels:
   - minor
@@ -15,6 +16,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2148
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2153
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2249
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
@@ -7,6 +7,7 @@ changes:
   - fix: The wording in French tool tip strings is more consistent now.
   - fix: The French tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
   - fix: The TOOLTIP:NumberOfVotes, GUI:Ok, LAN:OK, MapTransfer:Done strings now have French text.
+  - fix: The tool tip string of the GLA Scud Launcher now has more consistent wording.
 
 labels:
   - minor
@@ -17,6 +18,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2249
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2249_scud_launcher_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2249_scud_launcher_tooltip.yaml
@@ -5,6 +5,7 @@ title: Adds proper tool tip variants to GLA Demo Scud Launcher and Toxin Scud La
 
 changes:
   - fix: The tool tip strings of the GLA Demo Scud Launcher and Toxin Scud Launcher now properly state the kind of warhead they carry in all latin languages.
+  - fix: The science strings of the GLA Scud Launcher no longer describe details about the rocket types.
 
 labels:
   - gla

--- a/Patch104pZH/Design/Changes/v1.0/2249_scud_launcher_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2249_scud_launcher_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Adds proper tool tip variants to GLA Demo Scud Launcher and Toxin Scud Launcher
+
+changes:
+  - fix: The tool tip strings of the GLA Demo Scud Launcher and Toxin Scud Launcher now properly state the kind of warhead they carry in all latin languages.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2249
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5739,7 +5739,7 @@ CommandButton Demo_Command_ConstructGLAVehicleScudLauncher
   TextLabel     = CONTROLBAR:ConstructGLAVehicleScudLauncher
   ButtonImage   = SUScudLauncher
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildSCUDLauncher
+  DescriptLabel           = CONTROLBAR:Demo_ToolTipGLABuildSCUDLauncher ; Patch104p @tweak from CONTROLBAR:ToolTipGLABuildSCUDLauncher (#2249)
 End
 
 
@@ -6034,7 +6034,7 @@ CommandButton Slth_Command_ConstructGLAVehicleScudLauncher
   TextLabel     = CONTROLBAR:ConstructGLAVehicleScudLauncher
   ButtonImage   = SUScudLauncher
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildSCUDLauncher
+  DescriptLabel           = CONTROLBAR:Demo_ToolTipGLABuildSCUDLauncher ; Patch104p @tweak from CONTROLBAR:ToolTipGLABuildSCUDLauncher (#2249)
 End
 
 CommandButton Slth_Command_DisguiseAsVehicle
@@ -6429,7 +6429,7 @@ CommandButton Chem_Command_ConstructGLAVehicleScudLauncher
   TextLabel     = CONTROLBAR:ConstructGLAVehicleScudLauncher
   ButtonImage   = SUScudLauncher
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildSCUDLauncher
+  DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildSCUDLauncher ; Patch104p @tweak from CONTROLBAR:ToolTipGLABuildSCUDLauncher (#2249)
 End
 
 


### PR DESCRIPTION
**Merge with Rebase**

This change adds correct tool tip strings to all GLA Scud Launcher variants for all latin languages. It also fixes 2 minor inconsistencies in French and Polish tool tip strings.