### PR TITLE
Change: Increase bonus firepower of China Frenzy to 30% flat, increase max duration from 30 to 40 s, decrease recharge from 240 to 180 s

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2251_frenzy_buff.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2251_frenzy_buff.yaml
@@ -14,7 +14,7 @@ labels:
   - v1.0
 
 links:
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/xxxx
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2251
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2251_frenzy_buff.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2251_frenzy_buff.yaml
@@ -1,16 +1,19 @@
 ---
 date: 2023-08-20
 
-title: Buffs Frenzy General's Power ability
+title: Increases effectiveness of China Frenzy ability
 
 changes:
-  - tweak: All levels of Frenzy now grant +30% fire power.
-  - tweak: Effect duration increased at Frenzy level 3: Progression is now 10, 20 and 40 seconds.
+  - tweak: All levels of China Frenzy now grant +30% fire power.
+  - tweak: Effect duration increased at Frenzy level 3. Progression is now 10, 20 and 40 seconds.
+  - tweak: Recharge time reduced to 3 minutes.
 
 labels:
   - buff
   - china
-  - minor
+  - controversial
+  - design
+  - major
   - v1.0
 
 links:

--- a/Patch104pZH/Design/Changes/v1.0/xxxx_frenzy_buff.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/xxxx_frenzy_buff.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-20
+
+title: Buffs Frenzy General's Power ability
+
+changes:
+  - tweak: All levels of Frenzy now grant +30% fire power.
+  - tweak: Effect duration increased at Frenzy level 3: Progression is now 10, 20 and 40 seconds.
+
+labels:
+  - buff
+  - china
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/xxxx
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -556,13 +556,14 @@ Object Frenzy_InvisibleMarker_Level1
     InitialHealth = 1
   End
 
+  ; Patch104p @balance commy2 20/08/2023 Change bonus to +30% damage for all Frenzy levels. (#xxxx)
   Behavior = WeaponBonusUpdate ModuleTag_02
     RequiredAffectKindOf = CAN_ATTACK ; Must be set
     ForbiddenAffectKindOf = STRUCTURE ; Must be clear
     BonusDuration = 10000             ; How long effect lasts
     BonusDelay = 100000               ; How often to pulse (short lifetime will trump, of course)
     BonusRange = 200                  ; Keep in line with radius cursor size in special power template
-    BonusConditionType = FRENZY_ONE   ; And which bonus to give
+    BonusConditionType = FRENZY_THREE ; And which bonus to give
   End
 
   Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
@@ -593,13 +594,14 @@ Object Frenzy_InvisibleMarker_Level2
     InitialHealth = 1
   End
 
+  ; Patch104p @balance commy2 20/08/2023 Change bonus to +30% damage for all Frenzy levels. (#xxxx)
   Behavior = WeaponBonusUpdate ModuleTag_02
     RequiredAffectKindOf = CAN_ATTACK ; Must be set
     ForbiddenAffectKindOf = STRUCTURE ; Must be clear
     BonusDuration = 20000             ; How long effect lasts
     BonusDelay = 100000               ; How often to pulse (short lifetime will trump, of course)
     BonusRange = 200                  ; Keep in line with radius cursor size in special power template
-    BonusConditionType = FRENZY_TWO   ; And which bonus to give
+    BonusConditionType = FRENZY_THREE ; And which bonus to give
   End
 
   Behavior = DeletionUpdate ModuleTag_03 ; Not LifetimeUpdate, since I can't die.  This will DestroyObject me.
@@ -630,10 +632,11 @@ Object Frenzy_InvisibleMarker_Level3
     InitialHealth = 1
   End
 
+  ; Patch104p @balance commy2 20/08/2023 Increase BonusDuration from 30000, so it doubles from level 2 to level 3. (#xxxx)
   Behavior = WeaponBonusUpdate ModuleTag_02
     RequiredAffectKindOf = CAN_ATTACK ; Must be set
     ForbiddenAffectKindOf = STRUCTURE ; Must be clear
-    BonusDuration = 30000             ; How long effect lasts
+    BonusDuration = 40000             ; How long effect lasts
     BonusDelay = 100000               ; How often to pulse (short lifetime will trump, of course)
     BonusRange = 200                  ; Keep in line with radius cursor size in special power template
     BonusConditionType = FRENZY_THREE ; And which bonus to give

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -556,7 +556,7 @@ Object Frenzy_InvisibleMarker_Level1
     InitialHealth = 1
   End
 
-  ; Patch104p @balance commy2 20/08/2023 Change bonus to +30% damage for all Frenzy levels. (#xxxx)
+  ; Patch104p @balance commy2 20/08/2023 Change bonus to +30% damage for all Frenzy levels. (#2251)
   Behavior = WeaponBonusUpdate ModuleTag_02
     RequiredAffectKindOf = CAN_ATTACK ; Must be set
     ForbiddenAffectKindOf = STRUCTURE ; Must be clear
@@ -594,7 +594,7 @@ Object Frenzy_InvisibleMarker_Level2
     InitialHealth = 1
   End
 
-  ; Patch104p @balance commy2 20/08/2023 Change bonus to +30% damage for all Frenzy levels. (#xxxx)
+  ; Patch104p @balance commy2 20/08/2023 Change bonus to +30% damage for all Frenzy levels. (#2251)
   Behavior = WeaponBonusUpdate ModuleTag_02
     RequiredAffectKindOf = CAN_ATTACK ; Must be set
     ForbiddenAffectKindOf = STRUCTURE ; Must be clear
@@ -632,7 +632,7 @@ Object Frenzy_InvisibleMarker_Level3
     InitialHealth = 1
   End
 
-  ; Patch104p @balance commy2 20/08/2023 Increase BonusDuration from 30000, so it doubles from level 2 to level 3. (#xxxx)
+  ; Patch104p @balance commy2 20/08/2023 Increase BonusDuration from 30000, so it doubles from level 2 to level 3. (#2251)
   Behavior = WeaponBonusUpdate ModuleTag_02
     RequiredAffectKindOf = CAN_ATTACK ; Must be set
     ForbiddenAffectKindOf = STRUCTURE ; Must be clear

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -270,7 +270,7 @@ End
 ;-----------------------------------------------------------------------------
 SpecialPower SuperweaponFrenzy
   Enum                = SPECIAL_FRENZY
-  ReloadTime          = 240000   ; in milliseconds. min is 2x door/open close time!
+  ReloadTime          = 180000   ; in milliseconds. min is 2x door/open close time!
   RequiredScience     = SCIENCE_Frenzy1
 ;  InitiateSound       = FireArtilleryCannonSound
   PublicTimer         = No
@@ -284,7 +284,7 @@ End
 ;-----------------------------------------------------------------------------
 SpecialPower Early_SuperweaponFrenzy
   Enum                = EARLY_SPECIAL_FRENZY
-  ReloadTime          = 240000   ; in milliseconds. min is 2x door/open close time!
+  ReloadTime          = 180000   ; in milliseconds. min is 2x door/open close time!
   RequiredScience     = Early_SCIENCE_Frenzy1
   InitiateAtLocationSound = FrenzyActivate
   PublicTimer         = No
@@ -297,7 +297,7 @@ End
 ;-----------------------------------------------------------------------------
 SpecialPower SuperweaponCashHack
   Enum              = SPECIAL_CASH_HACK
-  ReloadTime        = 240000   ; in milliseconds
+  ReloadTime        = 180000   ; in milliseconds
   RequiredScience   = SCIENCE_CashHack1
   PublicTimer       = No
   SharedSyncedTimer   = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -266,7 +266,7 @@ SpecialPower SuperweaponArtilleryBarrage
 End
 
 ; Patch104p @bugfix commy2 23/10/2021 Fix Frenzy special power revealed map.
-
+; Patch104p @balance commy2 20/08/2023 Decrease ReloadTime from 240000. (#2251)
 ;-----------------------------------------------------------------------------
 SpecialPower SuperweaponFrenzy
   Enum                = SPECIAL_FRENZY


### PR DESCRIPTION
- close https://github.com/TheSuperHackers/GeneralsGamePatch/issues/709

This change buffs the Frenzy ability at all levels.

### The bonus is now always +30% firepower. 

- 10% and even 20% are not meaningful enough bonuses, especially for a temporary ability.
- It is now immediately obvious what bonus applies: Glows red = +30% firepower.
- Frenzy is now useful right from the start. Upgraded levels only increase bonus duration.

### Duration of the bonus doubles with every level of Frenzy

- To make level 3 Frenzy somewhat appealing, the duration is now 40 seconds.
- The progression is now 10, 20 and 40 seconds. This follows to rule of many abilities to double in effectiveness on each level (Rebel Ambush 3 spawns 4 times as many Rebels as Ambush 1; Paradrop 3 spawns 4 times as many Rangers as Paradrop 1; Cash Hack: $1000, $2000, $4000, Cash Bounty: 5%, 10%, 20% etc.)

### The recharge time is now 3 minutes

- Unlike Artillery Barrage or Carpet Bombing, which are useful immediately after they recharged, Frenzy is situational (only useful if combat happens), so this inherent disadvantage is priced in into the recharge time now.

---

The Frenzy scan bug was previously removed: https://github.com/TheSuperHackers/GeneralsGamePatch/pull/593

---

Things left to consider: 

- Infantry General is the only sub-faction that starts out with Rank 1 Frenzy 1. Infantry General is also considered to be the strongest China sub-faction over all. It may be necessary to move Frenzy 1 to rank 3 for all factions if the buffed Frenzy 1 is deemed too effective to be available from the very beginning.
- This can be done in a follow-up change

---

Side effects:

- This change fixes a bug where different levels of Frenzy can be stacked on top of each other in team games for increased bonuses.

---

## Original

| Stat               | Frenzy 1 | Frenzy 2 | Frenzy 3 |
|--------------------|----------|----------|----------|
| Damage Bonus       | +10%     | +20%     | +30%     |
| Bonus Duration (s) | 10       | 20       | 30       |
| Recharge Time (s)  | 240      | 240      | 240      |

## Patched

| Stat               | Frenzy 1 | Frenzy 2 | Frenzy 3 |
|--------------------|----------|----------|----------|
| Damage Bonus       | +30%     | +30%     | +30%     |
| Bonus Duration (s) | 10       | 20       | 40       |
| Recharge Time (s)  | 180      | 180      | 180      |
| Overall Buff %     | +275%    | +87%    | +67%     |

# Rationale

The original Frenzy Power is rarely used. China Players typically prefer the Artillery Powers (3), Carpet Bomber (1), Mines (1) and EMP Pulse Bomb (1). Infantry General uses Frenzy (1) sometimes to scan at the start of the match, even though the Frenzy Power is not designed or advertised as a scan ability.

The new patched Frenzy Power makes it considerably more attractive to use due its favorable progression with higher bonus damages in the lower Frenzy levels, its longer bonus duration at the last level and the overall reduced recharge time.