### PR TITLE
Fix: Errors in GLA Terrorist tool tip strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
@@ -6,6 +6,7 @@ title: Fixes errors in Spanish tool tip strings
 changes:
   - fix: The wording in Spanish tool tip strings is more consistent now.
   - fix: The TOOLTIP:NumberOfVotes string now has Spanish text.
+  - fix: The Spanish tool tip for the GLA Terrorist now describes the unit as "Soldado suicida" and is therefore more consistent with the English wording.
 
 labels:
   - minor
@@ -16,6 +17,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2151
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_german_tool_tip_text.yaml
@@ -9,6 +9,7 @@ changes:
   - fix: More German tool tip strings now list the correct strengths and weaknesses.
   - fix: The TOOLTIP:GameInfoPlayer string now shows its number format in German text.
   - fix: The CONTROLBAR:PowerDescription string now shows proper sentences and number format in German text.
+  - fix: The German tool tip for the GLA Terrorist now describes the unit as "Kamikaze Bombe" and is therefore more consistent with the English wording.
 
 labels:
   - minor
@@ -20,6 +21,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2252_chem_terrorist_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2252_chem_terrorist_tooltip.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-20
+
+title: Fixes inconsistencies and missing information in tool tip strings of GLA Toxin Terrorist
+
+changes:
+  - fix: The tool tip strings of the GLA Toxin Terrorist now list its strenghts and weaknesses.
+  - fix: The tool tip strings of the GLA Toxin Terrorist now have consistent wording with the regular Terrorist.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2252_demo_terrorist_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2252_demo_terrorist_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Adds proper tool tip variant to GLA Demo Terrorist
+
+changes:
+  - fix: The tool tip strings of the GLA Demo Terrorist now describe its stronger explosives for all latin languages.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5596,7 +5596,7 @@ CommandButton Demo_Command_ConstructGLAInfantryTerrorist
   TextLabel     = CONTROLBAR:ConstructGLAInfantryTerrorist
   ButtonImage   = SUTerrorist
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildTerrorist
+  DescriptLabel           = CONTROLBAR:Demo_ToolTipGLABuildTerrorist ; Patch104 @tweak from CONTROLBAR:ToolTipGLABuildTerrorist (#2252)
 End
 
 CommandButton Demo_Command_ConstructGLAInfantryAngryMob


### PR DESCRIPTION
**Merge with Rebase**

This change fixers errors in GLA Terrorist tool tip strings.

* ~~German Toxin Terrorist now shows full name "Fahrende Säure-Bombe".~~
* German tool tip now says "Kamikaze Bombe" under "Fahrende Bombe" to better name what its purpose is, like the other languages.
* Brazilian tool tip now says "Soldado suicida", consistent with the other names.
* Tool tip strings for Toxin Terrorist now have consistent naming and style.
* Tool tip strings for Toxin Terrorist now list strengths and weaknesses.
* Demo Terrorist now has its own tool tip that indicates more damage output (latin strings only).