### PR TITLE
Fix: Cash Bounty does not mention Command Center requirement in General's promotion menu

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2253_cash_bounty_info.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2253_cash_bounty_info.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-08-20
+
+title: Add dynamic "Requires Command Center" line to GLA Cash Bounty tooltip
+
+changes:
+  - fix: The tooltip for GLA Cash Bounty now mentions the Command Center requirement if no Command Center is owned by the player.
+
+labels:
+  - boss
+  - enhancement
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2253
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -4138,9 +4138,11 @@ CommandButton Command_PurchaseScienceRebelAmbush3
 End
 
 
+; Patch104p @balance commy2 20/08/2023 Add dynamic "Requires Command Center" line to tooltip. (#2253)
 CommandButton Command_PurchaseScienceCashBounty1
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_CashBounty1
+  Object            = GLAHoleCommandCenter ; something with Command Center as prerequisite
   ButtonImage       = SSCashBounty
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
@@ -4148,6 +4150,7 @@ End
 CommandButton Command_PurchaseScienceCashBounty2
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_CashBounty2
+  Object            = GLAHoleCommandCenter
   ButtonImage       = SSCashBounty2
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
@@ -4155,9 +4158,155 @@ End
 CommandButton Command_PurchaseScienceCashBounty3
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_CashBounty3
+  Object            = GLAHoleCommandCenter
   ButtonImage       = SSCashBounty3
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
+
+CommandButton Demo_Command_PurchaseScienceCashBounty1
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty1
+  Object            = Demo_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Demo_Command_PurchaseScienceCashBounty2
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty2
+  Object            = Demo_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty2
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Demo_Command_PurchaseScienceCashBounty3
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty3
+  Object            = Demo_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty3
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Chem_Command_PurchaseScienceCashBounty1
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty1
+  Object            = Chem_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Chem_Command_PurchaseScienceCashBounty2
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty2
+  Object            = Chem_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty2
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Chem_Command_PurchaseScienceCashBounty3
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty3
+  Object            = Chem_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty3
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Slth_Command_PurchaseScienceCashBounty1
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty1
+  Object            = Slth_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Slth_Command_PurchaseScienceCashBounty2
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty2
+  Object            = Slth_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty2
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Slth_Command_PurchaseScienceCashBounty3
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty3
+  Object            = Slth_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty3
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton GC_Chem_Command_PurchaseScienceCashBounty1
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty1
+  Object            = GC_Chem_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton GC_Chem_Command_PurchaseScienceCashBounty2
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty2
+  Object            = GC_Chem_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty2
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton GC_Chem_Command_PurchaseScienceCashBounty3
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty3
+  Object            = GC_Chem_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty3
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton GC_Slth_Command_PurchaseScienceCashBounty1
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty1
+  Object            = GC_Slth_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton GC_Slth_Command_PurchaseScienceCashBounty2
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty2
+  Object            = GC_Slth_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty2
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton GC_Slth_Command_PurchaseScienceCashBounty3
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty3
+  Object            = GC_Slth_GLAHoleCommandCenter
+  ButtonImage       = SSCashBounty3
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Boss_Command_PurchaseScienceCashBounty1
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty1
+  Object            = Boss_HoleScudStorm ; something with Command Center as prerequisite
+  ButtonImage       = SSCashBounty
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Boss_Command_PurchaseScienceCashBounty2
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty2
+  Object            = Boss_HoleScudStorm
+  ButtonImage       = SSCashBounty2
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
+CommandButton Boss_Command_PurchaseScienceCashBounty3
+  Command           = PURCHASE_SCIENCE
+  Science           = SCIENCE_CashBounty3
+  Object            = Boss_HoleScudStorm
+  ButtonImage       = SSCashBounty3
+  ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
+End
+
 
 CommandButton Command_PurchaseScienceEmergencyRepair1
   Command           = PURCHASE_SCIENCE

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -1626,9 +1626,9 @@ CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank3
   4 = GC_Chem_Command_PurchaseScienceRebelAmbush1
   5 = GC_Chem_Command_PurchaseScienceRebelAmbush2
   6 = GC_Chem_Command_PurchaseScienceRebelAmbush3
-  7 = Command_PurchaseScienceCashBounty1
-  8 = Command_PurchaseScienceCashBounty2
-  9 = Command_PurchaseScienceCashBounty3
+  7 = GC_Chem_Command_PurchaseScienceCashBounty1
+  8 = GC_Chem_Command_PurchaseScienceCashBounty2
+  9 = GC_Chem_Command_PurchaseScienceCashBounty3
   10 = Command_PurchaseScienceEmergencyRepair1
   11 = Command_PurchaseScienceEmergencyRepair2
   12 = Command_PurchaseScienceEmergencyRepair3
@@ -1770,9 +1770,9 @@ CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank3
   4 = Command_PurchaseScienceRebelAmbush1
   5 = Command_PurchaseScienceRebelAmbush2
   6 = Command_PurchaseScienceRebelAmbush3
-  7 = Command_PurchaseScienceCashBounty1
-  8 = Command_PurchaseScienceCashBounty2
-  9 = Command_PurchaseScienceCashBounty3
+  7 = GC_Slth_Command_PurchaseScienceCashBounty1
+  8 = GC_Slth_Command_PurchaseScienceCashBounty2
+  9 = GC_Slth_Command_PurchaseScienceCashBounty3
   10 = Early_Command_PurchaseScienceEmergencyRepair2
   11 = Early_Command_PurchaseScienceEmergencyRepair3
 END
@@ -2224,9 +2224,9 @@ CommandSet Demo_SCIENCE_GLA_CommandSetRank3
   4 = Demo_Command_PurchaseScienceRebelAmbush1
   5 = Demo_Command_PurchaseScienceRebelAmbush2
   6 = Demo_Command_PurchaseScienceRebelAmbush3
-  7 = Command_PurchaseScienceCashBounty1
-  8 = Command_PurchaseScienceCashBounty2
-  9 = Command_PurchaseScienceCashBounty3
+  7 = Demo_Command_PurchaseScienceCashBounty1
+  8 = Demo_Command_PurchaseScienceCashBounty2
+  9 = Demo_Command_PurchaseScienceCashBounty3
   10 = Command_PurchaseScienceEmergencyRepair1
   11 = Command_PurchaseScienceEmergencyRepair2
   12 = Command_PurchaseScienceEmergencyRepair3
@@ -2895,9 +2895,9 @@ CommandSet Slth_SCIENCE_GLA_CommandSetRank3
   4 = Command_PurchaseScienceRebelAmbush1
   5 = Command_PurchaseScienceRebelAmbush2
   6 = Command_PurchaseScienceRebelAmbush3
-  7 = Command_PurchaseScienceCashBounty1
-  8 = Command_PurchaseScienceCashBounty2
-  9 = Command_PurchaseScienceCashBounty3
+  7 = Slth_Command_PurchaseScienceCashBounty1
+  8 = Slth_Command_PurchaseScienceCashBounty2
+  9 = Slth_Command_PurchaseScienceCashBounty3
   10 = Early_Command_PurchaseScienceEmergencyRepair2
   11 = Early_Command_PurchaseScienceEmergencyRepair3
 END
@@ -3214,9 +3214,9 @@ CommandSet Chem_SCIENCE_GLA_CommandSetRank3
   4 = Chem_Command_PurchaseScienceRebelAmbush1
   5 = Chem_Command_PurchaseScienceRebelAmbush2
   6 = Chem_Command_PurchaseScienceRebelAmbush3
-  7 = Command_PurchaseScienceCashBounty1
-  8 = Command_PurchaseScienceCashBounty2
-  9 = Command_PurchaseScienceCashBounty3
+  7 = Chem_Command_PurchaseScienceCashBounty1
+  8 = Chem_Command_PurchaseScienceCashBounty2
+  9 = Chem_Command_PurchaseScienceCashBounty3
   10 = Command_PurchaseScienceEmergencyRepair1
   11 = Command_PurchaseScienceEmergencyRepair2
   12 = Command_PurchaseScienceEmergencyRepair3
@@ -5542,9 +5542,9 @@ CommandSet Boss_SCIENCE_CHINA_CommandSetRank3
   4 = Command_PurchaseScienceArtilleryBarrage1
   5 = Command_PurchaseScienceArtilleryBarrage2
   6 = Command_PurchaseScienceArtilleryBarrage3
-  7 = Command_PurchaseScienceCashBounty1
-  8 = Command_PurchaseScienceCashBounty2
-  9 = Command_PurchaseScienceCashBounty3
+  7 = Boss_Command_PurchaseScienceCashBounty1
+  8 = Boss_Command_PurchaseScienceCashBounty2
+  9 = Boss_Command_PurchaseScienceCashBounty3
 ; 10 = Command_PurchaseScienceParadrop1
 ; 11 = Command_PurchaseScienceParadrop2
 ; 12 = Command_PurchaseScienceParadrop3


### PR DESCRIPTION
![shot_20230820_110959_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/8d0e85f5-38be-47f8-bc32-afbb632bfa69)

This line disappears if the player owns a Command Center.