### PR TITLE
Fix: Add tool tip variant to GLA Demo Scud Storm for all latin languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2254_demo_scud_storm_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2254_demo_scud_storm_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Adds proper tool tip variant to GLA Demo Scud Storm
+
+changes:
+  - fix: The tool tip strings of the GLA Demo Scud Storm now describe its stronger missiles for all latin languages.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2254
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5524,7 +5524,7 @@ CommandButton Demo_Command_ConstructGLAScudStorm
   TextLabel     = CONTROLBAR:ConstructGLAScudStorm
   ButtonImage   = SUScudStorm
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildScudStorm
+  DescriptLabel           = CONTROLBAR:Demo_ToolTipGLABuildScudStorm ; Patch104p @tweak from CONTROLBAR:ToolTipGLABuildScudStorm (#2254)
 End
 
 CommandButton Demo_Command_ConstructGLATunnelNetwork


### PR DESCRIPTION
This change adds better tool tip strings to GLA Demo Scud Storm for all latin languages. It now indicates higher damage output by stating it shoots high explosive warheads.