### PR TITLE
Tweak: Partisan and Milita Man Guard radius

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2192_militia_man.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2192_militia_man.yaml
@@ -15,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2192
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2255
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2192_partisans.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2192_partisans.yaml
@@ -15,6 +15,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2192
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2255
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -8978,7 +8978,7 @@ Object Partisan01
     DamageFX        = InfantryDamageFX
   End
 
-  VisionRange = 150
+  VisionRange = 100
   ShroudClearingRange = 200
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -9220,7 +9220,7 @@ Object Partisan02
     DamageFX        = InfantryDamageFX
   End
 
-  VisionRange = 150
+  VisionRange = 100
   ShroudClearingRange = 200
   DisplayName = OBJECT:PartisanMale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -9449,7 +9449,7 @@ Object Partisan03
     DamageFX        = InfantryDamageFX
   End
 
-  VisionRange = 150
+  VisionRange = 100
   ShroudClearingRange = 200
   DisplayName = OBJECT:PartisanFemale
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
@@ -9679,7 +9679,7 @@ Object MilitiaMan
     DamageFX        = InfantryDamageFX
   End
 
-  VisionRange = 150
+  VisionRange = 100
   ShroudClearingRange = 200
   DisplayName = OBJECT:Militia
   CrushableLevel = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles


### PR DESCRIPTION
This change reduces the Guard radius from Rebel level to Red Guard and Ranger level for the Partisans and the Militia Man, because I think that matches the units better than what I initially chose.