### PR TITLE
Fix: Add tool tip variant to GLA Toxin Demo Trap for all languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2256_toxin_demo_trap_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2256_toxin_demo_trap_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Adds proper tool tip variant to GLA Toxin Demo Trap
+
+changes:
+  - fix: The tool tip strings of the GLA Toxin Demo Trap now describe its toxin puddle effect for all languages.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2256
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -6309,7 +6309,7 @@ CommandButton Chem_Command_ConstructGLADemoTrap
   TextLabel     = CONTROLBAR:ConstructGLADemoTrap
   ButtonImage   = SSHideBomb
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABUildDemoTrap
+  DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildDemoTrap ; Patch104p @tweak from CONTROLBAR:ToolTipGLABUildDemoTrap (#2256)
 End
 
 CommandButton Chem_Command_ConstructGLACommandCenter
@@ -6590,7 +6590,7 @@ CommandButton GC_Chem_Command_ConstructGLADemoTrap
   TextLabel     = CONTROLBAR:ConstructGLADemoTrap
   ButtonImage   = SSHideBomb
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABUildDemoTrap
+  DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildDemoTrap ; Patch104p @tweak from CONTROLBAR:ToolTipGLABUildDemoTrap (#2256)
 End
 
 CommandButton GC_Chem_Command_ConstructGLACommandCenter


### PR DESCRIPTION
This change adds better tool tip strings to GLA Toxin Demo Trap for all languages. Same as Toxin Terrorist, it now says that it explodes in a cloud of toxins.