### PR TITLE
Fix: Set correct names for GLA Booby Trap and GLA Demo Trap in Brazilian language

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
@@ -5,6 +5,7 @@ title: Fixes errors in Brazilian tool tip strings
 
 changes:
   - fix: The wording in Brazilian tool tip strings is more consistent now.
+  - fix: The Brazilian names for GLA Booby Trap and Demo Trap are now distinguishable from each other.
 
 labels:
   - minor
@@ -14,6 +15,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2257
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2257_demo_trap_booby_trap_names.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2257_demo_trap_booby_trap_names.txt
@@ -1,0 +1,1 @@
+2195_brazilian_tool_tip_text.yaml


### PR DESCRIPTION
This change corrects the names for GLA Booby Trap and GLA Demo Trap in Brazilian language.