### PR TITLE
Fix: Add object name variant to GLA Toxin Demo Trap for latin languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2258_toxin_demo_trap_name.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2258_toxin_demo_trap_name.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Adds object name variant to GLA Toxin Demo Trap
+
+changes:
+  - fix: The GLA Toxin Demo Trap now shows its own name for all latin languages.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2258
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -6306,7 +6306,7 @@ End
 CommandButton Chem_Command_ConstructGLADemoTrap
   Command       = DOZER_CONSTRUCT
   Object        = Chem_GLADemoTrap
-  TextLabel     = CONTROLBAR:ConstructGLADemoTrap
+  TextLabel     = CONTROLBAR:Chem_ConstructGLADemoTrap ; Patch104p @tweak from CONTROLBAR:ConstructGLADemoTrap (#2258)
   ButtonImage   = SSHideBomb
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildDemoTrap ; Patch104p @tweak from CONTROLBAR:ToolTipGLABUildDemoTrap (#2256)
@@ -6587,7 +6587,7 @@ End
 CommandButton GC_Chem_Command_ConstructGLADemoTrap
   Command       = DOZER_CONSTRUCT
   Object        = GC_Chem_GLADemoTrap
-  TextLabel     = CONTROLBAR:ConstructGLADemoTrap
+  TextLabel     = CONTROLBAR:Chem_ConstructGLADemoTrap ; Patch104p @tweak from CONTROLBAR:ConstructGLADemoTrap (#2258)
   ButtonImage   = SSHideBomb
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Chem_ToolTipGLABuildDemoTrap ; Patch104p @tweak from CONTROLBAR:ToolTipGLABUildDemoTrap (#2256)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -5888,7 +5888,7 @@ Object Chem_GLADemoTrap
   PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:DemoTrap
+  DisplayName      = OBJECT:Chem_DemoTrap ; Patch104p @tweak from OBJECT:DemoTrap (#2258)
   Side             = GLAToxinGeneral
   EditorSorting    = STRUCTURE
   Prerequisites

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -1496,7 +1496,7 @@ Object GC_Chem_GLADemoTrap
   PlacementViewAngle = -45
 
   ; ***DESIGN parameters ***
-  DisplayName      = OBJECT:DemoTrap
+  DisplayName      = OBJECT:Chem_DemoTrap ; Patch104p @tweak from OBJECT:DemoTrap (#2258)
   Side             = GLAToxinGeneral
   EditorSorting    = STRUCTURE
   Prerequisites


### PR DESCRIPTION
This change adds a text variant for GLA Toxin Demo Trap for latin languages.