### PR TITLE
Fix: Add brief sentence to tool tip strings of China Nuke Mig

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2259_nuke_mig_tooltip_text.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2259_nuke_mig_tooltip_text.txt
@@ -1,0 +1,1 @@
+840_nuke_mig_tooltip_text.yaml

--- a/Patch104pZH/Design/Changes/v1.0/840_nuke_mig_tooltip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/840_nuke_mig_tooltip_text.yaml
@@ -5,6 +5,7 @@ title: Fixes description error in tooltip text of China Nuke Mig
 
 changes:
   - fix: The tooltip text of the China Nuke Mig no longer claims that it creates a fire storm.
+  - fix: The tooltip text of the China Nuke Mig now tells that it shoots missiles with radiation shells.
 
 labels:
   - bug
@@ -15,6 +16,8 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/840
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2259
 
 authors:
   - commy2
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/840_nuke_mig_tooltip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/840_nuke_mig_tooltip_text.yaml
@@ -4,8 +4,8 @@ date: 2022-08-06
 title: Fixes description error in tooltip text of China Nuke Mig
 
 changes:
-  - fix: The tooltip text of the China Nuke Mig no longer claims that it creates a fire storm.
-  - fix: The tooltip text of the China Nuke Mig now tells that it shoots missiles with radiation shells.
+  - fix: The tool tip strings of the China Nuke Mig no longer claim that it creates a fire storm.
+  - fix: The tool tip strings of the China Nuke Mig now explain that it shoots nuke missiles.
 
 labels:
   - bug


### PR DESCRIPTION
* Follow up for #840

Adds a brief sentence to CONTROLBAR:Nuke_ToolTipChinaBuildMIG for all languages.