### PR TITLE
Fix: Add object name variant to China Nuke MiG

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2260_nuke_mig_name.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2260_nuke_mig_name.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Adds object name variant to China Nuke MiG
+
+changes:
+  - fix: The China Nuke MiG now shows its own name for all languages.
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2260
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -7142,7 +7142,7 @@ End
 CommandButton Nuke_Command_ConstructChinaJetMIG
   Command       = UNIT_BUILD
   Object        = Nuke_ChinaJetMIG
-  TextLabel     = CONTROLBAR:ConstructChinaJetMIG
+  TextLabel     = CONTROLBAR:Nuke_ConstructChinaJetMIG ; Patch104p @tweak from CONTROLBAR:ConstructChinaJetMIG (#2260)
   ButtonImage   = SNMig
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Nuke_ToolTipChinaBuildMIG

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -1027,7 +1027,7 @@ Object Nuke_ChinaJetMIG
   End
 
   ; ***DESIGN parameters ***
-  DisplayName             = OBJECT:MIG
+  DisplayName             = OBJECT:Nuke_MIG ; Patch104p @tweak from OBJECT:MIG (#2260)
   EditorSorting           = VEHICLE
   Side                    = ChinaNukeGeneral
   TransportSlotCount      = 0          ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
This change adds an object name variant for the China Nuke MiG. It is now called "Nuke MiG".