### PR TITLE
Fix: Resolve errors in tool tip strings of China Helix for all latin languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
@@ -7,6 +7,7 @@ changes:
   - fix: The wording in Polish tool tip strings is more consistent now.
   - fix: The wording in Polish tool tip strings for the GLA Scud Launcher is more consistent now.
   - fix: The China Helix is now called "Helis" instead of "Spiral" in Polish strings.
+  - fix: The Polish tool tip string of the China Infantry Helix no longer claims to let passengers shoot at each other.
 
 labels:
   - china
@@ -20,6 +21,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2153
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2249
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2150_english_tool_tip_text.yaml
@@ -16,6 +16,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2150
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2151_spanish_tool_tip_text.yaml
@@ -18,6 +18,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2195_brazilian_tool_tip_text.yaml
@@ -16,6 +16,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2257
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2219_italian_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2219_italian_tool_tip_text.yaml
@@ -13,6 +13,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2261_helix_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2261_helix_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Fixes errors in tool tip strings of China Infantry Helix
+
+changes:
+  - fix: The latin tool tip strings of the China Infantry Helix no longer claim to be upgradable with all base defense structures.
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
+
+authors:
+  - xezon


### PR DESCRIPTION
This change improves the wording in tool tip strings of China Helix for all latin languages. The China Infantry Helix tool tip text no longer claims to be upgrade-able with all base defense structures. And the Polish tool tip string no longer claims that the Bunker passengers can shoot at each other.