### PR TITLE
Fix: Add object name variant to China Nuke Helix

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2262_nuke_helix_name.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2262_nuke_helix_name.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-20
+
+title: Adds object name variant to China Nuke Helix
+
+changes:
+  - fix: The China Nuke Helix now shows its own name for all languages.
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2262
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -7013,7 +7013,7 @@ End
 CommandButton Nuke_Command_ConstructChinaVehicleHelix
   Command       = UNIT_BUILD
   Object        = Nuke_ChinaVehicleHelix
-  TextLabel     = CONTROLBAR:ConstructChinaVehicleHelix
+  TextLabel     = CONTROLBAR:Nuke_ConstructChinaVehicleHelix ; Patch104p @tweak from CONTROLBAR:ConstructChinaVehicleHelix
   ButtonImage   = SNHelix
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
   DescriptLabel           = CONTROLBAR:Nuke_ToolTipChinaBuildHelix

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -340,7 +340,7 @@ Object Nuke_ChinaVehicleHelix
 
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Helix
+  DisplayName         = OBJECT:Nuke_Helix ; Patch104p @tweak from OBJECT:Helix
   EditorSorting       = VEHICLE
   Side                = ChinaNukeGeneral
   TransportSlotCount  = 0                 ;how many "slots" we take in a transport (0 == not transportable)


### PR DESCRIPTION
* Merge after #2265

This change adds a text variant for the China Nuke Helix.