### PR TITLE
Fix: Set better name for China Helix in Polish strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2148_polish_tool_tip_text.yaml
@@ -1,13 +1,16 @@
 ---
 date: 2023-07-26
 
-title: Fixes inconsistent wording in Polish tool tip strings
+title: Fixes errors in Polish strings
 
 changes:
   - fix: The wording in Polish tool tip strings is more consistent now.
-  - fix: The tool tip string of the GLA Scud Launcher now has more consistent wording.
+  - fix: The wording in Polish tool tip strings for the GLA Scud Launcher is more consistent now.
+  - fix: The China Helix is now called "Helis" instead of "Spiral" in Polish strings.
 
 labels:
+  - china
+  - gla
   - minor
   - text
   - v1.0

--- a/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_tool_tip_text.yaml
@@ -7,9 +7,10 @@ changes:
   - fix: The wording in French tool tip strings is more consistent now.
   - fix: The French tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
   - fix: The TOOLTIP:NumberOfVotes, GUI:Ok, LAN:OK, MapTransfer:Done strings now have French text.
-  - fix: The tool tip string of the GLA Scud Launcher now has more consistent wording.
+  - fix: The wording in French tool tip strings for the GLA Scud Launcher is more consistent now.
 
 labels:
+  - gla
   - minor
   - text
   - v1.0


### PR DESCRIPTION
This change sets appropriate name for China Helix in Polish strings. It is now called "Helis" instead of "Spiral".