### PR TITLE
Fix: Demo Jarmen Kell has no animation for placing demo charges

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2267_demo_jarmen_kell_planting_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2267_demo_jarmen_kell_planting_animation.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-21
+
+title: Adds missing bomb planting animation for GLA Demolition Jarmen Kell
+
+changes:
+  - fix: Add animation for placing timed and remote demo charges to GLA Demolition Jarmen Kell.
+
+labels:
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2267
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13352,6 +13352,17 @@ Object Demo_GLAInfantryJarmenKell
       AnimationMode     = ONCE
     End
 
+    ; Patch104p @bugfix commy2 21/08/2023 Add missing bomb planting animation for Demo Jarmen Kell. (#2267)
+    ; --- placing charge
+    ConditionState      = UNPACKING
+      Animation         = UIHERO_SKL.UIHERO_IDA
+      AnimationMode     = ONCE
+      WaitForStateToFinishIfPossible = NoWait
+    End
+    AliasConditionState = UNPACKING REALLYDAMAGED
+    AliasConditionState = MOVING UNPACKING
+    AliasConditionState = MOVING UNPACKING REALLYDAMAGED
+
     ; --- moving
     ConditionState      = MOVING
       Animation         = UIHERO_SKL.UIHERO_RNA2 30


### PR DESCRIPTION
### 1.04


https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/afe5ff3e-5d95-486e-b3ee-4a63218a6c72



### after

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/aca31e90-22bf-439d-adeb-cff05bf1d02e

- Demo Jarmen Kell has no bomb-planting animation. However, there is an idle animation where he ties his shoes... That looks perfect for bomb planting. Colonel Burton and CIA Agent do have animations for this.