### PR TITLE
Fix: Add tool tip variant to GLA Demo Jarmen Kell

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2249_scud_launcher_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2249_scud_launcher_tooltip.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-20
 
-title: Adds proper tool tip variants to GLA Demo Scud Launcher and Toxin Scud Launcher
+title: Adds tool tip variants to GLA Demo Scud Launcher and Toxin Scud Launcher
 
 changes:
   - fix: The tool tip strings of the GLA Demo Scud Launcher and Toxin Scud Launcher now properly state the kind of warhead they carry in all latin languages.

--- a/Patch104pZH/Design/Changes/v1.0/2252_demo_terrorist_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2252_demo_terrorist_tooltip.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-20
 
-title: Adds proper tool tip variant to GLA Demo Terrorist
+title: Adds tool tip variant to GLA Demo Terrorist
 
 changes:
   - fix: The tool tip strings of the GLA Demo Terrorist now describe its stronger explosives for all latin languages.

--- a/Patch104pZH/Design/Changes/v1.0/2254_demo_scud_storm_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2254_demo_scud_storm_tooltip.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-20
 
-title: Adds proper tool tip variant to GLA Demo Scud Storm
+title: Adds tool tip variant to GLA Demo Scud Storm
 
 changes:
   - fix: The tool tip strings of the GLA Demo Scud Storm now describe its stronger missiles for all latin languages.

--- a/Patch104pZH/Design/Changes/v1.0/2256_toxin_demo_trap_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2256_toxin_demo_trap_tooltip.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-20
 
-title: Adds proper tool tip variant to GLA Toxin Demo Trap
+title: Adds tool tip variant to GLA Toxin Demo Trap
 
 changes:
   - fix: The tool tip strings of the GLA Toxin Demo Trap now describe its toxin puddle effect for all languages.

--- a/Patch104pZH/Design/Changes/v1.0/2270_demo_jarmen_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2270_demo_jarmen_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-22
+
+title: Adds tool tip variant to GLA Demo Jarmen Kell
+
+changes:
+  - fix: The tool tip strings of the GLA Demo Jarmen Kell now mention its demolition charges for all languages.
+
+labels:
+  - gla
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2270
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5614,7 +5614,7 @@ CommandButton Demo_Command_ConstructGLAInfantryJarmenKell
   TextLabel     = CONTROLBAR:Demo_ConstructGLAInfantryJarmenKell ; Patch104p @tweak from CONTROLBAR:ConstructGLAInfantryJarmenKell (#2269)
   ButtonImage   = SUJermanKell1    ;NOTE: Asset spelling mistake
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildJarmenKell
+  DescriptLabel           = CONTROLBAR:Demo_ToolTipGLABuildJarmenKell ; Patch104p @tweak from CONTROLBAR:ToolTipGLABuildJarmenKell (#2270)
 End
 
 CommandButton Demo_Command_ConstructGLAVehicleRadarVan


### PR DESCRIPTION
This change adds better tool tip strings to GLA Demo Jarmen Kell for all languages. The sentences were copied from Burton and they highlight the bomb abilities.