### PR TITLE
Fix: Resolve errors in tool tip strings of USA Colonel Burton for all languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2153_korean_tool_tip_text.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2153_korean_tool_tip_text.yaml
@@ -5,6 +5,7 @@ title: Fixes errors in Korean tool tip strings
 
 changes:
   - fix: The wording in Korean tool tip strings is more consistent now.
+  - fix: The Korean tool tip string of the USA Burton now mentions its strengths.
 
 labels:
   - minor
@@ -13,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2153
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2271
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2271_burton_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2271_burton_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-22
+
+title: Removes build limit note from tool tip strings of USA Burton
+
+changes:
+  - fix: The tool tip strings of the USA Burton no longer list a fixed build limit for all languages.
+
+labels:
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2271
+
+authors:
+  - xezon


### PR DESCRIPTION
This change resolves errors in tool tip strings of USA Colonel Burton for all languages.

It no longer contains the "Build Limit: 1" sentence. It is not necessary. The other heroes do not have it too.

The Korean string now lists the strengths.

## Original

![shot_20230822_174625_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/7799974a-fe18-49c9-9a6e-01512d615178)
