### PR TITLE
Fix: Resolve inconsistencies, errors, missing information in tool tip strings of USA Chinook, Raptor, Aurora, Stealth Fighter for all languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2273_aurora_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2273_aurora_tooltip.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-22
+
+title: Fixes tool tip string of USA Auroras
+
+changes:
+  - fix: The tool tip strings of the USA Aurora now use consistent wording and style in all languages.
+  - fix: The tool tip strings of the USA Airforce Aurora now mention its Point Defense Laser in all languages.
+
+labels:
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2273
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2273_chinook_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2273_chinook_tooltip.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-22
+
+title: Fixes tool tip strings of USA Chinooks
+
+changes:
+  - fix: The tool tip strings of the USA Chinook now use consistent wording and style in all languages.
+  - fix: The tool tip strings of the USA Airforce Chinooks now mention their Point Defense Laser in all languages.
+
+labels:
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2273
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2273_raptor_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2273_raptor_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-22
+
+title: Fixes tool tip strings of USA Raptor
+
+changes:
+  - fix: The tool tip strings of the USA Raptor and King Raptor now use consistent wording and style in all languages.
+
+labels:
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2273
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2273_stealth_fighter_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2273_stealth_fighter_tooltip.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-22
+
+title: Fixes tool tip strings of USA Stealth Fighters
+
+changes:
+  - fix: The tool tip strings of the USA Stealth Fighter now use consistent wording and style in all languages.
+  - fix: The Spanish and Polish tool tip strings of the USA Stealth Fighter no longer mention wrong information.
+
+labels:
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2273
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5084,7 +5084,7 @@ CommandButton AirF_Command_ConstructAFGChinook
   TextLabel     = CONTROLBAR:ConstructAmericaVehicleChinook
   ButtonImage   = SAChinook
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipUSABUildChinook
+  DescriptLabel           = CONTROLBAR:AFG_ToolTipUSABuildChinook ; Patch104p @tweak from CONTROLBAR:ToolTipUSABUildChinook (#2273)
 End
 
 CommandButton AirF_Command_ConstructAmericaVehicleChinook


### PR DESCRIPTION
This change resolve inconsistencies, errors, missing information in tool tip strings of USA Chinook, Raptor, Aurora, Stealth Fighter for all languages

* The tool tip strings of USA Airforce Chinook, Combat Chinook, Aurora now also say that they have a Point Defense Laser
* The Spanish, Polish tool tip strings of the regular Stealth Fighter no longer say wrong things
* The tool tip strings of all USA Chinook, Aurora, Stealth Fighter, Raptor units now use consistent wording and style for all languages

## TODO

- [x] Raptor tool tip inconsistencies