### PR TITLE
Fix: USA Spy Drone can no longer be selected, but attacked, attempt 2

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/173_spydrone_select_all_key.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/173_spydrone_select_all_key.yaml
@@ -1,10 +1,10 @@
 ---
 date: 2021-09-03
 
-title: Removes Select All key bindings from USA Spy Drone
+title: USA Spy Drone can no longer be selected
 
 changes:
-  - fix: The USA Spy Drone can no longer be selected by using the Select Aircraft (W) and Select All (Q) keys.
+  - fix: The USA Spy Drone can no longer be selected. It can still be targeted by attacks and abilities.
 
 labels:
   - design
@@ -14,6 +14,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/173
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2277
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/173_spydrone_select_all_key.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/173_spydrone_select_all_key.yaml
@@ -4,7 +4,7 @@ date: 2021-09-03
 title: USA Spy Drone can no longer be selected
 
 changes:
-  - fix: The USA Spy Drone can no longer be selected. It can still be targeted by attacks and abilities.
+  - fix: The USA Spy Drone can no longer be selected by mouse or the Select Aircraft (W) and Select All (Q) keys. It can still be targeted by attacks and abilities.
 
 labels:
   - design

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6520,7 +6520,7 @@ Object AirF_AmericaVehicleSpyDrone
   RadarPriority = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
 
-  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  ; Patch104p @fix commy2 23/08/2023 This makes the drone entirely unselectable. (#2277)
   Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
     TriggeredBy = Upgrade_DummyUpgrade
     StatusToSet = UNSELECTABLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -6518,7 +6518,13 @@ Object AirF_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
+
+  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
+    TriggeredBy = Upgrade_DummyUpgrade
+    StatusToSet = UNSELECTABLE
+  End
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1301,7 +1301,13 @@ Object AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
+
+  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
+    TriggeredBy = Upgrade_DummyUpgrade
+    StatusToSet = UNSELECTABLE
+  End
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaVehicle.ini
@@ -1303,7 +1303,7 @@ Object AmericaVehicleSpyDrone
   RadarPriority = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
 
-  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  ; Patch104p @fix commy2 23/08/2023 This makes the drone entirely unselectable. (#2277)
   Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
     TriggeredBy = Upgrade_DummyUpgrade
     StatusToSet = UNSELECTABLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5745,7 +5745,7 @@ Object Lazr_AmericaVehicleSpyDrone
   RadarPriority = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
 
-  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  ; Patch104p @fix commy2 23/08/2023 This makes the drone entirely unselectable. (#2277)
   Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
     TriggeredBy = Upgrade_DummyUpgrade
     StatusToSet = UNSELECTABLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -5743,7 +5743,13 @@ Object Lazr_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
+
+  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
+    TriggeredBy = Upgrade_DummyUpgrade
+    StatusToSet = UNSELECTABLE
+  End
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6227,7 +6227,7 @@ Object SupW_AmericaVehicleSpyDrone
   RadarPriority = UNIT
   KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
 
-  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  ; Patch104p @fix commy2 23/08/2023 This makes the drone entirely unselectable. (#2277)
   Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
     TriggeredBy = Upgrade_DummyUpgrade
     StatusToSet = UNSELECTABLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -6225,7 +6225,13 @@ Object SupW_AmericaVehicleSpyDrone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = UNIT
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut.
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE SCORE DRONE SELECTABLE INERT NO_SELECT IGNORES_SELECT_ALL ; Patch104p @bugfix commy2 03/09/2021 No longer select Spy Drone with Q-shortcut. (#173)
+
+  ; Patch104p @fix commy2 23/08/2023 This makes the plane not attacked automatically and entirely unselectable. (#2277)
+  Behavior = StatusBitsUpgrade ModuleTag_MakeUnselectable
+    TriggeredBy = Upgrade_DummyUpgrade
+    StatusToSet = UNSELECTABLE
+  End
 
   Body = ActiveBody ModuleTag_02
     MaxHealth       = 200.0


### PR DESCRIPTION
* Fixes #115
* Relates to #1338

This change makes the USA Spy Drone no longer selectable, but still attackable. It behaves like vehicle drones.