### PR TITLE
Tweak: Make Supply Drop Zone Cargo Planes attackable again

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/836_unattackable_drop_zone_cargo_planes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/836_unattackable_drop_zone_cargo_planes.yaml
@@ -1,17 +1,17 @@
 ---
 date: 2022-08-06
 
-title: Makes USA Supply Drop Zone Cargo Planes unattackable
+title: Makes USA Supply Drop Zone Cargo Planes not automatically attacked
 
 changes:
-  - tweak: |
-      The USA Supply Drop Zone Cargo Planes can not longer be attacked. This
+  - tweak:
+      The USA Supply Drop Zone Cargo Planes are no longer attacked automatically. This
         - gets rid of attack notification spams on Radar and Voice
         - improves performance in spam and AOD matches where many planes no longer draw fire
         - removes the auto attack from Mig, Raptor in guard modes
         - preserves the Cargo Plane flight route so enemy player knows where it comes from
-        - removes the ability to stop a Cargo Plane before it can drop the money crates
         - removes this free and passive cannon fodder unit for the USA Faction
+      They can still be attacked by left-clicking on them with anti-air units selected.
 
 labels:
   - design
@@ -22,6 +22,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/836
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2279
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/836_unattackable_drop_zone_cargo_planes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/836_unattackable_drop_zone_cargo_planes.yaml
@@ -4,7 +4,7 @@ date: 2022-08-06
 title: Makes USA Supply Drop Zone Cargo Planes not automatically attacked
 
 changes:
-  - tweak:
+  - tweak: |
       The USA Supply Drop Zone Cargo Planes are no longer attacked automatically. This
         - gets rid of attack notification spams on Radar and Voice
         - improves performance in spam and AOD matches where many planes no longer draw fire

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -2627,7 +2627,13 @@ Object AmericaJetCargoPlane_SupplyDropZone
 
   ; *** ENGINEERING Parameters ***
   RadarPriority = NOT_ON_RADAR
-  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE TRANSPORT AIRCRAFT UNATTACKABLE IGNORED_IN_GUI EMP_HARDENED
+  KindOf = PRELOAD CAN_CAST_REFLECTIONS VEHICLE TRANSPORT AIRCRAFT SELECTABLE IGNORED_IN_GUI EMP_HARDENED NO_SELECT
+
+  Behavior = StatusBitsUpgrade ModuleTag_NoAutoAttack
+    TriggeredBy = Upgrade_DummyUpgrade
+    StatusToSet = NO_ATTACK_FROM_AI UNSELECTABLE
+  End
+
   Body = ActiveBody ModuleTag_03
     MaxHealth       = 1000.0
     InitialHealth   = 1000.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AmericaAir.ini
@@ -2514,7 +2514,7 @@ Object AmericaJetCargoPlane
   ShadowSizeX = 89  ; minimum elevation angle above horizon. Used to limit shadow length
 End
 
-; Patch104p @performance hanfield commy2 06/08/2022 A harmless plane that can not be attacked.
+; Patch104p @performance hanfield commy2 06/08/2022 A harmless plane that is not auto attacked. (#836) (#2279)
 ;------------------------------------------------------------------------------
 Object AmericaJetCargoPlane_SupplyDropZone
 


### PR DESCRIPTION
- continuation of https://github.com/TheSuperHackers/GeneralsGamePatch/pull/836

NO_ATTACK_FROM_AI + UNSELECTABLE combined with SELECTABLE + NO_SELECT (don't question it) gives the, in my opinion, desired behavior.

The planes are not automatically attacked. They are not attacked by guard mode either, including air guard mode. This hasn't changed. 

However, with this change, the planes can now be attacked by left clicking on them. This can be used to deny the drop (if you manage to sneak behind the enemy base), or to earn a small amount of experience from the kill, or to annoy the USA player with "unit under attack" EVA message.