### PR TITLE
Tweak: Make Command Centers grant the global Dummy Upgrade

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/AirforceGeneral.ini
@@ -8911,6 +8911,11 @@ Object AirF_AmericaCommandCenter
     TriggeredBy = Upgrade_AmericaMOAB
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 60.0
   GeometryMinorRadius = 70.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1405,6 +1405,11 @@ Object Boss_CommandCenter
     TriggeredBy = Upgrade_ChinaEMPMines
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   FactoryExitWidth    = 25
   GeometryMajorRadius = 60.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -1114,6 +1114,11 @@ Object Chem_GLACommandCenter
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1250,6 +1250,11 @@ Object Demo_GLACommandCenter
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -1478,6 +1478,11 @@ Object AmericaCommandCenter
     TriggeredBy = Upgrade_AmericaMOAB
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 60.0
   GeometryMinorRadius = 70.0
@@ -2291,6 +2296,11 @@ Object GLACommandCenter
     ReallyDamagedParticleSystem1 = Bone:None RandomBone:No PSys:StructureTransitionMediumSmoke
     ReallyDamagedParticleSystem2 = Bone:None RandomBone:No PSys:StructureTransitionMediumExplosion
     ReallyDamagedParticleSystem3 = Bone:None RandomBone:No PSys:StructureTransitionMediumShockwave
+  End
+
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
   End
 
   Geometry            = BOX
@@ -4196,6 +4206,11 @@ Object ChinaCommandCenter
     UpgradeOCL           = SCIENCE_Frenzy2 SUPERWEAPON_Frenzy2
     OCL                  = SUPERWEAPON_Frenzy1
     CreateLocation       = CREATE_AT_LOCATION
+  End
+
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
   End
 
   Geometry            = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -2408,6 +2408,11 @@ Object GC_Chem_GLACommandCenter
     ReferenceObject      = GLASneakAttackTunnelNetwork ;So we know what the final product is for script placement calculations
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -1135,6 +1135,11 @@ Object GC_Slth_GLACommandCenter
     OrderIdleEnemiesToAttackMeUponReveal  = Yes
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -4470,6 +4470,10 @@ Object Infa_ChinaCommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
 
   Geometry            = BOX
   FactoryExitWidth    = 25

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/LaserGeneral.ini
@@ -8600,6 +8600,11 @@ Object Lazr_AmericaCommandCenter
     TriggeredBy = Upgrade_AmericaMOAB
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 60.0
   GeometryMinorRadius = 70.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -6343,6 +6343,11 @@ Object Nuke_ChinaCommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   FactoryExitWidth    = 25
   GeometryMajorRadius = 60.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -1126,6 +1126,11 @@ Object Slth_GLACommandCenter
     TriggeredBy = Upgrade_GLACamoNetting
   END
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 65.0
   GeometryMinorRadius = 65.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/SuperWeaponGeneral.ini
@@ -9095,6 +9095,11 @@ Object SupW_AmericaCommandCenter
     TriggeredBy = Upgrade_AmericaMOAB
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
+
   Geometry            = BOX
   GeometryMajorRadius = 60.0
   GeometryMinorRadius = 70.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3086,7 +3086,6 @@ End
 
 ; Patch104p @bugfix commy2 24/10/2021 Logic that grants player Cash Bounty.
 ; Patch104p @bugfix commy2 15/08/2022 Do not use HighlanderBody for these dummies: It will cause unexpected resistance to particle beams.
-; Patch104p @bugfix commy2 20/08/2022 Use DeletionUpdate for ImmortalBody, because immortals cannot die.
 ;------------------------------------------------------------------------------
 Object CashBountyDummy
   ; ***DESIGN parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -17324,6 +17324,10 @@ Object Tank_ChinaCommandCenter
     TriggeredBy = Upgrade_ChinaEMPMines
   End
 
+  ; Patch104p @fix commy2 27/08/2023 We always need this. Used to trigger various upgrade modules like ArmorUpgrade or StatusBitsUpgrade. (#2280)
+  Behavior = GrantUpgradeCreate ModuleTag_GrantDummyUpgrade
+    UpgradeToGrant = Upgrade_DummyUpgrade
+  End
 
   Geometry            = BOX
   FactoryExitWidth    = 25


### PR DESCRIPTION
This avoids issues with further use of the DummyUpgrade where it may not apply if the structure was captured instead of constructed, or given to the player by a map script. It also enables the use with units that are not constructed, but spawned (and thus are unable to grant upgrades) such as the Spy Drone or the Cargo Plane.

The Command Center guarantees the dummy upgrade from the start of the map
- in skirmish
- in multiplayer
- in generals challenge

The dummy upgrade may be missing:
- in the campaign
- on custom maps without spots

I have not found a campaign mission where this may be an issue.