### PR TITLE
Change: Add demo charges to unused Demo Saboteur, add unique voice lines

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2283_demo_saboteur.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2283_demo_saboteur.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-24
 
-title: Adds demolition charges ability to unused Demo GLA Saboteur
+title: Adds demolition charges, Suicide ability and unique voice lines to unused Demo GLA Saboteur
 
 changes:
   - feature: Demo GLA Saboteur can now place timed and remote demo charges.

--- a/Patch104pZH/Design/Changes/v1.0/2283_demo_saboteur.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2283_demo_saboteur.yaml
@@ -1,12 +1,12 @@
 ---
 date: 2023-08-24
 
-title: Adds demolition charges, Suicide ability, and unique text and voice lines to unused Demo GLA Saboteur
+title: Completes implementation of unused GLA Demo Saboteur
 
 changes:
   - feature: Demo GLA Saboteur can now place timed and remote demo charges.
-  - tweak: Demo GLA Saboteur can no longer infiltrate buildings.
   - feature: Demo GLA Saboteur now unique texts and voice set.
+  - tweak: Demo GLA Saboteur can no longer infiltrate buildings.
   - fix: Demo GLA Saboteur can now use the Suicide ability from the Demolitions upgrade.
 
 labels:
@@ -17,7 +17,7 @@ labels:
   - worldbuilder
 
 links:
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/xxxx
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2283
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2283_demo_saboteur.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2283_demo_saboteur.yaml
@@ -1,11 +1,12 @@
 ---
 date: 2023-08-24
 
-title: Adds demolition charges, Suicide ability and unique voice lines to unused Demo GLA Saboteur
+title: Adds demolition charges, Suicide ability, and unique text and voice lines to unused Demo GLA Saboteur
 
 changes:
   - feature: Demo GLA Saboteur can now place timed and remote demo charges.
-  - feature: Demo GLA Saboteur now has a unique voice set.
+  - tweak: Demo GLA Saboteur can no longer infiltrate buildings.
+  - feature: Demo GLA Saboteur now unique texts and voice set.
   - fix: Demo GLA Saboteur can now use the Suicide ability from the Demolitions upgrade.
 
 labels:

--- a/Patch104pZH/Design/Changes/v1.0/xxxx_demo_saboteur.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/xxxx_demo_saboteur.yaml
@@ -1,0 +1,22 @@
+---
+date: 2023-08-24
+
+title: Adds demolition charges ability to unused Demo GLA Saboteur
+
+changes:
+  - feature: Demo GLA Saboteur can now place timed and remote demo charges.
+  - feature: Demo GLA Saboteur now has a unique voice set.
+  - fix: Demo GLA Saboteur can now use the Suicide ability from the Demolitions upgrade.
+
+labels:
+  - enhancement
+  - gla
+  - minor
+  - v1.0
+  - worldbuilder
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/xxxx
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5604,6 +5604,16 @@ CommandButton Demo_Command_ConstructGLAInfantryJarmenKell
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildJarmenKell
 End
 
+; Patch104p @bugfix commy2 24/08/2023 Add missing button to build Demo Saboteur. (#xxxx)
+CommandButton Demo_Command_ConstructGLAInfantrySaboteur
+  Command       = UNIT_BUILD
+  Object        = Demo_GLAInfantrySaboteur
+  TextLabel     = CONTROLBAR:ConstructGLAInfantrySaboteur
+  ButtonImage   = SUSaboteur
+  ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipGLABuildSaboteur
+End
+
 CommandButton Demo_Command_ConstructGLAVehicleRadarVan
   Command       = UNIT_BUILD
   Object        = Demo_GLAVehicleRadarVan
@@ -5692,6 +5702,43 @@ CommandButton Demo_Command_KellRemoteDemoCharge
 End
 
 CommandButton Demo_Command_KellDetonateCharges
+  Command                 = SPECIAL_POWER
+  SpecialPower            = Demo_SpecialAbilityKellRemoteCharges
+  Options                 = NEED_SPECIAL_POWER_SCIENCE OK_FOR_MULTI_SELECT
+  TextLabel               = CONTROLBAR:DetonateCharges
+  ButtonImage             = SSDetonate
+  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipUSABurtonDetonateCharges
+End
+
+; Patch104p @feature commy2 24/08/2023 Add buttons for bomb planting Saboteur. (#xxxx)
+CommandButton Demo_Command_SaboteurTimedDemoCharge
+  Command                 = SPECIAL_POWER
+  SpecialPower            = Demo_SpecialAbilityDemoKellTimedCharges
+  Options                 = NEED_SPECIAL_POWER_SCIENCE OK_FOR_MULTI_SELECT NEED_TARGET_ENEMY_OBJECT NEED_TARGET_NEUTRAL_OBJECT
+  TextLabel               = CONTROLBAR:TimedDemoCharge
+  ButtonImage             = SSTimedDemo
+  CursorName              = PlaceTimedCharge
+  InvalidCursorName       = PlaceChargeInvalid
+  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipUSAFireBurtonTimedDemo
+  UnitSpecificSound       = DemoSaboteurVoiceModeDemo
+End
+
+CommandButton Demo_Command_SaboteurRemoteDemoCharge
+  Command                 = SPECIAL_POWER
+  SpecialPower            = Demo_SpecialAbilityKellRemoteCharges
+  Options                 = NEED_SPECIAL_POWER_SCIENCE OK_FOR_MULTI_SELECT NEED_TARGET_ENEMY_OBJECT NEED_TARGET_NEUTRAL_OBJECT CONTEXTMODE_COMMAND
+  TextLabel               = CONTROLBAR:RemoteDemoCharge
+  ButtonImage             = SSRemoteDemo
+  CursorName              = PlaceRemoteCharge
+  InvalidCursorName       = PlaceChargeInvalid
+  ButtonBorderType        = ACTION ; Identifier for the User as to what kind of button this is
+  DescriptLabel           = CONTROLBAR:ToolTipUSABurtonPlaceRemoteCharge
+  UnitSpecificSound       = DemoSaboteurVoiceModeDemo
+End
+
+CommandButton Demo_Command_SaboteurDetonateCharges
   Command                 = SPECIAL_POWER
   SpecialPower            = Demo_SpecialAbilityKellRemoteCharges
   Options                 = NEED_SPECIAL_POWER_SCIENCE OK_FOR_MULTI_SELECT

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5604,7 +5604,7 @@ CommandButton Demo_Command_ConstructGLAInfantryJarmenKell
   DescriptLabel           = CONTROLBAR:ToolTipGLABuildJarmenKell
 End
 
-; Patch104p @bugfix commy2 24/08/2023 Add missing button to build Demo Saboteur. (#xxxx)
+; Patch104p @bugfix commy2 24/08/2023 Add missing button to build Demo Saboteur. (#2283)
 CommandButton Demo_Command_ConstructGLAInfantrySaboteur
   Command       = UNIT_BUILD
   Object        = Demo_GLAInfantrySaboteur
@@ -5711,7 +5711,7 @@ CommandButton Demo_Command_KellDetonateCharges
   DescriptLabel           = CONTROLBAR:ToolTipUSABurtonDetonateCharges
 End
 
-; Patch104p @feature commy2 24/08/2023 Add buttons for bomb planting Saboteur. (#xxxx)
+; Patch104p @feature commy2 24/08/2023 Add buttons for bomb planting Saboteur. (#2283)
 CommandButton Demo_Command_SaboteurTimedDemoCharge
   Command                 = SPECIAL_POWER
   SpecialPower            = Demo_SpecialAbilityDemoKellTimedCharges

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5608,10 +5608,10 @@ End
 CommandButton Demo_Command_ConstructGLAInfantrySaboteur
   Command       = UNIT_BUILD
   Object        = Demo_GLAInfantrySaboteur
-  TextLabel     = CONTROLBAR:ConstructGLAInfantrySaboteur
+  TextLabel     = CONTROLBAR:Demo_ConstructGLAInfantrySaboteur
   ButtonImage   = SUSaboteur
   ButtonBorderType        = BUILD ; Identifier for the User as to what kind of button this is
-  DescriptLabel           = CONTROLBAR:ToolTipGLABuildSaboteur
+  DescriptLabel           = CONTROLBAR:Demo_ToolTipGLABuildSaboteur
 End
 
 CommandButton Demo_Command_ConstructGLAVehicleRadarVan

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2343,6 +2343,7 @@ CommandSet Demo_GLABarracksCommandSet
   3  = Demo_Command_ConstructGLAInfantryTerrorist
   4  = Demo_Command_ConstructGLAInfantryAngryMob
   6  = Demo_Command_ConstructGLAInfantryJarmenKell
+  7  = Demo_Command_ConstructGLAInfantrySaboteur ; @TODO, debug remove
 ; 8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
   13 = Command_SetRallyPoint
@@ -2438,7 +2439,6 @@ CommandSet Demo_GLAInfantryAngryMobCommandSet
 End
 
 ; Patch104p @bugfix commy2 10/09/2021 Adjust Demo Charge buttons to occupy same slots as on Colonel Burton.
-
 CommandSet Demo_GLAInfantryJarmenKellCommandSet
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack
   2 = Demo_Command_KellTimedDemoCharge
@@ -2446,6 +2446,15 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   6 = Demo_Command_KellDetonateCharges
   11 = Command_AttackMove
   13 = Command_Guard
+  14 = Command_Stop
+End
+
+; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#xxxx)
+CommandSet Demo_GLAInfantrySaboteurCommandSet
+  1 = Command_SabotageBuilding
+  2 = Demo_Command_SaboteurTimedDemoCharge
+  4 = Demo_Command_SaboteurRemoteDemoCharge
+  6 = Demo_Command_SaboteurDetonateCharges
   14 = Command_Stop
 End
 
@@ -2703,6 +2712,7 @@ CommandSet Demo_GLABarracksCommandSetUpgrade ; unused
   3  = Demo_Command_ConstructGLAInfantryTerrorist
   4  = Demo_Command_ConstructGLAInfantryAngryMob
   6  = Demo_Command_ConstructGLAInfantryJarmenKell
+  7  = Demo_Command_ConstructGLAInfantrySaboteur ; @TODO, debug remove
 ; 8  = Command_UpgradeGLAInfantryRebelBoobyTrapAttack
   11 = Command_UpgradeGLARebelCaptureBuilding
   12 = Demo_Command_TertiarySuicide
@@ -2791,7 +2801,6 @@ CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
 End
 
 ; Patch104p @bugfix commy2 10/09/2021 Adjust Demo Charge buttons to occupy same slots as on Colonel Burton.
-
 CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   1 = Command_GLAInfantryJarmenKellSnipeVehicleAttack
   2 = Demo_Command_KellTimedDemoCharge
@@ -2800,6 +2809,16 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   11 = Command_AttackMove
   12 = Demo_Command_TertiarySuicide
   13 = Command_Guard
+  14 = Command_Stop
+End
+
+; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#xxxx)
+CommandSet Demo_GLAInfantrySaboteurCommandSetUpgrade
+  1 = Command_SabotageBuilding
+  2 = Demo_Command_SaboteurTimedDemoCharge
+  4 = Demo_Command_SaboteurRemoteDemoCharge
+  6 = Demo_Command_SaboteurDetonateCharges
+  12 = Demo_Command_TertiarySuicide
   14 = Command_Stop
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandSet.ini
@@ -2449,9 +2449,9 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   14 = Command_Stop
 End
 
-; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#xxxx)
+; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#2283)
 CommandSet Demo_GLAInfantrySaboteurCommandSet
-  1 = Command_SabotageBuilding
+  ;1 = Command_SabotageBuilding
   2 = Demo_Command_SaboteurTimedDemoCharge
   4 = Demo_Command_SaboteurRemoteDemoCharge
   6 = Demo_Command_SaboteurDetonateCharges
@@ -2812,9 +2812,9 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   14 = Command_Stop
 End
 
-; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#xxxx)
+; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#2283)
 CommandSet Demo_GLAInfantrySaboteurCommandSetUpgrade
-  1 = Command_SabotageBuilding
+  ;1 = Command_SabotageBuilding
   2 = Demo_Command_SaboteurTimedDemoCharge
   4 = Demo_Command_SaboteurRemoteDemoCharge
   6 = Demo_Command_SaboteurDetonateCharges

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17292,8 +17292,8 @@ Object Demo_GLAInfantryWorker
 
 End
 
-; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#xxxx)
-; Patch104p @bugfix commy2 24/08/2023 Add missing Suicide ability. (#xxxx)
+; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#2283)
+; Patch104p @bugfix commy2 24/08/2023 Add missing Suicide ability. (#2283)
 ;------------------------------------------------------------------------------
 Object Demo_GLAInfantrySaboteur
 
@@ -17491,41 +17491,42 @@ Object Demo_GLAInfantrySaboteur
     ;nothing
   End
 
-  Behavior = SabotagePowerPlantCrateCollide       SabotageTag_01
-    BuildingPickup = Yes
-    SabotagePowerDuration = 30000
-  End
-
-  ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
-
-  Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
-    BuildingPickup  = Yes
-    StealCashAmount = 1000
-  End
-  Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
-    BuildingPickup = Yes
-  End
-  Behavior = SabotageCommandCenterCrateCollide    SabotageTag_04
-    BuildingPickup = Yes
-  End
-  Behavior = SabotageSupplyCenterCrateCollide     SabotageTag_05
-    BuildingPickup  = Yes
-    StealCashAmount = 1000
-  End
-  Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
-    BuildingPickup = Yes
-    SabotageDuration = 30000
-  End
-
-  ; Patch104p @bugfix commy2 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
-
-  Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
-    BuildingPickup = Yes
-  End
-  Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
-    BuildingPickup = Yes
-    SabotageDuration = 15000
-  End
+  ; Patch104p @bugfix commy2 24/08/2023 Disable sabotage, because it conflicts with demo charges. (#2283)
+  ;Behavior = SabotagePowerPlantCrateCollide       SabotageTag_01
+  ;  BuildingPickup = Yes
+  ;  SabotagePowerDuration = 30000
+  ;End
+  ;
+  ;; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
+  ;
+  ;Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
+  ;  BuildingPickup  = Yes
+  ;  StealCashAmount = 1000
+  ;End
+  ;Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
+  ;  BuildingPickup = Yes
+  ;End
+  ;Behavior = SabotageCommandCenterCrateCollide    SabotageTag_04
+  ;  BuildingPickup = Yes
+  ;End
+  ;Behavior = SabotageSupplyCenterCrateCollide     SabotageTag_05
+  ;  BuildingPickup  = Yes
+  ;  StealCashAmount = 1000
+  ;End
+  ;Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
+  ;  BuildingPickup = Yes
+  ;  SabotageDuration = 30000
+  ;End
+  ;
+  ;; Patch104p @bugfix commy2 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.
+  ;
+  ;Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
+  ;  BuildingPickup = Yes
+  ;End
+  ;Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
+  ;  BuildingPickup = Yes
+  ;  SabotageDuration = 15000
+  ;End
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17410,7 +17410,7 @@ Object Demo_GLAInfantrySaboteur
   End
 
   ; ***DESIGN parameters ***
-  DisplayName         = OBJECT:Saboteur
+  DisplayName         = OBJECT:Demo_Saboteur // Patch104p @fix commy2 25/08/2023 Adds text variant for Demo Saboteur.
   Side                = GLADemolitionGeneral
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17292,6 +17292,8 @@ Object Demo_GLAInfantryWorker
 
 End
 
+; Patch104p @feature commy2 24/08/2023 Implement bomb planting for Demo Saboteur. (#xxxx)
+; Patch104p @bugfix commy2 24/08/2023 Add missing Suicide ability. (#xxxx)
 ;------------------------------------------------------------------------------
 Object Demo_GLAInfantrySaboteur
 
@@ -17299,7 +17301,7 @@ Object Demo_GLAInfantrySaboteur
   SelectPortrait         = SUSaboteur_L
   ButtonImage            = SUSaboteur
 
-  ;UpgradeCameo1 = NONE
+  UpgradeCameo1 = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo2 = NONE
   ;UpgradeCameo3 = NONE
   ;UpgradeCameo4 = NONE
@@ -17334,6 +17336,16 @@ Object Demo_GLAInfantrySaboteur
       WaitForStateToFinishIfPossible = NoWait
       ParticleSysBone = None InfantryDustTrails
     End
+
+    ; --- placing charge
+    ConditionState = UNPACKING
+      Animation = AIOFCR_SKL.AICIAOFF_PLNT
+      AnimationMode = ONCE
+      WaitForStateToFinishIfPossible = NoWait
+    End
+    AliasConditionState = UNPACKING REALLYDAMAGED
+    AliasConditionState = MOVING UNPACKING
+    AliasConditionState = MOVING UNPACKING REALLYDAMAGED
 
     ; Patch104p @bugfix commy2 30/07/2023 Fix units stuck in walk animation when dying. (#2175)
     ConditionState = DYING
@@ -17403,6 +17415,12 @@ Object Demo_GLAInfantrySaboteur
   EditorSorting       = INFANTRY
   TransportSlotCount  = 1                 ;how many "slots" we take in a transport (0 == not transportable)
 
+  WeaponSet
+    Conditions = None
+    Weapon = TERTIARY TerroristSuicideNotARealWeapon
+    AutoChooseSources = TERTIARY NONE
+  End
+
   ArmorSet
     Conditions      = None
     Armor           = HumanArmor
@@ -17421,24 +17439,24 @@ Object Demo_GLAInfantrySaboteur
   ;ExperienceRequired  = 0 40 60 120     ;Experience points needed to gain each level
   IsTrainable         = No             ;Can gain experience
   CrushableLevel      = 0  ;What am I?:        0 = for infantry, 1 = for trees, 2 = general vehicles
-  CommandSet          = GLAInfantrySaboteurCommandSet
+  CommandSet          = Demo_GLAInfantrySaboteurCommandSet
 
   ; *** AUDIO Parameters ***
   VoiceSelect = SaboteurVoiceSelect
-  VoiceMove = SaboteurVoiceMove
-  VoiceGuard = SaboteurVoiceMove
+  VoiceMove = DemoSaboteurVoiceMove
+  VoiceGuard = DemoSaboteurVoiceMove
   VoiceAttack = SaboteurVoiceAttack
   SoundStealthOn = StealthOn
   SoundStealthOff = StealthOff
   VoiceFear = SaboteurVoiceFear
   VoiceTaskComplete = NoSound
   UnitSpecificSounds
-    VoiceCreate = SaboteurVoiceCreate
-    VoiceSubdue = SaboteurVoiceMove
-    VoiceGarrison = SaboteurVoiceMove
-    VoiceEnter = SaboteurVoiceMove
+    VoiceCreate = DemoSaboteurVoiceCreate
+    VoiceSubdue = DemoSaboteurVoiceMove
+    VoiceGarrison = DemoSaboteurVoiceMove
+    VoiceEnter = DemoSaboteurVoiceMove
     VoiceEnterHostile = SaboteurVoiceAttack
-    VoiceGetHealed      = SaboteurVoiceMove
+    VoiceGetHealed      = DemoSaboteurVoiceMove
   End
 
   ; *** ENGINEERING Parameters ***
@@ -17581,7 +17599,76 @@ Object Demo_GLAInfantrySaboteur
     FlingPitchVariance  = 10
   End
 
+  ; Patch104p @bugfix commy2 30/07/2023 Exempt MASKED status to postpone death explosion until after passenger exit, if ever. (#2177)
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag998
+    DeathWeapon   = Demo_SuicideDynamitePackPlusFire
+    StartsActive  = No
+    TriggeredBy   = Demo_Upgrade_SuicideBomb
+    DeathTypes = NONE +SUICIDED
+    ExemptStatus  = MASKED
+  End;
 
+  Behavior = FireWeaponWhenDeadBehavior ModuleTag999
+    DeathWeapon   = Demo_DestroyedWeapon
+    StartsActive  = No
+    TriggeredBy   = Demo_Upgrade_SuicideBomb
+    DeathTypes = ALL -SUICIDED
+    ExemptStatus  = MASKED
+  End
+
+  Behavior = CommandSetUpgrade ModuleTag_17
+    CommandSet = Demo_GLAInfantrySaboteurCommandSetUpgrade
+    TriggeredBy = Demo_Upgrade_SuicideBomb
+  End
+
+  Behavior = SpecialAbility ModuleTag_18
+    SpecialPowerTemplate = Demo_SpecialAbilityKellRemoteCharges
+    UpdateModuleStartsAttack = Yes
+    InitiateSound             = DemoSaboteurVoiceAttackDemo
+  End
+
+  Behavior = SpecialAbilityUpdate ModuleTag_19
+    SpecialPowerTemplate = Demo_SpecialAbilityKellRemoteCharges
+    StartAbilityRange = 0.0
+    PreparationTime = 0
+    SpecialObject = RemoteC4Charge
+    MaxSpecialObjects = 8
+    SpecialObjectsPersistWhenOwnerDies = No ;Charges are removed instantly when owner dies (nobody can detonate).
+    AlwaysValidateSpecialObjects = Yes      ;Coupled with the above setting, this one is necessary for code optimization.
+    SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
+    UniqueSpecialObjectTargets = Yes        ;This prevents multiple charges placed on the same object.
+    UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
+    PackTime                = 0
+    SkipPackingWithNoTarget = Yes           ;When yes, the packing/unpacking will be ignored when detonating charges.
+    FlipOwnerAfterUnpacking = Yes
+    FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
+    LoseStealthOnTrigger      = Yes
+    PreTriggerUnstealthTime   = 5000 ; in milliseconds
+  End
+
+  Behavior = SpecialAbility ModuleTag_20
+    SpecialPowerTemplate = Demo_SpecialAbilityDemoKellTimedCharges
+    UpdateModuleStartsAttack = Yes
+    InitiateSound             = DemoSaboteurVoiceAttackDemo
+  End
+
+  Behavior = SpecialAbilityUpdate ModuleTag_21
+    SpecialPowerTemplate = Demo_SpecialAbilityDemoKellTimedCharges
+    StartAbilityRange = 0.0
+    PreparationTime = 0
+    SpecialObject = TimedC4Charge
+    MaxSpecialObjects = 10
+    SpecialObjectsPersistWhenOwnerDies = Yes
+    SpecialObjectsPersistent = Yes          ;Charges are persistent till lifetime expires or owner detonates them.
+    UniqueSpecialObjectTargets = Yes        ;This prevents multiple charges placed on the same object.
+    UnpackTime              = 5500          ;NOTE: Modifying this value will require modifying the delay for ColonelBurtonPlantCharge
+    FlipOwnerAfterUnpacking = Yes
+    FleeRangeAfterCompletion = 100.0         ;Runs away after finishing ability
+    UnpackSound               = NoSound ;ColonelBurtonPlantCharge
+    LoseStealthOnTrigger      = Yes
+    PreTriggerUnstealthTime   = 5000 ; in milliseconds
+  End
 
 ;  Behavior = SpecialAbility ModuleTag_17
 ;    SpecialPowerTemplate      = SpecialAbilityRebelCaptureBuilding

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -4827,6 +4827,38 @@ AudioEvent SaboteurVoiceDie
 End
 
 
+; Demo Saboteur
+
+AudioEvent DemoSaboteurVoiceCreate
+  Sounds =  isadsea
+  Control = random
+  Volume = 90
+  Type = world voice player ; Patch104p @tweak from 'ui' to 'world'
+End
+
+AudioEvent DemoSaboteurVoiceMove
+  Sounds =  isabmoa isabmob isabmoc isabmod isabmoe isadmoa
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+AudioEvent DemoSaboteurVoiceModeDemo
+  Sounds = isadmda isadmdb isadmdc
+  Control = random
+  Volume = 90
+  Type = ui voice player
+  Limit = 1
+End
+
+AudioEvent DemoSaboteurVoiceAttackDemo
+  Sounds = isada2a isada2b isada2c
+  Control = random
+  Volume = 90
+  Type = ui voice player
+End
+
+
 ;Avenger
 
 AudioEvent AvengerVoiceSelect


### PR DESCRIPTION
- Adds previously unused voice set to the worldbuilder only Demo General Saboteur.
- Adds Suicide ability to Demo General Saboteur
- Adds placing timed and remote demo charges ability to Demo General Saboteur -- he has voice lines specifically for that
- Animation used for placing charges is from CIA Agent. It looks neat with the Saboteur model.