### PR TITLE
Fix: Toxin General RPG-Soldier and USA05 Toxin RPG-Soldier missing muzzle flash when firing at ground targets

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2284_toxin_general_rpg_soldier_muzzle_flash.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2284_toxin_general_rpg_soldier_muzzle_flash.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-08-27
+
+title: Fixes missing Toxin GLA RPG Soldier muzzle flash
+
+changes:
+  - fix: Toxin GLA RPG Soldier now shows a muzzle flash when firing at ground targets.
+  - fix: Toxin GLA RPG Soldier (USA05 campaign) now shows a muzzle flash when firing at ground targets.
+
+labels:
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2284
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13294,7 +13294,7 @@ Object Chem_GLAInfantryTunnelDefender
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition between cheering and standing.
-  ; Patch104p @bugfix commy2 24/08/2023 Fix missing muzzle flash when firing at ground targets. (#xxxx)
+  ; Patch104p @bugfix commy2 24/08/2023 Fix missing muzzle flash when firing at ground targets. (#2284)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -13287,7 +13287,6 @@ Object Chem_GLAInfantryTunnelDefender
   ButtonImage            = SURPG
 
   ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
-
   UpgradeCameo1 = Upgrade_GLAAPRockets
   UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
   ;UpgradeCameo3 = NONE
@@ -13295,6 +13294,7 @@ Object Chem_GLAInfantryTunnelDefender
   ;UpgradeCameo5 = NONE
 
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition between cheering and standing.
+  ; Patch104p @bugfix commy2 24/08/2023 Fix missing muzzle flash when firing at ground targets. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -13309,8 +13309,6 @@ Object Chem_GLAInfantryTunnelDefender
       WeaponMuzzleFlash = PRIMARY MuzzleFX
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponLaunchBone = PRIMARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX      ;Fixes shooting at the hip.
-      WeaponFireFXBone = SECONDARY Muzzle         ;Fixes shooting at the hip.
       WeaponLaunchBone = SECONDARY Muzzle         ;Fixes shooting at the hip.
     End
 
@@ -13366,7 +13364,16 @@ Object Chem_GLAInfantryTunnelDefender
       TransitionKey = TRANS_START_FIRING
       WaitForStateToFinishIfPossible = NoWait
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState = FIRING_B
+      Animation = UITunF_SKL.UITunF_ATA
+      AnimationMode = ONCE
+      TransitionKey = TRANS_START_FIRING
+      WaitForStateToFinishIfPossible = NoWait
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      WeaponFireFXBone = SECONDARY Muzzle
+    End
+
     ConditionState = BETWEEN_FIRING_SHOTS_A
       Animation = UITunF_SKL.UITunF_STA
       AnimationMode = ONCE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -822,7 +822,7 @@ Object GC_Chem_GLAInfantryTunnelDefender
   UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
 
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition between cheering and standing.
-  ; Patch104p @bugfix commy2 24/08/2023 Fix missing muzzle flash when firing at ground targets. (#xxxx)
+  ; Patch104p @bugfix commy2 24/08/2023 Fix missing muzzle flash when firing at ground targets. (#2284)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -818,11 +818,11 @@ Object GC_Chem_GLAInfantryTunnelDefender
   ButtonImage            = SUToxinRPG
 
   ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Gamma.
-
   UpgradeCameo1 = Upgrade_GLAAPRockets
   UpgradeCameo2 = Chem_Upgrade_GLAAnthraxGamma
 
   ; Patch104p @bugfix commy2 10/08/2023 Fix rough transition between cheering and standing.
+  ; Patch104p @bugfix commy2 24/08/2023 Fix missing muzzle flash when firing at ground targets. (#xxxx)
   Draw = W3DModelDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
@@ -837,8 +837,6 @@ Object GC_Chem_GLAInfantryTunnelDefender
       WeaponMuzzleFlash = PRIMARY MuzzleFX
       WeaponFireFXBone = PRIMARY Muzzle
       WeaponLaunchBone = PRIMARY Muzzle
-      WeaponMuzzleFlash = SECONDARY MuzzleFX      ;Fixes shooting at the hip.
-      WeaponFireFXBone = SECONDARY Muzzle         ;Fixes shooting at the hip.
       WeaponLaunchBone = SECONDARY Muzzle         ;Fixes shooting at the hip.
     End
 
@@ -894,7 +892,16 @@ Object GC_Chem_GLAInfantryTunnelDefender
       TransitionKey = TRANS_START_FIRING
       WaitForStateToFinishIfPossible = NoWait
     End
-    AliasConditionState = FIRING_B
+
+    ConditionState = FIRING_B
+      Animation = UITunF_SKL.UITunF_ATA
+      AnimationMode = ONCE
+      TransitionKey = TRANS_START_FIRING
+      WaitForStateToFinishIfPossible = NoWait
+      WeaponMuzzleFlash = SECONDARY MuzzleFX
+      WeaponFireFXBone = SECONDARY Muzzle
+    End
+
     ConditionState = BETWEEN_FIRING_SHOTS_A
       Animation = UITunF_SKL.UITunF_STA
       AnimationMode = ONCE


### PR DESCRIPTION
They have the muzzle fire when aiming at airborne targets, but not when aiming at ground targets due to a bug.

Note that there is a exhaust glow associated with RPG missiles that are missing from the Stinger missiles they fire, so it still does not has all the fire effects of the other/regular RPG Soldiers.