### PR TITLE
Tweak: Make USA05 GLA infantry no longer weak to rocketeer infantry

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2285_usa05_campaign_enemy_infantry.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2285_usa05_campaign_enemy_infantry.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-25
+
+title: Fixes armor of enemy infantry on the USA05 campaign map.
+
+changes:
+  - fix: The GLA enemy infantry on the fifth USA campaign map is no longer weak to rocket infantry.
+
+labels:
+  - enhancement
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2285
+
+authors:
+  - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2285_usa05_campaign_enemy_infantry.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2285_usa05_campaign_enemy_infantry.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-25
 
-title: Fixes armor of enemy infantry on the USA05 campaign map.
+title: Fixes armor of USA05 campaign map enemy infantry against rocket infantry
 
 changes:
   - fix: The GLA enemy infantry on the fifth USA campaign map is no longer weak to rocket infantry.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Armor.ini
@@ -64,6 +64,7 @@ End
 Armor HazMatHumanArmor
   Armor = CRUSH             200%    ;humans are easily crushed ["I'm crushing your head"]
   Armor = ARMOR_PIERCING    10%     ;humans don't get hit by tank rounds.
+  Armor = INFANTRY_MISSILE  10% ; Patch104p @tweak commy2 24/08/2023 Makes certain infantry units resist RPG missiles. (#2285)
   Armor = SNIPER            200%
   Armor = FLAME             25%     ;Hazmat's have a good resistance to fire.
   Armor = LASER             25%     ;Hazmat's can resist laser fire a bit better than infantry.


### PR DESCRIPTION
This mainly makes the USA05 campaign mission enemy infantry no longer crumble against Missile Defenders.

This armor is not used on any multiplayer unit. Is is used by the Biohazard Tech and the USA05 Dr. Thrax infantry. It is also referenced by some Infantry General units, but looked behind an undefined upgrade and thus unreachable.

I am pretty sure this definition is supposed to be there, but was forgotten.