### PR TITLE
Tweak: Add Anthrax Bomb and Rebel Ambush from USA05 GLA allies to shortcut bar

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2286_usa05_campaign_shortcut_bar.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2286_usa05_campaign_shortcut_bar.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-25
+
+title: Adds Ambush and Anthrax bomb to the players shortcut bar on the USA05 campaign map
+
+changes:
+  - fix: The Rebel Ambush and Anthrax Bomb powers of the recruited GLA allies are now available on the General's Power shortcut bar.
+
+labels:
+  - enhancement
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2286
+
+authors:
+  - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2286_usa05_campaign_shortcut_bar.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2286_usa05_campaign_shortcut_bar.yaml
@@ -1,10 +1,10 @@
 ---
 date: 2023-08-25
 
-title: Adds Ambush and Anthrax bomb to the players shortcut bar on the USA05 campaign map
+title: Adds Ambush and Anthrax Bomb to the players shortcut bar on the USA05 campaign map
 
 changes:
-  - fix: The Rebel Ambush and Anthrax Bomb powers of the recruited GLA allies are now available on the General's Power shortcut bar.
+  - fix: The Rebel Ambush and Anthrax Bomb powers of the recruited GLA allies on the fifth USA campaign map are now available on the General's Power shortcut bar.
 
 labels:
   - enhancement

--- a/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/PlayerTemplate.ini
@@ -55,7 +55,7 @@ PlayerTemplate FactionAmerica
   PurchaseScienceCommandSetRank8  = SCIENCE_AMERICA_CommandSetRank8
   SpecialPowerShortcutCommandSet  = SpecialPowerShortcutUSA
   SpecialPowerShortcutWinName     = GenPowersShortcutBarUS.wnd
-  SpecialPowerShortcutButtonCount = 10
+  SpecialPowerShortcutButtonCount = 11 ; Patch104p @tweak commy2 24/08/2023 Unlock extra slot for campaign. (#2286)
   DisplayName       = INI:FactionAmerica
   StartingBuilding  = AmericaCommandCenter
   StartingUnit0     = AmericaStartingThings

--- a/Patch104pZH/GameFilesEdited/Maps/MD_USA05/map.ini
+++ b/Patch104pZH/GameFilesEdited/Maps/MD_USA05/map.ini
@@ -28,6 +28,21 @@ CommandSet GC_Chem_GLABarracksCommandSet
   14 = Command_Sell 
 End
 
+; Patch104p @tweak commy2 24/08/2023 Adds Anthrax Bomb and Rebel Ambush to shortcut bar. (#2286)
+CommandSet SpecialPowerShortcutUSA
+  1 = Command_SpyDroneFromShortcut
+  2 = Command_ParadropFromShortcut
+  3 = Command_A10ThunderboltMissileStrikeFromShortcut
+  4 = Command_EmergencyRepairFromShortcut
+  5 = Command_DaisyCutterFromShortcut
+  6 = Command_FireParticleUplinkCannonFromShortcut
+  7 = Command_SpySatelliteScanFromShortcut
+  8 = Command_SpectreGunshipFromShortcut
+  9 = Command_LeafletDropFromShortcut
+  10 = Command_AmbushFromShortcut
+  11 = Command_AnthraxBombFromShortcut
+END
+
 ;------------------------------------------
 ;--------Set Environment Overrides---------
 ;------------------------------------------


### PR DESCRIPTION
In USA05, you're given GLA allies. You can call Rebel Ambush level 3 and Anthrax Bomb from the GLA Command Center.

This is annoying though, because the powers do not appear on the shortcut bar. You will need to select the Command Center regularly to see if the powers have been recharged and to use them.

![shot_20230825_000855_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/13eb263f-f849-4e4f-812e-0d306dc4525d)
