### PR TITLE
Fix: Burton Knife Attack animation skip exploit

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2287_burton_insta_stab.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2287_burton_insta_stab.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-25
 
-title: Fix USA Colonel Burton Knife Attack animation skip
+title: Fix USA Colonel Burton instant Knife Attack exploit
 
 changes:
   - fix: Fixes an exploit that allows USA Colonel Burton to skip the animation before the Knife Attack.

--- a/Patch104pZH/Design/Changes/v1.0/2287_burton_insta_stab.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2287_burton_insta_stab.yaml
@@ -1,5 +1,5 @@
 ---
-date: 2023-05-05
+date: 2023-08-25
 
 title: Fix USA Colonel Burton Knife Attack animation skip
 

--- a/Patch104pZH/Design/Changes/v1.0/2287_burton_insta_stab.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2287_burton_insta_stab.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-05-05
+
+title: Fix USA Colonel Burton Knife Attack animation skip
+
+changes:
+  - fix: Fixes an exploit that allows USA Colonel Burton to skip the animation before the Knife Attack.
+
+labels:
+  - bug
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2287
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -996,7 +996,7 @@ Weapon ColonelBurtonKnifeWeapon
   ClipSize              = 1               ; how many shots in a Clip (0 == infinite)
   ClipReloadTime        = 1367               ; how long to reload a Clip, msec
   PreAttackDelay        = 833             ; 833 is natural time of the stabbing animation.
-  PreAttackType         = PER_ATTACK ; Do the delay each time we attack a new target
+  PreAttackType         = PER_CLIP ; Patch104p @bugfix commy2 24/08/2023 Don't use PER_ATTACK so pre attack delay cannot be skipped by using gun first. (#2287)
 End
 
 ;------------------------------------------------------------------------------


### PR DESCRIPTION
PER_ATTACK is a bad choice here, because it will be skipped if Burton already engages the target with his other weapon. This can be abused to insta stab infantry.


https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/9bd07aff-dc05-43d4-8346-e4f06a249efc

