### PR TITLE
Fix: Injured members slow down the Angry Mob, can never catch up

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2227_boss_burton_recoil_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2227_boss_burton_recoil_animation.yaml
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-08
+date: 2023-08-12
 
 title: Fixes recoil animation issue of Boss Colonel Burton
 

--- a/Patch104pZH/Design/Changes/v1.0/2227_boss_jarmen_recoil_animation.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2227_boss_jarmen_recoil_animation.yaml
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-08
+date: 2023-08-12
 
 title: Fixes recoil animation issue of Boss Jarmen Kell
 

--- a/Patch104pZH/Design/Changes/v1.0/2290_angry_mob_movement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2290_angry_mob_movement.yaml
@@ -15,7 +15,7 @@ labels:
   - v1.0
 
 links:
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/xxxx
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2290
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
@@ -4,7 +4,7 @@ date: 2023-08-26
 title: Fixes movement speed of injured Angry Mob members
 
 changes:
-  - fix: Injured members no longer slow down the GLA Angry Mob.
+  - fix: Injured members no longer slow down the GLA Angry Mob. This way they no longer lag behind and die off at a distance.
 
 labels:
   - buff

--- a/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-08-26
 
-title: Fixes movement speed of injured Angry Mob members
+title: Increases movement speed of injured GLA Angry Mob members to prevent them from falling behind and dying
 
 changes:
   - fix: Injured members no longer slow down the GLA Angry Mob. This way they no longer lag behind and die off at a distance.

--- a/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
@@ -8,6 +8,8 @@ changes:
 
 labels:
   - buff
+  - bug
+  - controversial
   - gla
   - minor
   - v1.0

--- a/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/xxxx_angry_mob_movement.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-08-26
+
+title: Fixes movement speed of injured Angry Mob members
+
+changes:
+  - fix: Injured members no longer slow down the GLA Angry Mob.
+
+labels:
+  - buff
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/xxxx
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -2789,7 +2789,7 @@ Locomotor AngryMobNexusLocomotor
   StickToGround = Yes       ; walking guys aren't allowed to catch huge (or even small) air.
 End
 
-; Patch104p @fix commy2 26/08/2023 Set SpeedDamaged equal to Speed for all Angry Mob locomotors to prevent damaged members lagging behind and dying off at a distance. (#2290)
+; Patch104p @fix commy2 26/08/2023 Set SpeedDamaged equal to Speed for all Angry Mob locomotors to prevent injured members lagging behind and dying off at a distance. (#2290)
 ;------------------------------------------------------------------------------
 Locomotor AngryMobNormalLocomotor
   Surfaces = GROUND RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -2789,7 +2789,7 @@ Locomotor AngryMobNexusLocomotor
   StickToGround = Yes       ; walking guys aren't allowed to catch huge (or even small) air.
 End
 
-; Patch104p @tweak commy2 26/08/2023 Set SpeedDamaged equal to Speed. (#xxxx)
+; Patch104p @fix commy2 26/08/2023 Set SpeedDamaged equal to Speed for all Angry Mob locomotors to prevent damaged members lagging behind and dying off at a distance. (#2290)
 ;------------------------------------------------------------------------------
 Locomotor AngryMobNormalLocomotor
   Surfaces = GROUND RUBBLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Locomotor.ini
@@ -2789,11 +2789,12 @@ Locomotor AngryMobNexusLocomotor
   StickToGround = Yes       ; walking guys aren't allowed to catch huge (or even small) air.
 End
 
+; Patch104p @tweak commy2 26/08/2023 Set SpeedDamaged equal to Speed. (#xxxx)
 ;------------------------------------------------------------------------------
 Locomotor AngryMobNormalLocomotor
   Surfaces = GROUND RUBBLE
   Speed = 20 ;30                ; in dist/sec
-  SpeedDamaged = 10 ;30         ; in dist/sec
+  SpeedDamaged = 20 ;10         ; in dist/sec
   TurnRate = 500            ; in degrees/sec
   TurnRateDamaged = 500    ; in degrees/sec
   Acceleration = 100        ; in dist/(sec^2)
@@ -2809,7 +2810,7 @@ End
 Locomotor AngryMobWanderLocomotor
   Surfaces = GROUND RUBBLE
   Speed = 13 ;;IMPORTANT THAT THIS STAYS SLOWER THAN A HUMAN WANDER, SO MOBSTER CAN LET THE OTHERS CATCH UP
-  SpeedDamaged = 10 ;30         ; in dist/sec
+  SpeedDamaged = 13 ;10         ; in dist/sec
   TurnRate = 500            ; in degrees/sec
   TurnRateDamaged = 500    ; in degrees/sec
   Acceleration = 100        ; in dist/(sec^2)
@@ -2825,7 +2826,7 @@ End
 Locomotor AngryMobPanicLocomotor
   Surfaces = GROUND RUBBLE
   Speed = 32 ;IMPORTANT THAT THIS STAYS FASTER THAN A HUMAN PANIC, SO MOBSTER CAN CATCH UP WITH NEXUS IN A CRISIS
-  SpeedDamaged = 10 ;30         ; in dist/sec
+  SpeedDamaged = 32 ;10         ; in dist/sec
   TurnRate = 500            ; in degrees/sec
   TurnRateDamaged = 500    ; in degrees/sec
   Acceleration = 100        ; in dist/(sec^2)


### PR DESCRIPTION
I think it would be better if injured Mob members didn't move slower.
There is no way for GLA to heal them before vet 2, aside from shooting them and waiting for their replacements.
They slow down the entire Mob and may cause Mob members to be killed as they get too far away from the center.

---

Only ways to heal are:
- Propaganda
- Ambulance
- Hospital
- Reaching vet 2

Barracks, Tunnels or other objects that heal passengers do not work, as Mobs can't enter them.
Jank way of healing members: shoot them, wait for replacement.
But it's not obvious which Mobsters are injured, as they have no individual healthbars and have no injured standing/idle animations.

The best way to figure out who's injured is to walk the Mob, and observe who's lagging behind. But this is also a bit unituitive, as Mob members have 3 different speed, depending on whether they are in front, close to, or behind the invisible nexus.

Also: Killing injured members with weapons with splash damage may injure healthy Mobsters.

---

There is a MobNexusContain module with "HealthRegen%PerSec" parameter, but it's not used anywhere and I expect it doesn't work.

