### PR TITLE
Fix: Boss Supply Truck and Civilian Toxic Supply Truck out of sync with patch changes

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1680_supply_truck_xp_reward.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1680_supply_truck_xp_reward.yaml
@@ -9,6 +9,7 @@ changes:
 labels:
   - buff
   - china
+  - civilian
   - controversial
   - design
   - major
@@ -16,6 +17,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1680
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2293
 
 authors:
   - Stubbjax

--- a/Patch104pZH/Design/Changes/v1.0/96_supply_truck_mass.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/96_supply_truck_mass.yaml
@@ -9,11 +9,13 @@ changes:
 labels:
   - bug
   - china
+  - civilian
   - minor
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/96
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2293
 
 authors:
   - hanfield

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -15078,8 +15078,10 @@ Object Boss_VehicleSupplyTruck
     SuppliesDepletedVoice = SupplyTruckVoiceSuppliesDepleted
   End
   Locomotor = SET_NORMAL SupplyTruckLocomotor
+
+  ; Patch104p @bugfix commy2 26/08/2023 Increase Supply Truck mass from 5. (#2293)
   Behavior = PhysicsBehavior ModuleTag_04
-    Mass = 5.0
+    Mass = 50.0
   End
 
   ; Patch104p @balance Stubbjax 12/02/2023 Decreases XP reward from 50. (#1680)

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2352,7 +2352,7 @@ Object ChinaVehicleSupplyTruck
   End
   Locomotor = SET_NORMAL SupplyTruckLocomotor
 
-  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50.
+  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50. (#96)
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 50.0
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/CivilianUnit.ini
@@ -11891,11 +11891,13 @@ Object ToxicSupplyTruck
 
   Locomotor = SET_NORMAL SupplyTruckLocomotor
 
+  ; Patch104p @bugfix commy2 26/08/2023 Increase Supply Truck mass from 5. (#2293)
   Behavior = PhysicsBehavior ModuleTag_04
-    Mass = 5.0
+    Mass = 50.0
   End
 
-  ExperienceValue    = 50 50 50 50 ;Experience point value at each level
+  ; Patch104p @balance commy2 26/08/2023 Decrease Supply Truck XP reward from 50. (#2293)
+  ExperienceValue    = 25 25 25 25 ;Experience point value at each level
 
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -2903,7 +2903,7 @@ Object Infa_ChinaVehicleSupplyTruck
   End
   Locomotor = SET_NORMAL SupplyTruckLocomotor
 
-  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50.
+  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50. (#96)
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 50.0
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4461,7 +4461,7 @@ Object Nuke_ChinaVehicleSupplyTruck
   End
   Locomotor = SET_NORMAL SupplyTruckLocomotor
 
-  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50.
+  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50. (#96)
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 50.0
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -4659,7 +4659,7 @@ Object Tank_ChinaVehicleSupplyTruck
   End
   Locomotor = SET_NORMAL SupplyTruckLocomotor
 
-  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50.
+  ; Patch104p @bugfix hanfield 28/08/2021 Increased Supply Truck mass from 5 to 50. (#96)
   Behavior = PhysicsBehavior ModuleTag_04
     Mass = 50.0
   End


### PR DESCRIPTION
Boss Supply Truck is missing the mass fix...

Toxic Supply Truck is a fully functional civilian copy / reskin of the Supply Truck and it should inherit all changes made to the regular Supply Truck.