### PR TITLE
Generate Arabic and Russian language files in English localization folders

### DIFF
--- a/Patch104pZH/ModBundleAudioItems.json
+++ b/Patch104pZH/ModBundleAudioItems.json
@@ -23,7 +23,7 @@
                         "sourceTargetList": [
                             {
                                 "source": "Data/Audio/Sounds/English/*.wav",
-                                "target": "Data/Audio/Sounds/Arabic/*.wav"
+                                "target": "Data/Audio/Sounds/English/*.wav"
                             }
                         ]
                     }
@@ -146,8 +146,11 @@
                 "files": [
                     {
                         "parent": "GameFilesEdited",
-                        "sourceList": [
-                            "Data/Audio/Sounds/Russian/*.wav"
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Audio/Sounds/Russian/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            }
                         ]
                     }
                 ]
@@ -199,27 +202,27 @@
                         "sourceTargetList": [
                             {
                                 "source": "Data/Audio/Sounds/English/*.wav",
-                                "target": "Data/Audio/Sounds/Arabic/*.wav"
+                                "target": "Data/Audio/Sounds/English/*.wav"
                             },
                             {
                                 "source": "Data/Audio/Sounds/Restoration/CommonVoice/*.wav",
-                                "target": "Data/Audio/Sounds/Arabic/*.wav"
+                                "target": "Data/Audio/Sounds/English/*.wav"
                             },
                             {
                                 "source": "Data/Audio/Sounds/Restoration/CommonVoice2/*.wav",
-                                "target": "Data/Audio/Sounds/Arabic/*.wav"
+                                "target": "Data/Audio/Sounds/English/*.wav"
                             },
                             {
                                 "source": "Data/Audio/Sounds/Restoration/EnglishVoice/*.wav",
-                                "target": "Data/Audio/Sounds/Arabic/*.wav"
+                                "target": "Data/Audio/Sounds/English/*.wav"
                             },
                             {
                                 "source": "Data/Audio/Sounds/Restoration/EnglishVoice2/*.wav",
-                                "target": "Data/Audio/Sounds/Arabic/*.wav"
+                                "target": "Data/Audio/Sounds/English/*.wav"
                             },
                             {
                                 "source": "Data/Audio/Speech/Restoration/EnglishEva/*.wav",
-                                "target": "Data/Audio/Speech/Arabic/*.wav"
+                                "target": "Data/Audio/Speech/English/*.wav"
                             }
                         ]
                     }
@@ -482,7 +485,7 @@
                         "sourceTargetList": [
                             {
                                 "source": "Data/Audio/Sounds/Russian/*.wav",
-                                "target": "Data/Audio/Sounds/Russian/*.wav"
+                                "target": "Data/Audio/Sounds/English/*.wav"
                             }
                         ]
                     }

--- a/Patch104pZH/ModBundleLanguageItems.json
+++ b/Patch104pZH/ModBundleLanguageItems.json
@@ -5,12 +5,15 @@
             {
                 "name": "CoreLangArabic",
                 "big": true,
-                "setGameLanguageOnInstall": "Arabic",
+                "setGameLanguageOnInstall": "English",
                 "files": [
                     {
                         "parent": "GameFilesEdited",
-                        "sourceList": [
-                            "Data/Arabic/*.ini"
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Arabic/*.ini",
+                                "target": "Data/English/*.ini"
+                            }
                         ]
                     },
                     {
@@ -27,7 +30,7 @@
                         "sourceTargetList": [
                             {
                                 "source": "Data/generals.str",
-                                "target": "Data/Arabic/generals.csf"
+                                "target": "Data/English/generals.csf"
                             }
                         ]
                     }
@@ -520,12 +523,15 @@
             {
                 "name": "CoreLangRussian",
                 "big": true,
-                "setGameLanguageOnInstall": "Russian",
+                "setGameLanguageOnInstall": "English",
                 "files": [
                     {
                         "parent": "GameFilesEdited",
-                        "sourceList": [
-                            "Data/Russian/*.ini"
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Russian/*.ini",
+                                "target": "Data/English/*.ini"
+                            }
                         ]
                     },
                     {
@@ -542,7 +548,7 @@
                         "sourceTargetList": [
                             {
                                 "source": "Data/generals.str",
-                                "target": "Data/Russian/generals.csf"
+                                "target": "Data/English/generals.csf"
                             }
                         ]
                     }


### PR DESCRIPTION
This change generates Arabic and Russian language files in English localization folders. This allows them to be tested in English retail game.