### PR TITLE
Change: Hide tower on Radar Van until Radar Van Scan upgrade

### DIFF
--- a/Patch104pZH/Design/Tasks/nproject_tasks.txt
+++ b/Patch104pZH/Design/Tasks/nproject_tasks.txt
@@ -1159,7 +1159,7 @@ the list of known bugs and how to prevent them. If you encounter bugs that not l
    Reason: Balance issue. Best to be discussed and reviewed further.
 
  RADAR VAN:
- - [IMPROVEMENT][MINOR] Radar Van's radar tower hidden until the Radar Van Scan upgrade purchased
+ - [DONE][MINOR] Radar Van's radar tower hidden until the Radar Van Scan upgrade purchased
  - [NOTRELEVANT] Radar Van now will not drop salvage crates when destroyed
 
  QUAD CANNON:

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6270,6 +6270,7 @@ Object GLAVehicleRadarVan
       Model = UVRadarVan
       Animation = UVRadarVan.UVRadarVan
       AnimationMode = LOOP
+      HideSubObject = RadarUpgrade Light02 Light03
     End
 
     ConditionState = REALLYDAMAGED
@@ -6372,6 +6373,11 @@ Object GLAVehicleRadarVan
   Behavior = UnpauseSpecialPowerUpgrade ModuleTag_07
     SpecialPowerTemplate = SpecialPowerRadarVanScan
     TriggeredBy = Upgrade_GLARadarVanScan
+  End
+
+  Behavior = SubObjectsUpgrade ModuleTag_07Model
+    ShowSubObjects = RadarUpgrade Light02 Light03
+    TriggeredBy    = Upgrade_GLARadarVanScan
   End
 
   Behavior = AutoHealBehavior ModuleTag_08


### PR DESCRIPTION
![shot_20230827_150805_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/16d0e21c-eb9a-47a5-83e0-b385dfe92f9b)

![shot_20230827_150820_2](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/181c9322-7e7e-425c-9a77-aa383cb5fb1d)

- [ ] Don't spawn round radar piece when destroyed without upgrade
- [ ] Spawn radar tower scaffold piece when destroyed with upgrade (just disappears in 1.04)

Looks odd to me. Not sure I like.


