### PR TITLE
Change: Add initial delay to Suicide ability

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2303_demo_suicide_initial_delay.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2303_demo_suicide_initial_delay.yaml
@@ -15,7 +15,7 @@ labels:
   - v1.0
 
 links:
-  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2236
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2303
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/2303_demo_suicide_initial_delay.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2303_demo_suicide_initial_delay.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-08-28
+
+title: Adds an initial delay to the Suicide ability of GLA Demolitions General.
+
+changes:
+  - fix: There now is a 3 second delay before a unit can use the Demolitions Suicide ability.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - major
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2236
+
+authors:
+  - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5452,7 +5452,7 @@ CommandButton Demo_UpgradeSuicideBomb
 End
 
 
-; Patch104p @balance commy2 28/08/2023 Change from FIRE_WEAPON to SPECIAL_POWER to add initial delay.
+; Patch104p @balance commy2 28/08/2023 Change from FIRE_WEAPON to SPECIAL_POWER to add initial delay. (#2303)
 CommandButton Demo_Command_TertiarySuicide
   Command                 = SPECIAL_POWER
   Upgrade                 = Demo_Upgrade_SuicideBomb

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5452,10 +5452,11 @@ CommandButton Demo_UpgradeSuicideBomb
 End
 
 
+; Patch104p @balance commy2 28/08/2023 Change from FIRE_WEAPON to SPECIAL_POWER to add initial delay.
 CommandButton Demo_Command_TertiarySuicide
-  Command                 = FIRE_WEAPON
+  Command                 = SPECIAL_POWER
   Upgrade                 = Demo_Upgrade_SuicideBomb
-  WeaponSlot              = TERTIARY
+  SpecialPower            = Demo_SuperweaponSuicideAttack
   Options                 = OK_FOR_MULTI_SELECT NEED_UPGRADE
   TextLabel               = CONTROLBAR:SuicideAttack
   ButtonImage             = SUSuicideAttk

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -5452,7 +5452,7 @@ CommandButton Demo_UpgradeSuicideBomb
 End
 
 
-; Patch104p @balance commy2 28/08/2023 Change from FIRE_WEAPON to SPECIAL_POWER to add initial delay. (#2303)
+; Patch104p @feature commy2 28/08/2023 Change from FIRE_WEAPON to SPECIAL_POWER to add initial delay. (#2303)
 CommandButton Demo_Command_TertiarySuicide
   Command                 = SPECIAL_POWER
   Upgrade                 = Demo_Upgrade_SuicideBomb

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13261,7 +13261,7 @@ Object Demo_GLAInfantryRebel
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -13791,7 +13791,7 @@ Object Demo_GLAInfantryJarmenKell
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -14084,7 +14084,7 @@ Object Demo_GLAInfantryTunnelDefender
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -14397,7 +14397,7 @@ Object Demo_GLAInfantryStingerSoldier
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -16845,7 +16845,7 @@ Object Demo_GLAInfantryHijacker
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -17328,7 +17328,7 @@ Object Demo_GLAInfantryWorker
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -17655,7 +17655,7 @@ Object Demo_GLAInfantrySaboteur
 ;    ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
 ;  End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -18039,7 +18039,7 @@ Object Demo_GLATankScorpion
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -18318,7 +18318,7 @@ Object Demo_GLAVehicleRocketBuggy
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -19395,7 +19395,7 @@ Object Demo_GLAVehicleCombatBike
     DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -19831,7 +19831,7 @@ Object Demo_GLAVehicleQuadCannon
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -19847,7 +19847,7 @@ Object Demo_GLAVehicleQuadCannon
 
 End
 
-; Patch104p @balance commy2 28/08/2023 Remove Anthrax Beta compatibility to free a weapon slot. (#2303)
+; Patch104p @change commy2 28/08/2023 Remove Anthrax Beta compatibility to free a weapon slot. (#2303)
 ;------------------------------------------------------------------------------
 ;Also called Toxin Tractor && ToxinTractor
 Object Demo_GLAVehicleToxinTruck
@@ -19994,7 +19994,7 @@ Object Demo_GLAVehicleToxinTruck
     AutoChooseSources = SECONDARY   NONE ;Special attack only
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Weapon sets unlocked right before blowing up via suicide ability. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Weapon sets unlocked right before blowing up via suicide ability. (#2303)
   WeaponSet
     Conditions        = PLAYER_UPGRADE
     Weapon            = TERTIARY TerroristSuicideNotARealWeapon
@@ -20222,7 +20222,7 @@ Object Demo_GLAVehicleToxinTruck
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OverlordContain ModuleTag_SuicideAttackUpgrade01
     Slots                 = 1
     DamagePercentToUnits  = 100%
@@ -20245,7 +20245,7 @@ Object Demo_GLAVehicleToxinTruck
 
 End
 
-; Patch104p @balance commy2 27/08/2023 Upgrades Tractor weapon set to unlock tertiary suicide.
+; Patch104p @feature commy2 27/08/2023 Upgrades Tractor weapon set to unlock tertiary suicide. (#2303)
 ;------------------------------------------------------------------------------
 Object Demo_SuicideWeaponSetUpgradeDummy
   EditorSorting   = SYSTEM
@@ -20867,7 +20867,7 @@ Object Demo_GLAVehicleScudLauncher
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -21379,7 +21379,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -22212,7 +22212,7 @@ Object Demo_GLATankMarauder
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -22461,7 +22461,7 @@ Object Demo_GLAVehicleRadarVan
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -22886,7 +22886,7 @@ Object Demo_GLAVehicleBattleBus
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -5900,6 +5900,11 @@ Object Demo_GLATunnelNetwork
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
 
   Geometry = CYLINDER
   GeometryMajorRadius = 25.0
@@ -6487,6 +6492,12 @@ Object Demo_GLAStingerSite
 
   Behavior = AIUpdateInterface ModuleTag_20
     AutoAcquireEnemiesWhenIdle = No
+  End
+
+  ; Patch104p @feature commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
   End
 
   Geometry            = CYLINDER

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19847,7 +19847,7 @@ Object Demo_GLAVehicleQuadCannon
 
 End
 
-; Patch104p @balance commy2 28/08/2023 Remove Anthrax Beta compatibility to free a weapon slot.
+; Patch104p @balance commy2 28/08/2023 Remove Anthrax Beta compatibility to free a weapon slot. (#2303)
 ;------------------------------------------------------------------------------
 ;Also called Toxin Tractor && ToxinTractor
 Object Demo_GLAVehicleToxinTruck
@@ -19994,7 +19994,7 @@ Object Demo_GLAVehicleToxinTruck
     AutoChooseSources = SECONDARY   NONE ;Special attack only
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Weapon sets unlocked right before blowing up via suicide ability.
+  ; Patch104p @balance commy2 28/08/2023 Weapon sets unlocked right before blowing up via suicide ability. (#2303)
   WeaponSet
     Conditions        = PLAYER_UPGRADE
     Weapon            = TERTIARY TerroristSuicideNotARealWeapon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13261,6 +13261,12 @@ Object Demo_GLAInfantryRebel
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
+
   Geometry = CYLINDER
   GeometryMajorRadius = 10.0
   GeometryMinorRadius = 10.0
@@ -13785,6 +13791,12 @@ Object Demo_GLAInfantryJarmenKell
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
+
   Geometry = CYLINDER
   GeometryMajorRadius = 10.0
   GeometryMinorRadius = 10.0
@@ -14070,6 +14082,12 @@ Object Demo_GLAInfantryTunnelDefender
   Behavior = CommandSetUpgrade ModuleTag_15
     CommandSet = Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
     TriggeredBy = Demo_Upgrade_SuicideBomb
+  End
+
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
   End
 
   Geometry = CYLINDER
@@ -14377,6 +14395,12 @@ Object Demo_GLAInfantryStingerSoldier
   Behavior = CommandSetUpgrade ModuleTag_17
     CommandSet = Demo_GLAInfantryRebelCommandSetUpgrade
     TriggeredBy = Demo_Upgrade_SuicideBomb
+  End
+
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
   End
 
   Geometry = CYLINDER
@@ -16821,6 +16845,12 @@ Object Demo_GLAInfantryHijacker
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
+
   Geometry = CYLINDER
   GeometryMajorRadius = 10.0
   GeometryMinorRadius = 10.0
@@ -17298,6 +17328,11 @@ Object Demo_GLAInfantryWorker
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
 
   Geometry = CYLINDER
   GeometryMajorRadius = 10.0
@@ -17619,6 +17654,12 @@ Object Demo_GLAInfantrySaboteur
 ;    AwardXPForTriggering  = 12
 ;    ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
 ;  End
+
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
 
   Geometry = CYLINDER
   GeometryMajorRadius = 10.0
@@ -17998,6 +18039,12 @@ Object Demo_GLATankScorpion
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 14.0
   GeometryMinorRadius = 9.0
@@ -18269,6 +18316,12 @@ Object Demo_GLAVehicleRocketBuggy
   Behavior = CommandSetUpgrade ModuleTag_19
     CommandSet = Demo_GLAVehicleRocketBuggyCommandSetUpgrade
     TriggeredBy = Demo_Upgrade_SuicideBomb
+  End
+
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
   End
 
   Geometry = BOX
@@ -19342,6 +19395,12 @@ Object Demo_GLAVehicleCombatBike
     DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 11.0
   GeometryMinorRadius = 2.5
@@ -19772,6 +19831,12 @@ Object Demo_GLAVehicleQuadCannon
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 18.0
   GeometryMinorRadius = 7.0
@@ -19782,6 +19847,7 @@ Object Demo_GLAVehicleQuadCannon
 
 End
 
+; Patch104p @balance commy2 28/08/2023 Remove Anthrax Beta compatibility to free a weapon slot.
 ;------------------------------------------------------------------------------
 ;Also called Toxin Tractor && ToxinTractor
 Object Demo_GLAVehicleToxinTruck
@@ -19792,7 +19858,7 @@ Object Demo_GLAVehicleToxinTruck
 
   ; Patch104p @bugfix commy2 13/09/2021 Add missing upgrade icon for Anthrax Beta.
 
-  UpgradeCameo1 = Upgrade_GLAAnthraxBeta
+  ;UpgradeCameo1 = Upgrade_GLAAnthraxBeta
   UpgradeCameo2 = Upgrade_GLAJunkRepair
   UpgradeCameo3 = Demo_Upgrade_SuicideBomb
   ;UpgradeCameo4 = NONE
@@ -19895,49 +19961,63 @@ Object Demo_GLAVehicleToxinTruck
     Conditions        = None
     Weapon            = PRIMARY     ToxinTruckGun
     Weapon            = SECONDARY   ToxinTruckSprayer
-    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
     AutoChooseSources = SECONDARY   NONE ;Special attack only
   End
   WeaponSet
-    Conditions        = PLAYER_UPGRADE
+    Conditions        = HERO
     Weapon            = PRIMARY     ToxinTruckGunUpgraded
     Weapon            = SECONDARY   ToxinTruckSprayerUpgraded
-    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
     AutoChooseSources = SECONDARY   NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_ONE
     Weapon            = PRIMARY     ToxinTruckGunPlusOne
     Weapon            = SECONDARY   ToxinTruckSprayerPlusOne
-    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
     AutoChooseSources = SECONDARY   NONE ;Special attack only
   End
   WeaponSet
-    Conditions        = CRATEUPGRADE_ONE PLAYER_UPGRADE
+    Conditions        = CRATEUPGRADE_ONE HERO
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusOne
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusOne
-    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
     AutoChooseSources = SECONDARY   NONE ;Special attack only
   End
   WeaponSet
     Conditions        = CRATEUPGRADE_TWO
     Weapon            = PRIMARY     ToxinTruckGunPlusTwo
     Weapon            = SECONDARY   ToxinTruckSprayerPlusTwo
-    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
     AutoChooseSources = SECONDARY   NONE ;Special attack only
   End
   WeaponSet
-    Conditions        = CRATEUPGRADE_TWO PLAYER_UPGRADE
+    Conditions        = CRATEUPGRADE_TWO HERO
     Weapon            = PRIMARY     ToxinTruckGunUpgradedPlusTwo
     Weapon            = SECONDARY   ToxinTruckSprayerUpgradedPlusTwo
-    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
-    AutoChooseSources = TERTIARY NONE
     AutoChooseSources = SECONDARY   NONE ;Special attack only
+  End
+
+  ; Patch104p @balance commy2 28/08/2023 Weapon sets unlocked right before blowing up via suicide ability.
+  WeaponSet
+    Conditions        = PLAYER_UPGRADE
+    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
+  End
+  WeaponSet
+    Conditions        = PLAYER_UPGRADE HERO
+    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
+  End
+  WeaponSet
+    Conditions        = PLAYER_UPGRADE CRATEUPGRADE_ONE
+    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
+  End
+  WeaponSet
+    Conditions        = PLAYER_UPGRADE CRATEUPGRADE_ONE HERO
+    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
+  End
+  WeaponSet
+    Conditions        = PLAYER_UPGRADE CRATEUPGRADE_TWO
+    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
+  End
+  WeaponSet
+    Conditions        = PLAYER_UPGRADE CRATEUPGRADE_TWO HERO
+    Weapon            = TERTIARY TerroristSuicideNotARealWeapon
   End
 
   ArmorSet
@@ -20041,7 +20121,7 @@ Object Demo_GLAVehicleToxinTruck
   End
 
   Behavior                    = StatusBitsUpgrade ModuleTag_05Upgrade
-    TriggeredBy               = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    TriggeredBy               = Upgrade_Veterancy_HEROIC
     StatusToSet               = STATUS_RIDER1
   End
 
@@ -20055,12 +20135,6 @@ Object Demo_GLAVehicleToxinTruck
     CrateData   = SalvageCrateData
     ;CrateData  = EliteTankCrateData
     ;CrateData  = HeroicTankCrateData
-  End
-
-  Behavior = WeaponSetUpgrade ModuleTag_08
-    ; the Toxin Tractor gets this upgrade if we either buy the upgrade,
-    ; or if it gets HEROIC status
-    TriggeredBy   = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
   End
 
   Behavior                          = TransitionDamageFX ModuleTag_11
@@ -20082,7 +20156,7 @@ Object Demo_GLAVehicleToxinTruck
 
   Behavior = FireOCLAfterWeaponCooldownUpdate ModuleTag_13
     WeaponSlot            = SECONDARY
-    ConflictsWith         = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    ConflictsWith         = Upgrade_Veterancy_HEROIC
     OCL                   = OCL_PoisonFieldMedium
     MinShotsToCreateOCL   = 4
     OCLLifetimePerSecond  = 10000
@@ -20090,7 +20164,7 @@ Object Demo_GLAVehicleToxinTruck
   End
   Behavior = FireOCLAfterWeaponCooldownUpdate ModuleTag_14
     WeaponSlot            = SECONDARY
-    TriggeredBy           = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
+    TriggeredBy           = Upgrade_Veterancy_HEROIC
     OCL                   = OCL_PoisonFieldUpgradedMedium
     MinShotsToCreateOCL   = 4
     OCLLifetimePerSecond  = 10000
@@ -20100,12 +20174,12 @@ Object Demo_GLAVehicleToxinTruck
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_15    ;These two make the right damage field at death
     DeathWeapon   = ToxinShellWeapon
     StartsActive  = Yes
-    ConflictsWith = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn off un-upgraded puddle when gaining vet 3.
+    ConflictsWith = Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn off un-upgraded puddle when gaining vet 3.
   End
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_16
     DeathWeapon   = ToxinShellWeaponUpgraded
     StartsActive  = No
-    TriggeredBy = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
+    TriggeredBy = Upgrade_Veterancy_HEROIC   ; Patch104p @bugfix commy2 27/08/2021 Turn on upgraded puddle when gaining vet 3.
   End
 
   ; Patch104p @bugfix commy2 29/08/2021 Customize SUICIDED death to resemble regular death module of this vehicle.
@@ -20148,6 +20222,19 @@ Object Demo_GLAVehicleToxinTruck
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OverlordContain ModuleTag_SuicideAttackUpgrade01
+    Slots                 = 1
+    DamagePercentToUnits  = 100%
+    AllowInsideKindOf     = PORTABLE_STRUCTURE
+    ArmedRidersUpgradeMyWeaponSet = Yes
+  End
+
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttackUpgrade02
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicideUpgrade
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 13.0
   GeometryMinorRadius = 9.0
@@ -20156,6 +20243,24 @@ Object Demo_GLAVehicleToxinTruck
   Shadow = SHADOW_VOLUME
   ShadowSizeX = 45  ; minimum elevation angle above horizon. Used to limit shadow length
 
+End
+
+; Patch104p @balance commy2 27/08/2023 Upgrades Tractor weapon set to unlock tertiary suicide.
+;------------------------------------------------------------------------------
+Object Demo_SuicideWeaponSetUpgradeDummy
+  EditorSorting   = SYSTEM
+  KindOf          = PORTABLE_STRUCTURE INFANTRY INERT ; I need to be INFANTRY to count as ArmedRider.
+  TransportSlotCount = 1
+
+  WeaponSet
+    Conditions = None
+    Weapon = PRIMARY TunnelNetworkGunDUMMY ; I need a weapon with PrimaryDamage > 0 to count as ArmedRider.
+  End
+
+  Body = ActiveBody ModuleTag_01
+    MaxHealth        = 1.0
+    InitialHealth    = 1.0
+  End
 End
 
 
@@ -20762,6 +20867,11 @@ Object Demo_GLAVehicleScudLauncher
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
 
   Geometry = BOX
   GeometryMajorRadius = 14.0
@@ -21267,6 +21377,12 @@ Object Demo_GLAVehicleTechnicalChassisOne
   Behavior = CommandSetUpgrade ModuleTag_20
     CommandSet = Demo_GLAVehicleTechnicalCommandSetUpgrade
     TriggeredBy = Demo_Upgrade_SuicideBomb
+  End
+
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
   End
 
   Geometry = BOX
@@ -22096,6 +22212,12 @@ Object Demo_GLATankMarauder
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
+  End
+
   Geometry = BOX
   GeometryMajorRadius = 17.0
   GeometryMinorRadius = 10.0
@@ -22337,6 +22459,12 @@ Object Demo_GLAVehicleRadarVan
   Behavior = CommandSetUpgrade ModuleTag_22
     CommandSet = Demo_GLAVehicleRadarVanCommandSetUpgrade
     TriggeredBy = Demo_Upgrade_SuicideBomb
+  End
+
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
   End
 
   Geometry = BOX
@@ -22756,6 +22884,12 @@ Object Demo_GLAVehicleBattleBus
   Behavior                 = TransitionDamageFX ModuleTag_36
     ReallyDamagedParticleSystem1 = Bone:Smoke RandomBone:Yes PSys:SmallLightSmokeColumn
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
+  End
+
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  Behavior = OCLSpecialPower ModuleTag_SuicideAttack
+    SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
+    OCL                  = Demo_OCL_TertiarySuicide
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13261,7 +13261,7 @@ Object Demo_GLAInfantryRebel
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -13791,7 +13791,7 @@ Object Demo_GLAInfantryJarmenKell
     PreTriggerUnstealthTime   = 5000 ; in milliseconds
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -14084,7 +14084,7 @@ Object Demo_GLAInfantryTunnelDefender
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -14397,7 +14397,7 @@ Object Demo_GLAInfantryStingerSoldier
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -16845,7 +16845,7 @@ Object Demo_GLAInfantryHijacker
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -17328,7 +17328,7 @@ Object Demo_GLAInfantryWorker
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -17655,7 +17655,7 @@ Object Demo_GLAInfantrySaboteur
 ;    ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
 ;  End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -18039,7 +18039,7 @@ Object Demo_GLATankScorpion
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -18318,7 +18318,7 @@ Object Demo_GLAVehicleRocketBuggy
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -19395,7 +19395,7 @@ Object Demo_GLAVehicleCombatBike
     DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -19831,7 +19831,7 @@ Object Demo_GLAVehicleQuadCannon
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -20222,7 +20222,7 @@ Object Demo_GLAVehicleToxinTruck
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OverlordContain ModuleTag_SuicideAttackUpgrade01
     Slots                 = 1
     DamagePercentToUnits  = 100%
@@ -20867,7 +20867,7 @@ Object Demo_GLAVehicleScudLauncher
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -21379,7 +21379,7 @@ Object Demo_GLAVehicleTechnicalChassisOne
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -22212,7 +22212,7 @@ Object Demo_GLATankMarauder
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -22461,7 +22461,7 @@ Object Demo_GLAVehicleRadarVan
     TriggeredBy = Demo_Upgrade_SuicideBomb
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide
@@ -22886,7 +22886,7 @@ Object Demo_GLAVehicleBattleBus
     ReallyDamagedFXList1 = Loc: X:0 Y:0 Z:0 FXList:FX_BattleMasterDamageTransition
   End
 
-  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon.
+  ; Patch104p @balance commy2 28/08/2023 Add special power module that fires tertiary suicide weapon. (#2303)
   Behavior = OCLSpecialPower ModuleTag_SuicideAttack
     SpecialPowerTemplate = Demo_SuperweaponSuicideAttack
     OCL                  = Demo_OCL_TertiarySuicide

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -10254,7 +10254,7 @@ ObjectCreationList Nuke_OCL_NuclearTankDeathDetonation
   End
 End
 
-; Patch104p @balance commy2 28/08/2023 OCLs to fire SUICIDE weapon via special power.
+; Patch104p @balance commy2 28/08/2023 OCLs to fire SUICIDE weapon via special power. (#2303)
 ; -----------------------------------------------------------------------------
 ObjectCreationList Demo_OCL_SuicideAttack ; unused, reference for later use with new engine
   FireWeapon

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -10254,7 +10254,7 @@ ObjectCreationList Nuke_OCL_NuclearTankDeathDetonation
   End
 End
 
-; Patch104p @balance commy2 28/08/2023 OCLs to fire SUICIDE weapon via special power. (#2303)
+; Patch104p @feature commy2 28/08/2023 OCLs to fire SUICIDE weapon via special power. (#2303)
 ; -----------------------------------------------------------------------------
 ObjectCreationList Demo_OCL_SuicideAttack ; unused, reference for later use with new engine
   FireWeapon
@@ -10274,8 +10274,8 @@ End
 ObjectCreationList Demo_OCL_TertiarySuicideUpgrade
   ; Special variant for Toxin Tractor. Step 1, upgrade weapon set.
   CreateObject
-    ObjectNames       = Demo_SuicideWeaponSetUpgradeDummy
-    Count             = 1
+    ObjectNames = Demo_SuicideWeaponSetUpgradeDummy
+    Count = 1
     ContainInsideSourceObject = Yes
   End
   ; Step 2, fire suicide weapon on upgraded weapon set.

--- a/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ObjectCreationList.ini
@@ -10254,6 +10254,37 @@ ObjectCreationList Nuke_OCL_NuclearTankDeathDetonation
   End
 End
 
+; Patch104p @balance commy2 28/08/2023 OCLs to fire SUICIDE weapon via special power.
+; -----------------------------------------------------------------------------
+ObjectCreationList Demo_OCL_SuicideAttack ; unused, reference for later use with new engine
+  FireWeapon
+    Weapon = TerroristSuicideNotARealWeapon
+  End
+End
+
+; -----------------------------------------------------------------------------
+ObjectCreationList Demo_OCL_TertiarySuicide
+  Attack
+    WeaponSlot = TERTIARY
+    NumberOfShots = 1
+  End
+End
+
+; -----------------------------------------------------------------------------
+ObjectCreationList Demo_OCL_TertiarySuicideUpgrade
+  ; Special variant for Toxin Tractor. Step 1, upgrade weapon set.
+  CreateObject
+    ObjectNames       = Demo_SuicideWeaponSetUpgradeDummy
+    Count             = 1
+    ContainInsideSourceObject = Yes
+  End
+  ; Step 2, fire suicide weapon on upgraded weapon set.
+  Attack
+    WeaponSlot = TERTIARY
+    NumberOfShots = 1
+  End
+End
+
 ; Patch104p @bugfix commy2 29/08/2021 Creates dummies used to handle Demolitions upgrade with the Battle Bus.
 ; Patch104p @tweak xezon 15/12/2022 Renames Battle Bus weapon dummy objects.
 ; -----------------------------------------------------------------------------

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -1006,6 +1006,6 @@ End
 ; Patch104p @balance commy2 28/08/2023 Adds special power that handles initial delay for Demolitions suicide. (#2303)
 ;-----------------------------------------------------------------------------
 SpecialPower Demo_SuperweaponSuicideAttack
-  Enum                = SPECIAL_LAUNCH_BAIKONUR_ROCKET
+  Enum                = SPECIAL_LAUNCH_BAIKONUR_ROCKET ; this is one of the enums hard-coded to not require a target location
   ReloadTime          = 3000 ; in milliseconds
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -1003,7 +1003,7 @@ SpecialPower SuperweaponSatelliteHackTwo
   ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
 End
 
-; Patch104p @balance commy2 28/08/2023 Adds special power that handles initial delay for Demolitions suicide.
+; Patch104p @balance commy2 28/08/2023 Adds special power that handles initial delay for Demolitions suicide. (#2303)
 ;-----------------------------------------------------------------------------
 SpecialPower Demo_SuperweaponSuicideAttack
   Enum                = SPECIAL_LAUNCH_BAIKONUR_ROCKET

--- a/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SpecialPower.ini
@@ -1002,3 +1002,10 @@ SpecialPower SuperweaponSatelliteHackTwo
   AcademyClassify     = ACT_SUPERPOWER ;Considered a powerful special power that a player could fire. Not for simpler unit based powers.
   ShortcutPower       = Yes     ;Capable of being fired by the side-bar shortcut.
 End
+
+; Patch104p @balance commy2 28/08/2023 Adds special power that handles initial delay for Demolitions suicide.
+;-----------------------------------------------------------------------------
+SpecialPower Demo_SuperweaponSuicideAttack
+  Enum                = SPECIAL_LAUNCH_BAIKONUR_ROCKET
+  ReloadTime          = 3000 ; in milliseconds
+End


### PR DESCRIPTION
- close https://github.com/TheSuperHackers/GeneralsGamePatch/issues/1184

This adds a configurable delay to the Suicide ability from Demogen.

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/6576312/1eb1d336-8de9-4b42-9528-09c398e516a9

The goal is to nerf Demo Rebel Ambush vs armies.