### PR TITLE
Fix: Demo Toxin Tractor explodes in wrong toxin cloud when suicided

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1618_wreck_spawn_before_death.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1618_wreck_spawn_before_death.yaml
@@ -29,6 +29,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1163
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1618
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1648
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2306
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/77_toxin_tractor_anthrax_color.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/77_toxin_tractor_anthrax_color.yaml
@@ -15,6 +15,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/77
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/78
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2306
 
 authors:
   - commy2

--- a/Patch104pZH/Design/Changes/v1.0/99_demo_vehicle_destruction.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/99_demo_vehicle_destruction.yaml
@@ -16,6 +16,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/99
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1722
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2306
 
 authors:
   - commy2

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18591,7 +18591,7 @@ Object Chem_GLAVehicleToxinTruck
     FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 
-  ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021
+  ; Patch104p @bugfix commy2 27/08/2021 Upgrade explosion effect with Anthrax upgrade. (#77)
   Behavior                    = SlowDeathBehavior  ModuleTag_05Anthrax
     DeathTypes                = ALL -CRUSHED -SPLATTED
     RequiredStatus            = STATUS_RIDER1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20042,7 +20042,7 @@ Object Demo_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = INITIAL Demo_OCL_ToxinTractorUpgradedDeathEffect
+    OCL                       = FINAL Demo_OCL_ToxinTractorUpgradedDeathEffect ; Patch104p @bugfix from INITIAL to spawn death hulk, debris and effects at the same time.
     ;FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 
@@ -20114,8 +20114,18 @@ Object Demo_GLAVehicleToxinTruck
 
   Behavior = SlowDeathBehavior ModuleTag_Death_14
     DeathTypes          = NONE +SUICIDED
+    ExemptStatus        = STATUS_RIDER1
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_ToxinTractorDeathEffect
+    ;FX                  = FINAL   FX_ToxinTruckExplosionOneFinal
+  End
+
+  ; Patch104p @bugfix commy2 28/08/2023 Upgrade explosion effect with Anthrax upgrade. (#2306)
+  Behavior = SlowDeathBehavior ModuleTag_Death_14Anthrax
+    DeathTypes          = NONE +SUICIDED
+    RequiredStatus      = STATUS_RIDER1
+    FX                  = INITIAL FX_TerroristExplode
+    OCL                 = FINAL   Demo_OCL_ToxinTractorUpgradedDeathEffect
     ;FX                  = FINAL   FX_ToxinTruckExplosionOneFinal
   End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20027,7 +20027,7 @@ Object Demo_GLAVehicleToxinTruck
     ;FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
-  ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021
+  ; Patch104p @bugfix commy2 27/08/2021 Upgrade explosion effect with Anthrax upgrade. (#77)
   Behavior                    = SlowDeathBehavior  ModuleTag_05Anthrax
     DeathTypes                = ALL -CRUSHED -SPLATTED -SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     RequiredStatus            = STATUS_RIDER1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20126,7 +20126,7 @@ Object Demo_GLAVehicleToxinTruck
     RequiredStatus      = STATUS_RIDER1
     FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_ToxinTractorUpgradedDeathEffect
-    ;FX                  = FINAL   FX_ToxinTruckExplosionOneFinal
+    ;FX                  = FINAL   FX_ToxinTruckExplosionUpgraded
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag998

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -20027,12 +20027,6 @@ Object Demo_GLAVehicleToxinTruck
     ;FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
-  Behavior                    = InstantDeathBehavior  ModuleTag_06
-    DeathTypes                = NONE +CRUSHED +SPLATTED
-    FX                        = FX_CarCrush
-    OCL                       = OCL_CrusaderTank_CrushEffect
-  End
-
   ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021
   Behavior                    = SlowDeathBehavior  ModuleTag_05Anthrax
     DeathTypes                = ALL -CRUSHED -SPLATTED -SUICIDED  ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
@@ -20042,13 +20036,19 @@ Object Demo_GLAVehicleToxinTruck
     DestructionDelay          = 0
     DestructionDelayVariance  = 200
     FX                        = INITIAL FX_ToxinTractorDie
-    OCL                       = FINAL Demo_OCL_ToxinTractorUpgradedDeathEffect ; Patch104p @bugfix from INITIAL to spawn death hulk, debris and effects at the same time.
+    OCL                       = FINAL Demo_OCL_ToxinTractorUpgradedDeathEffect
     ;FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 
   Behavior                    = StatusBitsUpgrade ModuleTag_05Upgrade
     TriggeredBy               = Upgrade_GLAAnthraxBeta Upgrade_Veterancy_HEROIC
     StatusToSet               = STATUS_RIDER1
+  End
+
+  Behavior                    = InstantDeathBehavior  ModuleTag_06
+    DeathTypes                = NONE +CRUSHED +SPLATTED
+    FX                        = FX_CarCrush
+    OCL                       = OCL_CrusaderTank_CrushEffect
   End
 
   Behavior = CreateCrateDie ModuleTag_07

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -1687,7 +1687,7 @@ Object GC_Chem_GLAVehicleToxinTruck
     FX                        = FINAL FX_ToxinTruckExplosionUpgraded
   End
 
-  ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021
+  ; Patch104p @bugfix commy2 27/08/2021 Upgrade explosion effect with Anthrax upgrade. (#77)
   Behavior                    = SlowDeathBehavior  ModuleTag_05Anthrax
     DeathTypes                = ALL -CRUSHED -SPLATTED
     RequiredStatus            = STATUS_RIDER1   ; Patch104p @bugfix commy2 27/08/2021 Disable effect once upgraded with Anthrax. commy2 27/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -4014,7 +4014,7 @@ Object GLAVehicleToxinTruck
     FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
-  ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021
+  ; Patch104p @bugfix commy2 27/08/2021 Upgrade explosion effect with Anthrax upgrade. (#77)
   Behavior                    = SlowDeathBehavior  ModuleTag_05Anthrax
     DeathTypes                = ALL -CRUSHED -SPLATTED
     RequiredStatus            = STATUS_RIDER1   ; Patch104p @bugfix commy2 27/08/2021 Disable effect once upgraded with Anthrax. commy2 27/08/2021

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -20076,7 +20076,7 @@ Object Slth_GLAVehicleToxinTruck
     FX                        = FINAL FX_ToxinTruckExplosionOneFinal
   End
 
-  ; Patch104p @bugfix Upgrade explosion effect with Anthrax upgrade. commy2 27/08/2021
+  ; Patch104p @bugfix commy2 27/08/2021 Upgrade explosion effect with Anthrax upgrade. (#77)
   Behavior                    = SlowDeathBehavior  ModuleTag_05Anthrax
     DeathTypes                = ALL -CRUSHED -SPLATTED
     RequiredStatus            = STATUS_RIDER1   ; Patch104p @bugfix commy2 27/08/2021 Disable effect once upgraded with Anthrax. commy2 27/08/2021


### PR DESCRIPTION
* Fixes #2305
* Follow up for #77
* Follow up for #1618