### PR TITLE
Change: Make GLA Demo Stinger soldiers explode on death

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -6404,10 +6404,11 @@ Object Demo_GLAStingerSite
     SpawnPointBoneName = SpawnPoint
   End
 
+  ; Patch104p @tweak xezon 29/08/2023 From GLAInfantryStingerSoldier to use soldiers with demolition death ability.
   Behavior                = SpawnBehavior ModuleTag_06
     SpawnNumber           = 3
     SpawnReplaceDelay     = 30000 ;msec
-    SpawnTemplateName     = GLAInfantryStingerSoldier
+    SpawnTemplateName     = Demo_GLAInfantryStingerSoldier
     CanReclaimOrphans     = No
     SpawnedRequireSpawner = Yes
   End


### PR DESCRIPTION
This change makes the GLA Demo Stinger soldiers explode on death after Demolitions Upgrade like regular units.