### PR TITLE
Improve the particle effect for destroyed GLA Demo units

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1076_demo_units_death_particles.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1076_demo_units_death_particles.yaml
@@ -14,6 +14,8 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1076
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2311
 
 authors:
   - commy2
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2308_demo_stinger_death_damage.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2308_demo_stinger_death_damage.yaml
@@ -5,7 +5,6 @@ title: Fixes death explosion damage of upgraded GLA Demo Stinger Site
 
 changes:
   - fix: The upgraded GLA Demo Stinger Site no longer deals 20 times more damage than it should when killed.
-  - fix: The upgraded GLA Demo Stinger Site now properly deals damage when killed by poison.
 
 labels:
   - bug

--- a/Patch104pZH/Design/Changes/v1.0/2311_demo_units_death_particles.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2311_demo_units_death_particles.txt
@@ -1,0 +1,1 @@
+1076_demo_units_death_particles.yaml

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -9895,17 +9895,20 @@ FXList WeaponFX_DemoSuicideDynamitePackDetonationPlusFire
   End
 End
 
-; Patch104p @tweak commy2 02/09/2022 Effect for unit with Demolitions upgrade getting destroyed by enemy.
+; Patch104p @tweak commy2 02/09/2022 Effect for unit with Demolitions upgrade getting destroyed by enemy. (#1076) (#2311)
 ; ----------------------------------------------
 FXList WeaponFX_DemoDestroyedDynamitePackDetonation
   Sound
     Name = ExplosionBarrel
   End
   ParticleSystem
-    Name = Explosion
+    Name = ExplosionSmall
   End
   ParticleSystem
-    Name = DemoExplosionSmoke
+    Name = DemoExplosionSmokeLite
+  End
+  ParticleSystem
+    Name = RedDonuteCloudLite
   End
   ViewShake
     Type = SUBTLE

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -4419,6 +4419,64 @@ ParticleSystem RedDonuteCloud
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @feature xezon 29/08/2023 A copy of RedDonuteCloud, but smaller and shorter. (#2311)
+ParticleSystem RedDonuteCloudLite
+  Priority = CRITICAL
+  IsOneShot = No
+  Shader = ALPHA
+  Type = PARTICLE
+  ParticleName = EXSmokePuf07.tga
+  AngleZ = 0.00 7.00
+  AngularRateZ = -0.01 0.01
+  AngularDamping = 1.00 1.00
+  VelocityDamping = 0.70 0.70
+  Gravity = 0.00
+  Lifetime = 80.00 80.00
+  SystemLifetime = 1
+  Size = 3.00 3.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 3.00 3.00
+  SizeRateDamping = 0.80 0.80
+  Alpha1 = 0.40 0.40 0
+  Alpha2 = -2.00 0.00 80
+  Alpha3 = 0.00 0.00 0
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:130 G:36 B:36 0
+  Color2 = R:0 G:0 B:0 0
+  Color3 = R:0 G:0 B:0 0
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 99999.00 99999.00
+  BurstCount = 75.00 75.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.04 Y:0.08 Z:0.10
+  VelocityType = OUTWARD
+  VelOutward = 7.00 7.00
+  VelOutwardOther = 0.00 0.00
+  VolumeType = CYLINDER
+  VolCylinderRadius = 3.00
+  VolCylinderLength = 0.00
+  IsHollow = No
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
 ParticleSystem SubExplosionSmoke01
   Priority = UNIT_DAMAGE_FX
   IsOneShot = No
@@ -8275,6 +8333,62 @@ ParticleSystem Explosion
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @feature xezon 29/08/2023 A copy of Explosion, but smaller and shorter. (#2311)
+ParticleSystem ExplosionSmall
+  Priority = WEAPON_EXPLOSION
+  IsOneShot = No
+  Shader = ADDITIVE
+  Type = PARTICLE
+  ParticleName = EXexplo03.tga
+  AngleZ = 0.00 7.00
+  AngularRateZ = 0.00 0.00
+  AngularDamping = 0.96 0.98
+  VelocityDamping = 0.30 0.30
+  Gravity = 0.25
+  Lifetime = 80.00 80.00
+  SystemLifetime = 1
+  Size = 1.00 1.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 6.00 8.00
+  SizeRateDamping = 0.90 0.90
+  Alpha1 = 1.00 1.00 0
+  Alpha2 = 0.00 0.00 0
+  Alpha3 = 0.00 0.00 0
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:255 G:255 B:255 0
+  Color2 = R:0 G:0 B:0 80
+  Color3 = R:0 G:0 B:0 0
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = -5.00 -3.00
+  BurstDelay = 99999.00 99999.00
+  BurstCount = 3.00 3.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.00
+  VelocityType = SPHERICAL
+  VelSpherical = 15.00 15.00
+  VolumeType = SPHERE
+  VolSphereRadius = 3.00
+  IsHollow = No
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
 ParticleSystem LargeStructureExplosionShockwave
   Priority = DEATH_EXPLOSION
   IsOneShot = No
@@ -12103,6 +12217,64 @@ ParticleSystem DemoExplosionSmoke
   SizeRateDamping = 0.90 0.90
   Alpha1 = 1.00 1.00 0
   Alpha2 = 0.00 0.00 75
+  Alpha3 = 0.00 0.00 0
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:162 G:62 B:62 0
+  Color2 = R:0 G:0 B:0 0
+  Color3 = R:0 G:0 B:0 0
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 99999.00 99999.00
+  BurstCount = 6.00 6.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.10
+  VelocityType = OUTWARD
+  VelOutward = 0.00 5.00
+  VelOutwardOther = 0.00 0.00
+  VolumeType = CYLINDER
+  VolCylinderRadius = 1.00
+  VolCylinderLength = 0.00
+  IsHollow = Yes
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
+; Patch104p @feature xezon 29/08/2023 A copy of DemoExplosionSmoke, but smaller and shorter. (#2311)
+ParticleSystem DemoExplosionSmokeLite
+  Priority = WEAPON_EXPLOSION
+  IsOneShot = No
+  Shader = ALPHA
+  Type = PARTICLE
+  ParticleName = EXCloud01.tga
+  AngleZ = 0.00 7.00
+  AngularRateZ = -0.03 0.01
+  AngularDamping = 0.96 0.99
+  VelocityDamping = 0.75 0.80
+  Gravity = 0.00
+  Lifetime = 80.00 80.00
+  SystemLifetime = 1
+  Size = 0.00 0.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = 5.00 7.00
+  SizeRateDamping = 0.90 0.90
+  Alpha1 = 0.40 0.40 0
+  Alpha2 = 0.00 0.00 80
   Alpha3 = 0.00 0.00 0
   Alpha4 = 0.00 0.00 0
   Alpha5 = 0.00 0.00 0

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -4435,7 +4435,7 @@ ParticleSystem RedDonuteCloudLite
   SystemLifetime = 1
   Size = 3.00 3.00
   StartSizeRate = 0.00 0.00
-  SizeRate = 3.00 3.00
+  SizeRate = 2.50 2.50
   SizeRateDamping = 0.80 0.80
   Alpha1 = 0.40 0.40 0
   Alpha2 = -2.00 0.00 80
@@ -4459,7 +4459,7 @@ ParticleSystem RedDonuteCloudLite
   InitialDelay = 0.00 0.00
   DriftVelocity = X:0.04 Y:0.08 Z:0.10
   VelocityType = OUTWARD
-  VelOutward = 7.00 7.00
+  VelOutward = 6.00 6.00
   VelOutwardOther = 0.00 0.00
   VolumeType = CYLINDER
   VolCylinderRadius = 3.00
@@ -8349,7 +8349,7 @@ ParticleSystem ExplosionSmall
   SystemLifetime = 1
   Size = 1.00 1.00
   StartSizeRate = 0.00 0.00
-  SizeRate = 6.00 8.00
+  SizeRate = 5.00 7.00
   SizeRateDamping = 0.90 0.90
   Alpha1 = 1.00 1.00 0
   Alpha2 = 0.00 0.00 0
@@ -12271,7 +12271,7 @@ ParticleSystem DemoExplosionSmokeLite
   SystemLifetime = 1
   Size = 0.00 0.00
   StartSizeRate = 0.00 0.00
-  SizeRate = 5.00 7.00
+  SizeRate = 4.00 6.00
   SizeRateDamping = 0.90 0.90
   Alpha1 = 0.40 0.40 0
   Alpha2 = 0.00 0.00 80

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7255,7 +7255,7 @@ Weapon Demo_DestroyedWeapon
   ClipSize = 1
   ClipReloadTime = 0
   AutoReloadsClip = No
-  FireFX = WeaponFX_DemoDestroyedDynamitePackDetonation ; Patch104p @tweak commy2 02/09/2022 Use different effect for passive destruction.
+  FireFX = WeaponFX_DemoDestroyedDynamitePackDetonation ; Patch104p @tweak commy2 02/09/2022 Use different effect for passive destruction. (#1076)
   ;FireSound = CarBomberDie
 End
 


### PR DESCRIPTION
This change improves the particle effect for destroyed GLA Demo units. It now looks more similar to the regular Demo Suicide explosion, but with slightly smaller effects and without the explosion pillars.

![shot_20230830_193613_3](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/5bfc3005-dcc3-4f6d-9a17-9986ed8467df)
