### PR TITLE
Fix: Optimize suicide explosion effects of GLA Demo units

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -3359,7 +3359,7 @@ End
 
 ; Patch104p @bugfix xezon 08/07/2023 Removes explosion sound effect and adds it to weapon effects, so it can be heard in all death conditions. (#2075)
 ; ----------------------------------------------
-FXList FX_TerroristExplode ; Alias FX_TerroristSuicide
+FXList FX_TerroristExplode ; legacy
   ParticleSystem
     Name = Explosion
   End
@@ -9836,7 +9836,7 @@ End
 
 ; Patch104p @bugfix xezon 08/07/2023 Adds sound effect here so it is bound to weapon. Was previously referenced in FX_TerroristExplode. (#2075)
 ; ----------------------------------------------
-FXList WeaponFX_DemoSuicideDynamitePackDetonation
+FXList WeaponFX_DemoSuicideDynamitePackDetonation ; Alias Demo_WeaponFX_DemoSuicideDynamitePackDetonation
   Sound
     Name = TerroristSuicides
   End
@@ -9863,7 +9863,7 @@ FXList WeaponFX_DemoSuicideDynamitePackDetonation
 End
 
 ; ----------------------------------------------
-FXList WeaponFX_DemoSuicideDynamitePackDetonationPlusFire
+FXList WeaponFX_DemoSuicideDynamitePackDetonationPlusFire ; Alias Demo_WeaponFX_SuicideDynamitePackDetonationPlusFire
   Sound
     Name = TerroristSuicides
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -14108,7 +14108,7 @@ Object Chem_GLAInfantryTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -13210,7 +13210,7 @@ Object Demo_GLAInfantryRebel
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -13684,7 +13684,7 @@ Object Demo_GLAInfantryJarmenKell
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -14043,7 +14043,7 @@ Object Demo_GLAInfantryTunnelDefender
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -14350,7 +14350,7 @@ Object Demo_GLAInfantryStingerSoldier
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -14640,7 +14640,7 @@ Object Demo_GLAInfantryTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -15199,7 +15199,7 @@ Object Demo_GLAInfantryAngryMobPistol01
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -15549,7 +15549,7 @@ Object Demo_GLAInfantryAngryMobRock02
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -16495,7 +16495,7 @@ Object Demo_GLAInfantryAngryMobMolotov02
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -16792,7 +16792,7 @@ Object Demo_GLAInfantryHijacker
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -17270,7 +17270,7 @@ Object Demo_GLAInfantryWorker
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -17594,7 +17594,7 @@ Object Demo_GLAInfantrySaboteur
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -17974,7 +17974,7 @@ Object Demo_GLATankScorpion
 
   Behavior = SlowDeathBehavior ModuleTag_Death17
     DeathTypes          = NONE +SUICIDED
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_ScorpionTankDeathEffect
     ;FX                  = FINAL   FX_BattleMasterExplosionOneFinal
   End
@@ -18239,7 +18239,7 @@ Object Demo_GLAVehicleRocketBuggy
 
   Behavior = SlowDeathBehavior ModuleTag_Death17
     DeathTypes          = NONE +SUICIDED
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   OCL_RocketBuggyAirDeathStart
     FX                  = FINAL   ScorchlessFX_DEMOBuggyNewDeathExplosion
   End
@@ -19748,7 +19748,7 @@ Object Demo_GLAVehicleQuadCannon
 
   Behavior = SlowDeathBehavior ModuleTag_Death_14
     DeathTypes          = NONE +SUICIDED
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_QuadCannonDeathEffect
     ;FX                  = FINAL   FX_BattleMasterExplosionOneFinal
   End
@@ -20115,7 +20115,7 @@ Object Demo_GLAVehicleToxinTruck
   Behavior = SlowDeathBehavior ModuleTag_Death_14
     DeathTypes          = NONE +SUICIDED
     ExemptStatus        = STATUS_RIDER1
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_ToxinTractorDeathEffect
     ;FX                  = FINAL   FX_ToxinTruckExplosionOneFinal
   End
@@ -20124,7 +20124,7 @@ Object Demo_GLAVehicleToxinTruck
   Behavior = SlowDeathBehavior ModuleTag_Death_14Anthrax
     DeathTypes          = NONE +SUICIDED
     RequiredStatus      = STATUS_RIDER1
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_ToxinTractorUpgradedDeathEffect
     ;FX                  = FINAL   FX_ToxinTruckExplosionUpgraded
   End
@@ -20715,7 +20715,7 @@ Object Demo_GLAVehicleScudLauncher
 
   Behavior = SlowDeathBehavior ModuleTag_Death24
     DeathTypes          = NONE +SUICIDED
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_SCUDLauncherDeathEffect
     ;FX                  = FINAL   FX_ScudLauncherExplosionOneFinal
   End
@@ -22072,7 +22072,7 @@ Object Demo_GLATankMarauder
 
   Behavior = SlowDeathBehavior ModuleTag_Death_22
     DeathTypes          = NONE +SUICIDED
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_MarauderTankDeathEffect
     ;FX                  = FINAL   FX_BattleMasterExplosionOneFinal
   End
@@ -22315,7 +22315,7 @@ Object Demo_GLAVehicleRadarVan
 
   Behavior = SlowDeathBehavior ModuleTag_Death_20
     DeathTypes          = NONE +SUICIDED
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL Demo_OCL_RadarVanDeathEffect
     ;FX                  = FINAL FX_BuggyNewDeathExplosion
   End
@@ -22748,7 +22748,7 @@ Object Demo_GLAVehicleBattleBus
   Behavior = SlowDeathBehavior ModuleTag_35 ; Sorry, because the terrorist does Suicide damage to others, we cannot tell if it is a legit suicide (us killing self)
     DeathTypes          = NONE +SUICIDED
     OCL                 = INITIAL Demo_OCL_BattleBusSuicideWeaponDummy ; Patch104p @bugfix commy2 29/08/2021 Spawns dummy object to let Battle Bus deal damage by suicide. (#102)
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     OCL                 = FINAL   Demo_OCL_BattleBusDeath
     ;FX                  = FINAL   FX_BattleBusDeathExplosion
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -4151,7 +4151,7 @@ Object GC_Chem_GLAInfantryTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2442,7 +2442,7 @@ Object GC_Slth_GLAInfantryTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -5685,7 +5685,7 @@ Object CINE_GLAInfantryTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60
@@ -7589,7 +7589,7 @@ Object CINE_CheeringTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1568,7 +1568,7 @@ Object GLAInfantryTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -15124,7 +15124,7 @@ Object Slth_GLAInfantryTerrorist
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
-    FX                  = INITIAL FX_TerroristExplode
+    ;FX                  = INITIAL FX_TerroristExplode
     FlingForce          = 8
     FlingForceVariance  = 3
     FlingPitch          = 60

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2960,7 +2960,7 @@ Weapon QuadCannonGunUpgradeTwoAir
 End
 
 ;------------------------------------------------------------------------------
-Weapon SuicideBomb
+Weapon SuicideBomb ; unused
   PrimaryDamage = 300.0
   PrimaryDamageRadius = 10.0
   SecondaryDamage = 60.0


### PR DESCRIPTION
This change simplifies suicide explosion effects. All `FX_TerroristSuicide` effects are removed. Death weapons use just one death effect now.

