### PR TITLE
Change: Make 100% completed Command Center required to upgrade Cash Bounty, 2

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -4151,9 +4151,11 @@ CommandButton Command_PurchaseScienceRebelAmbush3
 End
 
 
+; Patch104p @feature commy2 30/08/2023 Adds dynamic "Requires Command Center" line to tooltip. (#2308)
 CommandButton Command_PurchaseScienceCashBounty1
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_CashBounty1
+  Object            = CashBountyPrerequisiteDummy
   ButtonImage       = SSCashBounty
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
@@ -4161,6 +4163,7 @@ End
 CommandButton Command_PurchaseScienceCashBounty2
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_CashBounty2
+  Object            = CashBountyPrerequisiteDummy
   ButtonImage       = SSCashBounty2
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End
@@ -4168,6 +4171,7 @@ End
 CommandButton Command_PurchaseScienceCashBounty3
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_CashBounty3
+  Object            = CashBountyPrerequisiteDummy
   ButtonImage       = SSCashBounty3
   ButtonBorderType  = UPGRADE ; Identifier for the User as to what kind of button this is
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/CommandButton.ini
@@ -4151,7 +4151,7 @@ CommandButton Command_PurchaseScienceRebelAmbush3
 End
 
 
-; Patch104p @feature commy2 30/08/2023 Adds dynamic "Requires Command Center" line to tooltip. (#2308)
+; Patch104p @feature commy2 30/08/2023 Adds dynamic "Requires Command Center" line to tooltip. (#2315)
 CommandButton Command_PurchaseScienceCashBounty1
   Command           = PURCHASE_SCIENCE
   Science           = SCIENCE_CashBounty1

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1368,7 +1368,7 @@ Object Boss_CommandCenter
     ReferenceObject      = GLASneakAttackTunnelNetwork ;So we know what the final product is for script placement calculations
   End
 
-  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2315)
   Behavior = FireWeaponUpdate ModuleTag_96
     Weapon = CashBountyDummyWeapon
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -1368,17 +1368,9 @@ Object Boss_CommandCenter
     ReferenceObject      = GLASneakAttackTunnelNetwork ;So we know what the final product is for script placement calculations
   End
 
-  Behavior = CashBountyPower ModuleTag_96
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_97
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_98
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  Behavior = FireWeaponUpdate ModuleTag_96
+    Weapon = CashBountyDummyWeapon
   End
 
   Behavior = FlammableUpdate ModuleTag_23

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -1086,17 +1086,9 @@ Object Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = CashBountyDummyWeapon
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -1086,7 +1086,7 @@ Object Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2315)
   Behavior = FireWeaponUpdate ModuleTag_15
     Weapon = CashBountyDummyWeapon
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1222,7 +1222,7 @@ Object Demo_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2315)
   Behavior = FireWeaponUpdate ModuleTag_15
     Weapon = CashBountyDummyWeapon
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -1222,17 +1222,9 @@ Object Demo_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = CashBountyDummyWeapon
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -2270,7 +2270,7 @@ Object GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2315)
   Behavior = FireWeaponUpdate ModuleTag_15
     Weapon = CashBountyDummyWeapon
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/FactionBuilding.ini
@@ -2270,17 +2270,9 @@ Object GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = CashBountyDummyWeapon
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -2374,17 +2374,9 @@ Object GC_Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = CashBountyDummyWeapon
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLABuildings.ini
@@ -2374,7 +2374,7 @@ Object GC_Chem_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2315)
   Behavior = FireWeaponUpdate ModuleTag_15
     Weapon = CashBountyDummyWeapon
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -1100,7 +1100,7 @@ Object GC_Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2315)
   Behavior = FireWeaponUpdate ModuleTag_15
     Weapon = CashBountyDummyWeapon
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLABuildings.ini
@@ -1100,17 +1100,9 @@ Object GC_Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = CashBountyDummyWeapon
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -1088,17 +1088,9 @@ Object Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  Behavior = CashBountyPower ModuleTag_15
-    SpecialPowerTemplate    = SpecialAbilityCashBounty1
-    Bounty                  = 5%
-  End
-  Behavior = CashBountyPower ModuleTag_16
-    SpecialPowerTemplate    = SpecialAbilityCashBounty2
-    Bounty                  = 10%
-  End
-  Behavior = CashBountyPower ModuleTag_17
-    SpecialPowerTemplate    = SpecialAbilityCashBounty3
-    Bounty                  = 20%
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  Behavior = FireWeaponUpdate ModuleTag_15
+    Weapon = CashBountyDummyWeapon
   End
 
   Behavior = FlammableUpdate ModuleTag_19

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -1088,7 +1088,7 @@ Object Slth_GLACommandCenter
     CreateLocation       = CREATE_AT_LOCATION
   End
 
-  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2308)
+  ; Patch104p @balance commy2 30/08/2023 Require completed Command Center to upgrade Cash Bounty. (#2315)
   Behavior = FireWeaponUpdate ModuleTag_15
     Weapon = CashBountyDummyWeapon
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/System.ini
@@ -3089,6 +3089,7 @@ End
 ;------------------------------------------------------------------------------
 Object CashBountyDummy
   ; ***DESIGN parameters ***
+  DisplayName = OBJECT:CommandCenter ; CashBountyPrerequisiteDummy uses this
   EditorSorting   = SYSTEM
   KindOf = NO_COLLIDE IMMOBILE UNATTACKABLE INERT
 
@@ -3096,6 +3097,11 @@ Object CashBountyDummy
   Body = ImmortalBody ModuleTag_01
     MaxHealth = 1.0
     InitialHealth = 1.0
+  End
+
+  Behavior = DeletionUpdate ModuleTag_02
+    MinLifetime = 1000   ; min lifetime in msec
+    MaxLifetime = 1000   ; max lifetime in msec
   End
 
   Behavior = CashBountyPower ModuleTag_15
@@ -3109,6 +3115,14 @@ Object CashBountyDummy
   Behavior = CashBountyPower ModuleTag_17
     SpecialPowerTemplate    = SpecialAbilityCashBounty3
     Bounty                  = 20%
+  End
+End
+
+;------------------------------------------------------------------------------
+Object CashBountyPrerequisiteDummy
+  EditorSorting   = SYSTEM
+  Prerequisites
+    Object = CashBountyDummy
   End
 End
 
@@ -3340,12 +3354,6 @@ Object GLAStartingThings
     MaxDelay = 0
     OCL      = OCL_GLAInfantryWorker
   End
-
-  Behavior = OCLUpdate ModuleTag_04
-    MinDelay = 0
-    MaxDelay = 0
-    OCL      = OCL_CashBountyDummy
-  End
 End
 
 ;------------------------------------------------------------------------------
@@ -3367,12 +3375,6 @@ Object Chem_GLAStartingThings
     MinDelay = 0
     MaxDelay = 0
     OCL      = OCL_Chem_GLAInfantryWorker
-  End
-
-  Behavior = OCLUpdate ModuleTag_04
-    MinDelay = 0
-    MaxDelay = 0
-    OCL      = OCL_CashBountyDummy
   End
 
 ;Toxin General gets these for free.
@@ -3406,12 +3408,6 @@ Object Demo_GLAStartingThings
     OCL      = OCL_Demo_GLAInfantryWorker
   End
 
-  Behavior = OCLUpdate ModuleTag_04
-    MinDelay = 0
-    MaxDelay = 0
-    OCL      = OCL_CashBountyDummy
-  End
-
 ; DemoGen gets free booby trap power.
   Behavior = GrantUpgradeCreate ModuleTag_23
     UpgradeToGrant = Upgrade_GLAInfantryRebelBoobyTrapAttack
@@ -3439,12 +3435,6 @@ Object Slth_GLAStartingThings
     OCL      = OCL_Slth_GLAInfantryWorker
   End
 
-  Behavior = OCLUpdate ModuleTag_04
-    MinDelay = 0
-    MaxDelay = 0
-    OCL      = OCL_CashBountyDummy
-  End
-
   Behavior = GrantUpgradeCreate ModuleTag_10
     UpgradeToGrant = Upgrade_GLACamouflage
   End
@@ -3469,11 +3459,5 @@ Object Boss_StartingThings
     MinDelay = 0
     MaxDelay = 0
     OCL      = OCL_Boss_VehicleDozer
-  End
-
-  Behavior = OCLUpdate ModuleTag_04
-    MinDelay = 0
-    MaxDelay = 0
-    OCL      = OCL_CashBountyDummy
   End
 End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -9349,7 +9349,7 @@ Weapon PrisonSpyVisionDummyWeapon
   FireOCL = OCL_PrisonSpyVisionDummy
 End
 
-; Patch104p @balance commy2 30/08/2023 Spawns temporary object with cash bounty logic over and over. (#2308)
+; Patch104p @balance commy2 30/08/2023 Spawns temporary object with cash bounty logic over and over. (#2315)
 ;------------------------------------------------------------------------------
 Weapon CashBountyDummyWeapon
   DelayBetweenShots = 1000                ; time between shots, msec

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -9348,3 +9348,10 @@ Weapon PrisonSpyVisionDummyWeapon
   DelayBetweenShots = 1000                ; time between shots, msec
   FireOCL = OCL_PrisonSpyVisionDummy
 End
+
+; Patch104p @balance commy2 30/08/2023 Spawns temporary object with cash bounty logic over and over. (#2308)
+;------------------------------------------------------------------------------
+Weapon CashBountyDummyWeapon
+  DelayBetweenShots = 1000                ; time between shots, msec
+  FireOCL = OCL_CashBountyDummy
+End


### PR DESCRIPTION
In case it is decided to go this route again, 1 PR fix with all the necessary changes.