### PR TITLE
Fix: Punctuation inconsistencies in tool tip strings for all languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_text_errors.yaml
@@ -12,6 +12,7 @@ changes:
   - fix: The China Assault Transport tool tip strings now show correct strengths and weaknesses for all languages.
   - fix: The China Listening Outpost tool tip strings now show correct strengths and weaknesses for all languages.
   - fix: The GLA Demolition upgrade now has consistent names in all latin languages.
+  - fix: Fixes punctuation inconsistencies in tool tip strings for all languages.
 
 labels:
   - minor
@@ -24,6 +25,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2146
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2149
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2316
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2316_punctuation_inconsistencies_in_tooltip_text.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2316_punctuation_inconsistencies_in_tooltip_text.txt
@@ -1,0 +1,1 @@
+2156_misc_text_errors.yaml


### PR DESCRIPTION
This change fixes punctuation inconsistencies in CONTROLBAR tool tip strings for all languages.

Affects

* CONTROLBAR

Was reviewed by hand without algorithm. Likely did not catch everything, but the bulk of it.