### PR TITLE
Fix: Punctuation inconsistencies in various strings for all languages (2)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_text_errors.yaml
@@ -12,7 +12,7 @@ changes:
   - fix: The China Assault Transport tool tip strings now show correct strengths and weaknesses for all languages.
   - fix: The China Listening Outpost tool tip strings now show correct strengths and weaknesses for all languages.
   - fix: The GLA Demolition upgrade now has consistent names in all latin languages.
-  - fix: Fixes punctuation inconsistencies in tool tip strings for all languages.
+  - fix: Fixes punctuation inconsistencies in controlbar, map, gui, dialogevent, tooltip, mdgla02, mdgla03, md_gla05, help, generic, lose, academy, wol, buddy, script, qm strings for all languages.
 
 labels:
   - minor
@@ -26,6 +26,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2149
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2316
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2317
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2316_punctuation_inconsistencies_in_controlbar_text.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2316_punctuation_inconsistencies_in_controlbar_text.txt
@@ -1,0 +1,1 @@
+2156_misc_text_errors.yaml

--- a/Patch104pZH/Design/Changes/v1.0/2316_punctuation_inconsistencies_in_tooltip_text.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2316_punctuation_inconsistencies_in_tooltip_text.txt
@@ -1,1 +1,0 @@
-2156_misc_text_errors.yaml

--- a/Patch104pZH/Design/Changes/v1.0/2317_punctuation_inconsistencies_in_various_text.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2317_punctuation_inconsistencies_in_various_text.txt
@@ -1,0 +1,1 @@
+2156_misc_text_errors.yaml


### PR DESCRIPTION
**Merge with Rebase**

* Follow up for #2316

This change fixes punctuation inconsistencies in various strings for all languages.

Affects

* DIALOGEVENT
* MAP
* GUI
* TOOLTIP
* MD_GLA05-MilitaryBriefing
* MDGLA02
* MDGLA03
* HELP
* GENERIC
* LOSE
* ACADEMY
* SCRIPT
* WOL
* Buddy
* QM

Was reviewed by hand without algorithm. Likely did not catch everything, but the bulk of it.

The rules are:

* English, Russian sentences to do not end with a dot before text end and before line feed.
* German, French, Spanish, Italian, Korean, Chinese, Brazilian, Polish sentences do end with a dot before text end and before line feed.
* Arabic untouched as usual.