### PR TITLE
Fix: Incorrect ini format in SoundEffects.ini for drone voices

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -789,7 +789,7 @@ AudioEvent BattleDroneVoiceCreate
   Sounds = vdrocrea vdrocreb
   Control = random
   Limit = 3
-  Delay 0 800
+  Delay = 0 800
   Volume = 55
   PitchShift= -10 10
   VolumeShift= -10
@@ -801,7 +801,7 @@ AudioEvent HellfireDroneVoiceCreate
   Sounds = vdrocrea vdrocreb
   Control = random
   Limit = 3
-  Delay 0 800
+  Delay = 0 800
   Volume = 55
   PitchShift= -10 10
   VolumeShift= -10
@@ -835,7 +835,7 @@ AudioEvent ScoutDroneVoiceCreate
   Sounds = vdr2crea vdr2creb
   Control = random
   Limit = 3
-  Delay 0 800
+  Delay = 0 800
   Volume = 65
   PitchShift= -10 10
   VolumeShift= -10
@@ -858,7 +858,7 @@ AudioEvent SpyDroneCreate
   Sounds = vdr2crea vdr2creb
   Control = random
   Limit = 3
-  Delay 0 800
+  Delay = 0 800
   Volume = 75
   PitchShift= -10 10
   VolumeShift= -10


### PR DESCRIPTION
This change fixes incorrect ini format in SoundEffects.ini for drone voices.

I don't know if it changes anything in game.