### PR TITLE
Fix: Add priority and limit to creation voices of China Overlord attachments, Helix attachments, GLA Bomb Truck attachments, Angry Mob, Saboteur

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2320_creation_voice_volumes.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2320_creation_voice_volumes.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-09-03
 
-title: Balances creation voice volumes of various units and their upgrades
+title: Balances creation voice volumes of units and unit upgrades
 
 changes:
   - fix: The creation voices of units and their upgrades have comparable volumes now.

--- a/Patch104pZH/Design/Changes/v1.0/2321_creation_voice_limits.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2321_creation_voice_limits.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-09-03
+
+title: Adds missing limits to creation voices and sounds of units and unit upgrades
+
+changes:
+  - fix: The creation voices and sounds of the China Overlord upgrades, Helix upgrades and GLA Bomb Truck upgrades can no longer stack up.
+
+labels:
+  - audio
+  - bug
+  - china
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2321
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2321_creation_voice_priorities.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2321_creation_voice_priorities.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-09-03
+
+title: Adds missing high priority to creation voices of units and unit upgrades
+
+changes:
+  - fix: The creation voices of the China Overlord upgrades, Helix upgrades, GLA Saboteur, Angry Mob, Bomb Truck upgrades now have high priorities like other creation voices.
+
+labels:
+  - audio
+  - bug
+  - china
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2321
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -4394,11 +4394,13 @@ AudioEvent SalvageUpgrade
   Type        = world shrouded player
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds limit. (#2321)
 AudioEvent OverlordExpansion
   Sounds      = voveupgr
   Volume      = 90
   Priority    = high
   Type        = world shrouded player
+  Limit       = 2
 End
 
 AudioEvent SpySatellite

--- a/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Voice.ini
@@ -2121,18 +2121,22 @@ AudioEvent OverlordTankVoiceUnload
   Type = ui voice player
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent OverlordTankVoiceModeBunker
   Sounds = voveu1a
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
   Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent OverlordTankVoiceModeSpeakerTower
   Sounds = voveu2a
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
   Limit = 1
 End
@@ -2146,27 +2150,35 @@ AudioEvent OverlordTankVoiceModeGattling
   Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent OverlordTankBunkerVoiceCreate
   Sounds = voveu1b
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
 ; Patch104p @fix xezon 03/09/2023 Changes volume from 80. (#2320)
+; Patch104p @fix xezon 03/09/2023 Adds limit. (#2321)
 AudioEvent OverlordTankGattlingCannonVoiceCreate
   Sounds = voveu3b
   Control = random
   Volume = 90
   Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent OverlordTankPropagandaTowerVoiceCreate
   Sounds = voveu2b
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
 
@@ -3262,34 +3274,44 @@ AudioEvent BombTruckVoiceModeDisguise
   Limit = 1
 End
 
+; Patch104p @tweak xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent BombTruckVoiceModeHiEx
   Sounds = vbommha
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
   Limit = 1
 End
 
+; Patch104p @tweak xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent BombTruckVoiceModeBioBomb
   Sounds = vbommba
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
   Limit = 1
 End
 
+; Patch104p @tweak xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent BombTruckVoiceUpgradeHiEx
   Sounds = vbomu2
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
+; Patch104p @tweak xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent BombTruckVoiceUpgradeBioBomb
   Sounds = vbomu1
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
 
@@ -3936,6 +3958,7 @@ AudioEvent AngryMobVoiceSelect
   Type = world global player
 End
 
+; Patch104p @tweak xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent AngryMobVoiceCreate
   Sounds =  iangsela iangselb iangselc iangseld
   Control = random
@@ -3943,7 +3966,8 @@ AudioEvent AngryMobVoiceCreate
   MaxRange = 2000
   Volume  = 90
   MinVolume = 80
- Type = world global player
+  Priority = high
+  Type = world global player
 End
 
 AudioEvent AngryMobVoiceMove
@@ -4790,11 +4814,13 @@ End
 
 ; Patch104p @fix Changes type from 'ui' to 'world'. (#1282)
 ; Patch104p @fix xezon 03/09/2023 Changes volume from 90, adds minvolume. (#2320)
+; Patch104p @fix xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent SaboteurVoiceCreate
   Sounds =  isabsea
   Control = random
   Volume  = 110
   MinVolume = 100
+  Priority = high
   Type = world voice player 
 End
 
@@ -5068,22 +5094,26 @@ AudioEvent HelixVoiceUnload
   Type = ui voice player
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent HelixVoiceModeBunker
   Sounds = vhelu1a
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
   Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority. (#2321)
 AudioEvent HelixVoiceModeSpeakerTower
   Sounds = vhelu1b
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
   Limit = 1
 End
@@ -5121,34 +5151,44 @@ AudioEvent HelixVoiceModeNuclearBomb
   Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent HelixBunkerVoiceCreate
   Sounds = vhelu2a
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent HelixSpeakerTowerVoiceCreate
   Sounds = vhelu2b
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent HelixGattlingVoiceCreate
   Sounds = vhelu2c
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
 ; Patch104p @fix xezon 03/09/2023 Changes volume from 80. (#2320)
+; Patch104p @fix xezon 03/09/2023 Adds limit. (#2321)
 AudioEvent HelixNapalmBombVoiceCreate
   Sounds = vhelu2d
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
@@ -5157,15 +5197,19 @@ AudioEvent HelixNapalmBombVoiceCreate
   Volume = 90
   Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
+; Patch104p @fix xezon 03/09/2023 Adds priority, limit. (#2321)
 AudioEvent HelixNuclearBombVoiceCreate
   Sounds = vhelu2e
   Attack = gradio1a gradio1b gradio1c gradio1d gradio1e gradio1f
   Decay = gradio3a gradio3b gradio3c gradio3d gradio3e
   Control = random
   Volume = 90
+  Priority = high
   Type = ui voice player
+  Limit = 1
 End
 
 


### PR DESCRIPTION
This change adds appropriate priority and limit to creation voices of various units. The high priority is consistent with other creation priorities. And the limits avoid audio spam when multiples are created at the same time.

Affects

* Overlord Expansion effect
* Overlord Bunker
* Overlord Speaker Tower
* Overlord Gattling Cannon
* Helix Bunker
* Helix Speaker Tower
* Helix Gattling Cannon
* Helix Napalm Bomb
* Helix Nuke Bomb
* GLA Bomb Truck Bio Bomb
* GLA Bomb Truck High Explosive Bomb
* GLA Angry Mob
* GLA Saboteur