### PR TITLE
Fix: Streamline China Overlord and Helix Speaker Tower names with the tool tip names and/or the actual voice lines

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2322_french_overlord_speaker_tower_name.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2322_french_overlord_speaker_tower_name.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-09-03
+
+title: Fixes wrong name of China Overlord Speaker Tower in French language
+
+changes:
+  - fix: The China Overlord Speaker Tower is now named "Haut-parleur d'embrigadement" and matches the other Speaker Tower names in French language.
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2322
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2322_overlord_helix_speaker_tower_name.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2322_overlord_helix_speaker_tower_name.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-09-03
+
+title: Fixes inconsistent names of China Overlord and Helix Speaker Towers
+
+changes:
+  - fix: The China Overlord and Helix Speaker Towers now have names that are consistent with the regular Speaker Tower names and/or the voice lines in English, German, Spanish, Korean, Brazilian languages.
+
+labels:
+  - china
+  - minor
+  - optional
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2322
+
+authors:
+  - xezon


### PR DESCRIPTION
**Merge with Rebase**

This change fixes the French Overlord Speaker Tower name. It no longer mismatches with the name in the tool tip.

And optionally it streamlines all Overlord and Helix Speaker Tower attachment names to be consistent with the tool tip and/or voice line names.

Affects:

* English
* German
* French
* Spanish
* Korean
* Brazilian