### PR TITLE
Fix: Add additional information to tool tip strings of China Overlord and Helix Speaker Tower for all languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2323_overlord_helix_speaker_tower_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2323_overlord_helix_speaker_tower_tooltip.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-09-03
+
+title: Adds additional information to tool tip strings of China Overlord and Helix Speaker Tower
+
+changes:
+  - fix: The tool tip strings of the China Overlord and Helix Speaker Tower now mention its effects for all languages.
+
+labels:
+  - china
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2323
+
+authors:
+  - xezon


### PR DESCRIPTION
This change adds additional information to tool tip strings of China Overlord and Helix Speaker Tower for all languages. The sentences are copies of the Speaker Tower building tool tip.