### PR TITLE
Fix: Speed up briefings and speech subtitles

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2326_briefings_subtitles_text_speed.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2326_briefings_subtitles_text_speed.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-09-06
+
+title: Fixes slow speed of briefings and speech subtitles
+
+changes:
+  - fix: Increases briefings and speech subtitles print speed for Spanish, Italian, Korean, Chinese languages.
+  - tweak: Increases briefings print speed for English, German, French, Brazilian, Polish languages.
+
+labels:
+  - bug
+  - major
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2326
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/Arabic/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Arabic/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @tweak xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to speed up the briefing texts. (#2326)
 Language
   UnicodeFontName = AlGhadTV
   LocalFontFile = Generals.TTF                              ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = AlGhadTV 12 Yes                           ; Used to display copyright at start of game
   MessageFont = AlGhadTV 10 Yes                             ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = AlGhadTV 12 Yes              ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = AlGhadTV 12 No                    ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 750

--- a/Patch104pZH/GameFilesEdited/Data/Brazilian/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Brazilian/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @tweak xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to speed up the briefing texts. (#2326)
 Language
   UnicodeFontName = "Arial Unicode MS"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Arial 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Courier New" 12 Yes           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Courier New" 12 No                 ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 750

--- a/Patch104pZH/GameFilesEdited/Data/Chinese/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Chinese/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to allow quick subtitles to print in time. (#2326)
 Language
   UnicodeFontName = Batang
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   UseHardWordWrap = Yes                                     ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Batang 10 Yes                               ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = Batang 12 Yes                ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = Batang 12 No                      ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 250

--- a/Patch104pZH/GameFilesEdited/Data/Chinese/Language9x.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Chinese/Language9x.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to allow quick subtitles to print in time. (#2326)
 Language
   UnicodeFontName = ²Ó©úÅé
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   UseHardWordWrap = Yes                                     ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = ²Ó©úÅé 12 Yes                              ; Used to display copyright at start of game
   MessageFont = ²Ó©úÅé 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = ²Ó©úÅé 12 Yes                   ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = ²Ó©úÅé 12 No                         ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 250

--- a/Patch104pZH/GameFilesEdited/Data/English/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/English/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @tweak xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to speed up the briefing texts. (#2326)
 Language
   UnicodeFontName = "Arial Unicode MS"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Arial 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Courier New" 12 Yes           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Courier New" 12 No                 ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 750

--- a/Patch104pZH/GameFilesEdited/Data/French/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/French/Language.ini
@@ -2,16 +2,17 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @tweak xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to speed up the briefing texts. (#2326)
 Language
   UnicodeFontName = "Arial Unicode MS"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Arial 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Courier New" 12 Yes           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Courier New" 12 No                 ; Mission briefing text in bottom left corner.
-  MilitaryCaptionDelayMS = 750  
+  MilitaryCaptionDelayMS = 750
   SuperweaponCountdownNormalFont = Arial 10 No              ; superweapon countdown in top right
   SuperweaponCountdownReadyFont = Arial 10 Yes              ; superweapon countdown in top right
   NamedTimerCountdownNormalFont = Arial 10 No               ; mission specific timer

--- a/Patch104pZH/GameFilesEdited/Data/German/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/German/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @tweak xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to speed up the briefing texts. (#2326)
 Language
   UnicodeFontName = "Arial Unicode MS"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Arial 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Courier New" 12 Yes           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Courier New" 12 No                 ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 750

--- a/Patch104pZH/GameFilesEdited/Data/Italian/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Italian/Language.ini
@@ -2,16 +2,18 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to allow quick subtitles to print in time. (#2326)
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionDelayMS from 750 to allow quick subtitles to print in time. (#2326)
 Language
   UnicodeFontName = "Arial Unicode MS"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Arial 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Courier New" 12 Yes           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Courier New" 12 No                 ; Mission briefing text in bottom left corner.
-  MilitaryCaptionDelayMS = 750
+  MilitaryCaptionDelayMS = 150
   SuperweaponCountdownNormalFont = Arial 10 No              ; superweapon countdown in top right
   SuperweaponCountdownReadyFont = Arial 10 Yes              ; superweapon countdown in top right
   NamedTimerCountdownNormalFont = Arial 10 No               ; mission specific timer

--- a/Patch104pZH/GameFilesEdited/Data/Korean/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Korean/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to allow quick subtitles to print in time. (#2326)
 Language
   UnicodeFontName = Gulim
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Gulim 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = Gulim 12 Yes                   ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = Gulim 12 No                         ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 250

--- a/Patch104pZH/GameFilesEdited/Data/Korean/Language9x.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Korean/Language9x.ini
@@ -2,16 +2,17 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to allow quick subtitles to print in time. (#2326)
 Language
   UnicodeFontName = ±¼¸²
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = ±¼¸² 10 Yes                                 ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = ±¼¸² 12 Yes                    ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = ±¼¸² 12 No                          ; Mission briefing text in bottom left corner.
-  MilitaryCaptionDelayMS = 250  
+  MilitaryCaptionDelayMS = 250
   SuperweaponCountdownNormalFont = ±¼¸² 10 No               ; superweapon countdown in top right
   SuperweaponCountdownReadyFont = ±¼¸² 10 Yes               ; superweapon countdown in top right
   NamedTimerCountdownNormalFont = ±¼¸² 10 No                ; mission specific timer

--- a/Patch104pZH/GameFilesEdited/Data/Polish/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Polish/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @tweak xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to speed up the briefing texts. (#2326)
 Language
   UnicodeFontName = "Arial Narrow"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = "Arial Narrow" 14 No                      ; Used to display copyright at start of game
   MessageFont = "Arial Narrow" 10 No                        ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Arial Narrow" 12 No           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Arial Narrow" 12 No                ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 750

--- a/Patch104pZH/GameFilesEdited/Data/Russian/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Russian/Language.ini
@@ -2,13 +2,14 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @tweak xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to speed up the briefing texts. (#2326)
 Language
   UnicodeFontName = "Arial Unicode MS"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Arial 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Courier New" 12 Yes           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Courier New" 12 No                 ; Mission briefing text in bottom left corner.
   MilitaryCaptionDelayMS = 750

--- a/Patch104pZH/GameFilesEdited/Data/Spanish/Language.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Spanish/Language.ini
@@ -2,16 +2,18 @@
 ;// This file contains all declarations that are specific to a language.
 ;// for example, this is where we set the unicode font for a language
 
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionSpeed from 1 to allow quick subtitles to print in time. (#2326)
+; Patch104p @bugfix xezon 06/09/2023 Changes MilitaryCaptionDelayMS from 750 to allow quick subtitles to print in time. (#2326)
 Language
   UnicodeFontName = "Arial Unicode MS"
   ;LocalFontFile = PLCC____.TTF                             ; When we add our game fonts... this is where we do it.
   ;UseHardWordWrap = Yes                                    ; Used to force word wrapping no matter what character we are on at the end of the space
   CopyrightFont = Courier 12 Yes                            ; Used to display copyright at start of game
   MessageFont = Arial 10 Yes                                ; Used for messages at top of screen.
-  MilitaryCaptionSpeed = 1                                  ; the caption speed for the mission location type
+  MilitaryCaptionSpeed = 0                                  ; the caption speed for the mission location type
   MilitaryCaptionTitleFont = "Courier New" 12 Yes           ; Mission briefing text in bottom left corner.
   MilitaryCaptionFont = "Courier New" 12 No                 ; Mission briefing text in bottom left corner.
-  MilitaryCaptionDelayMS = 750
+  MilitaryCaptionDelayMS = 150
   SuperweaponCountdownNormalFont = Arial 10 No              ; superweapon countdown in top right
   SuperweaponCountdownReadyFont = Arial 10 Yes              ; superweapon countdown in top right
   NamedTimerCountdownNormalFont = Arial 10 No               ; mission specific timer


### PR DESCRIPTION
**Merge with Rebase**

This change speeds up the military briefing texts for all languages.

And it significantly reduces the briefing delays for Spanish and Italian because these languages use subtitles for speeches and need to have fast prints to be able to properly show texts in time.

Korean and Chinese use subtitles too.