### PR TITLE
Fix: Use three dot character consistently in Korean, Chinese language strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2153_korean_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2153_korean_text_errors.yaml
@@ -7,6 +7,7 @@ changes:
   - fix: The wording in Korean tool tip strings is more consistent now.
   - fix: The Korean tool tip string of the USA Burton now mentions its strengths.
   - fix: The Korean speech subtitles no longer print the first row in bold font.
+  - fix: Three dot symbols are now used consistently in Korean strings.
 
 labels:
   - bug
@@ -18,6 +19,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2153
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2271
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2331
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2332
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
@@ -7,6 +7,7 @@ changes:
   - fix: The TOOLTIP:NumberOfVotes string now has Chinese text.
   - fix: The TOOLTIP:GameInfoPlayer string now shows its number format in Chinese text.
   - fix: Quote symbols are now properly paired and spaced in Chinese strings.
+  - fix: Three dot symbols are now used consistently in Chinese strings.
 
 labels:
   - minor
@@ -17,6 +18,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2216
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2330
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2332
 
 authors:
   - xezon


### PR DESCRIPTION
This change applies the three dot character consistently in Korean, Chinese language strings.