### PR TITLE
Fix: Add missing like breaks at the begin of Spanish, Italian, Chinese dialogevent strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2151_spanish_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2151_spanish_text_errors.yaml
@@ -1,12 +1,13 @@
 ---
 date: 2023-07-26
 
-title: Fixes errors in Spanish tool tip strings
+title: Fixes errors in Spanish strings
 
 changes:
   - fix: The wording in Spanish tool tip strings is more consistent now.
   - fix: The TOOLTIP:NumberOfVotes string now has Spanish text.
   - fix: The Spanish tool tip for the GLA Terrorist now describes the unit as "Soldado suicida" and is therefore more consistent with the English wording.
+  - fix: Some rare Spanish speech subtitles no longer print the first row in bold font.
 
 labels:
   - minor
@@ -19,6 +20,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2334
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
@@ -8,6 +8,7 @@ changes:
   - fix: The TOOLTIP:GameInfoPlayer string now shows its number format in Chinese text.
   - fix: Quote symbols are now properly paired and spaced in Chinese strings.
   - fix: Three dot symbols are now used consistently in Chinese strings.
+  - fix: Some rare Chinese speech subtitles no longer print the first row in bold font.
 
 labels:
   - minor
@@ -19,6 +20,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2217
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2330
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2332
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2334
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2219_italian_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2219_italian_text_errors.yaml
@@ -1,10 +1,11 @@
 ---
 date: 2023-08-07
 
-title: Fixes errors in Italian tool tip strings
+title: Fixes errors in Italian strings
 
 changes:
   - fix: The wording in Italian tool tip strings is more consistent now.
+  - fix: Some rare Italian speech subtitles no longer print the first row in bold font.
 
 labels:
   - minor
@@ -14,6 +15,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2334
 
 authors:
   - xezon


### PR DESCRIPTION
* Follow up for #2331

This change add missing like breaks at the begin of Spanish, Italian, Chinese dialogevent strings.