### PR TITLE
Fix: Add missing words and sentences to Italian mission strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2338_italian_mission_speech_subtitles.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2338_italian_mission_speech_subtitles.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-09-09
+
+title: Adds missing translations to Italian mission subtitles
+
+changes:
+  - fix: All Italian mission speech subtitles now have translations.
+  - tweak: Most Italian mission speech subtitles now use normal structured sentences.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2338
+
+authors:
+  - xezon


### PR DESCRIPTION
**Merge with Rebase**

This change adds missing words and sentences to Italian mission strings. And gets rid of a bunch of strange sentence delimiters.

Primarily affects

* DIALOGEVENT:Eva*
* DIALOGEVENT:Mis*

Also reviewed a bit:

* MDGLA02:
* MDGLA03:
* MD_GLA05:
* MAP:
* HINT: