### PR TITLE
Fix: Add missing words and sentences to Spanish mission strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2339_spanish_mission_speech_subtitles.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2339_spanish_mission_speech_subtitles.yaml
@@ -1,0 +1,19 @@
+---
+date: 2023-09-10
+
+title: Adds missing translations to Spanish mission subtitles
+
+changes:
+  - fix: All Spanish mission speech subtitles now have translations.
+  - tweak: Most Spanish mission speech subtitles now use normal structured sentences.
+
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2339
+
+authors:
+  - xezon


### PR DESCRIPTION
**Merge with Rebase**

This change adds missing words and sentences to Spanish mission strings. And gets rid of a bunch of strange sentence delimiters and optimizes some more line breaks ( \n ).

Primarily affects

* DIALOGEVENT:Mis*
