### PR TITLE
Fix: Add missing string formats to language strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
@@ -4,8 +4,9 @@ date: 2023-08-07
 title: Fixes errors in Chinese strings
 
 changes:
-  - fix: The TOOLTIP:NumberOfVotes string now has Chinese text.
-  - fix: The TOOLTIP:GameInfoPlayer string now shows its number format in Chinese text.
+  - fix: The Chinese string of TOOLTIP:NumberOfVotes now has text.
+  - fix: The Chinese string of TOOLTIP:GameInfoPlayer now contains the number format.
+  - fix: The Chinese string of WOL:BuddyOffline now contains the string format.
   - fix: Quote symbols are now properly paired and spaced in Chinese strings.
   - fix: Three dot symbols are now used consistently in Chinese strings.
   - fix: Some rare Chinese speech subtitles no longer print the first row in bold font.
@@ -21,6 +22,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2330
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2332
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2334
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2340
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_french_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_text_errors.yaml
@@ -1,12 +1,13 @@
 ---
 date: 2023-08-07
 
-title: Fixes errors in French tool tip strings
+title: Fixes errors in French strings
 
 changes:
   - fix: The wording in French tool tip strings is more consistent now.
   - fix: The French tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
-  - fix: The TOOLTIP:NumberOfVotes, GUI:Ok, LAN:OK, MapTransfer:Done strings now have French text.
+  - fix: The French strings of TOOLTIP:NumberOfVotes, GUI:Ok, LAN:OK, MapTransfer:Done now contain text.
+  - fix: The French strings of Version:BuildTime, Version:BuildMachine, Version:BuildUser now contain the number format.
   - fix: The wording in French tool tip strings for the GLA Scud Launcher is more consistent now.
 
 labels:
@@ -20,6 +21,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2249
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2340
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_german_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_german_text_errors.yaml
@@ -1,14 +1,15 @@
 ---
 date: 2023-08-07
 
-title: Fixes errors in German tool tip strings
+title: Fixes errors in German strings
 
 changes:
   - fix: The wording in German tool tip strings is more consistent now.
   - fix: The German tool tip strings for China Red Guard, Tank Hunter and Battlemaster now explain the horde bonus better.
   - fix: More German tool tip strings now list the correct strengths and weaknesses.
-  - fix: The TOOLTIP:GameInfoPlayer string now shows its number format in German text.
-  - fix: The CONTROLBAR:PowerDescription string now shows proper sentences and number format in German text.
+  - fix: The German string of TOOLTIP:GameInfoPlayer now contains the number format.
+  - fix: The German string of CONTROLBAR:PowerDescription now contains proper sentences and the number format.
+  - fix: The German string of Buddy:Chatting now contains text.
   - fix: The German tool tip for the GLA Terrorist now describes the unit as "Kamikaze Bombe" and is therefore more consistent with the English wording.
 
 labels:
@@ -22,6 +23,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2218
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2340
 
 authors:
   - xezon


### PR DESCRIPTION
* Follow up for #2216

This change adds missing string formats to language strings. And fixes a few styling issues.

Mainly affects:

* WOL:BuddyOffline
* Version:BuildTime
* Version:BuildMachine
* Version:BuildUser