### PR TITLE
Fix: Improve tool tip strings of China Neutron Upgrade for latin languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2343_neutron_shells_tooltip.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2343_neutron_shells_tooltip.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-09-10
+
+title: Fixes tool tip strings of China Neutron Shells
+
+changes:
+  - fix: The German tool tip string of the China Neutron Shell upgrade now properly describes the upgrade.
+  - fix: The latin tool tip strings of the China Neutron Shell upgrade now also list neutralizing infantry inside buildings.
+
+labels:
+  - minor
+  - text
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2273
+
+authors:
+  - xezon


### PR DESCRIPTION
This change improves the tool tip strings of China Neutron Upgrade.

The German text is more precise now.

And the latin languages now also clarify that it can neutralize infantry in buildings.