### PR TITLE
Fix: Use consistent listing style in strength and weakness lists of tool tip strings for latin languages

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2156_misc_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2156_misc_text_errors.yaml
@@ -32,6 +32,7 @@ changes:
         - script
         - tooltip
         - wol
+  - fix: The strength and weakness lists in tool tip strings now use consistent listing styles in latin languages.
 
 labels:
   - minor
@@ -48,6 +49,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2333
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2341
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2359
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2346
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2346_strength_weakness_tooltip_listing_style.txt
+++ b/Patch104pZH/Design/Changes/v1.0/2346_strength_weakness_tooltip_listing_style.txt
@@ -1,0 +1,1 @@
+2156_misc_text_errors.yaml


### PR DESCRIPTION
This change fixes inconsistent listing style in strength and weaknesses of tool tip strings for latin languages.

German, French and Russian use `comma` and `and`.
English, Spanish, Italian, Brazilian, Polish use `comma` only.