### PR TITLE
Fix: Add consistent wording in tool tip strings (2)

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2148_polish_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2148_polish_text_errors.yaml
@@ -10,6 +10,10 @@ changes:
   - fix: The Polish tool tip string of the China Infantry Helix no longer claims to let passengers shoot at each other.
   - tweak: The Polish string for failed Rally Point placement is more concise now.
 
+subchanges:
+  - fix: Polish tool tip strings now consistently refer to rocket soldiers as "piechocie rakietowej".
+  - fix: Polish tool tip strings now consistently refer to anti-air defenses as "obronie przeciwlotniczej".
+
 labels:
   - china
   - gla

--- a/Patch104pZH/Design/Changes/v1.0/2151_spanish_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2151_spanish_text_errors.yaml
@@ -9,6 +9,12 @@ changes:
   - fix: The Spanish tool tip for the GLA Terrorist now describes the unit as "Soldado suicida" and is therefore more consistent with the English wording.
   - fix: Some rare Spanish speech subtitles no longer print the first row in bold font.
 
+subchanges:
+  - fix: Spanish tool tip strings now consistently refer to rocket soldiers as "infantería con misiles".
+  - fix: Spanish tool tip strings now consistently refer to anti-air defenses as "defensas antiaéreas".
+  - fix: Spanish tool tip strings now consistently refer to aircraft as "aviación" instead of "aviones".
+  - fix: Spanish tool tip strings now consistently refer to scouts as "exploradores" instead of "unidades exploradoras".
+
 labels:
   - minor
   - text
@@ -21,6 +27,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2252
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2334
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2350
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2195_brazilian_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2195_brazilian_text_errors.yaml
@@ -1,11 +1,16 @@
 ---
 date: 2023-08-02
 
-title: Fixes errors in Brazilian tool tip strings
+title: Fixes errors in Brazilian strings
 
 changes:
   - fix: The wording in Brazilian tool tip strings is more consistent now.
   - fix: The Brazilian names for GLA Booby Trap and Demo Trap are now distinguishable from each other.
+
+subchanges:
+  - fix: Brazilian tool tip strings now consistently refer to rocket soldiers as "Infantaria com Mísseis" instead of "Soldados c/ Mísseis".
+  - fix: Brazilian tool tip strings now consistently refer to anti-air defenses as "Defesas Antiaéreas".
+  - fix: Brazilian tool tip strings now consistently refer to scouts as "Unidades de Reconhecimento" instead of "Batedores".
 
 labels:
   - minor
@@ -17,6 +22,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2257
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2350
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_french_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_text_errors.yaml
@@ -10,6 +10,11 @@ changes:
   - fix: The French strings of Version:BuildTime, Version:BuildMachine, Version:BuildUser now contain the number format.
   - fix: The wording in French tool tip strings for the GLA Scud Launcher is more consistent now.
 
+subchanges:
+  - fix: French tool tip strings now consistently refer to rocket soldiers as "l'infanterie armée de missiles".
+  - fix: French tool tip strings now consistently refer to anti-air defenses as "défenses antiaériennes".
+  - fix: French tool tip strings now consistently refer to scouts as "éclaireurs" instead of "unités de reconnaissance".
+
 labels:
   - gla
   - minor
@@ -22,6 +27,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2249
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2340
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2350
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_german_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_german_text_errors.yaml
@@ -15,6 +15,11 @@ changes:
   - fix: The German science string of the GLA Hijacker no longer claims that the unit is perfectly stealthed.
   - fix: The German gui title string for host match close now has a descriptive title.
 
+subchanges:
+  - fix: German tool tip strings now consistently refer to rocket soldiers as "Raketen-Bots".
+  - fix: German tool tip strings now consistently refer to anti-air defenses as "Flugabwehrgeschütze".
+  - fix: German tool tip strings now consistently refer to base defenses as "Abwehreinrichtungen".
+
 labels:
   - minor
   - text

--- a/Patch104pZH/Design/Changes/v1.0/2219_italian_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2219_italian_text_errors.yaml
@@ -7,6 +7,11 @@ changes:
   - fix: The wording in Italian tool tip strings is more consistent now.
   - fix: Some rare Italian speech subtitles no longer print the first row in bold font.
 
+subchanges:
+  - fix: Italian tool tip strings now consistently refer to rocket soldiers as "fanteria con missili".
+  - fix: Italian tool tip strings now consistently refer to anti-air defenses as "difese contraerea".
+  - fix: Italian tool tip strings now consistently refer to base defenses as "difese della base" instead of "difese di terra".
+
 labels:
   - minor
   - text
@@ -16,6 +21,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2334
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2350
 
 authors:
   - xezon


### PR DESCRIPTION
* Follow up for #2219

This change fixes more wording inconsistencies in tool tip strings.

* Spanish tool tip strings now consistently refer to aircraft as "aviación" instead of "aviones"
* Italian tool tip strings now consistently refer to base defenses as "difese della base" instead of "difese di terra"
* French tool tip strings now consistently refer to scouts as "éclaireurs" instead of "unités de reconnaissance" 
* Spanish tool tip strings now consistently refer to scouts as "exploradores" instead of "unidades exploradoras" 
* Brazilian tool tip strings now consistently refer to scouts as "Unidades de Reconhecimento" instead of "Batedores" 
* Brazilian tool tip strings now consistently refer to rocket soldiers as "Infantaria com Mísseis" instead of "Soldados c/ Mísseis" 