### PR TITLE
Fix: Improve tool tip strings of GLA Rocket Buggy

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2150_english_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2150_english_text_errors.yaml
@@ -1,11 +1,12 @@
 ---
 date: 2023-07-26
 
-title: Fixes errors in English tool tip strings
+title: Fixes errors in English strings
 
 changes:
   - fix: The wording in English tool tip strings is more consistent now.
   - fix: The capitalization of words in English tool tip strings is more consistent now.
+  - fix: The English tool tip string of the GLA Rocket Buggy now also mentions it being strong vs infantry.
 
 labels:
   - minor
@@ -17,6 +18,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2195
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2219
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2261
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2353
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2216_chinese_text_errors.yaml
@@ -11,6 +11,7 @@ changes:
   - fix: Three dot symbols are now used consistently in Chinese strings.
   - fix: Some rare Chinese speech subtitles no longer print the first row in bold font.
   - tweak: The Chinese tool tip string for map start positions is more concise now.
+  - fix: The Chinese tool tip string of the GLA Rocket Buggy now also mentions it being strong vs infantry.
 
 labels:
   - minor
@@ -25,6 +26,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2334
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2340
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2345
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2353
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2218_french_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2218_french_text_errors.yaml
@@ -9,6 +9,7 @@ changes:
   - fix: The French strings of TOOLTIP:NumberOfVotes, GUI:Ok, LAN:OK, MapTransfer:Done now contain text.
   - fix: The French strings of Version:BuildTime, Version:BuildMachine, Version:BuildUser now contain the number format.
   - fix: The wording in French tool tip strings for the GLA Scud Launcher is more consistent now.
+  - fix: The French tool tip string of the GLA Rocket Buggy now also mentions it being strong vs infantry.
 
 subchanges:
   - fix: French tool tip strings now consistently refer to rocket soldiers as "l'infanterie armée de missiles".
@@ -28,6 +29,7 @@ links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2249
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2340
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2350
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2353
 
 authors:
   - xezon


### PR DESCRIPTION
This change improves the tool tip strings of the GLA Rocket Buggy. All languages now list the same strengths.