### PR TITLE
Change: Increase steal cash amount of GLA Saboteur from 1000 to 1200

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
@@ -7,6 +7,7 @@ changes:
   - tweak: Increases the steal cash amount of the GLA Saboteur from 1000 to 1200.
 
 labels:
+  - buff
   - controversial
   - design
   - gla

--- a/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-09-13
+
+title: Increases steal cash amount of GLA Saboteur from 1000 to 1200
+
+changes:
+  - tweak: Increases the steal cash amount of the GLA Saboteur from 1000 to 1200.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2355
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17456,7 +17456,7 @@ Object Demo_GLAInfantrySaboteur
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
   ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
-  ;   Max gain factor is 2x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
+  ;   Max gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17455,10 +17455,12 @@ Object Demo_GLAInfantrySaboteur
   End
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
+  ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
+  ;   Max gain factor is 2x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes
-    StealCashAmount = 1000
+    StealCashAmount = 1200
   End
   Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
     BuildingPickup = Yes
@@ -17468,7 +17470,7 @@ Object Demo_GLAInfantrySaboteur
   End
   Behavior = SabotageSupplyCenterCrateCollide     SabotageTag_05
     BuildingPickup  = Yes
-    StealCashAmount = 1000
+    StealCashAmount = 1200
   End
   Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
     BuildingPickup = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -4411,7 +4411,7 @@ Object GLAInfantrySaboteur
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets. Prevents ability to tell apart fake and real Black Markets by cursor.
   ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
-  ;   Max gain factor is 2x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
+  ;   Max gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -4410,10 +4410,12 @@ Object GLAInfantrySaboteur
   End
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets. Prevents ability to tell apart fake and real Black Markets by cursor.
+  ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
+  ;   Max gain factor is 2x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes
-    StealCashAmount = 1000
+    StealCashAmount = 1200
   End
   Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
     BuildingPickup = Yes
@@ -4423,7 +4425,7 @@ Object GLAInfantrySaboteur
   End
   Behavior = SabotageSupplyCenterCrateCollide     SabotageTag_05
     BuildingPickup  = Yes
-    StealCashAmount = 1000
+    StealCashAmount = 1200
   End
   Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
     BuildingPickup = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17820,7 +17820,7 @@ Object Slth_GLAInfantrySaboteur
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
   ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
-  ;   Max gain factor is 2x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
+  ;   Max gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17819,10 +17819,12 @@ Object Slth_GLAInfantrySaboteur
   End
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
+  ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
+  ;   Max gain factor is 2x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes
-    StealCashAmount = 1000
+    StealCashAmount = 1200
   End
   Behavior = SabotageSuperweaponCrateCollide      SabotageTag_03
     BuildingPickup = Yes
@@ -17832,7 +17834,7 @@ Object Slth_GLAInfantrySaboteur
   End
   Behavior = SabotageSupplyCenterCrateCollide     SabotageTag_05
     BuildingPickup  = Yes
-    StealCashAmount = 1000
+    StealCashAmount = 1200
   End
   Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
     BuildingPickup = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -6088,7 +6088,7 @@ End
 
 
 
-Object PatriotMissileEMPHelper
+Object PatriotMissileEMPHelper ; unused
 
 ; *** ART Parameters ***
 ; ***DESIGN parameters ***

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -8027,7 +8027,7 @@ Weapon SupW_PatriotMissileAssistWeapon
   ProjectileCollidesWith      = STRUCTURES
 End
 
-Weapon SupW_EMPBlast
+Weapon SupW_EMPBlast ; unused
   PrimaryDamage               = 0.0
   PrimaryDamageRadius         = 0.0
   ScatterRadiusVsInfantry     = 10.0     ;When this weapon is used against infantry, it can randomly miss by as much as this distance.


### PR DESCRIPTION
* Refers to #2097

This change increases the steal cash amount of the GLA Saboteur from 1000 to 1200.

This bumps the max gain factor from 2.5 to 3.0.

### Original Saboteur reward

1x Saboteur, entering enemy Supply Center

```
-800 build cost
+1000 cash reward
+1000 enemy cash loss

= +200 self cash reward
= +1200 total cash gain

Max cash gain factor 2.5 aka +150%
```

### Patched Saboteur reward

1x Saboteur, entering enemy Supply Center

```
-800 build cost
+1200 cash reward
+1200 enemy cash loss

= +400 self cash reward
= +1600 total cash gain

Max cash gain factor 3.0 aka +200%
```

### Terrorists kill reward

4x Terrorist, killing enemy War Factory

```
-800 build cost
+2000 enemy cash loss
+15 or more seconds production delay
+200 XP

= +0 self cash reward
= +1200 total cash gain

Common cash gain factor 2.5 aka +150%
```

1x Technical + 4x Terrorist, killing enemy War Factory

```
-800 build cost for Terrors
-500 build cost for Technical
+2000 enemy cash loss
+15 or more seconds production delay
+200 XP

= +0 self cash reward
= +700 total cash gain

Common cash gain factor 1.54 aka +54%
```

# Rationale

The GLA Saboteur is seldom used to steal cash from an opponent. The max gain factor of 2.5 is not more attractive in comparison to the Terrorists.

The Terrorists have the same gain factor, but they also delay enemy income or production and give experience points for kills.

The Saboteur is stealth, but is unarmed and has no utility other than sabotaging enemy structures. It needs to have a valuable reward, otherwise it is not attractive to invest in. It is a gamble unit, similar to the Terrorist and Bomb Truck. The max steal cash value is not guaranteed: If the target player has less cash on the bank, then the Saboteur will withdraw just as much cash is available, anywhere from 0 to 1200. The Saboteur requires an Arms Dealer to build and has a relatively long build time of 30 seconds (without Power).

Raising the max gain factor from 2.5 to 3.0 appears reasonable to make the Saboteur more attractive to use.