### PR TITLE
Disable Cash Stolen EVA event

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/1940_misspelled_dialog_event_sounds.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/1940_misspelled_dialog_event_sounds.yaml
@@ -12,6 +12,7 @@ changes:
   - fix: Fixes misspelled filename in Cin_SquadronFlyBy02.
   - fix: Fixes misspelled filename in Taunts_Turtle087.
   - fix: Fixes misspelled filename in EvaGLA_FundsTransferred.
+  - tweak: The CashStolen EVA event is now properly disabled.
 
 labels:
   - audio
@@ -21,6 +22,7 @@ labels:
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1940
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2356
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Eva.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Eva.ini
@@ -3132,79 +3132,84 @@ EvaEvent BuildingSabotaged
 End
 
 ;=================================================================== CashStolen
-EvaEvent CashStolen
-  Priority = 4
-  TimeBetweenChecksMS = 5000
-  ExpirationTimeMS  = 5000
 
-  ; American XO
-  SideSounds
-    Side = America
-    Sounds = EvaUSA_CashStolen
-  End
+; Patch104p @tweak xezon 13/09/2023 Disables this eva event. (#2356)
+; It is played when the GLA Saboteur enters a Supply Center to steal cash from.
+; It was broken in the original game and is still undesired, because it makes the Saboteur interactions way too obvious.
 
-  SideSounds
-    Side = AmericaSuperWeaponGeneral
-    Sounds = EvaUSA_CashStolen
-  End
-
-  SideSounds
-    Side = AmericaLaserGeneral
-    Sounds = EvaUSA_CashStolen
-  End
-
-  SideSounds
-    Side = AmericaAirForceGeneral
-    Sounds = EvaUSA_CashStolen
-  End
-
-  ; Chinese XO
-  SideSounds
-    Side = China
-    Sounds = EvaChina_CashStolen
-  End
-
-  SideSounds
-    Side = ChinaTankGeneral
-    Sounds = EvaChina_CashStolen
-  End
-
-  SideSounds
-    Side = ChinaInfantryGeneral
-    Sounds = EvaChina_CashStolen
-  End
-
-  SideSounds
-    Side = ChinaNukeGeneral
-    Sounds = EvaChina_CashStolen
-  End
-
-  SideSounds
-    Side = Boss
-    Sounds = EvaChina_CashStolen
-  End
-
-  ; GLA XO
-  SideSounds
-    Side = GLA
-    Sounds = EvaGLA_CashStolen
-  End
-
-  SideSounds
-    Side = GLAToxinGeneral
-    Sounds = EvaGLA_CashStolen
-  End
-
-  SideSounds
-    Side = GLADemolitionGeneral
-    Sounds = EvaGLA_CashStolen
-  End
-
-  SideSounds
-    Side = GLAStealthGeneral
-    Sounds = EvaGLA_CashStolen
-  End
-End
+;EvaEvent CashStolen
+;  Priority = 4
+;  TimeBetweenChecksMS = 5000
+;  ExpirationTimeMS  = 5000
+;
+;  ; American XO
+;  SideSounds
+;    Side = America
+;    Sounds = EvaUSA_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = AmericaSuperWeaponGeneral
+;    Sounds = EvaUSA_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = AmericaLaserGeneral
+;    Sounds = EvaUSA_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = AmericaAirForceGeneral
+;    Sounds = EvaUSA_CashStolen
+;  End
+;
+;  ; Chinese XO
+;  SideSounds
+;    Side = China
+;    Sounds = EvaChina_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = ChinaTankGeneral
+;    Sounds = EvaChina_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = ChinaInfantryGeneral
+;    Sounds = EvaChina_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = ChinaNukeGeneral
+;    Sounds = EvaChina_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = Boss
+;    Sounds = EvaChina_CashStolen
+;  End
+;
+;  ; GLA XO
+;  SideSounds
+;    Side = GLA
+;    Sounds = EvaGLA_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = GLAToxinGeneral
+;    Sounds = EvaGLA_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = GLADemolitionGeneral
+;    Sounds = EvaGLA_CashStolen
+;  End
+;
+;  SideSounds
+;    Side = GLAStealthGeneral
+;    Sounds = EvaGLA_CashStolen
+;  End
+;End
 
 ;============================================================== UpgradeComplete
 EvaEvent UpgradeComplete


### PR DESCRIPTION
* Follow up for TheSuperHackers/GeneralsGamePatch#1940
* Refers to TheSuperHackers/GeneralsGameCode#195

This change explicitly disables the Cash Stolen EVA event. This restores how it works originally user facing.