### PR TITLE
Change: Increase Internet Center sabotage duration of GLA Saboteur from 15000 to 60000 ms

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
@@ -4,7 +4,7 @@ date: 2023-09-13
 title: Increases steal cash amount of GLA Saboteur from 1000 to 1200
 
 changes:
-  - tweak: Increases the steal cash amount of the GLA Saboteur from 1000 to 1200.
+  - tweak: Increases the steal cash amount of the GLA Saboteur from 1000 to 1200. The maximum cash gain factor against a Supply Center increases from 2.5 to 3.0.
 
 labels:
   - buff

--- a/Patch104pZH/Design/Changes/v1.0/2357_saboteur_internet_center_sabotage_duration.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2357_saboteur_internet_center_sabotage_duration.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-09-13
+
+title: Increases Internet Center sabotage duration of GLA Saboteur from 15 to 60 seconds
+
+changes:
+  - tweak: Increases the Internet Center sabotage duration of the GLA Saboteur from 15 to 60 seconds. The average cash gain factor against an Internet Center with 8 Hackers increases from 0.68 to 2.72. Internet Center upgrade research and Satellite Hack I & II are paused for the same sabotage duration.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2357
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17456,7 +17456,7 @@ Object Demo_GLAInfantrySaboteur
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
   ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
-  ;   Max gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
+  ;   Max cash gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes
@@ -17483,6 +17483,8 @@ Object Demo_GLAInfantrySaboteur
     BuildingPickup = Yes
   End
   ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 15000 to achieve fair value. (#2357)
+  ;   Cash gain factor varies with amount of Hackers and their veterancy level(s).
+  ;   Average cash gain factor with 8 Hackers is 2.72x: -800 build cost (+36.25 cash/second * 60 seconds) = 1375 gain.
   Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
     BuildingPickup = Yes
     SabotageDuration = 60000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17482,9 +17482,10 @@ Object Demo_GLAInfantrySaboteur
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes
   End
+  ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 15000 to achieve fair value. (#2357)
   Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
     BuildingPickup = Yes
-    SabotageDuration = 15000
+    SabotageDuration = 60000
   End
 
 ; --- begin Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -4434,9 +4434,10 @@ Object GLAInfantrySaboteur
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes
   End
+  ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 15000 to achieve fair value. (#2357)
   Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
     BuildingPickup = Yes
-    SabotageDuration = 15000
+    SabotageDuration = 60000
   End
 
 ; --- begin Death modules ---

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -4411,7 +4411,7 @@ Object GLAInfantrySaboteur
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets. Prevents ability to tell apart fake and real Black Markets by cursor.
   ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
-  ;   Max gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
+  ;   Max cash gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes
@@ -4435,6 +4435,8 @@ Object GLAInfantrySaboteur
     BuildingPickup = Yes
   End
   ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 15000 to achieve fair value. (#2357)
+  ;   Cash gain factor varies with amount of Hackers and their veterancy level(s).
+  ;   Average cash gain factor with 8 Hackers is 2.72x: -800 build cost (+36.25 cash/second * 60 seconds) = 1375 gain.
   Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
     BuildingPickup = Yes
     SabotageDuration = 60000

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17846,9 +17846,10 @@ Object Slth_GLAInfantrySaboteur
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes
   End
+  ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 15000 to achieve fair value. (#2357)
   Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
     BuildingPickup = Yes
-    SabotageDuration = 15000
+    SabotageDuration = 60000
   End
 
   ; Patch104p @bugfix hanfield 28/08/2021 Replaced FX_RebelDie with FX_SaboteurDie.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17820,7 +17820,7 @@ Object Slth_GLAInfantrySaboteur
 
   ; Patch104p @bugfix commy2 10/10/2021 Add ability to enter Supply Drop Zones and Black Markets.
   ; Patch104p @tweak xezon 13/09/2023 Changes steal cash amount from 1000. (#2355)
-  ;   Max gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
+  ;   Max cash gain factor is 3x: -800 build cost +1200 reward +1200 enemy loss = 1600 gain.
 
   Behavior = SabotageSupplyDropzoneCrateCollide   SabotageTag_02
     BuildingPickup  = Yes
@@ -17847,6 +17847,8 @@ Object Slth_GLAInfantrySaboteur
     BuildingPickup = Yes
   End
   ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 15000 to achieve fair value. (#2357)
+  ;   Cash gain factor varies with amount of Hackers and their veterancy level(s).
+  ;   Average cash gain factor with 8 Hackers is 2.72x: -800 build cost (+36.25 cash/second * 60 seconds) = 1375 gain.
   Behavior = SabotageInternetCenterCrateCollide   SabotageTag_08
     BuildingPickup = Yes
     SabotageDuration = 60000


### PR DESCRIPTION
* Refers to #2097
* Related to #2355

This change increases the Internet Center sabotage duration of the GLA Saboteur from 15000 to 60000 ms.

This bumps the average gain factor on disabling 8 Hackers from 0.68 to 2.71. The gain factor can be lower or higher depending on the veterancy and amount of Hackers inside the Internet Center.

Saboteur build cost is 800.

### Math

Hackers give 5, 6, 8, 10 cash per tick, averaging at 7.25 cash per tick.

Internet Center tick is 1.6 seconds. 7.25 cash / 1.6 seconds = 4.53125 cash per second.

8 hackers * 4.53125 cash per second = 36.25 cash per second.

For fair sabotage value we use 2000, as much as original max cash gain.

2000 cash / 36.25 cash per second = 55 seconds.

We can round it up to 60 seconds.

## Original Internet Center sabotage

With a sabotage duration of 15 seconds.

| Hackers  | Sabotage cash value | Sabotage real value | Sabotage gain |
|----------|---------------------|---------------------|---------------|
| 8x Vet 0 | 375                 | -425                | 0.47 (-53%)   |
| 8x Vet 1 | 450                 | -350                | 0.56 (-44%)   |
| 8x Vet 2 | 600                 | -200                | 0.75 (-25%)   |
| 8x Vet 3 | 750                 | -50                 | 0.94 (-6%)    |

## Patched Internet Center sabotage

With a sabotage duration of 60 seconds.

| Hackers  | Sabotage cash value | Sabotage real value | Sabotage gain |
|----------|---------------------|---------------------|---------------|
| 8x Vet 0 | 1500                | +700                | 1.88 (+88%)   |
| 8x Vet 1 | 1800                | +1000               | 2.25 (+125%)  |
| 8x Vet 2 | 2400                | +1600               | 3.00 (+200%)  |
| 8x Vet 3 | 3000                | +2200               | 3.75 (+375%)  |

## Other things that can disable for reference

| Object                   | DisabledDuration |
|--------------------------|------------------|
| EMPPulseEffectSpheroid   |  30000           |
| LeafletContainer         |  20000           |
| EMPPatriotEffectSpheroid |  10000           |

## Patch China Economy buffs for reference

China has gotten a lot of buffs for its economy so far. Therefore this buff for GLA against China should be no major concern for China, but make the game content richer by giving the GLA Saboteur more valuable utility.

* #768
* #769
* #770
* #771
* #772
* #773
* #1533
* #1989
* #2027

# Rationale

In original game, it is not worthwhile to send the Saboteur into an Internet Center, because the maximum return for the sabotage duration of 15 seconds is lower than the actual cost of the Saboteur. Therefore the cash gain is negative. The only tangible advantage is the pausing of upgrade research and Satellite Hack spying for those 15 seconds.

This change increases the sabotage duration by +300% to achieve an average gain factor of 2.71 against a fully occupied Internet Center, which is similar to the max cash gain factor of 2.5 or 3.0 with the Supply Center (#2355).

The Internet Center can be easily defended from Saboteurs with the Mines upgrade.