### PR TITLE
Change: Increase Factory sabotage duration of GLA Saboteur from 30000 to 45000 ms

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2358_saboteur_factory_sabotage_duration.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2358_saboteur_factory_sabotage_duration.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-09-13
+
+title: Increases Factory sabotage duration of GLA Saboteur from 30 to 45 seconds
+
+changes:
+  - tweak: Increases the Factory sabotage duration of the GLA Saboteur from 30 to 45 seconds. Applies to unit production facilities only.
+
+labels:
+  - buff
+  - controversial
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2358
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -17472,9 +17472,10 @@ Object Demo_GLAInfantrySaboteur
     BuildingPickup  = Yes
     StealCashAmount = 1200
   End
+  ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 30000. (#2358)
   Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
     BuildingPickup = Yes
-    SabotageDuration = 30000
+    SabotageDuration = 45000
   End
 
   ; Patch104p @bugfix commy2 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -4427,9 +4427,10 @@ Object GLAInfantrySaboteur
     BuildingPickup  = Yes
     StealCashAmount = 1200
   End
+  ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 30000. (#2358)
   Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
     BuildingPickup = Yes
-    SabotageDuration = 30000
+    SabotageDuration = 45000
   End
   Behavior = SabotageFakeBuildingCrateCollide     SabotageTag_07
     BuildingPickup = Yes

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -17836,9 +17836,10 @@ Object Slth_GLAInfantrySaboteur
     BuildingPickup  = Yes
     StealCashAmount = 1200
   End
+  ; Patch104p @tweak xezon 13/09/2023 Changes sabotage duration from 30000. (#2358)
   Behavior = SabotageMilitaryFactoryCrateCollide  SabotageTag_06
     BuildingPickup = Yes
-    SabotageDuration = 30000
+    SabotageDuration = 45000
   End
 
   ; Patch104p @bugfix commy2 10/10/2021 Fix this factions Saboteur cannot enter Fake buildings and Internet Centers.


### PR DESCRIPTION
* Relates to #2097

This change increases the Factory sabotage duration of the GLA Saboteur from 30000 to 45000 ms. Does not apply to Power Plant, Internet Center, Command Center, Fake Building.

The Saboteur build time is 30 seconds without power. The build cost is 800. Requires an Arms Dealer to build.

### Other things that can disable for reference

| Object                   | DisabledDuration |
|--------------------------|------------------|
| EMPPulseEffectSpheroid   |  30000           |
| LeafletContainer         |  20000           |
| EMPPatriotEffectSpheroid |  10000           |

# Rationale

The GLA Saboteur is seldom used to deactivate enemy production facilitates. The new +50% sabotage duration provides more incentive to invest in and micro manage the Saboteur to try disable production facilities.