### PR TITLE
Fix: Set EXPLODED death type for weapon of USA Missile Defender

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2355_saboteur_steal_cash_amount.yaml
@@ -4,7 +4,7 @@ date: 2023-09-13
 title: Increases steal cash amount of GLA Saboteur from 1000 to 1200
 
 changes:
-  - tweak: Increases the steal cash amount of the GLA Saboteur from 1000 to 1200. The maximum cash gain factor against a Supply Center increases from 2.5 to 3.0.
+  - tweak: The GLA Saboteur can now steal up to 1200 cash. The maximum cash gain factor against a Supply Center increases from 2.5 to 3.0.
 
 labels:
   - buff

--- a/Patch104pZH/Design/Changes/v1.0/2357_saboteur_internet_center_sabotage_duration.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2357_saboteur_internet_center_sabotage_duration.yaml
@@ -4,7 +4,7 @@ date: 2023-09-13
 title: Increases Internet Center sabotage duration of GLA Saboteur from 15 to 60 seconds
 
 changes:
-  - tweak: Increases the Internet Center sabotage duration of the GLA Saboteur from 15 to 60 seconds. The average cash gain factor against an Internet Center with 8 Hackers increases from 0.68 to 2.72. Internet Center upgrade research and Satellite Hack I & II are paused for the same sabotage duration.
+  - tweak: The GLA Saboteur can now sabotage the China Internet Center for 60 seconds. The average cash gain factor against an Internet Center with 8 Hackers increases from 0.68 to 2.72. Internet Center upgrade research and Satellite Hack I & II are paused for the same sabotage duration.
 
 labels:
   - buff

--- a/Patch104pZH/Design/Changes/v1.0/2358_saboteur_factory_sabotage_duration.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2358_saboteur_factory_sabotage_duration.yaml
@@ -4,7 +4,7 @@ date: 2023-09-13
 title: Increases Factory sabotage duration of GLA Saboteur from 30 to 45 seconds
 
 changes:
-  - tweak: Increases the Factory sabotage duration of the GLA Saboteur from 30 to 45 seconds. Applies to unit production facilities only.
+  - tweak: The GLA Saboteur can now sabotage production factories for 45 seconds.
 
 labels:
   - buff

--- a/Patch104pZH/Design/Changes/v1.0/2362_missile_defender_weapon_death_type.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2362_missile_defender_weapon_death_type.yaml
@@ -1,0 +1,21 @@
+---
+date: 2023-09-15
+
+title: Fixes incorrect weapon death types of USA Missile Defender
+
+changes:
+  - fix: The weapons of the USA Missile Defender now incur the EXPLODED instead of NORMAL death type. This will trigger the GLA Terrorist suicide explosion on kill.
+
+labels:
+  - bug
+  - controversial
+  - major
+  - nerf
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2362
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2362_missile_defender_weapon_death_type.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2362_missile_defender_weapon_death_type.yaml
@@ -4,7 +4,7 @@ date: 2023-09-15
 title: Fixes incorrect weapon death types of USA Missile Defender
 
 changes:
-  - fix: The weapons of the USA Missile Defender now incur the EXPLODED instead of NORMAL death type. This will trigger the GLA Terrorist suicide explosion on kill.
+  - fix: The weapons of the USA Missile Defender now incur the EXPLODED instead of NORMAL death type. On kill, this will trigger the GLA Terrorist suicide explosion and the GLA Demo Bike suicide explosion before Demo Upgrade. This is consistent with other missile weapons, such as missiles of Humvee TOW, Hellfire Drone, Tank Hunter and RPG-Trooper.
 
 labels:
   - bug

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -778,6 +778,7 @@ Weapon CINE_RangerAdvancedCombatRifle
   WeaponBonus             = DRONE_SPOTTING DAMAGE       200%
 End
 
+; Patch104p @bugfix xezon 15/09/2023 Changes death type from NORMAL. (#2362)
 ;------------------------------------------------------------------------------
 Weapon MissileDefenderMissileWeapon
   PrimaryDamage               = 40.0
@@ -786,7 +787,7 @@ Weapon MissileDefenderMissileWeapon
   AttackRange                 = 175.0
   ;MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE
-  DeathType                   = NORMAL
+  DeathType                   = EXPLODED
   WeaponSpeed                 = 600
   ProjectileObject            = MissileDefenderMissile
   ProjectileExhaust           = MissileDefenderMissileExhaust
@@ -807,6 +808,7 @@ Weapon MissileDefenderMissileWeapon
 End
 
 ; Patch104p @tweak xezon 14/01/2023 Adds missile exhaust particles. (#1552)
+; Patch104p @bugfix xezon 15/09/2023 Changes death type from NORMAL. (#2362)
 ;------------------------------------------------------------------------------
 Weapon MissileDefenderLaserGuidedMissileWeapon
   PrimaryDamage = 40.0
@@ -815,7 +817,7 @@ Weapon MissileDefenderLaserGuidedMissileWeapon
   AttackRange = 300.0     ;Extending this range, allows the special ability to work better.
   ;MinimumAttackRange = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType = ARMOR_PIERCING
-  DeathType = NORMAL
+  DeathType = EXPLODED
   WeaponSpeed = 600
   ProjectileObject = MissileDefenderMissile
   ProjectileExhaust = MissileDefenderMissileExhaust


### PR DESCRIPTION
This change sets the expected EXPLODED death type for the weapon of the USA Missile Defender. It is now consistent with weapons of Tank Hunter and RPG Trooper.

The major consequence is that the missiles will now explode the GLA Terrorists and therefore trigger their suicide weapon. It will also trigger the suicide weapon of the GLA Demo Bike before Demolitions Upgrade.

This is a fix but also nerf on USA.

## Original

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/9f71ba02-2f89-4265-a88b-e1a7358c885b
