### PR TITLE
Fix: GLA Battle Bus wreck no longer shows salvage upgrades

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2363_battle_bus_wreck.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2363_battle_bus_wreck.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-09-15
+
+title: Fixes wreck model of GLA Battle Bus
+
+changes:
+  - fix: The wreck of the GLA Battle Bus no longer shows bus salvage upgrades.
+
+labels:
+  - art
+  - bug
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2363
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/Hulk.ini
@@ -1627,8 +1627,10 @@ Object DeadBattleBusHulk
 
   ; *** ART Parameters ***
   Draw = W3DModelDraw ModuleTag_01
+    ; Patch104p @fix xezon 15/09/2023 Hide upgrades on wreck. (#2363)
     ConditionState = NONE
       Model = UVBattBus_D1
+      HideSubObject = BUSUP01 BUSUP02
     End
   End
 


### PR DESCRIPTION
The GLA Battle Bus wreck no longer shows salvage upgrades.