### PR TITLE
Fix: Remove destruction delay from GLA Battle Bus death

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2363_battle_bus_wreck.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2363_battle_bus_wreck.yaml
@@ -5,16 +5,19 @@ title: Fixes wreck model of GLA Battle Bus
 
 changes:
   - fix: The wreck of the GLA Battle Bus no longer shows bus salvage upgrades.
+  - tweak: The wreck of the GLA Battle Bus no longer spawns with a small random delay.
 
 labels:
   - art
   - bug
+  - design
   - gla
   - minor
   - v1.0
 
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2363
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2364
 
 authors:
   - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -21021,6 +21021,7 @@ Object Chem_GLAVehicleBattleBus
 
   Locomotor = SET_NORMAL BattleBusLocomotor
 
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay variance from 200 to trigger the final death explosion immediately. (#2364)
   Behavior = BattleBusSlowDeathBehavior  ModuleTag_08
     DeathTypes = ALL -CRUSHED -SPLATTED -EXTRA_4
     ProbabilityModifier = 5
@@ -21037,7 +21038,7 @@ Object Chem_GLAVehicleBattleBus
 
     ; Part the second, normal fields of a SlowDeathBehavior
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0
     FX = FINAL FX_BattleBusDeathExplosion
     OCL = FINAL OCL_BattleBusDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -22562,7 +22562,7 @@ Object Demo_GLAVehicleBattleBus
   Locomotor = SET_NORMAL BattleBusLocomotor
 
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
-
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay variance from 200 to trigger the final death explosion immediately. (#2364)
   Behavior = BattleBusSlowDeathBehavior  ModuleTag_08
     DeathTypes = ALL -CRUSHED -SPLATTED -EXTRA_4 -SUICIDED ;Crushed and splatted are cover by a DestroyDie.  Extra4(loneliness) and Suicide(DemoBomb) are covered in a normal slowdeath
     ProbabilityModifier = 5
@@ -22579,7 +22579,7 @@ Object Demo_GLAVehicleBattleBus
 
     ; Part the second, normal fields of a SlowDeathBehavior
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0
 
     OCL = FINAL Demo_OCL_BattleBusDeath
     ;FX  = FINAL FX_BattleBusDeathExplosion

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -4319,7 +4319,7 @@ Object GC_Slth_GLAVehicleBattleBus
 
   Locomotor = SET_NORMAL      BattleBusLocomotor
 
-
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay variance from 200 to trigger the final death explosion immediately. (#2364)
   Behavior = BattleBusSlowDeathBehavior  ModuleTag_08
     DeathTypes = ALL -CRUSHED -SPLATTED -EXTRA_4
     ProbabilityModifier = 5
@@ -4336,7 +4336,7 @@ Object GC_Slth_GLAVehicleBattleBus
 
     ; Part the second, normal fields of a SlowDeathBehavior
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0
     FX = FINAL FX_BattleBusDeathExplosion
     OCL = FINAL OCL_BattleBusDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6741,6 +6741,7 @@ Object GLAVehicleBattleBus
 
   Locomotor = SET_NORMAL BattleBusLocomotor
 
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay variance from 200 to trigger the final death explosion immediately. (#2364)
   Behavior = BattleBusSlowDeathBehavior  ModuleTag_08
     DeathTypes = ALL -CRUSHED -SPLATTED -EXTRA_4
     ProbabilityModifier = 5
@@ -6757,7 +6758,7 @@ Object GLAVehicleBattleBus
 
     ; Part the second, normal fields of a SlowDeathBehavior
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0
     FX = FINAL FX_BattleBusDeathExplosion
     OCL = FINAL OCL_BattleBusDeath
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -22613,6 +22613,7 @@ Object Slth_GLAVehicleBattleBus
 
   Locomotor = SET_NORMAL BattleBusLocomotor
 
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay variance from 200 to trigger the final death explosion immediately. (#2364)
   Behavior = BattleBusSlowDeathBehavior  ModuleTag_08
     DeathTypes = ALL -CRUSHED -SPLATTED -EXTRA_4
     ProbabilityModifier = 5
@@ -22629,7 +22630,7 @@ Object Slth_GLAVehicleBattleBus
 
     ; Part the second, normal fields of a SlowDeathBehavior
     DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelayVariance = 0
     FX = FINAL FX_BattleBusDeathExplosion
     OCL = FINAL OCL_BattleBusDeath
   End


### PR DESCRIPTION
This change removes the random destruction delay from the GLA Battle Bus. Reason being, it looks odd when the passengers die but the final death explosion effect is slightly delayed behind.