### PR TITLE
Fix: Prevent radar dish animation reset on damage transition of GLA Radar Van, China Overlord, Listening Outpost

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2365_radar_dish_animation_reset.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2365_radar_dish_animation_reset.yaml
@@ -1,0 +1,22 @@
+---
+date: 2023-09-16
+
+title: Fixes animation reset on damage transition of vehicles
+
+changes:
+  - fix: The radar dish rotation of the GLA Radar Van no longer resets on a damage transition.
+  - fix: The radar dish rotation of the China Overlord no longer resets on a damage transition.
+  - fix: The radar dish rotation of the China Listening Outpost no longer resets on a damage transition.
+
+labels:
+  - bug
+  - china
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2365
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -21131,10 +21131,12 @@ Object Boss_TankOverlord
 
   Draw = W3DOverlordTankDraw ModuleTag_01
     ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -21146,6 +21148,7 @@ Object Boss_TankOverlord
       Model               = NVOvrlrd_d
       Animation           = NVOvrlrd_d.NVOvrlrd_d
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -20548,22 +20548,26 @@ Object Chem_GLAVehicleRadarVan
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model = UVRadarVan
       Animation = UVRadarVan.UVRadarVan
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = REALLYDAMAGED
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = RUBBLE
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaCINEUnit.ini
@@ -1306,10 +1306,12 @@ Object CINE_ChinaTankOverlord
 
   Draw = W3DOverlordTankDraw ModuleTag_01
     ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -1321,6 +1323,7 @@ Object CINE_ChinaTankOverlord
       Model               = NVOvrlrd_d
       Animation           = NVOvrlrd_d.NVOvrlrd_d
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -238,10 +238,12 @@ Object ChinaTankOverlord
 
   Draw = W3DOverlordTankDraw ModuleTag_01
     ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -253,6 +255,7 @@ Object ChinaTankOverlord
       Model               = NVOvrlrd_d
       Animation           = NVOvrlrd_d.NVOvrlrd_d
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaVehicle.ini
@@ -2852,16 +2852,19 @@ Object ChinaVehicleListeningOutpost
   Draw = W3DModelDraw ModuleTag_33
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish and legs. (#2365)
     ConditionState = NONE
       Model = NVLOUTPOST_B
       Animation = NVLOUTPOST_B.NVLOUTPOST_B
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed
     End
     ConditionState = REALLYDAMAGED
       Model = NVLOUTPOST_BD
       Animation = NVLOUTPOST_BD.NVLOUTPOST_BD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed_ReallyDamaged
     End
 
@@ -2869,12 +2872,14 @@ Object ChinaVehicleListeningOutpost
       Model = NVLOUTPOST_A
       Animation = NVLOUTPOST_A.NVLOUTPOST_A
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving
     End
     ConditionState = REALLYDAMAGED MOVING
       Model = NVLOUTPOST_AD
       Animation = NVLOUTPOST_AD.NVLOUTPOST_AD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving_ReallyDamaged
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -22045,22 +22045,26 @@ Object Demo_GLAVehicleRadarVan
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model = UVRadarVan
       Animation = UVRadarVan.UVRadarVan
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = REALLYDAMAGED
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = RUBBLE
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2405,22 +2405,26 @@ Object GC_Chem_GLAVehicleRadarVan
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model = UVRadarVan
       Animation = UVRadarVan.UVRadarVan
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = REALLYDAMAGED
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = RUBBLE
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2840,22 +2840,26 @@ Object GC_Slth_GLAVehicleRadarVan
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model = UVRadarVan
       Animation = UVRadarVan.UVRadarVan
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = REALLYDAMAGED
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = RUBBLE
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -6266,22 +6266,26 @@ Object GLAVehicleRadarVan
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model = UVRadarVan
       Animation = UVRadarVan.UVRadarVan
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = REALLYDAMAGED
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = RUBBLE
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -16337,16 +16337,19 @@ Object Infa_ChinaVehicleListeningOutpost
   Draw = W3DModelDraw ModuleTag_33
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish and legs. (#2365)
     ConditionState = NONE
       Model = NVLOUTPOST_B
       Animation = NVLOUTPOST_B.NVLOUTPOST_B
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed
     End
     ConditionState = REALLYDAMAGED
       Model = NVLOUTPOST_BD
       Animation = NVLOUTPOST_BD.NVLOUTPOST_BD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed_ReallyDamaged
     End
 
@@ -16354,12 +16357,14 @@ Object Infa_ChinaVehicleListeningOutpost
       Model = NVLOUTPOST_A
       Animation = NVLOUTPOST_A.NVLOUTPOST_A
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving
     End
     ConditionState = REALLYDAMAGED MOVING
       Model = NVLOUTPOST_AD
       Animation = NVLOUTPOST_AD.NVLOUTPOST_AD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving_ReallyDamaged
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -4959,16 +4959,19 @@ Object Nuke_ChinaVehicleListeningOutpost
   Draw = W3DModelDraw ModuleTag_33
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish and legs. (#2365)
     ConditionState = NONE
       Model = NVLOUTPOST_B
       Animation = NVLOUTPOST_B.NVLOUTPOST_B
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed
     End
     ConditionState = REALLYDAMAGED
       Model = NVLOUTPOST_BD
       Animation = NVLOUTPOST_BD.NVLOUTPOST_BD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed_ReallyDamaged
     End
 
@@ -4976,12 +4979,14 @@ Object Nuke_ChinaVehicleListeningOutpost
       Model = NVLOUTPOST_A
       Animation = NVLOUTPOST_A.NVLOUTPOST_A
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving
     End
     ConditionState = REALLYDAMAGED MOVING
       Model = NVLOUTPOST_AD
       Animation = NVLOUTPOST_AD.NVLOUTPOST_AD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving_ReallyDamaged
     End
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -17387,10 +17387,12 @@ Object Nuke_ChinaTankOverlord
 
   Draw = W3DOverlordTankDraw ModuleTag_01
     ; Patch104p @bugfix xezon 09/02/2023 Hide all muzzle flash meshes explicitly because otherwise they can show on death.
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model               = NVOvrlrd
       Animation           = NVOvrlrd.NVOvrlrd
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       HideSubObject       = MuzzleFX01 MuzzleFX02
       WeaponFireFXBone    = PRIMARY Muzzle
@@ -17402,6 +17404,7 @@ Object Nuke_ChinaTankOverlord
       Model               = NVOvrlrd_d
       Animation           = NVOvrlrd_d.NVOvrlrd_d
       AnimationMode       = LOOP
+      Flags               = MAINTAIN_FRAME_ACROSS_STATES
       Turret              = Turret01
       WeaponFireFXBone    = PRIMARY Muzzle
       WeaponRecoilBone    = PRIMARY Barrel

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -22140,22 +22140,26 @@ Object Slth_GLAVehicleRadarVan
   Draw = W3DTruckDraw ModuleTag_01
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish. (#2365)
     DefaultConditionState
       Model = UVRadarVan
       Animation = UVRadarVan.UVRadarVan
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = REALLYDAMAGED
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     ConditionState = RUBBLE
       Model = UVRadarVan_D
       Animation = UVRadarVan_D.UVRadarVan_D
       AnimationMode = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
     End
 
     TrackMarks = EXTireTrack.tga

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -5162,16 +5162,19 @@ Object Tank_ChinaVehicleListeningOutpost
   Draw = W3DModelDraw ModuleTag_33
     OkToChangeModelColor = Yes
 
+    ; Patch104p @bugfix xezon 16/09/2023 Maintain frame across states for the radar dish and legs. (#2365)
     ConditionState = NONE
       Model = NVLOUTPOST_B
       Animation = NVLOUTPOST_B.NVLOUTPOST_B
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed
     End
     ConditionState = REALLYDAMAGED
       Model = NVLOUTPOST_BD
       Animation = NVLOUTPOST_BD.NVLOUTPOST_BD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Deployed_ReallyDamaged
     End
 
@@ -5179,12 +5182,14 @@ Object Tank_ChinaVehicleListeningOutpost
       Model = NVLOUTPOST_A
       Animation = NVLOUTPOST_A.NVLOUTPOST_A
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving
     End
     ConditionState = REALLYDAMAGED MOVING
       Model = NVLOUTPOST_AD
       Animation = NVLOUTPOST_AD.NVLOUTPOST_AD
       AnimationMode     = LOOP
+      Flags = MAINTAIN_FRAME_ACROSS_STATES
       TransitionKey = Trans_Moving_ReallyDamaged
     End
 


### PR DESCRIPTION
This change prevents the radar dish animation to reset on a damage transition of the GLA Radar Van.