### PR TITLE
Change: Improve death effects of GLA Quad Cannon, Radar Van

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2366_radar_van_quad_cannon_death_fx.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2366_radar_van_quad_cannon_death_fx.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-09-15
+
+title: Improves death effects of GLA Radar Van and Quad Cannon
+
+changes:
+  - fix: The final destructions of the GLA Radar Van and Quad Cannon now have a suitable delay to better accomodate the immediate explosion effect with the Demo Upgrade.
+  - fix: The GLA Radar Van and Quad Cannon now have an initial death effect and sound to better show their exact moment of death.
+
+labels:
+  - design
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2366
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/FXList.ini
@@ -2083,6 +2083,21 @@ FXList FX_CrusaderCatchFire
 End
 
 ; -----------------------------------------------------------------------------
+; Patch104p @feature, A copy of FX_CrusaderCatchFire, but for non-tank vehicles. (#2366)
+FXList FX_VehicleCatchFire
+  ParticleSystem
+    Name = VehicleFire
+    Offset = X:0 Y:0 Z:10
+  End
+  ViewShake
+    Type = SUBTLE
+  End
+  Sound
+    Name = VehicleExplosion
+  End
+End
+
+; -----------------------------------------------------------------------------
 FXList FX_HumveeExplosionOneInitial
   ParticleSystem
     Name = HotPillarArms
@@ -2932,7 +2947,7 @@ FXList FX_DragonTankDeathExplosionFinal
 End
 
 ; -----------------------------------------------------------------------------
-FXList FX_QuadCannonCatchFire
+FXList FX_QuadCannonCatchFire ; unused
   ParticleSystem
     Name = TankFire
     Offset = X:0 Y:0 Z:10

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -18321,11 +18321,14 @@ Object Chem_GLAVehicleQuadCannon
   End
 
   ; Catch fire, and explode death
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 150 to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 411
-    DestructionDelay = 150
+    DestructionDelay = 250
     DestructionDelayVariance = 250
+    FX  = INITIAL  FX_VehicleCatchFire
     OCL = FINAL    OCL_QuadCannonDeathEffect
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
   End
@@ -20679,12 +20682,15 @@ Object Chem_GLAVehicleRadarVan
   End
 
 ; The default explosion
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 0, destruction delay variance from 200, to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior  ModuleTag_11
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelay = 250
+    DestructionDelayVariance = 250
+    FX = INITIAL FX_VehicleCatchFire
     FX = FINAL FX_BuggyNewDeathExplosion
     OCL = FINAL OCL_RadarVanDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -19636,12 +19636,14 @@ Object Demo_GLAVehicleQuadCannon
 
   ; Catch fire, and explode death
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
-
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 150 to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 411
-    DestructionDelay = 150
+    DestructionDelay = 250
     DestructionDelayVariance = 250
+    FX  = INITIAL  FX_VehicleCatchFire
     OCL = FINAL    Demo_OCL_QuadCannonDeathEffect
     ;FX  = FINAL    FX_BattleMasterExplosionOneFinal
   End
@@ -22184,13 +22186,15 @@ Object Demo_GLAVehicleRadarVan
 
   ; The default explosion
   ; Patch104p @feature xezon 11/12/2022 Adds new FINAL OCL to customize delayed death effects with and without Demo Upgrade.
-
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 0, destruction delay variance from 200, to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior  ModuleTag_11
     DeathTypes = ALL -CRUSHED -SPLATTED -SUICIDED   ; Patch104p @bugfix commy2 29/08/2021 Fix SUICIDED death being overloaded.
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelay = 250
+    DestructionDelayVariance = 250
+    FX = INITIAL FX_VehicleCatchFire
     OCL = FINAL Demo_OCL_RadarVanDeathEffect
     ;FX  = FINAL FX_BuggyNewDeathExplosion
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -2536,12 +2536,15 @@ Object GC_Chem_GLAVehicleRadarVan
   End
 
 ; The default explosion
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 0, destruction delay variance from 200, to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior  ModuleTag_11
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelay = 250
+    DestructionDelayVariance = 250
+    FX = INITIAL FX_VehicleCatchFire
     FX = FINAL FX_BuggyNewDeathExplosion
     OCL = FINAL OCL_RadarVanDeathEffect
   End
@@ -2932,11 +2935,14 @@ Object GC_Chem_GLAVehicleQuadCannon
   End
 
   ; Catch fire, and explode death
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 150 to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 411
-    DestructionDelay = 150
+    DestructionDelay = 250
     DestructionDelayVariance = 250
+    FX  = INITIAL  FX_VehicleCatchFire
     OCL = FINAL    OCL_QuadCannonDeathEffect
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2971,12 +2971,15 @@ Object GC_Slth_GLAVehicleRadarVan
   End
 
 ; The default explosion
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 0, destruction delay variance from 200, to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior  ModuleTag_11
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelay = 250
+    DestructionDelayVariance = 250
+    FX = INITIAL FX_VehicleCatchFire
     FX = FINAL FX_BuggyNewDeathExplosion
     OCL = FINAL OCL_RadarVanDeathEffect
   End
@@ -7752,11 +7755,14 @@ Object GC_Slth_GLAVehicleQuadCannon
   End
 
   ; Catch fire, and explode death
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 150 to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 411
-    DestructionDelay = 150
+    DestructionDelay = 250
     DestructionDelayVariance = 250
+    FX  = INITIAL  FX_VehicleCatchFire
     OCL = FINAL    OCL_QuadCannonDeathEffect
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -3728,11 +3728,14 @@ Object GLAVehicleQuadCannon
   End
 
   ; Catch fire, and explode death
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 150 to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 411
-    DestructionDelay = 150
+    DestructionDelay = 250
     DestructionDelayVariance = 250
+    FX  = INITIAL  FX_VehicleCatchFire
     OCL = FINAL    OCL_QuadCannonDeathEffect
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
   End
@@ -6397,12 +6400,15 @@ Object GLAVehicleRadarVan
   End
 
 ; The default explosion
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 0, destruction delay variance from 200, to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior  ModuleTag_11
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelay = 250
+    DestructionDelayVariance = 250
+    FX = INITIAL FX_VehicleCatchFire
     FX = FINAL FX_BuggyNewDeathExplosion
     OCL = FINAL OCL_RadarVanDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -19806,11 +19806,14 @@ Object Slth_GLAVehicleQuadCannon
   End
 
   ; Catch fire, and explode death
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 150 to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior ModuleTag_05
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 411
-    DestructionDelay = 150
+    DestructionDelay = 250
     DestructionDelayVariance = 250
+    FX  = INITIAL  FX_VehicleCatchFire
     OCL = FINAL    OCL_QuadCannonDeathEffect
     FX  = FINAL    FX_BattleMasterExplosionOneFinal
   End
@@ -22271,12 +22274,15 @@ Object Slth_GLAVehicleRadarVan
   End
 
 ; The default explosion
+  ; Patch104p @tweak xezon 15/09/2023 Changes destruction delay from 0, destruction delay variance from 200, to add more time between demolition explosions. (#2366)
+  ; Patch104p @feature xezon 15/06/2023 Adds initial destruction fx. (#2366)
   Behavior = SlowDeathBehavior  ModuleTag_11
     DeathTypes = ALL -CRUSHED -SPLATTED
     ProbabilityModifier = 5
     ModifierBonusPerOverkillPercent = 20%  ; negative means less likely to pick this in the face of much damage, positive means more likely
-    DestructionDelay = 0
-    DestructionDelayVariance = 200
+    DestructionDelay = 250
+    DestructionDelayVariance = 250
+    FX = INITIAL FX_VehicleCatchFire
     FX = FINAL FX_BuggyNewDeathExplosion
     OCL = FINAL OCL_RadarVanDeathEffect
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/ParticleSystem.ini
@@ -17482,6 +17482,64 @@ ParticleSystem TankFire
   WindPingPongEndAngleMax = 6.283185
 End
 
+; Patch104p @feature A copy of TankFire, but smaller and shorter. (#2366)
+ParticleSystem VehicleFire
+  Priority = WEAPON_EXPLOSION
+  IsOneShot = No
+  Shader = ADDITIVE
+  Type = PARTICLE
+  ParticleName = EXexplo03.tga
+  AngleZ = 0.00 7.00
+  AngularRateZ = -0.01 0.01
+  AngularDamping = 1.00 1.00
+  VelocityDamping = 0.95 0.95
+  Gravity = 0.10
+  Lifetime = 25.00 25.00
+  SystemLifetime = 80
+  Size = 16.00 16.00
+  StartSizeRate = 0.00 0.00
+  SizeRate = -0.40 -0.60
+  SizeRateDamping = 0.80 0.95
+  Alpha1 = 0.00 0.00 0
+  Alpha2 = 0.00 0.00 0
+  Alpha3 = 0.00 0.00 0
+  Alpha4 = 0.00 0.00 0
+  Alpha5 = 0.00 0.00 0
+  Alpha6 = 0.00 0.00 0
+  Alpha7 = 0.00 0.00 0
+  Alpha8 = 0.00 0.00 0
+  Color1 = R:0 G:0 B:0 0
+  Color2 = R:255 G:186 B:117 10
+  Color3 = R:0 G:0 B:0 25
+  Color4 = R:0 G:0 B:0 0
+  Color5 = R:0 G:0 B:0 0
+  Color6 = R:0 G:0 B:0 0
+  Color7 = R:0 G:0 B:0 0
+  Color8 = R:0 G:0 B:0 0
+  ColorScale = 0.00 0.00
+  BurstDelay = 1.00 3.00
+  BurstCount = 2.00 2.00
+  InitialDelay = 0.00 0.00
+  DriftVelocity = X:0.00 Y:0.00 Z:0.01
+  VelocityType = OUTWARD
+  VelOutward = -0.30 -0.15
+  VelOutwardOther = 0.00 0.00
+  VolumeType = CYLINDER
+  VolCylinderRadius = 10.00
+  VolCylinderLength = 2.00
+  IsHollow = No
+  IsGroundAligned = No
+  IsEmitAboveGroundOnly = No
+  IsParticleUpTowardsEmitter = No
+  WindMotion = Unused
+  WindAngleChangeMin = 0.149924
+  WindAngleChangeMax = 0.449946
+  WindPingPongStartAngleMin = 0.000000
+  WindPingPongStartAngleMax = 0.785398
+  WindPingPongEndAngleMin = 5.497787
+  WindPingPongEndAngleMax = 6.283185
+End
+
 ParticleSystem BombTruckAnthraxExplosion
   Priority = WEAPON_EXPLOSION
   IsOneShot = No

--- a/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/SoundEffects.ini
@@ -559,6 +559,19 @@ AudioEvent ExplosionBarrel
   Type   = world shrouded everyone
 End
 
+; Patch104p @feature A copy of ExplosionBarrel, but quieter. (#2366)
+AudioEvent VehicleExplosion
+  Sounds = gexpbara gexpbarb gexpbarc gexpbard gexpbare gexpbarf
+  Control = interrupt random
+  Limit = 2
+  VolumeShift = -20
+  PitchShift = -20 20
+  Volume = 80
+  Priority = low
+  LowPassCutoff = 50
+  Type = world shrouded everyone
+End
+
 AudioEvent CINE_ExplosionBarrel01
   Sounds =  gbridama gbridamb gexpdirb
   Control = interrupt random


### PR DESCRIPTION
This change improves death effects of the GLA Quad Cannon and Radar Van. The destruction delays are increased and a new initial death explosion is added.

The increased destruction delay has been added to better accommodate the Demolition Upgrade explosion. If there is too little of a gap between these, then it is more difficult to see and hear the demo explosion.

And the initial death explosion makes it easier to see when the vehicle actually dies. It has an effect that is smaller and sound that is quieter than that of tanks.