### PR TITLE
Fix: Set EXPLODED death type for GLA Demo death weapon

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2367_demo_destroyed_weapon_death_type.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2367_demo_destroyed_weapon_death_type.yaml
@@ -1,0 +1,20 @@
+---
+date: 2023-09-16
+
+title: Fixes incorrect weapon death types of GLA Demo destroyed weapon
+
+changes:
+  - fix: The destroyed weapon of GLA Demo units after Demo Upgrade now incur the EXPLODED instead of NORMAL death type. On kill, this will trigger the GLA Terrorist suicide explosion and the GLA Demo Bike suicide explosion before Demo Upgrade. This is consistent with other explosion weapons.
+
+labels:
+  - bug
+  - controversial
+  - gla
+  - minor
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2367
+
+authors:
+  - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2367_demo_destroyed_weapon_death_type.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2367_demo_destroyed_weapon_death_type.yaml
@@ -1,7 +1,7 @@
 ---
 date: 2023-09-16
 
-title: Fixes incorrect weapon death types of GLA Demo destroyed weapon
+title: Fixes incorrect destroyed weapon death type of GLA Demo units after Demo Upgrade
 
 changes:
   - fix: The destroyed weapon of GLA Demo units after Demo Upgrade now incur the EXPLODED instead of NORMAL death type. On kill, this will trigger the GLA Terrorist suicide explosion and the GLA Demo Bike suicide explosion before Demo Upgrade. This is consistent with other explosion weapons.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7246,7 +7246,7 @@ Weapon Demo_SuicideDynamitePackPlusFire
   ;FireSound = CarBomberDie
 End
 
-; Patch104p @bugfix xezon 16/09/2023 Changes death type from NORMAL.
+; Patch104p @bugfix xezon 16/09/2023 Changes death type from NORMAL. (#2367)
 ;------------------------------------------------------------------------------
 Weapon Demo_DestroyedWeapon
   PrimaryDamage = 50.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7246,6 +7246,7 @@ Weapon Demo_SuicideDynamitePackPlusFire
   ;FireSound = CarBomberDie
 End
 
+; Patch104p @bugfix xezon 16/09/2023 Changes death type from NORMAL.
 ;------------------------------------------------------------------------------
 Weapon Demo_DestroyedWeapon
   PrimaryDamage = 50.0
@@ -7254,7 +7255,7 @@ Weapon Demo_DestroyedWeapon
   SecondaryDamageRadius = 70.0
   AttackRange = 5.0       ; must be very close to use this weapon!
   DamageType = EXPLOSION
-  DeathType = NORMAL
+  DeathType = EXPLODED
   WeaponSpeed = 99999.0
   ProjectileObject = NONE
   DamageDealtAtSelfPosition = Yes   ; this is a suicide bomber... remember?


### PR DESCRIPTION
This change sets the EXPLODED death type for the GLA Demo death weapon. This affects the small death explosion weapons of GLA after Demolitions Upgrade. The consequence is minor and means that it can trigger the suicide weapons of an enemy GLA Terrorist or Demo Bike before Demo Upgrade.