### PR TITLE
Change: All infantry missiles will incur crushed death on GLA Terrorists

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -23204,7 +23204,7 @@ Object Boss_VehicleCombatBikeTerrorist
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -23212,7 +23212,7 @@ Object Boss_VehicleCombatBikeTerrorist
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChemicalGeneral.ini
@@ -14145,7 +14145,7 @@ Object Chem_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ExemptStatus  = MASKED
   End
 
@@ -17909,7 +17909,7 @@ Object Chem_GLAVehicleCombatBike
     RequiredStatus  = STATUS_RIDER5
     DeathWeapon   = CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   Behavior = FireWeaponWhenDeadBehavior ModuleTag91
@@ -17944,7 +17944,7 @@ Object Chem_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/DemoGeneral.ini
@@ -14617,7 +14617,7 @@ Object Demo_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = Demo_CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ExemptStatus  = MASKED
   End
 
@@ -19200,7 +19200,7 @@ Object Demo_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ConflictsWith  = Demo_Upgrade_SuicideBomb
   End
 
@@ -19209,7 +19209,7 @@ Object Demo_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
     ConflictsWith  = Demo_Upgrade_SuicideBomb
   End
 
@@ -19229,7 +19229,7 @@ Object Demo_GLAVehicleCombatBike
     StartsActive  = No
     TriggeredBy   = Demo_Upgrade_SuicideBomb
     RequiresAllTriggers = Yes
-    DeathTypes = ALL -SUICIDED -CRUSHED -SPLATTED -LASERED
+    DeathTypes = ALL -SUICIDED -CRUSHED -SPLATTED -LASERED -EXTRA_8
   End
 
   ;Non-terrorist with suicide bomb upgrade (no fire)
@@ -19250,7 +19250,7 @@ Object Demo_GLAVehicleCombatBike
     StartsActive        = No
     TriggeredBy         = Demo_Upgrade_SuicideBomb
     RequiresAllTriggers = Yes
-    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ;Terrorist with suicide bomb upgrade (fire)
@@ -19260,7 +19260,7 @@ Object Demo_GLAVehicleCombatBike
     StartsActive   = No
     TriggeredBy    = Demo_Upgrade_SuicideBomb
     RequiresAllTriggers = Yes
-    DeathTypes     = ALL -SUICIDED -CRUSHED -SPLATTED -LASERED
+    DeathTypes     = ALL -SUICIDED -CRUSHED -SPLATTED -LASERED -EXTRA_8
   End
 
   ;Terrorist with suicide bomb upgrade (no fire)
@@ -19281,7 +19281,7 @@ Object Demo_GLAVehicleCombatBike
     StartsActive        = No
     TriggeredBy         = Demo_Upgrade_SuicideBomb
     RequiresAllTriggers = Yes
-    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes          = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   Geometry = BOX

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Chem_GLAUnits.ini
@@ -4199,7 +4199,7 @@ Object GC_Chem_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ExemptStatus  = MASKED
     ConflictsWith = Chem_Upgrade_GLAAnthraxGamma
   End
@@ -4216,7 +4216,7 @@ Object GC_Chem_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath_2
     DeathWeapon   = CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ExemptStatus  = MASKED
     TriggeredBy   = Chem_Upgrade_GLAAnthraxGamma
   End

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GC_Slth_GLAUnits.ini
@@ -2478,7 +2478,7 @@ Object GC_Slth_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ExemptStatus  = MASKED
   End
 
@@ -5356,7 +5356,7 @@ Object GC_Slth_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -5364,7 +5364,7 @@ Object GC_Slth_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -6297,7 +6297,7 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -6305,7 +6305,7 @@ Object GC_Slth_GLAVehicleCombatBikeRocket
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -7238,7 +7238,7 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -7246,7 +7246,7 @@ Object GC_Slth_GLAVehicleCombatBikeTerrorist
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLACINEUnit.ini
@@ -1516,7 +1516,7 @@ Object CINE_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = SuicideBikeBomb ; Retain 1.04 damage for Cinematics
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   Behavior = StealthUpdate ModuleTag_19
@@ -5655,7 +5655,7 @@ Object CINE_GLAInfantryTerrorist
 
 ; --- begin Death modules ---
   Behavior = SlowDeathBehavior ModuleTag_Death01
-    DeathTypes          = ALL -CRUSHED -SPLATTED -SUICIDED -EXPLODED -BURNED -LASERED -POISONED -POISONED_BETA -POISONED_GAMMA
+    DeathTypes          = ALL -CRUSHED -SPLATTED -SUICIDED -EXPLODED -BURNED -LASERED -EXTRA_8 -POISONED -POISONED_BETA -POISONED_GAMMA
     SinkDelay           = 3000
     SinkRate            = 0.5     ; in Dist/Sec
     DestructionDelay    = 8000
@@ -5702,7 +5702,7 @@ Object CINE_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = SuicideBikeBomb ; Retain 1.04 damage for Cinematics
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
 ; --- end Death modules ---
@@ -7605,7 +7605,7 @@ Object CINE_CheeringTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = SuicideBikeBomb ; Retain 1.04 damage for Cinematics
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 ; --- end Death modules ---
 

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAInfantry.ini
@@ -1604,7 +1604,7 @@ Object GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ExemptStatus  = MASKED
   End
   

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/GLAVehicle.ini
@@ -1457,7 +1457,7 @@ Object GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -1465,7 +1465,7 @@ Object GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -2409,7 +2409,7 @@ Object GLAVehicleCombatBikeRocket
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -2417,7 +2417,7 @@ Object GLAVehicleCombatBikeRocket
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -3349,7 +3349,7 @@ Object GLAVehicleCombatBikeTerrorist
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -3357,7 +3357,7 @@ Object GLAVehicleCombatBikeTerrorist
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/StealthGeneral.ini
@@ -15160,7 +15160,7 @@ Object Slth_GLAInfantryTerrorist
   Behavior = FireWeaponWhenDeadBehavior ModuleTag_CrushedDeath
     DeathWeapon   = CrushedDynamitePack
     StartsActive  = Yes
-    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes    = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
     ExemptStatus  = MASKED
   End
 ; --- end Death modules ---
@@ -19428,7 +19428,7 @@ Object Slth_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = CrushedBikeBomb
     StartsActive   = Yes
-    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED
+    DeathTypes     = NONE +CRUSHED +SPLATTED +LASERED +EXTRA_8
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.
@@ -19436,7 +19436,7 @@ Object Slth_GLAVehicleCombatBike
     RequiredStatus = STATUS_RIDER5
     DeathWeapon    = Demo_CombatBikeDeathWeapon
     StartsActive   = Yes
-    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -TOPPLED
+    DeathTypes     = ALL -SUICIDED -BURNED -EXPLODED -CRUSHED -SPLATTED -LASERED -EXTRA_8 -TOPPLED
   End
 
   ; Patch104p @feature Fires dummy weapon to spawn some effects in the absence of a real death weapon.

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -786,7 +786,7 @@ Weapon MissileDefenderMissileWeapon
   AttackRange                 = 175.0
   ;MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE
-  DeathType                   = NORMAL
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600
   ProjectileObject            = MissileDefenderMissile
   ProjectileExhaust           = MissileDefenderMissileExhaust
@@ -2116,7 +2116,7 @@ Weapon TunnelDefenderRocketWeapon
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = MissileExhaust
@@ -2144,7 +2144,7 @@ Weapon TunnelDefenderBikerRocketWeapon
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = MissileExhaust
@@ -2613,7 +2613,7 @@ Weapon ChinaInfantryTankHunterMissileLauncher
   AttackRange = 175.0
   MinimumAttackRange = 5.0  ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType = INFANTRY_MISSILE   ;ignored for projectile weapons
-  DeathType = EXPLODED
+  DeathType = EXTRA_8
   WeaponSpeed = 600               ; ignored for projectile weapons
   ProjectileObject = TankHunterMissile
   ProjectileExhaust           = MissileExhaust
@@ -5690,7 +5690,7 @@ Weapon GC_Chem_TunnelDefenderRocketWeaponBeta
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = GC_Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
@@ -5719,7 +5719,7 @@ Weapon GC_Chem_TunnelDefenderRocketWeaponGamma
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = GC_Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
@@ -5748,7 +5748,7 @@ Weapon GC_Chem_TunnelDefenderRocketWeaponBetaAir
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = GC_Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
@@ -5776,7 +5776,7 @@ Weapon GC_Chem_TunnelDefenderRocketWeaponGammaAir
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = GC_Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
@@ -7540,7 +7540,7 @@ Weapon Chem_TunnelDefenderRocketWeaponBeta
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
@@ -7569,7 +7569,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGamma
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
@@ -7598,7 +7598,7 @@ Weapon Chem_TunnelDefenderRocketWeaponBetaAir
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
@@ -7626,7 +7626,7 @@ Weapon Chem_TunnelDefenderRocketWeaponGammaAir
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = Chem_StingerMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
@@ -7790,7 +7790,7 @@ Weapon Chem_TunnelDefenderBikerRocketWeapon
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaust
@@ -7820,7 +7820,7 @@ Weapon Chem_TunnelDefenderBikerRocketWeaponGamma
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = Chem_InfantryStingerMissileExhaustGamma
@@ -9008,7 +9008,7 @@ Weapon DEMO_TunnelDefenderBikerRocketWeapon
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = MissileExhaust
@@ -9036,7 +9036,7 @@ Weapon DemoTunnelDefenderRocketWeapon
   AttackRange                 = 175.0
   MinimumAttackRange          = 5.0 ; Rockets take some distance to target, and you don't want them to blow up in your face.
   DamageType                  = INFANTRY_MISSILE  ; ignored for projectile weapons
-  DeathType                   = EXPLODED
+  DeathType                   = EXTRA_8
   WeaponSpeed                 = 600               ; ignored for projectile weapons
   ProjectileObject            = TunnelDefenderMissile
   ProjectileExhaust           = MissileExhaust


### PR DESCRIPTION
* Alternative to #2362

With this change all infantry missiles will incur crushed death on GLA Terrorists. This means they apply less damage.

This is a nerf for USA against Terrorist and Demo Bikes. But a buff against Demo Bikes after Demolitions Upgrade.

This is a buff for China against Terrorist and Demo Bikes. And a buff against Demo Bikes after Demolitions Upgrade.

### TODO

- [ ] Add EXTRA_8 death type to all other EXPLODED deaths to retain original death effects

## Humvee, Outpost, Rocket Men health left after killing 1 Terrorist with Rocket Men

Rocket men outside of vehicles will now take critical damage when killing 1 nearby Terrorist.

Humvees and Outposts with Rocket Men will now take fair damage when killing 1 nearby Terrorist.

![shot_20230917_115813_3](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/78497946-167a-44b4-ba20-81af8601a889)

## Humvee, Outpost health left after killing 1 Demo Bike with Rocket Men

Rocket men outside of vehicles will take lethal damage when killing 1 nearby Demo Bike.

Humvees and Outposts with Rocket Men will now take critical damage when killing 1 nearby Demo Bike.

![shot_20230917_114937_1](https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/7761becc-e69b-456d-8274-a5c912502177)

## Original vs Terrorist

USA Missile Defender will **NOT** trigger lethal suicide weapon of Terrorist.
China Tank Hunter will trigger lethal suicide weapon of Terrorist.
GLA RPG Trooper will trigger lethal suicide weapon of Terrorist.

## Patched vs Terrorist

USA Missile Defender will trigger weaker crushed weapon of Terrorist.
China Tank Hunter will trigger weaker crushed weapon of Terrorist.
GLA RPG Trooper will trigger weaker crushed weapon of Terrorist.

## Original vs Terror Bike

USA Missile Defender will **NOT** trigger lethal suicide weapon of Demo Bike before Demo Upgrade.
USA Missile Defender will trigger lethal suicide weapon of Demo Bike after Demo Upgrade.
China Tank Hunter will trigger lethal suicide weapon of Demo Bike before Demo Upgrade.
China Tank Hunter will trigger lethal suicide weapon of Demo Bike after Demo Upgrade.
GLA RPG Trooper will trigger lethal suicide weapon of Demo Bike before Demo Upgrade.
GLA RPG Trooper will trigger lethal suicide weapon of Demo Bike after Demo Upgrade.

## Patched vs Terrorist

USA Missile Defender will trigger weaker crushed weapon of Demo Bike before Demo Upgrade.
USA Missile Defender will trigger weaker crushed weapon of Demo Bike after Demo Upgrade.
China Tank Hunter will trigger weaker crushed weapon of Demo Bike before Demo Upgrade.
China Tank Hunter will trigger weaker crushed weapon of Demo Bike after Demo Upgrade.
GLA RPG Trooper will trigger weaker crushed weapon of Demo Bike before Demo Upgrade.
GLA RPG Trooper will trigger weaker crushed weapon of Demo Bike after Demo Upgrade.


# Rationale

Terrorists and Demo Bikes respond differently to USA, China and GLA Rocket Men. USA can kill Terrorists and Demo Bikes without damaging itself. China and GLA cannot. With this change the behavior is consistent, also for after Demolitions Upgrade.

This is a pure buff for China, and a nerf + buff for USA. Terrorists and Bikes will now always apply damage when killed by Rocket Men, but the damage will be weaker than originally.

Demo Bikes will be weaker.