### PR TITLE
Fix: China TNT Bombs now hit structures with their primary damage reliably

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/BossGeneral.ini
@@ -18950,9 +18950,11 @@ Object Boss_InfantryTankHunter
     UpdateModuleStartsAttack = Yes
     InitiateSound = TankHunterVoiceTNT
   End
+
+  ; Patch104p @bugfix xezon 08/10/2023 Changes start ability range from 5.0 to place the bomb closer to structures so that the primary damage can hit it more reliably. (#2375)
   Behavior = SpecialAbilityUpdate ModuleTag_08
     SpecialPowerTemplate = SpecialAbilityTankHunterTNTAttack
-    StartAbilityRange = 5.0
+    StartAbilityRange = 0.0
     PreparationTime = 0
     SpecialObject = TNTStickyBomb
     MaxSpecialObjects = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/ChinaInfantry.ini
@@ -1164,9 +1164,11 @@ Object ChinaInfantryTankHunter
     UpdateModuleStartsAttack = Yes
     InitiateSound = TankHunterVoiceTNT
   End
+
+  ; Patch104p @bugfix xezon 08/10/2023 Changes start ability range from 5.0 to place the bomb closer to structures so that the primary damage can hit it more reliably. (#2375)
   Behavior = SpecialAbilityUpdate ModuleTag_08
     SpecialPowerTemplate = SpecialAbilityTankHunterTNTAttack
-    StartAbilityRange = 5.0
+    StartAbilityRange = 0.0
     PreparationTime = 0
     SpecialObject = TNTStickyBomb
     MaxSpecialObjects = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/InfantryGeneral.ini
@@ -1167,9 +1167,11 @@ Object Infa_ChinaInfantryTankHunter
     UpdateModuleStartsAttack = Yes
     InitiateSound = TankHunterVoiceTNT
   End
+
+  ; Patch104p @bugfix xezon 08/10/2023 Changes start ability range from 5.0 to place the bomb closer to structures so that the primary damage can hit it more reliably. (#2375)
   Behavior = SpecialAbilityUpdate ModuleTag_08
     SpecialPowerTemplate = SpecialAbilityTankHunterTNTAttack
-    StartAbilityRange = 5.0
+    StartAbilityRange = 0.0
     PreparationTime = 0
     SpecialObject = TNTStickyBomb
     MaxSpecialObjects = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/NukeGeneral.ini
@@ -2556,9 +2556,11 @@ Object Nuke_ChinaInfantryTankHunter
     UpdateModuleStartsAttack = Yes
     InitiateSound = TankHunterVoiceTNT
   End
+
+  ; Patch104p @bugfix xezon 08/10/2023 Changes start ability range from 5.0 to place the bomb closer to structures so that the primary damage can hit it more reliably. (#2375)
   Behavior = SpecialAbilityUpdate ModuleTag_08
     SpecialPowerTemplate = SpecialAbilityTankHunterTNTAttack
-    StartAbilityRange = 5.0
+    StartAbilityRange = 0.0
     PreparationTime = 0
     SpecialObject = TNTStickyBomb
     MaxSpecialObjects = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/TankGeneral.ini
@@ -2288,9 +2288,11 @@ Object Tank_ChinaInfantryTankHunter
     UpdateModuleStartsAttack = Yes
     InitiateSound = TankHunterVoiceTNT
   End
+
+  ; Patch104p @bugfix xezon 08/10/2023 Changes start ability range from 5.0 to place the bomb closer to structures so that the primary damage can hit it more reliably. (#2375)
   Behavior = SpecialAbilityUpdate ModuleTag_08
     SpecialPowerTemplate = SpecialAbilityTankHunterTNTAttack
-    StartAbilityRange = 5.0
+    StartAbilityRange = 0.0
     PreparationTime = 0
     SpecialObject = TNTStickyBomb
     MaxSpecialObjects = 8

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2638,10 +2638,11 @@ Weapon ChinaInfantryTankHunterMissileLauncher
   ProjectileCollidesWith = STRUCTURES
 End
 
+; Patch104p @bugfix xezon 08/10/2023 Changes primary damage radius from 10.0 so that the primary damage can hit structures more reliably. (#2375)
 ;------------------------------------------------------------------------------
 Weapon TNTDetonationWeapon ;Created by tankhunters
   PrimaryDamage = 500.0
-  PrimaryDamageRadius = 10.0
+  PrimaryDamageRadius = 15.0
   SecondaryDamage = 150.0
   SecondaryDamageRadius = 50.0
   AttackRange = 5.0


### PR DESCRIPTION
* Fixes #2373

With this change the primary damage of the China TNT Bomb can now hit structures reliably. Before they would hit with their secondary damage most of the time, because the TNT Bombs would be located too far away from the target structure.

Placing the TNT Bomb on an approaching vehicle still works before the instigator is crushed. Damage on vehicles is unchanged, because the TNT Bomb is placed at the center of the vehicle, meaning it will apply primary damage always.

The reduced ability range requires Tank Hunters to walk closer to their target before the TNT bomb is placed. The increased primary damage radius gives the TNT bomb more reach.

## Damages

The damage surplus of a correctly placed TNT Bomb is significant. Buildings will now suffer +233% explosion damage from a single TNT Bomb.

```
Weapon TNTDetonationWeapon ;Created by tankhunters
  PrimaryDamage = 500.0
  PrimaryDamageRadius = 15.0
  SecondaryDamage = 150.0
  SecondaryDamageRadius = 50.0
...
End
```

## Original

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/e295d28f-18ce-407d-9475-dd272375b67e

## Patched

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/1a4271a7-2f32-4e51-8dbc-bf82a5f9fc9b
