### PR TITLE
Change: Decreases primary damage of China TNT Bomb from 500 to 325

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2638,9 +2638,10 @@ Weapon ChinaInfantryTankHunterMissileLauncher
   ProjectileCollidesWith = STRUCTURES
 End
 
+; Patch104p @tweak xezon 08/10/2023 Changes primary damage from 500.0 to reduce bomb effectiveness against buildings after bug fix.
 ;------------------------------------------------------------------------------
 Weapon TNTDetonationWeapon ;Created by tankhunters
-  PrimaryDamage = 500.0
+  PrimaryDamage = 325.0
   PrimaryDamageRadius = 10.0
   SecondaryDamage = 150.0
   SecondaryDamageRadius = 50.0


### PR DESCRIPTION
* Follow up for #2375
* Relates to #2373

This change decreases the primary damage of China TNT Bomb from 500 to 325. This makes it weaker against both vehicles and buildings, however, the bug fix of #2375 makes the TNT Bomb much better against structures.

Why 325 damage? Because 150 + ((500 - 150) / 2) = 350

Compared to Original, practical damage vs buildings is +175 and damage vs vehicles is -175. Damage output of TNT Bomb is essentially redistributed from vehicles to buildings. This makes the TNT Bomb equally useful against structures and vehicles.

Vehicles now have better chances to survive the TNT Bomb.

## Practical difference

| Weapon                   | Effective Damage vs vehicles | Effective Damage vs buildings |
|--------------------------|------------------------------|-------------------------------|
| Original TNT Bomb        | 500                          | 150                           |
| Patched TNT Bomb (#2375) | 500                          | 500                           |
| Patched TNT Bomb (this)  | 325                          | 325                           |

## TNT Bombs vs buildings

It now takes 7 patched TNT Bombs to kill a strong structure such as a strong house or Oil Derrick.

| Weapon                   | Count to kill Oil Derrick |
|--------------------------|---------------------------|
| Original TNT Bomb        | 14                        |
| Patched TNT Bomb (#2375) | 4                         |
| Patched TNT Bomb (this)  | 7                         |

## TNT Bombs vs vehicles

| Patched TNT Bomb target      | Damage      |
|------------------------------|-------------|
| USA Dozer                    | killed      |
| USA Humvee (2 Star)          | killed      |
| USA Humvee (3 Star)          | 95% damage  |
| USA Tomahawk (3 Star)        | killed      |
| USA Crusader                 | 70% damage  |
| GLA Technical (3 Star)       | killed      |
| GLA Scorpion                 | 90% damage  |
| GLA Quad Cannon              | killed      |
| GLA Quad Cannon (1 Star)     | 95% damage  |
| China Overlord               | 30% damage  |
| China Dragon Tank            | killed      |
| China Dragon Tank (1 Star)   | 99% damage  |
| China Truck                  | killed      |
| China ECM Tank               | killed      |
| China Gattling Tank          | killed      |
| China Gattling Tank (1 Star) | 95% damage  |
| China Battle Master          | 90% damage  |

## TNT Bomb damage compared to other bombs

| Weapon                  | Primary Damage | Secondary Damage | PrimaryDamageRadius | SecondaryDamage |
|-------------------------|----------------|------------------|---------------------|-----------------|
| Original C4 Charge      | 2000           | 150              | 25                  | 75              |
| SuicideBikeBomb         | 700            | 100              | 20                  | 50              |
| Original Demo Trap      | 600            | 400              | 25                  | 50              |
| SuicideDynamitePack     | 500            | 300              | 18                  | 50              |
| Original TNT Bomb       | 500            | 150              | 10                  | 50              |
| Patched TNT Bomb (this) | 325            | 150              | 10                  | 50              |
| SuicideBomb             | 300            | 60               | 10                  | 50              |
| Original Booby Trap     | 200            | 50               | 5                   | 15              |
| Original Fake Structure | 200            | 50               | 50                  | 200             |
| CrushedDynamitePack (Patch) | 110            | 66               | 18                  | 50              |
| Demo_DestroyedWeapon    | 50             | 10               | 60                  | 70              |

## And some other weapons for reference

| Weapon                  | Primary Damage | Secondary Damage | PrimaryDamageRadius | SecondaryDamage |
|-------------------------|----------------|------------------|---------------------|-----------------|
| AuroraBombWeapon        | 400            | 0                | 20                  | 0               |
| ChinaCarpetBombWeapon   | 300            | 0                | 75                  | 0               |
| CarpetBombWeapon        | 300            | 0                | 50                  | 0               |
| NapalmBombWeapon        | 75             | 40               | 5                   | 30              |
| HumveeMissileWeapon     | 30             | 0                | 5                   | 0               |
