### PR TITLE
Change: Decrease damage radius of GLA Demo death weapon

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2420_demo_destroyed_weapon_radius.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2420_demo_destroyed_weapon_radius.yaml
@@ -1,10 +1,10 @@
 ---
 date: 2024-06-11
 
-title: Decreases damage radius of destroyed weapon of GLA Demo units after Demo Upgrade by 29%
+title: Decreases damage radius of destroyed GLA Demo units after Demo Upgrade from 70 to 50
 
 changes:
-  - tweak: The destroyed weapon of GLA Demo units after Demo Upgrade has its damage radius reduced from 70 to 50. This matches the damage radius of other demolition suicide weapons.
+  - tweak: The destroyed GLA Demo units after Demo Upgrade have their damage radius reduced from 70 to 50. This matches the damage radius of other demolition suicide weapons.
 
 labels:
   - controversial

--- a/Patch104pZH/Design/Changes/v1.0/2420_demo_destroyed_weapon_radius.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2420_demo_destroyed_weapon_radius.yaml
@@ -1,0 +1,21 @@
+---
+date: 2024-06-11
+
+title: Decreases damage radius of destroyed weapon of GLA Demo units after Demo Upgrade by 29%
+
+changes:
+  - tweak: The destroyed weapon of GLA Demo units after Demo Upgrade has its damage radius reduced from 70 to 50. This matches the damage radius of other demolition suicide weapons.
+
+labels:
+  - controversial
+  - design
+  - gla
+  - minor
+  - nerf
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2420
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7249,9 +7249,9 @@ End
 ;------------------------------------------------------------------------------
 Weapon Demo_DestroyedWeapon
   PrimaryDamage = 50.0
-  PrimaryDamageRadius = 40.0 ; Patch104p @tweak from 60
-  SecondaryDamage = 30.0 ; Patch104p @tweak from 10
-  SecondaryDamageRadius = 50.0 ; Patch104p @tweak from 70
+  PrimaryDamageRadius = 40.0 ; Patch104p @tweak from 60. (#2420)
+  SecondaryDamage = 30.0 ; Patch104p @tweak from 10. (#2420)
+  SecondaryDamageRadius = 50.0 ; Patch104p @tweak from 70. (#2420)
   AttackRange = 5.0       ; must be very close to use this weapon!
   DamageType = EXPLOSION
   DeathType = EXPLODED

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -7245,7 +7245,7 @@ Weapon Demo_SuicideDynamitePackPlusFire
 End
 
 ; Patch104p @bugfix xezon 16/09/2023 Changes death type from NORMAL. (#2367)
-; Patch104p @tweak xezon 11/06/2024 Decreases damage radii to better match the other suicide weapons.
+; Patch104p @tweak xezon 11/06/2024 Decreases damage radii to better match the other suicide weapons. (#2420)
 ;------------------------------------------------------------------------------
 Weapon Demo_DestroyedWeapon
   PrimaryDamage = 50.0

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -2962,7 +2962,7 @@ Weapon QuadCannonGunUpgradeTwoAir
 End
 
 ;------------------------------------------------------------------------------
-Weapon SuicideBomb
+Weapon SuicideBomb ; unused
   PrimaryDamage = 300.0
   PrimaryDamageRadius = 10.0
   SecondaryDamage = 60.0
@@ -7245,12 +7245,13 @@ Weapon Demo_SuicideDynamitePackPlusFire
 End
 
 ; Patch104p @bugfix xezon 16/09/2023 Changes death type from NORMAL. (#2367)
+; Patch104p @tweak xezon 11/06/2024 Decreases damage radii to better match the other suicide weapons.
 ;------------------------------------------------------------------------------
 Weapon Demo_DestroyedWeapon
   PrimaryDamage = 50.0
-  PrimaryDamageRadius = 60.0
-  SecondaryDamage = 10.0
-  SecondaryDamageRadius = 70.0
+  PrimaryDamageRadius = 40.0 ; Patch104p @tweak from 60
+  SecondaryDamage = 30.0 ; Patch104p @tweak from 10
+  SecondaryDamageRadius = 50.0 ; Patch104p @tweak from 70
   AttackRange = 5.0       ; must be very close to use this weapon!
   DamageType = EXPLOSION
   DeathType = EXPLODED


### PR DESCRIPTION
This change decreases the damage radius of the GLA Demo death weapon to better match the other suicide weapons. Affects most GLA Demo units after Demo Upgrade. It is a minor nerf.

Note:
The death/destroyed weapon refers to the weak Demo unit explosion after Demo Upgrade, when a unit is killed.
The suicide weapon refers to the strong Demo unit explosion after Demo Upgrade, when a unit is suicided.

| Weapon                              | PrimaryDamage | PrimaryDamageRadius | SecondaryDamage | SecondaryDamageRadius |
|-------------------------------------|--------------:|--------------------:|----------------:|----------------------:|
| Original SuicideDynamitePack        | 500           | 18                  | 300             | 50                    |
| Original SuicideBikeBomb            | 700           | 20                  | 100             | 50                    |
| Original Demo_DestroyedWeapon       | 50            | 60                  | 10              | 70                    |
| Patched Demo_DestroyedWeapon (this) | 50            | 40                  | 30              | 50                    |

In other words:

| Damage Radius Range | Damage Original | Damage Patched | Damage Difference |
|---------------------|----------------:|---------------:|------------------:|
| 0-40                | 50              | 50             | 0                 |
| 40-50               | 50              | 30             | -20               |
| 50-60               | 50              | 0              | -50               |
| 60-70               | 10              | 0              | -10               |

# Rationale

It is not logical that the death weapon of GLA Demo units has a larger damage radius than the suicide weapon of GLA Demo units, despite dealing much less damage. The damage radius reduction helps to make the damage setup more predictable and consistent.

Consequently this change nerfs the Demo Upgrade just a bit, which is welcomed, because Demo Upgrade is a very strong upgrade for the GLA Demolition General.