### PR TITLE
Fix: Wrong USA Humvee TOW Missile object when shooting at airborne units

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2424_tow_missile_air_object.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2424_tow_missile_air_object.yaml
@@ -1,0 +1,19 @@
+---
+date: 2024-06-13
+
+title: Fixes incorrect USA Humvee TOW Missile object visuals when firing at airborne units
+
+changes:
+  - fix: The TOW Missile object of the USA Humvee now looks identical when shooting at air and ground units. Originally the airborne TOW missile looked like the USA Patriot missile.
+
+labels:
+  - bug
+  - minor
+  - usa
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2424
+
+authors:
+  - xezon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -563,6 +563,87 @@ Object HumveeMissile
 
 End
 
+; Patch104p @fix xezon 12/06/2024 Fixes wrong TOW missile object when firing on airborne units.
+;   This object is originally a copy of PatriotMissile.
+;------------------------------------------------------------------------------
+Object HumveeMissileAir
+
+  ; *** ART Parameters ***
+  Draw = W3DModelDraw ModuleTag_01
+    OkToChangeModelColor = Yes
+    DefaultConditionState
+      Model = UVRockBug_m
+    End
+    ConditionState = JAMMED
+      ParticleSysBone = None SparksMedium
+    End
+  End
+
+  ; ***DESIGN parameters ***
+  EditorSorting = SYSTEM
+  VisionRange = 300.0
+  ShroudClearingRange = 0
+
+  ArmorSet
+    Conditions = None
+    Armor = ProjectileArmor
+    DamageFX = None
+  End
+
+  ; *** ENGINEERING Parameters ***
+  KindOf = PROJECTILE SMALL_MISSILE
+
+  Body = ActiveBody ModuleTag_02
+    MaxHealth = 100.0
+    InitialHealth = 100.0
+
+    SubdualDamageCap = 200
+    SubdualDamageHealRate = 100000
+    SubdualDamageHealAmount = 50
+  End
+
+  ; ---- begin Projectile death behaviors
+  Behavior = InstantDeathBehavior DeathModuleTag_01
+    DeathTypes = NONE +DETONATED
+    ; we detonated normally.
+    ; no FX, just quiet destroy ourselves
+  End
+  Behavior = InstantDeathBehavior DeathModuleTag_02
+    DeathTypes = NONE +LASERED
+    ; shot down by laser.
+    FX = FX_GenericMissileDisintegrate
+    OCL = OCL_GenericMissileDisintegrate
+  End
+  Behavior = InstantDeathBehavior DeathModuleTag_03
+    DeathTypes = ALL -LASERED -DETONATED
+    ; shot down by nonlaser.
+    FX = FX_GenericMissileDeath
+  End
+  ; ---- end Projectile death behaviors
+
+  Behavior = PhysicsBehavior ModuleTag_04
+    Mass = 1
+  End
+
+  ; Patch104p @note Uses the Patriot Missile AI update settings because this is what the original game does.
+  Behavior = MissileAIUpdate ModuleTag_05
+    TryToFollowTarget = Yes
+    FuelLifetime = 10000
+    InitialVelocity = 50                ; in dist/sec
+    IgnitionDelay = 0
+    DistanceToTravelBeforeTurning = 5
+    DistanceToTargetForLock = 100  ; If it gets within 100 of the target, it kills the target.
+    IgnitionFX = FX_HumveeMissileIgnition
+  End
+
+  ; Patch104p @note Uses the Patriot Missile locomotor because this is what the original game does.
+  Locomotor = SET_NORMAL PatriotMissileLocomotor
+
+  Geometry = Sphere
+  GeometryIsSmall = Yes
+  GeometryMajorRadius = 2.0
+End
+
 ; Missiles used by the Patriot.  This is the projectile attached to PatriotMissileWeapon in Weapon.ini
 ;------------------------------------------------------------------------------
 Object PatriotMissile

--- a/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Object/WeaponObjects.ini
@@ -563,7 +563,7 @@ Object HumveeMissile
 
 End
 
-; Patch104p @fix xezon 12/06/2024 Fixes wrong TOW missile object when firing on airborne units.
+; Patch104p @fix xezon 12/06/2024 Fixes wrong TOW missile object when firing at airborne units. (#2424)
 ;   This object is originally a copy of PatriotMissile.
 ;------------------------------------------------------------------------------
 Object HumveeMissileAir

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -656,6 +656,7 @@ Weapon HumveeMissileWeapon
   ProjectileCollidesWith = STRUCTURES
 End
 
+; Patch104p @fix xezon 12/06/2024 Fixes wrong TOW missile object when firing on airborne units.
 ;------------------------------------------------------------------------------
 Weapon HumveeMissileWeaponAir
   PrimaryDamage = 50.0
@@ -665,8 +666,8 @@ Weapon HumveeMissileWeaponAir
   DamageType = EXPLOSION          ; ignored for projectile weapons
   DeathType = EXPLODED
   WeaponSpeed = 600               ; ignored for projectile weapons
-  ProjectileObject            = PatriotMissile
-  ProjectileExhaust = MissileExhaust
+  ProjectileObject = HumveeMissileAir ; Patch104p @fix from PatriotMissile
+  ProjectileExhaust = TowMissileExhaust ; Patch104p @fix from MissileExhaust
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 1000  ; time between shots, msec
   ClipSize = 1            ; how many shots in a Clip (0 == infinite) ; You have to have a clip size as a missile weapon

--- a/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
+++ b/Patch104pZH/GameFilesEdited/Data/INI/Weapon.ini
@@ -656,7 +656,7 @@ Weapon HumveeMissileWeapon
   ProjectileCollidesWith = STRUCTURES
 End
 
-; Patch104p @fix xezon 12/06/2024 Fixes wrong TOW missile object when firing on airborne units.
+; Patch104p @fix xezon 12/06/2024 Fixes wrong TOW missile object when firing at airborne units. (#2424)
 ;------------------------------------------------------------------------------
 Weapon HumveeMissileWeaponAir
   PrimaryDamage = 50.0
@@ -666,8 +666,8 @@ Weapon HumveeMissileWeaponAir
   DamageType = EXPLOSION          ; ignored for projectile weapons
   DeathType = EXPLODED
   WeaponSpeed = 600               ; ignored for projectile weapons
-  ProjectileObject = HumveeMissileAir ; Patch104p @fix from PatriotMissile
-  ProjectileExhaust = TowMissileExhaust ; Patch104p @fix from MissileExhaust
+  ProjectileObject = HumveeMissileAir ; Patch104p @fix from PatriotMissile (#2424)
+  ProjectileExhaust = TowMissileExhaust ; Patch104p @fix from MissileExhaust (#2424)
   RadiusDamageAffects = ALLIES ENEMIES NEUTRALS
   DelayBetweenShots = 1000  ; time between shots, msec
   ClipSize = 1            ; how many shots in a Clip (0 == infinite) ; You have to have a clip size as a missile weapon


### PR DESCRIPTION
* Fixes #2421

This change fixes the wrong USA Humvee TOW Missile object when shooting at airborne units. Originally it used the Patriot missile object instead of the Humvee missile object. The missile behavior is unchanged.

## Patched

https://github.com/TheSuperHackers/GeneralsGamePatch/assets/4720891/7705cf54-62c6-4cdb-ad32-30c829b8cf12
