### PR TITLE
Fix errors and inconsistencies in Ukrainian mission strings

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2141_text_key_mapping_format.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2141_text_key_mapping_format.yaml
@@ -17,6 +17,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2141
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2248
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2516
 
 authors:
   - xezon

--- a/Patch104pZH/Design/Changes/v1.0/2228_mission_text_errors.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2228_mission_text_errors.yaml
@@ -18,6 +18,7 @@ labels:
 links:
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2228
   - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2336
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2518
 
 authors:
   - xezon


### PR DESCRIPTION
* Follow up for #2228

This change fixes inconsistencies in mission texts for Ukrainian language.

Inconsistencies are

* Incorrect words
* Missing colon symbols
* Missing line breaks

Affects

* "MISSION OBJECTIVE:"
* "MISSION OBJECTIVES:"
* "HINT:"
* "WARNING:"
* "INCOMING TRANSMISSION:"