### PR TITLE
Improvements to `OptionsMenu.wnd`

### DIFF
--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -983,7 +983,7 @@ WINDOW
                            IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
           COMBOBOXDATA = ISEDITABLE: 0,
                         MAXCHARS: 16,
-                        MAXDISPLAY: 5,
+                        MAXDISPLAY: 2,
                         ASCIIONLY: 0,
                         LETTERSANDNUMBERS: 0;
           COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA = IMAGE: VSliderDownButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -4274,7 +4274,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = USER;
           SCREENRECT = UPPERLEFT: 160 112,
-                       BOTTOMRIGHT: 622 301,
+                       BOTTOMRIGHT: 640 300,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED;
@@ -4319,8 +4319,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 168 144,
-                         BOTTOMRIGHT: 368 169,
+            SCREENRECT = UPPERLEFT: 170 151,
+                         BOTTOMRIGHT: 400 176,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:Check3DShadows";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4368,8 +4368,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 384 168,
-                         BOTTOMRIGHT: 615 192,
+            SCREENRECT = UPPERLEFT: 405 179,
+                         BOTTOMRIGHT: 630 204,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckShowProps";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4417,8 +4417,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 384 144,
-                         BOTTOMRIGHT: 614 168,
+            SCREENRECT = UPPERLEFT: 405 151,
+                         BOTTOMRIGHT: 630 176,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckBehindBuilding";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4466,8 +4466,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 168 168,
-                         BOTTOMRIGHT: 368 193,
+            SCREENRECT = UPPERLEFT: 170 179,
+                         BOTTOMRIGHT: 400 204,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:Check2DShadows";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4515,8 +4515,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 168 216,
-                         BOTTOMRIGHT: 368 240,
+            SCREENRECT = UPPERLEFT: 170 235,
+                         BOTTOMRIGHT: 400 260,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckGroundLighting";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4564,8 +4564,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 384 216,
-                         BOTTOMRIGHT: 615 240,
+            SCREENRECT = UPPERLEFT: 405 235,
+                         BOTTOMRIGHT: 630 260,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckNoDynamicLOD";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4613,8 +4613,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 384 240,
-                         BOTTOMRIGHT: 615 264,
+            SCREENRECT = UPPERLEFT: 405 263,
+                         BOTTOMRIGHT: 630 288,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckHeatEffects";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4662,8 +4662,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 384 264,
-                         BOTTOMRIGHT: 615 288,
+            SCREENRECT = UPPERLEFT: 405 264,
+                         BOTTOMRIGHT: 630 288,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckUnlockFPS";
             STATUS = ENABLED+HIDDEN+IMAGE+BORDER;
@@ -4711,8 +4711,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 168 192,
-                         BOTTOMRIGHT: 368 216,
+            SCREENRECT = UPPERLEFT: 170 207,
+                         BOTTOMRIGHT: 400 232,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckCloudShadows";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4760,8 +4760,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 384 192,
-                         BOTTOMRIGHT: 616 216,
+            SCREENRECT = UPPERLEFT: 405 207,
+                         BOTTOMRIGHT: 630 232,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckExtraAnimations";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4809,8 +4809,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 168 240,
-                         BOTTOMRIGHT: 368 265,
+            SCREENRECT = UPPERLEFT: 170 263,
+                         BOTTOMRIGHT: 400 288,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckSmoothWater";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4859,7 +4859,7 @@ WINDOW
           WINDOW
             WINDOWTYPE = USER;
             SCREENRECT = UPPERLEFT: 160 139,
-                         BOTTOMRIGHT: 622 140,
+                         BOTTOMRIGHT: 640 140,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:ToggleOnOffLine";
             STATUS = ENABLED;
@@ -4905,8 +4905,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 167 112,
-                         BOTTOMRIGHT: 607 140,
+            SCREENRECT = UPPERLEFT: 170 112,
+                         BOTTOMRIGHT: 630 140,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED+WRAP_CENTERED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -4956,8 +4956,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 160 312,
-                       BOTTOMRIGHT: 625 399,
+          SCREENRECT = UPPERLEFT: 160 310,
+                       BOTTOMRIGHT: 640 405,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:LowResWin";
           STATUS = ENABLED;
@@ -5002,8 +5002,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 172 315,
-                         BOTTOMRIGHT: 461 339,
+            SCREENRECT = UPPERLEFT: 170 310,
+                         BOTTOMRIGHT: 640 340,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5051,8 +5051,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = HORZSLIDER;
-            SCREENRECT = UPPERLEFT: 240 355,
-                         BOTTOMRIGHT: 526 379,
+            SCREENRECT = UPPERLEFT: 285 355,
+                         BOTTOMRIGHT: 515 380,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:LowResSlider";
             STATUS = ENABLED+IMAGE+TABSTOP;
@@ -5128,8 +5128,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 427 375,
-                         BOTTOMRIGHT: 625 399,
+            SCREENRECT = UPPERLEFT: 400 375,
+                         BOTTOMRIGHT: 630 400,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5172,13 +5172,13 @@ WINDOW
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
-            STATICTEXTDATA = CENTERED: 0;
+            STATICTEXTDATA = CENTERED: 1;
           END
           CHILD
           WINDOW
             WINDOWTYPE = USER;
             SCREENRECT = UPPERLEFT: 160 342,
-                         BOTTOMRIGHT: 625 343,
+                         BOTTOMRIGHT: 640 343,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:LowResLine";
             STATUS = ENABLED;
@@ -5224,8 +5224,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 160 375,
-                         BOTTOMRIGHT: 373 399,
+            SCREENRECT = UPPERLEFT: 170 375,
+                         BOTTOMRIGHT: 400 400,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5268,7 +5268,7 @@ WINDOW
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
-            STATICTEXTDATA = CENTERED: 0;
+            STATICTEXTDATA = CENTERED: 1;
           END
           ENDALLCHILDREN
         END

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -2563,8 +2563,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 151 272,
-                     BOTTOMRIGHT: 635 400,
+        SCREENRECT = UPPERLEFT: 150 272,
+                     BOTTOMRIGHT: 650 395,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ScrollParent";
         STATUS = ENABLED;
@@ -2609,8 +2609,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 161 273,
-                       BOTTOMRIGHT: 635 297,
+          SCREENRECT = UPPERLEFT: 160 273,
+                       BOTTOMRIGHT: 640 297,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED;
@@ -2659,7 +2659,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = CHECKBOX;
           SCREENRECT = UPPERLEFT: 160 302,
-                       BOTTOMRIGHT: 352 326,
+                       BOTTOMRIGHT: 397 326,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckAlternateMouse";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -2708,7 +2708,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = STATICTEXT;
           SCREENRECT = UPPERLEFT: 160 348,
-                       BOTTOMRIGHT: 624 372,
+                       BOTTOMRIGHT: 640 372,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ScrollSpeedLabel";
           STATUS = ENABLED;
@@ -2756,8 +2756,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 167 373,
-                       BOTTOMRIGHT: 611 397,
+          SCREENRECT = UPPERLEFT: 170 373,
+                       BOTTOMRIGHT: 630 390,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderScrollSpeed";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -2833,8 +2833,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 387 302,
-                       BOTTOMRIGHT: 633 326,
+          SCREENRECT = UPPERLEFT: 402 302,
+                       BOTTOMRIGHT: 640 326,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckDoubleClickAttackMove";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -2883,7 +2883,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = CHECKBOX;
           SCREENRECT = UPPERLEFT: 160 326,
-                       BOTTOMRIGHT: 352 350,
+                       BOTTOMRIGHT: 397 350,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:Retaliation";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -3892,8 +3892,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 151 276,
-                     BOTTOMRIGHT: 635 301,
+        SCREENRECT = UPPERLEFT: 150 296,
+                     BOTTOMRIGHT: 650 297,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line3";
         STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -438,8 +438,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 151 399,
-                     BOTTOMRIGHT: 635 520,
+        SCREENRECT = UPPERLEFT: 150 400,
+                     BOTTOMRIGHT: 650 523,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:NetworkParent";
         STATUS = ENABLED+NOFOCUS;
@@ -484,8 +484,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 480 496,
-                       BOTTOMRIGHT: 608 520,
+          SCREENRECT = UPPERLEFT: 450 495,
+                       BOTTOMRIGHT: 640 520,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckSendDelay";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -533,8 +533,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 152 432,
-                       BOTTOMRIGHT: 240 456,
+          SCREENRECT = UPPERLEFT: 160 439,
+                       BOTTOMRIGHT: 215 464,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextOnlineIpAddresses";
           STATUS = ENABLED;
@@ -582,8 +582,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
-          SCREENRECT = UPPERLEFT: 480 464,
-                       BOTTOMRIGHT: 596 489,
+          SCREENRECT = UPPERLEFT: 265 495,
+                       BOTTOMRIGHT: 375 520,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonFirewallRefresh";
           STATUS = ENABLED+IMAGE;
@@ -631,8 +631,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 161 400,
-                       BOTTOMRIGHT: 573 424,
+          SCREENRECT = UPPERLEFT: 160 403,
+                       BOTTOMRIGHT: 640 436,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -680,8 +680,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = ENTRYFIELD;
-          SCREENRECT = UPPERLEFT: 304 488,
-                       BOTTOMRIGHT: 448 512,
+          SCREENRECT = UPPERLEFT: 510 467,
+                       BOTTOMRIGHT: 640 492,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:TextEntryHTTPProxy";
           STATUS = ENABLED+IMAGE;
@@ -734,8 +734,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 151 488,
-                       BOTTOMRIGHT: 267 512,
+          SCREENRECT = UPPERLEFT: 370 467,
+                       BOTTOMRIGHT: 505 492,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextHTTPProxy";
           STATUS = ENABLED;
@@ -783,8 +783,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = ENTRYFIELD;
-          SCREENRECT = UPPERLEFT: 304 464,
-                       BOTTOMRIGHT: 448 488,
+          SCREENRECT = UPPERLEFT: 510 439,
+                       BOTTOMRIGHT: 640 464,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:TextEntryFirewallPortOverride";
           STATUS = ENABLED+IMAGE;
@@ -837,8 +837,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 152 464,
-                       BOTTOMRIGHT: 304 488,
+          SCREENRECT = UPPERLEFT: 370 439,
+                       BOTTOMRIGHT: 505 464,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextFirewallPortOverride";
           STATUS = ENABLED;
@@ -886,8 +886,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 376 432,
-                       BOTTOMRIGHT: 480 456,
+          SCREENRECT = UPPERLEFT: 160 467,
+                       BOTTOMRIGHT: 215 492,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextLANIpAddresses";
           STATUS = ENABLED;
@@ -935,8 +935,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 480 432,
-                       BOTTOMRIGHT: 608 456,
+          SCREENRECT = UPPERLEFT: 220 467,
+                       BOTTOMRIGHT: 330 492,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxIP";
           STATUS = ENABLED+IMAGE;
@@ -1177,8 +1177,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 240 432,
-                       BOTTOMRIGHT: 368 456,
+          SCREENRECT = UPPERLEFT: 220 439,
+                       BOTTOMRIGHT: 330 464,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxOnlineIP";
           STATUS = ENABLED+IMAGE;
@@ -3939,8 +3939,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 151 422,
-                     BOTTOMRIGHT: 635 423,
+        SCREENRECT = UPPERLEFT: 150 435,
+                     BOTTOMRIGHT: 650 436,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line4";
         STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -486,8 +486,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 450 495,
-                       BOTTOMRIGHT: 640 520,
+          SCREENRECT = UPPERLEFT: 475 494,
+                       BOTTOMRIGHT: 640 519,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckSendDelay";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -535,8 +535,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 439,
-                       BOTTOMRIGHT: 215 464,
+          SCREENRECT = UPPERLEFT: 160 434,
+                       BOTTOMRIGHT: 235 459,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextOnlineIpAddresses";
           STATUS = ENABLED;
@@ -584,8 +584,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
-          SCREENRECT = UPPERLEFT: 265 495,
-                       BOTTOMRIGHT: 375 520,
+          SCREENRECT = UPPERLEFT: 360 494,
+                       BOTTOMRIGHT: 470 519,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonFirewallRefresh";
           STATUS = ENABLED+IMAGE;
@@ -634,7 +634,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = STATICTEXT;
           SCREENRECT = UPPERLEFT: 160 403,
-                       BOTTOMRIGHT: 640 436,
+                       BOTTOMRIGHT: 640 429,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -682,8 +682,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = ENTRYFIELD;
-          SCREENRECT = UPPERLEFT: 510 467,
-                       BOTTOMRIGHT: 640 492,
+          SCREENRECT = UPPERLEFT: 360 464,
+                       BOTTOMRIGHT: 470 489,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:TextEntryHTTPProxy";
           STATUS = ENABLED+IMAGE;
@@ -736,8 +736,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 370 467,
-                       BOTTOMRIGHT: 505 492,
+          SCREENRECT = UPPERLEFT: 475 464,
+                       BOTTOMRIGHT: 640 489,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextHTTPProxy";
           STATUS = ENABLED;
@@ -785,8 +785,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = ENTRYFIELD;
-          SCREENRECT = UPPERLEFT: 510 439,
-                       BOTTOMRIGHT: 640 464,
+          SCREENRECT = UPPERLEFT: 360 434,
+                       BOTTOMRIGHT: 470 459,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:TextEntryFirewallPortOverride";
           STATUS = ENABLED+IMAGE;
@@ -839,8 +839,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 370 439,
-                       BOTTOMRIGHT: 505 464,
+          SCREENRECT = UPPERLEFT: 475 434,
+                       BOTTOMRIGHT: 640 459,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextFirewallPortOverride";
           STATUS = ENABLED;
@@ -888,8 +888,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 467,
-                       BOTTOMRIGHT: 215 492,
+          SCREENRECT = UPPERLEFT: 160 464,
+                       BOTTOMRIGHT: 235 489,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextLANIpAddresses";
           STATUS = ENABLED;
@@ -937,8 +937,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 220 467,
-                       BOTTOMRIGHT: 330 492,
+          SCREENRECT = UPPERLEFT: 240 464,
+                       BOTTOMRIGHT: 350 489,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxIP";
           STATUS = ENABLED+IMAGE;
@@ -1179,8 +1179,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 220 439,
-                       BOTTOMRIGHT: 330 464,
+          SCREENRECT = UPPERLEFT: 240 434,
+                       BOTTOMRIGHT: 350 459,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxOnlineIP";
           STATUS = ENABLED+IMAGE;
@@ -3947,8 +3947,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 435,
-                     BOTTOMRIGHT: 650 436,
+        SCREENRECT = UPPERLEFT: 150 428,
+                     BOTTOMRIGHT: 650 429,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line4";
         STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -53,7 +53,7 @@ WINDOW
   WINDOW
     WINDOWTYPE = USER;
     SCREENRECT = UPPERLEFT: 140 20,
-                 BOTTOMRIGHT: 660 537,
+                 BOTTOMRIGHT: 660 544,
                  CREATIONRESOLUTION: 800 600;
     NAME = "OptionsMenu.wnd:OptionsMenuParent";
     STATUS = ENABLED+NOFOCUS+SEE_THRU;
@@ -99,7 +99,7 @@ WINDOW
     WINDOW
       WINDOWTYPE = USER;
       SCREENRECT = UPPERLEFT: 140 20,
-                   BOTTOMRIGHT: 660 537,
+                   BOTTOMRIGHT: 660 544,
                    CREATIONRESOLUTION: 800 600;
       NAME = "OptionsMenu.wnd:OptionsMenuParentOld";
       STATUS = ENABLED;
@@ -293,7 +293,7 @@ WINDOW
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
         SCREENRECT = UPPERLEFT: 487 497,
-                     BOTTOMRIGHT: 650 522,
+                     BOTTOMRIGHT: 650 529,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonBack";
         STATUS = ENABLED+IMAGE;
@@ -342,7 +342,7 @@ WINDOW
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
         SCREENRECT = UPPERLEFT: 319 497,
-                     BOTTOMRIGHT: 481 522,
+                     BOTTOMRIGHT: 481 529,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonAccept";
         STATUS = ENABLED+IMAGE;
@@ -391,7 +391,7 @@ WINDOW
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
         SCREENRECT = UPPERLEFT: 150 497,
-                     BOTTOMRIGHT: 313 522,
+                     BOTTOMRIGHT: 313 529,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonDefaults";
         STATUS = ENABLED+IMAGE;
@@ -3610,8 +3610,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = STATICTEXT;
-        SCREENRECT = UPPERLEFT: 150 522,
-                     BOTTOMRIGHT: 650 537,
+        SCREENRECT = UPPERLEFT: 150 529,
+                     BOTTOMRIGHT: 650 544,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:LabelVersion";
         STATUS = ENABLED;
@@ -4043,7 +4043,7 @@ WINDOW
       WINDOW
         WINDOWTYPE = USER;
         SCREENRECT = UPPERLEFT: 150 64,
-                     BOTTOMRIGHT: 650 522,
+                     BOTTOMRIGHT: 650 529,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:WinAdvancedDisplayOptions";
         STATUS = ENABLED+HIDDEN;
@@ -4136,7 +4136,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
           SCREENRECT = UPPERLEFT: 308 488,
-                       BOTTOMRIGHT: 471 513,
+                       BOTTOMRIGHT: 471 520,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonAdvanceAccept";
           STATUS = ENABLED+IMAGE;
@@ -4185,7 +4185,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
           SCREENRECT = UPPERLEFT: 477 488,
-                       BOTTOMRIGHT: 640 513,
+                       BOTTOMRIGHT: 640 520,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonAdvanceBack";
           STATUS = ENABLED+IMAGE;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -7,7 +7,7 @@ ENDLAYOUTBLOCK
 WINDOW
   WINDOWTYPE = USER;
   SCREENRECT = UPPERLEFT: 0 0,
-               BOTTOMRIGHT: 799 599,
+               BOTTOMRIGHT: 800 600,
                CREATIONRESOLUTION: 800 600;
   NAME = "OptionsMenu.wnd:";
   STATUS = ENABLED;
@@ -52,8 +52,8 @@ WINDOW
   CHILD
   WINDOW
     WINDOWTYPE = USER;
-    SCREENRECT = UPPERLEFT: 120 12,
-                 BOTTOMRIGHT: 661 597,
+    SCREENRECT = UPPERLEFT: 140 15,
+                 BOTTOMRIGHT: 660 585,
                  CREATIONRESOLUTION: 800 600;
     NAME = "OptionsMenu.wnd:OptionsMenuParent";
     STATUS = ENABLED+NOFOCUS+SEE_THRU;
@@ -98,8 +98,8 @@ WINDOW
     CHILD
     WINDOW
       WINDOWTYPE = USER;
-      SCREENRECT = UPPERLEFT: 135 19,
-                   BOTTOMRIGHT: 650 586,
+      SCREENRECT = UPPERLEFT: 140 15,
+                   BOTTOMRIGHT: 660 585,
                    CREATIONRESOLUTION: 800 600;
       NAME = "OptionsMenu.wnd:OptionsMenuParentOld";
       STATUS = ENABLED;
@@ -291,8 +291,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
-        SCREENRECT = UPPERLEFT: 476 528,
-                     BOTTOMRIGHT: 635 560,
+        SCREENRECT = UPPERLEFT: 487 528,
+                     BOTTOMRIGHT: 650 560,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonBack";
         STATUS = ENABLED+IMAGE;
@@ -340,8 +340,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
-        SCREENRECT = UPPERLEFT: 312 528,
-                     BOTTOMRIGHT: 471 560,
+        SCREENRECT = UPPERLEFT: 319 528,
+                     BOTTOMRIGHT: 482 560,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonAccept";
         STATUS = ENABLED+IMAGE;
@@ -389,8 +389,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
-        SCREENRECT = UPPERLEFT: 152 528,
-                     BOTTOMRIGHT: 308 560,
+        SCREENRECT = UPPERLEFT: 150 528,
+                     BOTTOMRIGHT: 314 560,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonDefaults";
         STATUS = ENABLED+IMAGE;
@@ -3604,8 +3604,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = STATICTEXT;
-        SCREENRECT = UPPERLEFT: 152 560,
-                     BOTTOMRIGHT: 632 578,
+        SCREENRECT = UPPERLEFT: 150 560,
+                     BOTTOMRIGHT: 650 585,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:LabelVersion";
         STATUS = ENABLED;
@@ -3749,7 +3749,7 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 135 55,
+        SCREENRECT = UPPERLEFT: 150 55,
                      BOTTOMRIGHT: 650 56,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line";
@@ -3796,8 +3796,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = STATICTEXT;
-        SCREENRECT = UPPERLEFT: 152 21,
-                     BOTTOMRIGHT: 416 54,
+        SCREENRECT = UPPERLEFT: 150 21,
+                     BOTTOMRIGHT: 650 54,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:";
         STATUS = ENABLED;
@@ -3840,7 +3840,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                          IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                          IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
-        STATICTEXTDATA = CENTERED: 0;
+        STATICTEXTDATA = CENTERED: 1;
       END
       CHILD
       WINDOW

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -3513,18 +3513,18 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = CHECKBOX;
-        SCREENRECT = UPPERLEFT: 647 487,
-                     BOTTOMRIGHT: 919 511,
+        SCREENRECT = UPPERLEFT: 160 344,
+                     BOTTOMRIGHT: 387 369,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:CheckBoxSaveCamera";
-        STATUS = ENABLED+HIDDEN+IMAGE;
+        STATUS = ENABLED+IMAGE;
         STYLE = CHECKBOX+MOUSETRACK;
         SYSTEMCALLBACK = "[None]";
         INPUTCALLBACK = "[None]";
         TOOLTIPCALLBACK = "[None]";
         DRAWCALLBACK = "[None]";
-        FONT = NAME: "Arial", SIZE: 10, BOLD: 0;
-        HEADERTEMPLATE = "[NONE]";
+        FONT = NAME: "Arial", SIZE: 14, BOLD: 0;
+        HEADERTEMPLATE = "MinorTitle";
         TOOLTIPDELAY = -1;
         TEXT = "GUI:SaveCamera";
         TEXTCOLOR = ENABLED:  255 255 255 255, ENABLEDBORDER:  0 0 0 255,
@@ -3561,18 +3561,18 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = CHECKBOX;
-        SCREENRECT = UPPERLEFT: 647 511,
-                     BOTTOMRIGHT: 919 535,
+        SCREENRECT = UPPERLEFT: 160 372,
+                     BOTTOMRIGHT: 387 397,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:CheckBoxUseCamera";
-        STATUS = ENABLED+HIDDEN+IMAGE;
+        STATUS = ENABLED+IMAGE+BORDER;
         STYLE = CHECKBOX+MOUSETRACK;
         SYSTEMCALLBACK = "[None]";
         INPUTCALLBACK = "[None]";
         TOOLTIPCALLBACK = "[None]";
         DRAWCALLBACK = "[None]";
-        FONT = NAME: "Arial", SIZE: 10, BOLD: 0;
-        HEADERTEMPLATE = "[NONE]";
+        FONT = NAME: "Arial", SIZE: 14, BOLD: 0;
+        HEADERTEMPLATE = "MinorTitle";
         TOOLTIPDELAY = -1;
         TEXT = "GUI:UseCamera";
         TEXTCOLOR = ENABLED:  255 255 255 255, ENABLEDBORDER:  0 0 0 255,
@@ -3659,18 +3659,18 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = CHECKBOX;
-        SCREENRECT = UPPERLEFT: 647 535,
-                     BOTTOMRIGHT: 919 559,
+        SCREENRECT = UPPERLEFT: 160 400,
+                     BOTTOMRIGHT: 387 425,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:CheckBoxDrawAnchor";
-        STATUS = ENABLED+HIDDEN+IMAGE;
+        STATUS = ENABLED+IMAGE;
         STYLE = CHECKBOX+MOUSETRACK;
         SYSTEMCALLBACK = "[None]";
         INPUTCALLBACK = "[None]";
         TOOLTIPCALLBACK = "[None]";
         DRAWCALLBACK = "[None]";
-        FONT = NAME: "Arial", SIZE: 10, BOLD: 0;
-        HEADERTEMPLATE = "[NONE]";
+        FONT = NAME: "Arial", SIZE: 14, BOLD: 0;
+        HEADERTEMPLATE = "MinorTitle";
         TOOLTIPDELAY = -1;
         TEXT = "GUI:DrawScrollAnchor";
         TEXTCOLOR = ENABLED:  255 255 255 255, ENABLEDBORDER:  0 0 0 255,

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -3034,7 +3034,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = HORZSLIDER;
           SCREENRECT = UPPERLEFT: 411 239,
-                       BOTTOMRIGHT: 584 264,
+                       BOTTOMRIGHT: 640 264,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderVoiceVolume";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -3111,7 +3111,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = STATICTEXT;
           SCREENRECT = UPPERLEFT: 411 211,
-                       BOTTOMRIGHT: 584 236,
+                       BOTTOMRIGHT: 640 236,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:VoiceVolumeLabel";
           STATUS = ENABLED;
@@ -3161,7 +3161,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = STATICTEXT;
           SCREENRECT = UPPERLEFT: 411 99,
-                       BOTTOMRIGHT: 584 124,
+                       BOTTOMRIGHT: 640 124,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:MusicVolumeLabel";
           STATUS = ENABLED;
@@ -3211,7 +3211,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = STATICTEXT;
           SCREENRECT = UPPERLEFT: 411 155,
-                       BOTTOMRIGHT: 584 180,
+                       BOTTOMRIGHT: 640 180,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SFXVolumeLabel";
           STATUS = ENABLED;
@@ -3261,7 +3261,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = STATICTEXT;
           SCREENRECT = UPPERLEFT: 411 69,
-                       BOTTOMRIGHT: 584 95,
+                       BOTTOMRIGHT: 640 95,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -3312,7 +3312,7 @@ WINDOW
       WINDOW
         WINDOWTYPE = HORZSLIDER;
         SCREENRECT = UPPERLEFT: 411 127,
-                     BOTTOMRIGHT: 584 152,
+                     BOTTOMRIGHT: 640 152,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:SliderMusicVolume";
         STATUS = ENABLED+IMAGE+TABSTOP;
@@ -3389,7 +3389,7 @@ WINDOW
       WINDOW
         WINDOWTYPE = HORZSLIDER;
         SCREENRECT = UPPERLEFT: 411 183,
-                     BOTTOMRIGHT: 584 208,
+                     BOTTOMRIGHT: 640 208,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:SliderSFXVolume";
         STATUS = ENABLED+IMAGE+TABSTOP;
@@ -3756,8 +3756,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 55,
-                     BOTTOMRIGHT: 650 56,
+        SCREENRECT = UPPERLEFT: 140 54,
+                     BOTTOMRIGHT: 660 55,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line";
         STATUS = ENABLED;
@@ -3848,7 +3848,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                          IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                          IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
-        STATICTEXTDATA = CENTERED: 1;
+        STATICTEXTDATA = CENTERED: 0;
       END
       CHILD
       WINDOW
@@ -3900,8 +3900,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 296,
-                     BOTTOMRIGHT: 650 297,
+        SCREENRECT = UPPERLEFT: 150 298,
+                     BOTTOMRIGHT: 650 299,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line3";
         STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -2614,7 +2614,7 @@ WINDOW
         WINDOW
           WINDOWTYPE = STATICTEXT;
           SCREENRECT = UPPERLEFT: 160 273,
-                       BOTTOMRIGHT: 640 297,
+                       BOTTOMRIGHT: 640 299,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED;
@@ -2662,8 +2662,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 160 302,
-                       BOTTOMRIGHT: 397 326,
+          SCREENRECT = UPPERLEFT: 160 306,
+                       BOTTOMRIGHT: 397 331,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckAlternateMouse";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -2711,8 +2711,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 348,
-                       BOTTOMRIGHT: 640 372,
+          SCREENRECT = UPPERLEFT: 411 306,
+                       BOTTOMRIGHT: 640 331,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ScrollSpeedLabel";
           STATUS = ENABLED;
@@ -2755,13 +2755,13 @@ WINDOW
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
-          STATICTEXTDATA = CENTERED: 1;
+          STATICTEXTDATA = CENTERED: 0;
         END
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 170 373,
-                       BOTTOMRIGHT: 630 390,
+          SCREENRECT = UPPERLEFT: 411 334,
+                       BOTTOMRIGHT: 640 359,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderScrollSpeed";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -2837,8 +2837,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 402 302,
-                       BOTTOMRIGHT: 640 326,
+          SCREENRECT = UPPERLEFT: 160 362,
+                       BOTTOMRIGHT: 640 387,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckDoubleClickAttackMove";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -2886,8 +2886,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 160 326,
-                       BOTTOMRIGHT: 397 350,
+          SCREENRECT = UPPERLEFT: 160 334,
+                       BOTTOMRIGHT: 397 359,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:Retaliation";
           STATUS = ENABLED+IMAGE+BORDER;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -2982,8 +2982,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 391 69,
-                     BOTTOMRIGHT: 635 271,
+        SCREENRECT = UPPERLEFT: 401 69,
+                     BOTTOMRIGHT: 650 267,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:AudioParent";
         STATUS = ENABLED;
@@ -3028,8 +3028,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 404 244,
-                       BOTTOMRIGHT: 612 268,
+          SCREENRECT = UPPERLEFT: 411 239,
+                       BOTTOMRIGHT: 584 264,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderVoiceVolume";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -3105,8 +3105,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 399 220,
-                       BOTTOMRIGHT: 583 244,
+          SCREENRECT = UPPERLEFT: 411 211,
+                       BOTTOMRIGHT: 584 236,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:VoiceVolumeLabel";
           STATUS = ENABLED;
@@ -3155,8 +3155,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 400 104,
-                       BOTTOMRIGHT: 584 128,
+          SCREENRECT = UPPERLEFT: 411 99,
+                       BOTTOMRIGHT: 584 124,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:MusicVolumeLabel";
           STATUS = ENABLED;
@@ -3205,8 +3205,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 398 160,
-                       BOTTOMRIGHT: 623 184,
+          SCREENRECT = UPPERLEFT: 411 155,
+                       BOTTOMRIGHT: 584 180,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SFXVolumeLabel";
           STATUS = ENABLED;
@@ -3255,8 +3255,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 398 69,
-                       BOTTOMRIGHT: 610 97,
+          SCREENRECT = UPPERLEFT: 411 69,
+                       BOTTOMRIGHT: 584 95,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -3306,8 +3306,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = HORZSLIDER;
-        SCREENRECT = UPPERLEFT: 404 128,
-                     BOTTOMRIGHT: 612 154,
+        SCREENRECT = UPPERLEFT: 411 127,
+                     BOTTOMRIGHT: 584 152,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:SliderMusicVolume";
         STATUS = ENABLED+IMAGE+TABSTOP;
@@ -3383,8 +3383,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = HORZSLIDER;
-        SCREENRECT = UPPERLEFT: 404 184,
-                     BOTTOMRIGHT: 612 208,
+        SCREENRECT = UPPERLEFT: 411 183,
+                     BOTTOMRIGHT: 584 208,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:SliderSFXVolume";
         STATUS = ENABLED+IMAGE+TABSTOP;
@@ -3986,8 +3986,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 151 92,
-                     BOTTOMRIGHT: 386 93,
+        SCREENRECT = UPPERLEFT: 150 94,
+                     BOTTOMRIGHT: 397 95,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line1";
         STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -1519,8 +1519,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 163 239,
-                       BOTTOMRIGHT: 385 264,
+          SCREENRECT = UPPERLEFT: 163 224,
+                       BOTTOMRIGHT: 385 249,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderGamma";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -1596,8 +1596,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 211,
-                       BOTTOMRIGHT: 387 236,
+          SCREENRECT = UPPERLEFT: 160 196,
+                       BOTTOMRIGHT: 387 221,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:GammaLabel";
           STATUS = ENABLED;
@@ -1935,8 +1935,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 163 183,
-                       BOTTOMRIGHT: 303 208,
+          SCREENRECT = UPPERLEFT: 263 154,
+                       BOTTOMRIGHT: 385 179,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxDetail";
           STATUS = ENABLED+IMAGE;
@@ -2176,8 +2176,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 155,
-                       BOTTOMRIGHT: 397 180,
+          SCREENRECT = UPPERLEFT: 160 154,
+                       BOTTOMRIGHT: 255 179,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:DetailLabel";
           STATUS = ENABLED;
@@ -2225,8 +2225,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 163 127,
-                       BOTTOMRIGHT: 303 152,
+          SCREENRECT = UPPERLEFT: 263 112,
+                       BOTTOMRIGHT: 385 137,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxResolution";
           STATUS = ENABLED+IMAGE;
@@ -2466,8 +2466,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 99,
-                       BOTTOMRIGHT: 397 124,
+          SCREENRECT = UPPERLEFT: 160 112,
+                       BOTTOMRIGHT: 255 137,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ResolutionLabel";
           STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -5275,8 +5275,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 160 416,
-                       BOTTOMRIGHT: 625 503,
+          SCREENRECT = UPPERLEFT: 160 415,
+                       BOTTOMRIGHT: 640 505,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ParticleCapWin";
           STATUS = ENABLED;
@@ -5321,8 +5321,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 172 419,
-                         BOTTOMRIGHT: 461 443,
+            SCREENRECT = UPPERLEFT: 170 420,
+                         BOTTOMRIGHT: 430 445,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5370,8 +5370,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 160 476,
-                         BOTTOMRIGHT: 373 500,
+            SCREENRECT = UPPERLEFT: 170 475,
+                         BOTTOMRIGHT: 400 500,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5414,13 +5414,13 @@ WINDOW
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
-            STATICTEXTDATA = CENTERED: 0;
+            STATICTEXTDATA = CENTERED: 1;
           END
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 412 476,
-                         BOTTOMRIGHT: 625 500,
+            SCREENRECT = UPPERLEFT: 400 475,
+                         BOTTOMRIGHT: 630 500,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5463,13 +5463,13 @@ WINDOW
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                              IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
-            STATICTEXTDATA = CENTERED: 0;
+            STATICTEXTDATA = CENTERED: 1;
           END
           CHILD
           WINDOW
             WINDOWTYPE = USER;
             SCREENRECT = UPPERLEFT: 160 445,
-                         BOTTOMRIGHT: 625 446,
+                         BOTTOMRIGHT: 640 446,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:ParticleCapLine";
             STATUS = ENABLED;
@@ -5515,8 +5515,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = HORZSLIDER;
-            SCREENRECT = UPPERLEFT: 240 459,
-                         BOTTOMRIGHT: 526 483,
+            SCREENRECT = UPPERLEFT: 285 460,
+                         BOTTOMRIGHT: 515 485,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:ParticleCapSlider";
             STATUS = ENABLED+IMAGE+TABSTOP;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -4088,8 +4088,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 160 105,
-                       BOTTOMRIGHT: 640 106,
+          SCREENRECT = UPPERLEFT: 150 105,
+                       BOTTOMRIGHT: 650 106,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:AdvanceOptionsLine";
           STATUS = ENABLED;
@@ -4277,7 +4277,7 @@ WINDOW
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
-          STATICTEXTDATA = CENTERED: 1;
+          STATICTEXTDATA = CENTERED: 0;
         END
         CHILD
         WINDOW
@@ -5012,7 +5012,7 @@ WINDOW
           WINDOW
             WINDOWTYPE = STATICTEXT;
             SCREENRECT = UPPERLEFT: 170 310,
-                         BOTTOMRIGHT: 640 340,
+                         BOTTOMRIGHT: 640 338,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5186,8 +5186,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = USER;
-            SCREENRECT = UPPERLEFT: 160 342,
-                         BOTTOMRIGHT: 640 343,
+            SCREENRECT = UPPERLEFT: 160 338,
+                         BOTTOMRIGHT: 640 339,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:LowResLine";
             STATUS = ENABLED;
@@ -5330,8 +5330,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 170 420,
-                         BOTTOMRIGHT: 430 445,
+            SCREENRECT = UPPERLEFT: 170 415,
+                         BOTTOMRIGHT: 430 443,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5477,8 +5477,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = USER;
-            SCREENRECT = UPPERLEFT: 160 445,
-                         BOTTOMRIGHT: 640 446,
+            SCREENRECT = UPPERLEFT: 160 442,
+                         BOTTOMRIGHT: 640 443,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:ParticleCapLine";
             STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -4033,8 +4033,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 151 68,
-                     BOTTOMRIGHT: 636 560,
+        SCREENRECT = UPPERLEFT: 150 69,
+                     BOTTOMRIGHT: 650 560,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:WinAdvancedDisplayOptions";
         STATUS = ENABLED+HIDDEN;
@@ -4079,8 +4079,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 151 105,
-                       BOTTOMRIGHT: 636 106,
+          SCREENRECT = UPPERLEFT: 160 105,
+                       BOTTOMRIGHT: 640 106,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:AdvanceOptionsLine";
           STATUS = ENABLED;
@@ -4126,8 +4126,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
-          SCREENRECT = UPPERLEFT: 295 521,
-                       BOTTOMRIGHT: 454 553,
+          SCREENRECT = UPPERLEFT: 307 515,
+                       BOTTOMRIGHT: 471 547,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonAdvanceAccept";
           STATUS = ENABLED+IMAGE;
@@ -4175,8 +4175,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
-          SCREENRECT = UPPERLEFT: 466 521,
-                       BOTTOMRIGHT: 625 553,
+          SCREENRECT = UPPERLEFT: 476 515,
+                       BOTTOMRIGHT: 640 547,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonAdvanceBack";
           STATUS = ENABLED+IMAGE;
@@ -4224,8 +4224,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 162 74,
-                       BOTTOMRIGHT: 576 102,
+          SCREENRECT = UPPERLEFT: 160 74,
+                       BOTTOMRIGHT: 640 102,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -4268,7 +4268,7 @@ WINDOW
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255,
                            IMAGE: NoImage, COLOR: 255 255 255 255, BORDERCOLOR: 255 255 255 255;
-          STATICTEXTDATA = CENTERED: 0;
+          STATICTEXTDATA = CENTERED: 1;
         END
         CHILD
         WINDOW

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -4042,8 +4042,8 @@ WINDOW
       ; Win Advanced Display Options
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 69,
-                     BOTTOMRIGHT: 650 560,
+        SCREENRECT = UPPERLEFT: 150 64,
+                     BOTTOMRIGHT: 650 522,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:WinAdvancedDisplayOptions";
         STATUS = ENABLED+HIDDEN;
@@ -4088,8 +4088,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 150 105,
-                       BOTTOMRIGHT: 650 106,
+          SCREENRECT = UPPERLEFT: 150 97,
+                       BOTTOMRIGHT: 650 98,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:AdvanceOptionsLine";
           STATUS = ENABLED;
@@ -4135,8 +4135,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
-          SCREENRECT = UPPERLEFT: 307 515,
-                       BOTTOMRIGHT: 471 547,
+          SCREENRECT = UPPERLEFT: 308 488,
+                       BOTTOMRIGHT: 471 513,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonAdvanceAccept";
           STATUS = ENABLED+IMAGE;
@@ -4184,8 +4184,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
-          SCREENRECT = UPPERLEFT: 476 515,
-                       BOTTOMRIGHT: 640 547,
+          SCREENRECT = UPPERLEFT: 477 488,
+                       BOTTOMRIGHT: 640 513,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonAdvanceBack";
           STATUS = ENABLED+IMAGE;
@@ -4233,8 +4233,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 74,
-                       BOTTOMRIGHT: 640 102,
+          SCREENRECT = UPPERLEFT: 160 64,
+                       BOTTOMRIGHT: 640 97,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -4282,8 +4282,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 160 112,
-                       BOTTOMRIGHT: 640 300,
+          SCREENRECT = UPPERLEFT: 160 107,
+                       BOTTOMRIGHT: 640 284,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED;
@@ -4328,8 +4328,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 170 151,
-                         BOTTOMRIGHT: 400 176,
+            SCREENRECT = UPPERLEFT: 170 140,
+                         BOTTOMRIGHT: 397 165,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:Check3DShadows";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4377,8 +4377,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 405 179,
-                         BOTTOMRIGHT: 630 204,
+            SCREENRECT = UPPERLEFT: 403 168,
+                         BOTTOMRIGHT: 630 193,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckShowProps";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4426,8 +4426,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 405 151,
-                         BOTTOMRIGHT: 630 176,
+            SCREENRECT = UPPERLEFT: 403 140,
+                         BOTTOMRIGHT: 630 165,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckBehindBuilding";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4475,8 +4475,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 170 179,
-                         BOTTOMRIGHT: 400 204,
+            SCREENRECT = UPPERLEFT: 170 168,
+                         BOTTOMRIGHT: 397 193,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:Check2DShadows";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4524,8 +4524,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 170 235,
-                         BOTTOMRIGHT: 400 260,
+            SCREENRECT = UPPERLEFT: 170 224,
+                         BOTTOMRIGHT: 397 249,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckGroundLighting";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4573,8 +4573,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 405 235,
-                         BOTTOMRIGHT: 630 260,
+            SCREENRECT = UPPERLEFT: 403 224,
+                         BOTTOMRIGHT: 630 249,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckNoDynamicLOD";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4622,8 +4622,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 405 263,
-                         BOTTOMRIGHT: 630 288,
+            SCREENRECT = UPPERLEFT: 403 252,
+                         BOTTOMRIGHT: 630 277,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckHeatEffects";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4671,7 +4671,7 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 405 264,
+            SCREENRECT = UPPERLEFT: 403 264,
                          BOTTOMRIGHT: 630 288,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckUnlockFPS";
@@ -4720,8 +4720,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 170 207,
-                         BOTTOMRIGHT: 400 232,
+            SCREENRECT = UPPERLEFT: 170 196,
+                         BOTTOMRIGHT: 397 221,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckCloudShadows";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4769,8 +4769,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 405 207,
-                         BOTTOMRIGHT: 630 232,
+            SCREENRECT = UPPERLEFT: 403 196,
+                         BOTTOMRIGHT: 630 221,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckExtraAnimations";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4818,8 +4818,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = CHECKBOX;
-            SCREENRECT = UPPERLEFT: 170 263,
-                         BOTTOMRIGHT: 400 288,
+            SCREENRECT = UPPERLEFT: 170 252,
+                         BOTTOMRIGHT: 397 277,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:CheckSmoothWater";
             STATUS = ENABLED+IMAGE+BORDER;
@@ -4867,8 +4867,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = USER;
-            SCREENRECT = UPPERLEFT: 160 139,
-                         BOTTOMRIGHT: 640 140,
+            SCREENRECT = UPPERLEFT: 160 133,
+                         BOTTOMRIGHT: 640 134,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:ToggleOnOffLine";
             STATUS = ENABLED;
@@ -4914,8 +4914,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 170 112,
-                         BOTTOMRIGHT: 630 140,
+            SCREENRECT = UPPERLEFT: 170 107,
+                         BOTTOMRIGHT: 630 133,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED+WRAP_CENTERED;
@@ -4965,8 +4965,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 160 310,
-                       BOTTOMRIGHT: 640 405,
+          SCREENRECT = UPPERLEFT: 160 290,
+                       BOTTOMRIGHT: 640 383,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:LowResWin";
           STATUS = ENABLED;
@@ -5011,8 +5011,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 170 310,
-                         BOTTOMRIGHT: 640 338,
+            SCREENRECT = UPPERLEFT: 170 290,
+                         BOTTOMRIGHT: 640 316,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5060,8 +5060,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = HORZSLIDER;
-            SCREENRECT = UPPERLEFT: 285 355,
-                         BOTTOMRIGHT: 515 380,
+            SCREENRECT = UPPERLEFT: 284 323,
+                         BOTTOMRIGHT: 517 348,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:LowResSlider";
             STATUS = ENABLED+IMAGE+TABSTOP;
@@ -5137,8 +5137,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 400 375,
-                         BOTTOMRIGHT: 630 400,
+            SCREENRECT = UPPERLEFT: 403 351,
+                         BOTTOMRIGHT: 630 376,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5186,8 +5186,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = USER;
-            SCREENRECT = UPPERLEFT: 160 338,
-                         BOTTOMRIGHT: 640 339,
+            SCREENRECT = UPPERLEFT: 160 316,
+                         BOTTOMRIGHT: 640 317,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:LowResLine";
             STATUS = ENABLED;
@@ -5233,8 +5233,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 170 375,
-                         BOTTOMRIGHT: 400 400,
+            SCREENRECT = UPPERLEFT: 170 351,
+                         BOTTOMRIGHT: 397 376,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5284,8 +5284,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = USER;
-          SCREENRECT = UPPERLEFT: 160 415,
-                       BOTTOMRIGHT: 640 505,
+          SCREENRECT = UPPERLEFT: 160 389,
+                       BOTTOMRIGHT: 640 482,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ParticleCapWin";
           STATUS = ENABLED;
@@ -5330,8 +5330,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 170 415,
-                         BOTTOMRIGHT: 430 443,
+            SCREENRECT = UPPERLEFT: 170 389,
+                         BOTTOMRIGHT: 430 415,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5379,8 +5379,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 170 475,
-                         BOTTOMRIGHT: 400 500,
+            SCREENRECT = UPPERLEFT: 170 450,
+                         BOTTOMRIGHT: 397 475,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5428,8 +5428,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = STATICTEXT;
-            SCREENRECT = UPPERLEFT: 400 475,
-                         BOTTOMRIGHT: 630 500,
+            SCREENRECT = UPPERLEFT: 400 450,
+                         BOTTOMRIGHT: 630 475,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:";
             STATUS = ENABLED;
@@ -5477,8 +5477,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = USER;
-            SCREENRECT = UPPERLEFT: 160 442,
-                         BOTTOMRIGHT: 640 443,
+            SCREENRECT = UPPERLEFT: 160 415,
+                         BOTTOMRIGHT: 640 416,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:ParticleCapLine";
             STATUS = ENABLED;
@@ -5524,8 +5524,8 @@ WINDOW
           CHILD
           WINDOW
             WINDOWTYPE = HORZSLIDER;
-            SCREENRECT = UPPERLEFT: 285 460,
-                         BOTTOMRIGHT: 515 485,
+            SCREENRECT = UPPERLEFT: 284 422,
+                         BOTTOMRIGHT: 517 447,
                          CREATIONRESOLUTION: 800 600;
             NAME = "OptionsMenu.wnd:ParticleCapSlider";
             STATUS = ENABLED+IMAGE+TABSTOP;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -52,8 +52,8 @@ WINDOW
   CHILD
   WINDOW
     WINDOWTYPE = USER;
-    SCREENRECT = UPPERLEFT: 140 15,
-                 BOTTOMRIGHT: 660 585,
+    SCREENRECT = UPPERLEFT: 140 20,
+                 BOTTOMRIGHT: 660 537,
                  CREATIONRESOLUTION: 800 600;
     NAME = "OptionsMenu.wnd:OptionsMenuParent";
     STATUS = ENABLED+NOFOCUS+SEE_THRU;
@@ -98,8 +98,8 @@ WINDOW
     CHILD
     WINDOW
       WINDOWTYPE = USER;
-      SCREENRECT = UPPERLEFT: 140 15,
-                   BOTTOMRIGHT: 660 585,
+      SCREENRECT = UPPERLEFT: 140 20,
+                   BOTTOMRIGHT: 660 537,
                    CREATIONRESOLUTION: 800 600;
       NAME = "OptionsMenu.wnd:OptionsMenuParentOld";
       STATUS = ENABLED;
@@ -292,8 +292,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
-        SCREENRECT = UPPERLEFT: 487 528,
-                     BOTTOMRIGHT: 650 560,
+        SCREENRECT = UPPERLEFT: 487 497,
+                     BOTTOMRIGHT: 650 522,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonBack";
         STATUS = ENABLED+IMAGE;
@@ -341,8 +341,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
-        SCREENRECT = UPPERLEFT: 319 528,
-                     BOTTOMRIGHT: 482 560,
+        SCREENRECT = UPPERLEFT: 319 497,
+                     BOTTOMRIGHT: 481 522,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonAccept";
         STATUS = ENABLED+IMAGE;
@@ -390,8 +390,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
-        SCREENRECT = UPPERLEFT: 150 528,
-                     BOTTOMRIGHT: 314 560,
+        SCREENRECT = UPPERLEFT: 150 497,
+                     BOTTOMRIGHT: 313 522,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ButtonDefaults";
         STATUS = ENABLED+IMAGE;
@@ -440,8 +440,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 400,
-                     BOTTOMRIGHT: 650 523,
+        SCREENRECT = UPPERLEFT: 403 280,
+                     BOTTOMRIGHT: 650 491,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:NetworkParent";
         STATUS = ENABLED+NOFOCUS;
@@ -486,8 +486,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 475 494,
-                       BOTTOMRIGHT: 640 519,
+          SCREENRECT = UPPERLEFT: 413 456,
+                       BOTTOMRIGHT: 640 481,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckSendDelay";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -535,8 +535,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 434,
-                       BOTTOMRIGHT: 235 459,
+          SCREENRECT = UPPERLEFT: 413 316,
+                       BOTTOMRIGHT: 517 341,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextOnlineIpAddresses";
           STATUS = ENABLED;
@@ -584,8 +584,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = PUSHBUTTON;
-          SCREENRECT = UPPERLEFT: 360 494,
-                       BOTTOMRIGHT: 470 519,
+          SCREENRECT = UPPERLEFT: 520 428,
+                       BOTTOMRIGHT: 640 453,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ButtonFirewallRefresh";
           STATUS = ENABLED+IMAGE;
@@ -633,8 +633,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 403,
-                       BOTTOMRIGHT: 640 429,
+          SCREENRECT = UPPERLEFT: 413 280,
+                       BOTTOMRIGHT: 640 306,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -682,8 +682,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = ENTRYFIELD;
-          SCREENRECT = UPPERLEFT: 360 464,
-                       BOTTOMRIGHT: 470 489,
+          SCREENRECT = UPPERLEFT: 520 372,
+                       BOTTOMRIGHT: 640 397,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:TextEntryHTTPProxy";
           STATUS = ENABLED+IMAGE;
@@ -736,8 +736,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 475 464,
-                       BOTTOMRIGHT: 640 489,
+          SCREENRECT = UPPERLEFT: 413 372,
+                       BOTTOMRIGHT: 517 397,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextHTTPProxy";
           STATUS = ENABLED;
@@ -785,8 +785,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = ENTRYFIELD;
-          SCREENRECT = UPPERLEFT: 360 434,
-                       BOTTOMRIGHT: 470 459,
+          SCREENRECT = UPPERLEFT: 413 428,
+                       BOTTOMRIGHT: 517 453,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:TextEntryFirewallPortOverride";
           STATUS = ENABLED+IMAGE;
@@ -839,8 +839,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 475 434,
-                       BOTTOMRIGHT: 640 459,
+          SCREENRECT = UPPERLEFT: 413 400,
+                       BOTTOMRIGHT: 640 425,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextFirewallPortOverride";
           STATUS = ENABLED;
@@ -888,8 +888,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 464,
-                       BOTTOMRIGHT: 235 489,
+          SCREENRECT = UPPERLEFT: 413 344,
+                       BOTTOMRIGHT: 517 369,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:StaticTextLANIpAddresses";
           STATUS = ENABLED;
@@ -937,8 +937,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 240 464,
-                       BOTTOMRIGHT: 350 489,
+          SCREENRECT = UPPERLEFT: 520 344,
+                       BOTTOMRIGHT: 640 369,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxIP";
           STATUS = ENABLED+IMAGE;
@@ -983,7 +983,7 @@ WINDOW
                            IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
           COMBOBOXDATA = ISEDITABLE: 0,
                         MAXCHARS: 16,
-                        MAXDISPLAY: 2,
+                        MAXDISPLAY: 5,
                         ASCIIONLY: 0,
                         LETTERSANDNUMBERS: 0;
           COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA = IMAGE: VSliderDownButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,
@@ -1179,8 +1179,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 240 434,
-                       BOTTOMRIGHT: 350 459,
+          SCREENRECT = UPPERLEFT: 520 316,
+                       BOTTOMRIGHT: 640 341,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxOnlineIP";
           STATUS = ENABLED+IMAGE;
@@ -1473,8 +1473,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 69,
-                     BOTTOMRIGHT: 397 267,
+        SCREENRECT = UPPERLEFT: 150 64,
+                     BOTTOMRIGHT: 397 218,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:VideoParent";
         STATUS = ENABLED;
@@ -1519,8 +1519,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 163 224,
-                       BOTTOMRIGHT: 385 249,
+          SCREENRECT = UPPERLEFT: 160 183,
+                       BOTTOMRIGHT: 387 208,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderGamma";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -1596,8 +1596,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 196,
-                       BOTTOMRIGHT: 387 221,
+          SCREENRECT = UPPERLEFT: 160 155,
+                       BOTTOMRIGHT: 387 180,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:GammaLabel";
           STATUS = ENABLED;
@@ -1935,8 +1935,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 263 154,
-                       BOTTOMRIGHT: 385 179,
+          SCREENRECT = UPPERLEFT: 287 127,
+                       BOTTOMRIGHT: 387 152,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxDetail";
           STATUS = ENABLED+IMAGE;
@@ -2176,8 +2176,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 154,
-                       BOTTOMRIGHT: 255 179,
+          SCREENRECT = UPPERLEFT: 160 127,
+                       BOTTOMRIGHT: 284 152,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:DetailLabel";
           STATUS = ENABLED;
@@ -2225,8 +2225,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 263 112,
-                       BOTTOMRIGHT: 385 137,
+          SCREENRECT = UPPERLEFT: 287 99,
+                       BOTTOMRIGHT: 387 124,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxResolution";
           STATUS = ENABLED+IMAGE;
@@ -2466,8 +2466,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 112,
-                       BOTTOMRIGHT: 255 137,
+          SCREENRECT = UPPERLEFT: 160 99,
+                       BOTTOMRIGHT: 284 124,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ResolutionLabel";
           STATUS = ENABLED;
@@ -2515,8 +2515,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 69,
-                       BOTTOMRIGHT: 397 95,
+          SCREENRECT = UPPERLEFT: 160 64,
+                       BOTTOMRIGHT: 387 89,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -2567,8 +2567,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 272,
-                     BOTTOMRIGHT: 650 395,
+        SCREENRECT = UPPERLEFT: 150 224,
+                     BOTTOMRIGHT: 397 491,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:ScrollParent";
         STATUS = ENABLED;
@@ -2613,8 +2613,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 160 273,
-                       BOTTOMRIGHT: 640 299,
+          SCREENRECT = UPPERLEFT: 160 224,
+                       BOTTOMRIGHT: 387 250,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED;
@@ -2662,8 +2662,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 160 306,
-                       BOTTOMRIGHT: 397 331,
+          SCREENRECT = UPPERLEFT: 160 260,
+                       BOTTOMRIGHT: 387 285,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckAlternateMouse";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -2711,8 +2711,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 411 306,
-                       BOTTOMRIGHT: 640 331,
+          SCREENRECT = UPPERLEFT: 160 428,
+                       BOTTOMRIGHT: 387 453,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ScrollSpeedLabel";
           STATUS = ENABLED;
@@ -2760,8 +2760,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 411 334,
-                       BOTTOMRIGHT: 640 359,
+          SCREENRECT = UPPERLEFT: 160 456,
+                       BOTTOMRIGHT: 387 481,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderScrollSpeed";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -2837,8 +2837,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 160 362,
-                       BOTTOMRIGHT: 640 387,
+          SCREENRECT = UPPERLEFT: 160 316,
+                       BOTTOMRIGHT: 387 341,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:CheckDoubleClickAttackMove";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -2886,8 +2886,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = CHECKBOX;
-          SCREENRECT = UPPERLEFT: 160 334,
-                       BOTTOMRIGHT: 397 359,
+          SCREENRECT = UPPERLEFT: 160 288,
+                       BOTTOMRIGHT: 387 313,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:Retaliation";
           STATUS = ENABLED+IMAGE+BORDER;
@@ -2987,8 +2987,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 401 69,
-                     BOTTOMRIGHT: 650 267,
+        SCREENRECT = UPPERLEFT: 403 64,
+                     BOTTOMRIGHT: 650 274,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:AudioParent";
         STATUS = ENABLED;
@@ -3033,7 +3033,7 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 411 239,
+          SCREENRECT = UPPERLEFT: 413 239,
                        BOTTOMRIGHT: 640 264,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderVoiceVolume";
@@ -3110,7 +3110,7 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 411 211,
+          SCREENRECT = UPPERLEFT: 413 211,
                        BOTTOMRIGHT: 640 236,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:VoiceVolumeLabel";
@@ -3160,7 +3160,7 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 411 99,
+          SCREENRECT = UPPERLEFT: 413 99,
                        BOTTOMRIGHT: 640 124,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:MusicVolumeLabel";
@@ -3210,7 +3210,7 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 411 155,
+          SCREENRECT = UPPERLEFT: 413 155,
                        BOTTOMRIGHT: 640 180,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SFXVolumeLabel";
@@ -3260,8 +3260,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 411 69,
-                       BOTTOMRIGHT: 640 95,
+          SCREENRECT = UPPERLEFT: 413 64,
+                       BOTTOMRIGHT: 640 89,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -3311,7 +3311,7 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = HORZSLIDER;
-        SCREENRECT = UPPERLEFT: 411 127,
+        SCREENRECT = UPPERLEFT: 413 127,
                      BOTTOMRIGHT: 640 152,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:SliderMusicVolume";
@@ -3388,7 +3388,7 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = HORZSLIDER;
-        SCREENRECT = UPPERLEFT: 411 183,
+        SCREENRECT = UPPERLEFT: 413 183,
                      BOTTOMRIGHT: 640 208,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:SliderSFXVolume";
@@ -3610,8 +3610,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = STATICTEXT;
-        SCREENRECT = UPPERLEFT: 150 560,
-                     BOTTOMRIGHT: 650 585,
+        SCREENRECT = UPPERLEFT: 150 522,
+                     BOTTOMRIGHT: 650 537,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:LabelVersion";
         STATUS = ENABLED;
@@ -3756,8 +3756,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 140 54,
-                     BOTTOMRIGHT: 660 55,
+        SCREENRECT = UPPERLEFT: 140 53,
+                     BOTTOMRIGHT: 660 54,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line";
         STATUS = ENABLED;
@@ -3804,8 +3804,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = STATICTEXT;
-        SCREENRECT = UPPERLEFT: 150 21,
-                     BOTTOMRIGHT: 650 54,
+        SCREENRECT = UPPERLEFT: 150 20,
+                     BOTTOMRIGHT: 650 53,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:";
         STATUS = ENABLED;
@@ -3853,8 +3853,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 402 94,
-                     BOTTOMRIGHT: 650 95,
+        SCREENRECT = UPPERLEFT: 403 89,
+                     BOTTOMRIGHT: 650 90,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line2";
         STATUS = ENABLED;
@@ -3900,8 +3900,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 298,
-                     BOTTOMRIGHT: 650 299,
+        SCREENRECT = UPPERLEFT: 150 250,
+                     BOTTOMRIGHT: 397 251,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line3";
         STATUS = ENABLED;
@@ -3947,8 +3947,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 428,
-                     BOTTOMRIGHT: 650 429,
+        SCREENRECT = UPPERLEFT: 403 306,
+                     BOTTOMRIGHT: 650 307,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line4";
         STATUS = ENABLED;
@@ -3994,8 +3994,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 150 94,
-                     BOTTOMRIGHT: 397 95,
+        SCREENRECT = UPPERLEFT: 150 89,
+                     BOTTOMRIGHT: 397 90,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line1";
         STATUS = ENABLED;

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -288,6 +288,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
         RADIOBUTTONDATA = GROUP: 2;
       END
+      ; Dialog buttons
       CHILD
       WINDOW
         WINDOWTYPE = PUSHBUTTON;
@@ -435,6 +436,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
       END
+      ; Network Parent
       CHILD
       WINDOW
         WINDOWTYPE = USER;
@@ -1467,6 +1469,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
         STATICTEXTDATA = CENTERED: 1;
       END
+      ; Video Parent
       CHILD
       WINDOW
         WINDOWTYPE = USER;
@@ -2560,6 +2563,7 @@ WINDOW
         END
         ENDALLCHILDREN
       END
+      ; Control Options Parent
       CHILD
       WINDOW
         WINDOWTYPE = USER;
@@ -2979,6 +2983,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
       END
+      ; Audio Parent
       CHILD
       WINDOW
         WINDOWTYPE = USER;
@@ -3601,6 +3606,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
       END
+      ; Version
       CHILD
       WINDOW
         WINDOWTYPE = STATICTEXT;
@@ -3746,6 +3752,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
       END
+      ; Lines
       CHILD
       WINDOW
         WINDOWTYPE = USER;
@@ -3793,6 +3800,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
       END
+      ; Option Title
       CHILD
       WINDOW
         WINDOWTYPE = STATICTEXT;
@@ -4031,6 +4039,7 @@ WINDOW
                          IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
       END
       CHILD
+      ; Win Advanced Display Options
       WINDOW
         WINDOWTYPE = USER;
         SCREENRECT = UPPERLEFT: 150 69,

--- a/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
+++ b/Patch104pZH/GameFilesEdited/Window/Menus/OptionsMenu.wnd
@@ -1470,8 +1470,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 151 69,
-                     BOTTOMRIGHT: 387 271,
+        SCREENRECT = UPPERLEFT: 150 69,
+                     BOTTOMRIGHT: 397 267,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:VideoParent";
         STATUS = ENABLED;
@@ -1516,8 +1516,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = HORZSLIDER;
-          SCREENRECT = UPPERLEFT: 164 244,
-                       BOTTOMRIGHT: 372 268,
+          SCREENRECT = UPPERLEFT: 163 239,
+                       BOTTOMRIGHT: 385 264,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:SliderGamma";
           STATUS = ENABLED+IMAGE+TABSTOP;
@@ -1593,8 +1593,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 156 220,
-                       BOTTOMRIGHT: 352 245,
+          SCREENRECT = UPPERLEFT: 160 211,
+                       BOTTOMRIGHT: 387 236,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:GammaLabel";
           STATUS = ENABLED;
@@ -1932,8 +1932,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 159 182,
-                       BOTTOMRIGHT: 303 206,
+          SCREENRECT = UPPERLEFT: 163 183,
+                       BOTTOMRIGHT: 303 208,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxDetail";
           STATUS = ENABLED+IMAGE;
@@ -2173,8 +2173,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 156 160,
-                       BOTTOMRIGHT: 300 184,
+          SCREENRECT = UPPERLEFT: 160 155,
+                       BOTTOMRIGHT: 397 180,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:DetailLabel";
           STATUS = ENABLED;
@@ -2222,8 +2222,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = COMBOBOX;
-          SCREENRECT = UPPERLEFT: 160 128,
-                       BOTTOMRIGHT: 304 152,
+          SCREENRECT = UPPERLEFT: 163 127,
+                       BOTTOMRIGHT: 303 152,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ComboBoxResolution";
           STATUS = ENABLED+IMAGE;
@@ -2463,8 +2463,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 156 104,
-                       BOTTOMRIGHT: 300 128,
+          SCREENRECT = UPPERLEFT: 160 99,
+                       BOTTOMRIGHT: 397 124,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:ResolutionLabel";
           STATUS = ENABLED;
@@ -2512,8 +2512,8 @@ WINDOW
         CHILD
         WINDOW
           WINDOWTYPE = STATICTEXT;
-          SCREENRECT = UPPERLEFT: 155 69,
-                       BOTTOMRIGHT: 359 97,
+          SCREENRECT = UPPERLEFT: 160 69,
+                       BOTTOMRIGHT: 397 95,
                        CREATIONRESOLUTION: 800 600;
           NAME = "OptionsMenu.wnd:";
           STATUS = ENABLED+WRAP_CENTERED;
@@ -3845,8 +3845,8 @@ WINDOW
       CHILD
       WINDOW
         WINDOWTYPE = USER;
-        SCREENRECT = UPPERLEFT: 391 92,
-                     BOTTOMRIGHT: 635 93,
+        SCREENRECT = UPPERLEFT: 402 94,
+                     BOTTOMRIGHT: 650 95,
                      CREATIONRESOLUTION: 800 600;
         NAME = "OptionsMenu.wnd:Line2";
         STATUS = ENABLED;


### PR DESCRIPTION
# Pull Request: Improvements to `OptionsMenu.wnd`

## Summary
This PR introduces initial improvements to the `OptionsMenu.wnd` file, focusing on symmetry and visual organization of UI elements. The goal is to enhance the layout and readability. Future work may include improving the color scheme for better aesthetics.

---

## Questions and Considerations

### 1. Reorganizing the File Structure
I noticed that some controls are not aligned with their expected hierarchy in the file (e.g., not grouped under their logical containers).  
- Is it acceptable to reorganize the structure for clarity, or is there a preference to maintain the original order for legacy reasons?  

---

### 2. Unused or Hidden Controls
There are controls in the file that do not seem to be visible in the UI or linked to any current functionality. Examples include:  
(Edit: A separate issue has now been opened for this topic #2569 )
```
NAME = "OptionsMenu.wnd:RadioMedium";
TEXT = "GUI:MouseType";
NAME = "OptionsMenu.wnd:ComboBoxAntiAliasing";
NAME = "OptionsMenu.wnd:CheckLanguageFilter";
NAME = "OptionsMenu.wnd:ButtonKeyboardOptions";
NAME = "OptionsMenu.wnd:CheckBoxSaveCamera";
NAME = "OptionsMenu.wnd:CheckBoxUseCamera";
NAME = "OptionsMenu.wnd:CheckBoxDrawAnchor";
NAME = "OptionsMenu.wnd:CheckBoxMoveAnchor";
```

- Are these controls remnants of removed features, or do they serve a purpose that is not immediately apparent?  
- Should they be documented, removed, or commented out to clarify their status?  

---

### 3. Documentation
Would it be acceptable to add comments or documentation within the file for better maintainability? This could help future contributors understand the purpose and functionality of each control.  

---

## Before and After (getting updated)
### Main Options win
#### **Before:**  
![image](https://github.com/user-attachments/assets/daedaac1-6f0b-4704-b7cc-93b30c96da86)


#### **After:**  
![image](https://github.com/user-attachments/assets/329ac066-38de-4ef4-b6b3-296c5e52745c)



