### PR TITLE
Add missing text lines

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2571_Missing_lines_added.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2571_Missing_lines_added.yaml
@@ -1,0 +1,21 @@
+---
+date: 2025-03-26
+
+title: Added various missing lines
+
+
+changes:
+  - fix: Added missing lines for General Fai and Juhziz
+  - fix: Added missing lines for some entries
+subchanges:
+  
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2571
+
+authors:
+  - dmgreen


### PR DESCRIPTION
Edits only to TBD lines and empty lines at the end of generals str. They were recreated from German or Russian which were translated to English, and then they were translated to all missing languages.