### PR TITLE
add `-nologo` to disable gentool splash screen

### DIFF
--- a/Patch104pZH/Scripts/Windows/WindowsRunner.json
+++ b/Patch104pZH/Scripts/Windows/WindowsRunner.json
@@ -10,7 +10,7 @@
         "gameExeArgs": {
             "-win": "",
             "-quickstart": "",
-            "-noshellmap": ""
+            "-nologo": ""
         },
         "relevantGameDataFileTypes": [
             "ani",

--- a/Patch104pZH/Scripts/Windows/WindowsRunner.json
+++ b/Patch104pZH/Scripts/Windows/WindowsRunner.json
@@ -9,7 +9,8 @@
         "gameExeFile": "generals.exe",
         "gameExeArgs": {
             "-win": "",
-            "-quickstart": ""
+            "-quickstart": "",
+            "-noshellmap": ""
         },
         "relevantGameDataFileTypes": [
             "ani",


### PR DESCRIPTION
Add `-nologo` to disable GenTool splash screen on startup for a faster launch experience.