### PR TITLE
Fix: Incorrect name of China Patriotism upgrade

### DIFF
--- a/Patch104pZH/Design/Changes/v1.0/2702_fanaticism_string_fix.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2702_fanaticism_string_fix.yaml
@@ -1,0 +1,21 @@
+---
+date: 2025-03-28
+
+title: Improves texts of Fanaticism upgrade
+
+
+changes:
+  - fix: Changes text of all localization to match US localization
+  
+subchanges:
+  
+labels:
+  - minor
+  - text
+  - v1.0
+
+links:
+  - https://github.com/TheSuperHackers/GeneralsGamePatch/pull/2702
+
+authors:
+  - dmgreen

--- a/Patch104pZH/Design/Changes/v1.0/2702_patriotism_upgrade_name.yaml
+++ b/Patch104pZH/Design/Changes/v1.0/2702_patriotism_upgrade_name.yaml
@@ -1,17 +1,15 @@
 ---
 date: 2025-03-28
 
-title: Improves texts of Fanaticism upgrade
-
+title: Fixes incorrect name of China Patriotism upgrade for all languages
 
 changes:
-  - fix: Changes text of all localization to match US localization
-  
-subchanges:
+  - fix: The China Patriotism upgrade is no longer labeled as Fanaticism.
   
 labels:
   - minor
   - text
+  - china
   - v1.0
 
 links:


### PR DESCRIPTION
This change renames strings of the China upgrade from Fanaticism to Patriotism to match the actual voice lines.

As discussed here https://github.com/TheSuperHackers/GeneralsGamePatch/issues/2632