### PR TITLE
Adding Swedish entries in various json

### DIFF
--- a/Patch104pZH/ModBundleCoreAudioItems.json
+++ b/Patch104pZH/ModBundleCoreAudioItems.json
@@ -171,6 +171,21 @@
                         ]
                     }
                 ]
+            },
+            {
+                "name": "CoreAudioSwedish",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Audio/Sounds/English/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleCoreLanguageItems.json
+++ b/Patch104pZH/ModBundleCoreLanguageItems.json
@@ -396,6 +396,40 @@
                         }
                     }
                 ]
+            },
+            {
+                "name": "CoreLangSwedish",
+                "big": true,
+                "setGameLanguageOnInstall": "English",
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Swedish/*.ini",
+                                "target": "Data/English/*.ini"
+                            }
+                        ]
+                    },
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/generals.str",
+                                "target": "Data/English/generals.csf"
+                            }
+                        ],
+                        "params": {
+                            "language": "Swedish",
+                            "excludeMarkersList": [
+                                [
+                                    "//patch104p-optional-begin",
+                                    "//patch104p-optional-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleCorePacks.json
+++ b/Patch104pZH/ModBundleCorePacks.json
@@ -157,6 +157,20 @@
                     "CoreW3D",
                     "CoreWindow"
                 ]
+            },
+            {
+                "name": "CoreSwedish",
+                "itemNames": [
+                    "CoreAudio",
+                    "CoreAudioSwedish",
+                    "CoreINI",
+                    "CoreLangSwedish",
+                    "CoreMaps",
+                    "CoreMisc",
+                    "CoreTextures",
+                    "CoreW3D",
+                    "CoreWindow"
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleFullPacks.json
+++ b/Patch104pZH/ModBundleFullPacks.json
@@ -231,6 +231,27 @@
                     "CoreWindow",
                     "RecoveredTextures"
                 ]
+            },
+            {
+                "name": "FullSwedish",
+                "itemNames": [
+                    "OptionalAudio",
+                    "OptionalAudioSwedish",
+                    "OptionalINI",
+                    "OptionalLangSwedish",
+                    "OptionalTextures",
+                    "OptionalW3D",
+                    "CoreAudio",
+                    "CoreAudioSwedish",
+                    "CoreINI",
+                    "CoreLangSwedish",
+                    "CoreMaps",
+                    "CoreMisc",
+                    "CoreTextures",
+                    "CoreW3D",
+                    "CoreWindow",
+                    "RecoveredTextures"
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleOptionalAudioItems.json
+++ b/Patch104pZH/ModBundleOptionalAudioItems.json
@@ -291,6 +291,33 @@
                         ]
                     }
                 ]
+            },
+            {
+                "name": "OptionalAudioSwedish",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesOptional",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Audio/Sounds/English/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Sounds/Restoration/CommonVoice/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Sounds/Restoration/EnglishVoice/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Speech/Restoration/EnglishEva/*.wav",
+                                "target": "Data/Audio/Speech/English/*.wav"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleOptionalLanguageItems.json
+++ b/Patch104pZH/ModBundleOptionalLanguageItems.json
@@ -244,6 +244,30 @@
                         }
                     }
                 ]
+            },
+            {
+                "name": "OptionalLangSwedish",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/generals.str",
+                                "target": "Data/Swedish/generals.csf"
+                            }
+                        ],
+                        "params": {
+                            "language": "Swedish",
+                            "excludeMarkersList": [
+                                [
+                                    "//patch104p-core-begin",
+                                    "//patch104p-core-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
Adding various entries for the Swedish language in the .json located in /Patch104pZH/

This will not build with current gametextcompiler.