### PR TITLE
Fix Adding missing Arabic and Ukrainian in various JSON

### DIFF
--- a/Patch104pZH/ModBundleCoreAudioItems.json
+++ b/Patch104pZH/ModBundleCoreAudioItems.json
@@ -18,6 +18,7 @@
             },
             {
                 "name": "CoreAudioArabic",
+                "_comment": "This Arabic localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -144,6 +145,7 @@
             },
             {
                 "name": "CoreAudioRussian",
+                "_comment": "This Russian localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -174,6 +176,23 @@
             },
             {
                 "name": "CoreAudioSwedish",
+                "_comment": "This Swedish localization is community-made",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Audio/Sounds/English/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "CoreAudioUkrainian",
+                "_comment": "This Ukrainian localization is community-made",
                 "big": true,
                 "files": [
                     {

--- a/Patch104pZH/ModBundleCoreAudioItems.json
+++ b/Patch104pZH/ModBundleCoreAudioItems.json
@@ -171,6 +171,21 @@
                         ]
                     }
                 ]
+            },
+            {
+                "name": "CoreAudioSwedish",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Audio/Sounds/English/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleCoreAudioItems.json
+++ b/Patch104pZH/ModBundleCoreAudioItems.json
@@ -18,7 +18,6 @@
             },
             {
                 "name": "CoreAudioArabic",
-                "_comment": "This Arabic localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -145,7 +144,6 @@
             },
             {
                 "name": "CoreAudioRussian",
-                "_comment": "This Russian localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -176,7 +174,6 @@
             },
             {
                 "name": "CoreAudioSwedish",
-                "_comment": "This Swedish localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -192,7 +189,6 @@
             },
             {
                 "name": "CoreAudioUkrainian",
-                "_comment": "This Ukrainian localization is community-made",
                 "big": true,
                 "files": [
                     {

--- a/Patch104pZH/ModBundleCoreLanguageItems.json
+++ b/Patch104pZH/ModBundleCoreLanguageItems.json
@@ -396,6 +396,40 @@
                         }
                     }
                 ]
+            },
+            {
+                "name": "CoreLangSwedish",
+                "big": true,
+                "setGameLanguageOnInstall": "Swedish",
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceList": [
+                            "Data/Swedish/*.ini"
+                        ],
+                        "registryList": [
+                            "Resources/FileHashRegistry/Generals-108-GeneralsZH-104.csv"
+                        ]
+                    },
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/generals.str",
+                                "target": "Data/Swedish/generals.csf"
+                            }
+                        ],
+                        "params": {
+                            "language": "Swedish",
+                            "excludeMarkersList": [
+                                [
+                                    "//patch104p-optional-begin",
+                                    "//patch104p-optional-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleCoreLanguageItems.json
+++ b/Patch104pZH/ModBundleCoreLanguageItems.json
@@ -6,6 +6,7 @@
         "items": [
             {
                 "name": "CoreLangArabic",
+                "_comment": "This Arabic localization is community-made",
                 "big": true,
                 "setGameLanguageOnInstall": "English",
                 "files": [
@@ -331,6 +332,7 @@
             },
             {
                 "name": "CoreLangRussian",
+                "_comment": "This Russian localization is community-made",
                 "big": true,
                 "setGameLanguageOnInstall": "English",
                 "files": [
@@ -399,6 +401,7 @@
             },
             {
                 "name": "CoreLangSwedish",
+                "_comment": "This Swedish localization is community-made",
                 "big": true,
                 "setGameLanguageOnInstall": "Swedish",
                 "files": [
@@ -406,9 +409,6 @@
                         "sourceParent": "GameFilesEdited",
                         "sourceList": [
                             "Data/Swedish/*.ini"
-                        ],
-                        "registryList": [
-                            "Resources/FileHashRegistry/Generals-108-GeneralsZH-104.csv"
                         ]
                     },
                     {
@@ -421,6 +421,38 @@
                         ],
                         "params": {
                             "language": "Swedish",
+                            "excludeMarkersList": [
+                                [
+                                    "//patch104p-optional-begin",
+                                    "//patch104p-optional-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "CoreLangUkrainian",
+                "_comment": "This Ukrainian localization is community-made",
+                "big": true,
+                "setGameLanguageOnInstall": "Ukrainian",
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceList": [
+                            "Data/Ukrainian/*.ini"
+                        ]
+                    },
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/generals.str",
+                                "target": "Data/Ukrainian/generals.csf"
+                            }
+                        ],
+                        "params": {
+                            "language": "Ukrainian",
                             "excludeMarkersList": [
                                 [
                                     "//patch104p-optional-begin",

--- a/Patch104pZH/ModBundleCoreLanguageItems.json
+++ b/Patch104pZH/ModBundleCoreLanguageItems.json
@@ -6,7 +6,6 @@
         "items": [
             {
                 "name": "CoreLangArabic",
-                "_comment": "This Arabic localization is community-made",
                 "big": true,
                 "setGameLanguageOnInstall": "English",
                 "files": [
@@ -332,7 +331,6 @@
             },
             {
                 "name": "CoreLangRussian",
-                "_comment": "This Russian localization is community-made",
                 "big": true,
                 "setGameLanguageOnInstall": "English",
                 "files": [
@@ -401,7 +399,6 @@
             },
             {
                 "name": "CoreLangSwedish",
-                "_comment": "This Swedish localization is community-made",
                 "big": true,
                 "setGameLanguageOnInstall": "English",
                 "files": [
@@ -436,7 +433,6 @@
             },
             {
                 "name": "CoreLangUkrainian",
-                "_comment": "This Ukrainian localization is community-made",
                 "big": true,
                 "setGameLanguageOnInstall": "English",
                 "files": [

--- a/Patch104pZH/ModBundleCoreLanguageItems.json
+++ b/Patch104pZH/ModBundleCoreLanguageItems.json
@@ -403,12 +403,15 @@
                 "name": "CoreLangSwedish",
                 "_comment": "This Swedish localization is community-made",
                 "big": true,
-                "setGameLanguageOnInstall": "Swedish",
+                "setGameLanguageOnInstall": "English",
                 "files": [
                     {
                         "sourceParent": "GameFilesEdited",
-                        "sourceList": [
-                            "Data/Swedish/*.ini"
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Swedish/*.ini",
+                                "target": "Data/English/*.ini"
+                            }
                         ]
                     },
                     {
@@ -416,7 +419,7 @@
                         "sourceTargetList": [
                             {
                                 "source": "Data/generals.str",
-                                "target": "Data/Swedish/generals.csf"
+                                "target": "Data/English/generals.csf"
                             }
                         ],
                         "params": {
@@ -435,12 +438,15 @@
                 "name": "CoreLangUkrainian",
                 "_comment": "This Ukrainian localization is community-made",
                 "big": true,
-                "setGameLanguageOnInstall": "Ukrainian",
+                "setGameLanguageOnInstall": "English",
                 "files": [
                     {
                         "sourceParent": "GameFilesEdited",
-                        "sourceList": [
-                            "Data/Ukrainian/*.ini"
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Ukrainian/*.ini",
+                                "target": "Data/English/*.ini"
+                            }
                         ]
                     },
                     {
@@ -448,7 +454,7 @@
                         "sourceTargetList": [
                             {
                                 "source": "Data/generals.str",
-                                "target": "Data/Ukrainian/generals.csf"
+                                "target": "Data/English/generals.csf"
                             }
                         ],
                         "params": {

--- a/Patch104pZH/ModBundleCorePacks.json
+++ b/Patch104pZH/ModBundleCorePacks.json
@@ -6,6 +6,7 @@
         "packs": [
             {
                 "name": "CoreArabic",
+                "_comment": "This Arabic localization is community-made",
                 "itemNames": [
                     "CoreAudio",
                     "CoreAudioArabic",
@@ -132,6 +133,7 @@
             },
             {
                 "name": "CoreRussian",
+                "_comment": "This Russian localization is community-made",
                 "itemNames": [
                     "CoreAudio",
                     "CoreAudioRussian",
@@ -160,11 +162,27 @@
             },
             {
                 "name": "CoreSwedish",
+                "_comment": "This Swedish localization is community-made",
                 "itemNames": [
                     "CoreAudio",
                     "CoreAudioSwedish",
                     "CoreINI",
                     "CoreLangSwedish",
+                    "CoreMaps",
+                    "CoreMisc",
+                    "CoreTextures",
+                    "CoreW3D",
+                    "CoreWindow"
+                ]
+            },
+            {
+                "name": "CoreUkrainian",
+                "_comment": "This Ukrainian localization is community-made",
+                "itemNames": [
+                    "CoreAudio",
+                    "CoreAudioUkrainian",
+                    "CoreINI",
+                    "CoreLangUkrainian",
                     "CoreMaps",
                     "CoreMisc",
                     "CoreTextures",

--- a/Patch104pZH/ModBundleCorePacks.json
+++ b/Patch104pZH/ModBundleCorePacks.json
@@ -157,6 +157,20 @@
                     "CoreW3D",
                     "CoreWindow"
                 ]
+            },
+            {
+                "name": "CoreSwedish",
+                "itemNames": [
+                    "CoreAudio",
+                    "CoreAudioSwedish",
+                    "CoreINI",
+                    "CoreLangSwedish",
+                    "CoreMaps",
+                    "CoreMisc",
+                    "CoreTextures",
+                    "CoreW3D",
+                    "CoreWindow"
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleCorePacks.json
+++ b/Patch104pZH/ModBundleCorePacks.json
@@ -6,7 +6,6 @@
         "packs": [
             {
                 "name": "CoreArabic",
-                "_comment": "This Arabic localization is community-made",
                 "itemNames": [
                     "CoreAudio",
                     "CoreAudioArabic",
@@ -133,7 +132,6 @@
             },
             {
                 "name": "CoreRussian",
-                "_comment": "This Russian localization is community-made",
                 "itemNames": [
                     "CoreAudio",
                     "CoreAudioRussian",
@@ -162,7 +160,6 @@
             },
             {
                 "name": "CoreSwedish",
-                "_comment": "This Swedish localization is community-made",
                 "itemNames": [
                     "CoreAudio",
                     "CoreAudioSwedish",
@@ -177,7 +174,6 @@
             },
             {
                 "name": "CoreUkrainian",
-                "_comment": "This Ukrainian localization is community-made",
                 "itemNames": [
                     "CoreAudio",
                     "CoreAudioUkrainian",

--- a/Patch104pZH/ModBundleFullPacks.json
+++ b/Patch104pZH/ModBundleFullPacks.json
@@ -4,9 +4,11 @@
         "packs": [
             {
                 "name": "FullArabic",
+                "_comment": "This Arabic localization is community-made",
                 "itemNames": [
                     "OptionalAudio",
                     "OptionalAudioArabic",
+                    "OptionalLangArabic",
                     "OptionalINI",
                     "OptionalTextures",
                     "OptionalW3D",
@@ -192,6 +194,7 @@
             },
             {
                 "name": "FullRussian",
+                "_comment": "This Russian localization is community-made",
                 "itemNames": [
                     "OptionalAudio",
                     "OptionalAudioRussian",
@@ -234,16 +237,40 @@
             },
             {
                 "name": "FullSwedish",
+                "_comment": "This Swedish localization is community-made",
                 "itemNames": [
                     "OptionalAudio",
                     "OptionalAudioSwedish",
                     "OptionalINI",
+                    "OptionalLangSwedish",
                     "OptionalTextures",
                     "OptionalW3D",
                     "CoreAudio",
                     "CoreAudioSwedish",
                     "CoreINI",
                     "CoreLangSwedish",
+                    "CoreMaps",
+                    "CoreMisc",
+                    "CoreTextures",
+                    "CoreW3D",
+                    "CoreWindow",
+                    "RecoveredTextures"
+                ]
+            },
+            {
+                "name": "FullUkrainian",
+                "_comment": "This Ukrainian localization is community-made",
+                "itemNames": [
+                    "OptionalAudio",
+                    "OptionalAudioUkrainian",
+                    "OptionalINI",
+                    "OptionalLangUkrainian",
+                    "OptionalTextures",
+                    "OptionalW3D",
+                    "CoreAudio",
+                    "CoreAudioUkrainian",
+                    "CoreINI",
+                    "CoreLangUkrainian",
                     "CoreMaps",
                     "CoreMisc",
                     "CoreTextures",

--- a/Patch104pZH/ModBundleFullPacks.json
+++ b/Patch104pZH/ModBundleFullPacks.json
@@ -231,6 +231,26 @@
                     "CoreWindow",
                     "RecoveredTextures"
                 ]
+            },
+            {
+                "name": "FullSwedish",
+                "itemNames": [
+                    "OptionalAudio",
+                    "OptionalAudioSwedish",
+                    "OptionalINI",
+                    "OptionalTextures",
+                    "OptionalW3D",
+                    "CoreAudio",
+                    "CoreAudioSwedish",
+                    "CoreINI",
+                    "CoreLangSwedish",
+                    "CoreMaps",
+                    "CoreMisc",
+                    "CoreTextures",
+                    "CoreW3D",
+                    "CoreWindow",
+                    "RecoveredTextures"
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleFullPacks.json
+++ b/Patch104pZH/ModBundleFullPacks.json
@@ -4,7 +4,6 @@
         "packs": [
             {
                 "name": "FullArabic",
-                "_comment": "This Arabic localization is community-made",
                 "itemNames": [
                     "OptionalAudio",
                     "OptionalAudioArabic",
@@ -194,7 +193,6 @@
             },
             {
                 "name": "FullRussian",
-                "_comment": "This Russian localization is community-made",
                 "itemNames": [
                     "OptionalAudio",
                     "OptionalAudioRussian",
@@ -237,7 +235,6 @@
             },
             {
                 "name": "FullSwedish",
-                "_comment": "This Swedish localization is community-made",
                 "itemNames": [
                     "OptionalAudio",
                     "OptionalAudioSwedish",
@@ -259,7 +256,6 @@
             },
             {
                 "name": "FullUkrainian",
-                "_comment": "This Ukrainian localization is community-made",
                 "itemNames": [
                     "OptionalAudio",
                     "OptionalAudioUkrainian",

--- a/Patch104pZH/ModBundleOptionalAudioItems.json
+++ b/Patch104pZH/ModBundleOptionalAudioItems.json
@@ -291,6 +291,33 @@
                         ]
                     }
                 ]
+            },
+            {
+                "name": "OptionalAudioSwedish",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesOptional",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Audio/Sounds/English/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Sounds/Restoration/CommonVoice/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Sounds/Restoration/EnglishVoice/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Speech/Restoration/EnglishEva/*.wav",
+                                "target": "Data/Audio/Speech/English/*.wav"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleOptionalAudioItems.json
+++ b/Patch104pZH/ModBundleOptionalAudioItems.json
@@ -29,6 +29,7 @@
             },
             {
                 "name": "OptionalAudioArabic",
+                "_comment": "This community-made Arabic localization uses English Audio",
                 "big": true,
                 "files": [
                     {
@@ -252,6 +253,7 @@
             },
             {
                 "name": "OptionalAudioRussian",
+                "_comment": "This community-made Russian localization uses Russian Audio",
                 "big": true,
                 "files": [
                     {
@@ -294,6 +296,35 @@
             },
             {
                 "name": "OptionalAudioSwedish",
+                "_comment": "This community-made Swedish localization uses English Audio",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesOptional",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/Audio/Sounds/English/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Sounds/Restoration/CommonVoice/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Sounds/Restoration/EnglishVoice/*.wav",
+                                "target": "Data/Audio/Sounds/English/*.wav"
+                            },
+                            {
+                                "source": "Data/Audio/Speech/Restoration/EnglishEva/*.wav",
+                                "target": "Data/Audio/Speech/English/*.wav"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "OptionalAudioUkrainian",
+                "_comment": "This community-made Ukrainian localization uses English Audio",
                 "big": true,
                 "files": [
                     {

--- a/Patch104pZH/ModBundleOptionalAudioItems.json
+++ b/Patch104pZH/ModBundleOptionalAudioItems.json
@@ -29,7 +29,6 @@
             },
             {
                 "name": "OptionalAudioArabic",
-                "_comment": "This community-made Arabic localization uses English Audio",
                 "big": true,
                 "files": [
                     {
@@ -253,7 +252,6 @@
             },
             {
                 "name": "OptionalAudioRussian",
-                "_comment": "This community-made Russian localization uses Russian Audio",
                 "big": true,
                 "files": [
                     {
@@ -296,7 +294,6 @@
             },
             {
                 "name": "OptionalAudioSwedish",
-                "_comment": "This community-made Swedish localization uses English Audio",
                 "big": true,
                 "files": [
                     {
@@ -324,7 +321,6 @@
             },
             {
                 "name": "OptionalAudioUkrainian",
-                "_comment": "This community-made Ukrainian localization uses English Audio",
                 "big": true,
                 "files": [
                     {

--- a/Patch104pZH/ModBundleOptionalLanguageItems.json
+++ b/Patch104pZH/ModBundleOptionalLanguageItems.json
@@ -244,6 +244,30 @@
                         }
                     }
                 ]
+            },
+            {
+                "name": "OptionalLangSwedish",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/generals.str",
+                                "target": "Data/Swedish/generals.csf"
+                            }
+                        ],
+                        "params": {
+                            "language": "Swedish",
+                            "excludeMarkersList": [
+                                [
+                                    "//patch104p-core-begin",
+                                    "//patch104p-core-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
             }
         ]
     }

--- a/Patch104pZH/ModBundleOptionalLanguageItems.json
+++ b/Patch104pZH/ModBundleOptionalLanguageItems.json
@@ -5,6 +5,31 @@
         "itemsSuffix": "",
         "items": [
             {
+                "name": "OptionalLangArabic",
+                "_comment": "This Arabic localization is community-made",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/generals.str",
+                                "target": "Data/Arabic/generals.csf"
+                            }
+                        ],
+                        "params": {
+                            "language": "Arabic",
+                            "excludeMarkersList": [
+                                [
+                                    "//patch104p-core-begin",
+                                    "//patch104p-core-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
                 "name": "OptionalLangBrazilian",
                 "big": true,
                 "files": [
@@ -199,6 +224,7 @@
             },
             {
                 "name": "OptionalLangRussian",
+                "_comment": "This Russian localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -247,6 +273,7 @@
             },
             {
                 "name": "OptionalLangSwedish",
+                "_comment": "This Swedish localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -259,6 +286,31 @@
                         ],
                         "params": {
                             "language": "Swedish",
+                            "excludeMarkersList": [
+                                [
+                                    "//patch104p-core-begin",
+                                    "//patch104p-core-end"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "OptionalLangUkrainian",
+                "_comment": "This Ukrainian localization is community-made",
+                "big": true,
+                "files": [
+                    {
+                        "sourceParent": "GameFilesEdited",
+                        "sourceTargetList": [
+                            {
+                                "source": "Data/generals.str",
+                                "target": "Data/Ukrainian/generals.csf"
+                            }
+                        ],
+                        "params": {
+                            "language": "Ukrainian",
                             "excludeMarkersList": [
                                 [
                                     "//patch104p-core-begin",

--- a/Patch104pZH/ModBundleOptionalLanguageItems.json
+++ b/Patch104pZH/ModBundleOptionalLanguageItems.json
@@ -6,7 +6,6 @@
         "items": [
             {
                 "name": "OptionalLangArabic",
-                "_comment": "This Arabic localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -224,7 +223,6 @@
             },
             {
                 "name": "OptionalLangRussian",
-                "_comment": "This Russian localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -273,7 +271,6 @@
             },
             {
                 "name": "OptionalLangSwedish",
-                "_comment": "This Swedish localization is community-made",
                 "big": true,
                 "files": [
                     {
@@ -298,7 +295,6 @@
             },
             {
                 "name": "OptionalLangUkrainian",
-                "_comment": "This Ukrainian localization is community-made",
                 "big": true,
                 "files": [
                     {


### PR DESCRIPTION
Here is the requested Ukrainian addition together with a Missing? Arabic entry in Patch104pZH/ModBundleOptionalLanguageItems.json

Ukrainian will not build yet unless added to the gametextcompiler this will be fixed later 

My changes for gametextcompiler 
[~~gametextcompiler code Ukrainian UA~~](https://github.com/Polypheides/Thyme/commit/6b62017a283a034e27009e5586eabe9240a806b1)
[~~gametextcompiler code Ukrainian UK~~](https://github.com/Polypheides/Thyme/commit/61399aa8ed5747b0b1aa6dbe1c92e7b7d6596d15)
[~~gametextcompiler code Swedish SV and Ukrainian UK~~](https://github.com/Polypheides/Thyme/commit/95138dc9717b411b90dca9cb0b378bcbf3aa731c)
[~~gametextcompiler code Swedish SV, Ukrainian UK, Azerbaijani AZ Turkish TR~~](https://github.com/Polypheides/Thyme/commit/c064cf94f820eada0c5823296ef097e56d9504b2)
[gametextcompiler code Now adds almost all the languages in the world](https://github.com/Polypheides/Thyme/commit/0348489578f689730c8f062af6df44390c34b021)

~~I have also added _comments for each community-made language~~

Reason for the Swedish entries seen in the files changed is because Ukrainian entries comes after Swedish alphabetically in the JSON and that the Swedish PR #2715 is not merged yet.

- Closes: https://github.com/TheSuperHackers/GeneralsGamePatch/issues/2668