### PR TITLE
[ZH] Fix: Add missing key mappings for Unit Camera Tracking and Fast Forward Replay to French

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/French/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/French/CommandMap.ini
@@ -952,4 +952,19 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch104p @bugfix Adds missing key mapping.
+CommandMap TOGGLE_CAMERA_TRACKING_DRAWABLE
+  Key = KEY_T
+  Transition = DOWN
+  Modifiers = SHIFT_ALT_CTRL
+  UseableIn = GAME
+End
+
+; Patch104p @bugfix Adds missing key mapping.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 


### PR DESCRIPTION
This change adds the missing key mappings for Unit Camera Tracking and Fast Forward Replay to the French localization.

## TODO

- [ ] Add documentation