### PR TITLE
[ZH] Fix: Add missing key mappings for Select All Aircraft to Brazilian, Chinese, French, German, Italian

### DIFF
--- a/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/bp_commandsets.txt
@@ -5,22 +5,25 @@ CommandSet GenericCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet StopOnlyGenericCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet EmptyCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaDozerCommandSet
@@ -39,9 +42,10 @@ CommandSet AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, V, W, Y, 
+    Available keys: D, F, G, I, J, K, V, Y, 
 End
 
 CommandSet GLAWorkerCommandSet
@@ -60,9 +64,10 @@ CommandSet GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, O, V, W, Y, Z, 
+    Available keys: B, G, J, K, O, V, Y, Z, 
 End
 
 CommandSet GLAWorkerFakeBuildingsCommandSet
@@ -76,9 +81,10 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, R, T, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, O, P, R, T, Y, Z, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -98,9 +104,10 @@ CommandSet ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, O, V, W, Y, Z, 
+    Available keys: D, F, J, O, V, Y, Z, 
 End
 
 CommandSet AmericaTransportCommandSet
@@ -118,9 +125,10 @@ CommandSet AmericaTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaVehicleChinookCommandSet
@@ -138,9 +146,10 @@ CommandSet AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportCommandSet
@@ -158,9 +167,10 @@ CommandSet CivilianTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet RailedTransportCommandSet
@@ -179,9 +189,10 @@ CommandSet RailedTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
@@ -189,7 +200,8 @@ CommandSet CivilianTransportWithNukeCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -202,9 +214,10 @@ CommandSet AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryColonelBurtonCommandSet
@@ -218,9 +231,10 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryCIAAgentCommandSet
@@ -233,9 +247,10 @@ CommandSet AmericaInfantryCIAAgentCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryMissileDefenderCommandSet
@@ -246,9 +261,10 @@ CommandSet AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPathfinderCommandSet
@@ -258,9 +274,10 @@ CommandSet AmericaInfantryPathfinderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPilotCommandSet
@@ -268,9 +285,10 @@ CommandSet AmericaInfantryPilotCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleHumveeCommandSet
@@ -289,9 +307,10 @@ CommandSet AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaFireBaseCommandSet
@@ -304,7 +323,8 @@ CommandSet AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianVehicleLimoCommandSet
@@ -318,9 +338,10 @@ CommandSet CivilianVehicleLimoCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAInfantryRebelCommandSet
@@ -332,9 +353,10 @@ CommandSet GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTunnelDefenderCommandSet
@@ -344,9 +366,10 @@ CommandSet GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTerroristCommandSet
@@ -356,9 +379,10 @@ CommandSet GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryAngryMobCommandSet
@@ -368,9 +392,10 @@ CommandSet GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryHijackerCommandSet
@@ -380,9 +405,10 @@ CommandSet GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryJarmenKellCommandSet
@@ -393,9 +419,10 @@ CommandSet GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantrySaboteurCommandSet
@@ -404,9 +431,10 @@ CommandSet GLAInfantrySaboteurCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleComancheCommandSet
@@ -417,9 +445,10 @@ CommandSet AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleSentryDroneCommandSet
@@ -429,9 +458,10 @@ CommandSet AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleRocketBuggyCommandSet
@@ -441,9 +471,10 @@ CommandSet GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeDefaultCommandSet
@@ -454,9 +485,10 @@ CommandSet GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
@@ -468,9 +500,10 @@ CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLATankScorpionCommandSet
@@ -480,9 +513,10 @@ CommandSet GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleScudLauncherCommandSet
@@ -494,9 +528,10 @@ CommandSet GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleQuadCannon
@@ -506,9 +541,10 @@ CommandSet GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleToxinTruckCommandSet
@@ -519,9 +555,10 @@ CommandSet GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
@@ -535,9 +572,10 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -556,9 +594,10 @@ CommandSet GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleRadarVanCommandSet
@@ -568,9 +607,10 @@ CommandSet GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleTechnicalCommandSet
@@ -586,9 +626,10 @@ CommandSet GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaJetMIGCommandSet
@@ -599,9 +640,10 @@ CommandSet ChinaJetMIGCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryRedguardCommandSet
@@ -612,9 +654,10 @@ CommandSet ChinaInfantryRedguardCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryBlackLotusCommandSet
@@ -625,9 +668,10 @@ CommandSet ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaInfantryHackerCommandSet
@@ -637,9 +681,10 @@ CommandSet ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleECMTankCommandSet
@@ -650,9 +695,10 @@ CommandSet ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryTankHunterCommandSet
@@ -663,9 +709,10 @@ CommandSet ChinaInfantryTankHunterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet ChinaTroopCrawlerCommandSet
@@ -684,9 +731,10 @@ CommandSet ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaListeningOutpostCommandSet
@@ -699,9 +747,10 @@ CommandSet ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaVehicleNukeCannonCommandSet
@@ -713,9 +762,10 @@ CommandSet ChinaVehicleNukeCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleBattleMasterCommandSet
@@ -725,9 +775,10 @@ CommandSet ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleGattlingTankCommandSet
@@ -737,9 +788,10 @@ CommandSet ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleInfernoCannonCommandSet
@@ -749,9 +801,10 @@ CommandSet ChinaVehicleInfernoCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankDragonCommandSet
@@ -762,9 +815,10 @@ CommandSet ChinaTankDragonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankCrusaderCommandSet
@@ -777,9 +831,10 @@ CommandSet AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankPaladinCommandSet
@@ -792,9 +847,10 @@ CommandSet AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankMicrowaveCommandSet
@@ -807,9 +863,10 @@ CommandSet AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankAvengerCommandSet
@@ -822,9 +879,10 @@ CommandSet AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleAmbulanceCommandSet
@@ -843,9 +901,10 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, I, J, K, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaInfantryHazMatCommandSet
@@ -855,9 +914,10 @@ CommandSet AmericaInfantryHazMatCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleTomahawkCommandSet
@@ -870,9 +930,10 @@ CommandSet AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetRaptorCommandSet
@@ -883,9 +944,10 @@ CommandSet AmericaJetRaptorCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetAuroraCommandSet
@@ -895,9 +957,10 @@ CommandSet AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetStealthFighterCommandSet
@@ -907,9 +970,10 @@ CommandSet AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLATankMarauderCommandSet
@@ -919,9 +983,10 @@ CommandSet GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankBattlemasterCommandSet
@@ -931,9 +996,10 @@ CommandSet ChinaTankBattlemasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordDefaultCommandSet
@@ -946,9 +1012,10 @@ CommandSet ChinaTankOverlordDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordBattleBunkerCommandSet
@@ -967,9 +1034,10 @@ CommandSet ChinaTankOverlordBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordGattlingCannonCommandSet
@@ -979,9 +1047,10 @@ CommandSet ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordPropagandaTowerCommandSet
@@ -991,9 +1060,10 @@ CommandSet ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaSupplyTruckCommandSet
@@ -1001,9 +1071,10 @@ CommandSet ChinaSupplyTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleHelixCommandSet
@@ -1024,9 +1095,10 @@ CommandSet ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, M, O, P, R, U, W, Y, Z, 
+    Available keys: D, F, I, J, K, M, O, P, R, U, Y, Z, 
 End
 
 CommandSet ChinaHelixGattlingCannonCommandSet
@@ -1044,9 +1116,10 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixPropagandaTowerCommandSet
@@ -1064,9 +1137,10 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixBattleBunkerCommandSet
@@ -1084,9 +1158,10 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaCommandCenterCommandSet
@@ -1103,19 +1178,22 @@ CommandSet AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, O, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, O, T, U, V, X, Y, Z, 
 End
 
 CommandSet Command_ScriptedTransportDrops
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Command_ScriptedA10ThunderboltStrike
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaAirfieldCommandSet
@@ -1131,7 +1209,8 @@ CommandSet AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, G, J, K, M, N, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, G, J, K, M, N, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaAircraftCarrierCommandSet
@@ -1142,9 +1221,10 @@ CommandSet AmericaAircraftCarrierCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaWarFactoryCommandSet
@@ -1157,12 +1237,13 @@ CommandSet AmericaWarFactoryCommandSet
   7 = Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vingador: &G"
   8 = Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Tanque de Microondas: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma do Drone Sentinela: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, K, O, R, U, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, K, O, R, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaBarracksCommandSet
@@ -1177,7 +1258,8 @@ CommandSet AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet AmericaSupplyCenterCommandSet
@@ -1186,7 +1268,8 @@ CommandSet AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPowerPlantCommandSet
@@ -1194,7 +1277,8 @@ CommandSet AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaStrategyCenterCommandSet
@@ -1212,7 +1296,8 @@ CommandSet AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, G, J, K, L, O, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, G, J, K, L, O, T, V, X, Y, Z, 
 End
 
 CommandSet AmericaDetentionCampCommandSet
@@ -1220,7 +1305,8 @@ CommandSet AmericaDetentionCampCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaParticleUplinkCannonCommandSet
@@ -1228,13 +1314,15 @@ CommandSet AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet BaikonurLaunchTowerCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryCommandSet
@@ -1242,14 +1330,16 @@ CommandSet AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryNoSellCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaCommandCenterCommandSet
@@ -1268,7 +1358,8 @@ CommandSet ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, L, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, L, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet ChinaCommandCenterCommandSetUpgrade
@@ -1287,7 +1378,8 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, L, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, L, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet ChinaBunkerCommandSet
@@ -1302,7 +1394,8 @@ CommandSet ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaBunkerCommandSetUpgrade
@@ -1317,7 +1410,8 @@ CommandSet ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOne
@@ -1335,7 +1429,8 @@ CommandSet ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOneUpgrade
@@ -1353,7 +1448,8 @@ CommandSet ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwo
@@ -1371,7 +1467,8 @@ CommandSet ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwoUpgrade
@@ -1389,7 +1486,8 @@ CommandSet ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThree
@@ -1407,7 +1505,8 @@ CommandSet ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThreeUpgrade
@@ -1425,7 +1524,8 @@ CommandSet ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSet
@@ -1434,7 +1534,8 @@ CommandSet ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSetUpgrade
@@ -1443,7 +1544,8 @@ CommandSet ChinaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSet
@@ -1451,7 +1553,8 @@ CommandSet ChinaSpeakerTowerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSetUpgrade
@@ -1459,7 +1562,8 @@ CommandSet ChinaSpeakerTowerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSet
@@ -1468,7 +1572,8 @@ CommandSet ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSetUpgrade
@@ -1477,7 +1582,8 @@ CommandSet ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSet
@@ -1491,7 +1597,8 @@ CommandSet ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSetUpgrade
@@ -1505,7 +1612,8 @@ CommandSet ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSet
@@ -1525,7 +1633,8 @@ CommandSet ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, L, R, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSetUpgrade
@@ -1545,7 +1654,8 @@ CommandSet ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, L, R, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSet
@@ -1555,7 +1665,8 @@ CommandSet ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSetUpgrade
@@ -1565,7 +1676,8 @@ CommandSet ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSet
@@ -1577,7 +1689,8 @@ CommandSet ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSetUpgrade
@@ -1589,7 +1702,8 @@ CommandSet ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSet
@@ -1599,7 +1713,8 @@ CommandSet ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSetUpgrade
@@ -1609,7 +1724,8 @@ CommandSet ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSet
@@ -1621,7 +1737,8 @@ CommandSet ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSetUpgrade
@@ -1633,7 +1750,8 @@ CommandSet ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet GLACommandCenterCommandSet
@@ -1647,7 +1765,8 @@ CommandSet GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet GLAArmsDealerCommandSet
@@ -1667,7 +1786,8 @@ CommandSet GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, K, N, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, K, N, R, V, X, Y, Z, 
 End
 
 CommandSet GLABarracksCommandSet
@@ -1684,7 +1804,8 @@ CommandSet GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, E, F, I, K, L, M, N, O, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, E, F, I, K, L, M, N, O, U, V, X, Z, 
 End
 
 CommandSet FakeGLACommandCenterCommandSet
@@ -1693,7 +1814,8 @@ CommandSet FakeGLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
@@ -1702,7 +1824,8 @@ CommandSet FakeGLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
@@ -1711,7 +1834,8 @@ CommandSet FakeGLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
@@ -1720,7 +1844,8 @@ CommandSet FakeGLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
@@ -1729,7 +1854,8 @@ CommandSet FakeGLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -1742,7 +1868,8 @@ CommandSet GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, X, Y, Z, 
 End
 
 CommandSet GLAScudStormCommandSet
@@ -1750,7 +1877,8 @@ CommandSet GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLASupplyStashCommandSet
@@ -1759,7 +1887,8 @@ CommandSet GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet GLAPalaceCommandSet
@@ -1778,14 +1907,16 @@ CommandSet GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, F, G, I, J, K, L, N, O, P, R, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, F, G, I, J, K, L, N, O, P, R, U, X, Y, Z, 
 End
 
 CommandSet GLAPrisonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLADemoTrapCommandSet
@@ -1795,7 +1926,8 @@ CommandSet GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -1815,7 +1947,8 @@ CommandSet GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianCarBombCommandSet
@@ -1825,9 +1958,10 @@ CommandSet CivilianCarBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAStingerSiteCommandSet
@@ -1836,19 +1970,22 @@ CommandSet GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank8
@@ -1856,43 +1993,50 @@ CommandSet SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Mãe de Todas as Bombas: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutUSA
@@ -1908,7 +2052,8 @@ CommandSet SpecialPowerShortcutUSA
   10 = Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "Soltar Folhetos"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutChina
@@ -1923,7 +2068,8 @@ CommandSet SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Satélite Espião II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutGLA
@@ -1936,7 +2082,8 @@ CommandSet SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Desorientador de GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutBoss
@@ -1951,7 +2098,8 @@ CommandSet SpecialPowerShortcutBoss
   9 = Command_NeutronMissileFromShortcut : CONTROLBAR:NeutronMissileShortcut "Míssil Nuclear"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLASneakAttackTunnelCommandSet
@@ -1969,7 +2117,8 @@ CommandSet GLASneakAttackTunnelCommandSet
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet BattleShipCommandSet
@@ -1977,25 +2126,29 @@ CommandSet BattleShipCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Parar: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SpecialPowerShortcutGLA
@@ -2008,7 +2161,8 @@ CommandSet GC_Chem_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Desorientador de GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAWorkerCommandSet
@@ -2026,9 +2180,10 @@ CommandSet GC_Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, J, K, O, V, W, Y, Z, 
+    Available keys: B, F, G, J, K, O, V, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABarracksCommandSet
@@ -2043,7 +2198,8 @@ CommandSet GC_Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, E, F, I, K, L, M, N, O, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, E, F, I, K, L, M, N, O, S, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAPalaceCommandSet
@@ -2060,7 +2216,8 @@ CommandSet GC_Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, 
 End
 
 CommandSet GC_Chem_GLACommandCenterCommandSet
@@ -2074,7 +2231,8 @@ CommandSet GC_Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, G, I, J, K, L, M, N, O, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, G, I, J, K, L, M, N, O, R, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAArmsDealerCommandSet
@@ -2089,7 +2247,8 @@ CommandSet GC_Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, I, J, K, M, N, R, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, I, J, K, M, N, R, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLASupplyStashCommandSet
@@ -2098,7 +2257,8 @@ CommandSet GC_Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABlackMarketCommandSet
@@ -2110,7 +2270,8 @@ CommandSet GC_Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAScudStormCommandSet
@@ -2118,25 +2279,29 @@ CommandSet GC_Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SpecialPowerShortcutGLA
@@ -2149,7 +2314,8 @@ CommandSet GC_Slth_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Desorientador de GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAWorkerCommandSet
@@ -2167,9 +2333,10 @@ CommandSet GC_Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, G, J, K, O, V, W, Y, Z, 
+    Available keys: B, F, G, J, K, O, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLACommandCenterCommandSet
@@ -2184,7 +2351,8 @@ CommandSet GC_Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, J, K, L, M, N, O, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, J, K, L, M, N, O, R, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLASupplyStashCommandSet
@@ -2193,7 +2361,8 @@ CommandSet GC_Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABarracksCommandSet
@@ -2209,7 +2378,8 @@ CommandSet GC_Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, K, L, M, N, O, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, K, L, M, N, O, S, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAStingerSiteCommandSet
@@ -2217,7 +2387,8 @@ CommandSet GC_Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLATunnelNetworkCommandSet
@@ -2236,7 +2407,8 @@ CommandSet GC_Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAArmsDealerCommandSet
@@ -2250,7 +2422,8 @@ CommandSet GC_Slth_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, G, I, J, K, L, M, N, O, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, G, I, J, K, L, M, N, O, R, S, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAPalaceCommandSet
@@ -2266,7 +2439,8 @@ CommandSet GC_Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAScudStormCommandSet
@@ -2274,7 +2448,8 @@ CommandSet GC_Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABlackMarketCommandSet
@@ -2287,7 +2462,8 @@ CommandSet GC_Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLADemoTrapCommandSet
@@ -2297,7 +2473,8 @@ CommandSet GC_Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2308,9 +2485,10 @@ CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
@@ -2330,21 +2508,24 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
@@ -2352,7 +2533,8 @@ CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Mãe de Todas as Bombas: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SpecialPowerShortcutUSA
@@ -2369,7 +2551,8 @@ CommandSet AirF_SpecialPowerShortcutUSA
   11 = AirF_Command_CarpetBombFromShortcut : OBJECT:CarpetBomb "Bombardeio de Saturação"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaDozerCommandSet
@@ -2388,9 +2571,10 @@ CommandSet AirF_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, V, W, Y, 
+    Available keys: D, F, G, I, J, K, V, Y, 
 End
 
 CommandSet AirF_AmericaCommandCenterCommandSet
@@ -2407,7 +2591,8 @@ CommandSet AirF_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, O, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, O, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaPowerPlantCommandSet
@@ -2415,7 +2600,8 @@ CommandSet AirF_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaStrategyCenterCommandSet
@@ -2433,7 +2619,8 @@ CommandSet AirF_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, J, K, L, O, P, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, J, K, L, O, P, T, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaBarracksCommandSet
@@ -2447,7 +2634,8 @@ CommandSet AirF_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaFireBaseCommandSet
@@ -2460,7 +2648,8 @@ CommandSet AirF_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaAirfieldCommandSet
@@ -2477,7 +2666,8 @@ CommandSet AirF_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, G, J, K, M, N, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, G, J, K, M, N, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaParticleUplinkCannonCommandSet
@@ -2485,7 +2675,8 @@ CommandSet AirF_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleComancheCommandSet
@@ -2496,9 +2687,10 @@ CommandSet AirF_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleChinookCommandSet
@@ -2518,9 +2710,10 @@ CommandSet AirF_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_AmericaSupplyCenterCommandSet
@@ -2530,7 +2723,8 @@ CommandSet AirF_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaWarFactoryCommandSet
@@ -2541,12 +2735,13 @@ CommandSet AirF_AmericaWarFactoryCommandSet
   7 = AirF_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vingador: &G"
   8 = AirF_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Tanque de Microondas: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma do Drone Sentinela: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, K, L, O, R, U, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, K, L, O, R, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
@@ -2557,27 +2752,31 @@ CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SpecialPowerShortcutGLA
@@ -2590,7 +2789,8 @@ CommandSet Demo_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Desorientador de GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSet
@@ -2609,9 +2809,10 @@ CommandSet Demo_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, O, V, W, Y, Z, 
+    Available keys: B, G, J, K, O, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
@@ -2625,9 +2826,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, R, T, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, O, P, R, T, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -2641,7 +2843,8 @@ CommandSet Demo_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSet
@@ -2650,7 +2853,8 @@ CommandSet Demo_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSet
@@ -2667,7 +2871,8 @@ CommandSet Demo_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSet
@@ -2681,7 +2886,8 @@ CommandSet Demo_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, N, O, R, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, I, K, L, M, N, O, R, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSet
@@ -2694,7 +2900,8 @@ CommandSet Demo_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSet
@@ -2702,7 +2909,8 @@ CommandSet Demo_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSet
@@ -2710,7 +2918,8 @@ CommandSet Demo_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSet
@@ -2729,7 +2938,8 @@ CommandSet Demo_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSet
@@ -2749,7 +2959,8 @@ CommandSet Demo_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, K, N, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, K, N, R, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLADemoTrapCommandSet
@@ -2759,7 +2970,8 @@ CommandSet Demo_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2771,9 +2983,10 @@ CommandSet Demo_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
@@ -2783,9 +2996,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTerroristCommandSet
@@ -2795,9 +3009,10 @@ CommandSet Demo_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSet
@@ -2807,9 +3022,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSet
@@ -2823,9 +3039,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSet
@@ -2835,9 +3052,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannon
@@ -2847,9 +3065,10 @@ CommandSet Demo_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
@@ -2862,9 +3081,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -2874,9 +3094,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSet
@@ -2895,9 +3116,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSet
@@ -2907,9 +3129,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
@@ -2920,9 +3143,10 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
@@ -2934,9 +3158,10 @@ CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSet
@@ -2946,9 +3171,10 @@ CommandSet Demo_GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSet
@@ -2958,9 +3184,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSet
@@ -2971,9 +3198,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSet
@@ -2989,9 +3217,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSet
@@ -3001,9 +3230,10 @@ CommandSet Demo_GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
@@ -3014,9 +3244,10 @@ CommandSet Demo_GLATankMarauderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
@@ -3033,9 +3264,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
@@ -3047,9 +3279,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
@@ -3060,9 +3293,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
@@ -3073,9 +3307,10 @@ CommandSet Demo_GLATankScorpionCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSetUpgrade
@@ -3095,9 +3330,10 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, K, O, V, W, Y, Z, 
+    Available keys: B, G, K, O, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
@@ -3112,9 +3348,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, K, O, P, R, T, W, Y, Z, 
+    Available keys: B, D, F, G, I, K, O, P, R, T, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3129,7 +3366,8 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
@@ -3139,7 +3377,8 @@ CommandSet Demo_GLASupplyStashCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSetUpgrade
@@ -3156,7 +3395,8 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSetUpgrade
@@ -3171,7 +3411,8 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, N, O, R, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, I, K, L, M, N, O, R, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3184,7 +3425,8 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, G, I, K, L, M, N, O, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, G, I, K, L, M, N, O, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
@@ -3193,7 +3435,8 @@ CommandSet Demo_GLAStingerSiteCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
@@ -3202,7 +3445,8 @@ CommandSet Demo_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
@@ -3222,7 +3466,8 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSetUpgrade
@@ -3242,7 +3487,8 @@ CommandSet Demo_GLAArmsDealerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, K, N, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, K, N, R, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
@@ -3255,9 +3501,10 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
@@ -3268,9 +3515,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
@@ -3281,9 +3529,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
@@ -3298,9 +3547,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, K, L, M, O, P, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
@@ -3311,9 +3561,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
@@ -3324,9 +3575,10 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
@@ -3339,9 +3591,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3352,9 +3605,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
@@ -3374,9 +3628,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
@@ -3387,9 +3642,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
@@ -3400,27 +3656,31 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SpecialPowerShortcutGLA
@@ -3433,7 +3693,8 @@ CommandSet Slth_SpecialPowerShortcutGLA
   7 = Slth_Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Desorientador de GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerCommandSet
@@ -3452,9 +3713,10 @@ CommandSet Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, O, V, W, Y, Z, 
+    Available keys: B, G, J, K, O, V, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
@@ -3468,9 +3730,10 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, R, T, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, O, P, R, T, Y, Z, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -3485,7 +3748,8 @@ CommandSet Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, J, K, L, M, N, O, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, J, K, L, M, N, O, S, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLASupplyStashCommandSet
@@ -3495,7 +3759,8 @@ CommandSet Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, S, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAPalaceCommandSet
@@ -3513,7 +3778,8 @@ CommandSet Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, F, G, I, J, K, L, N, O, P, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, F, G, I, J, K, L, N, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLABarracksCommandSet
@@ -3530,7 +3796,8 @@ CommandSet Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, E, F, I, K, L, M, N, O, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, E, F, I, K, L, M, N, O, U, V, X, Z, 
 End
 
 CommandSet Slth_GLABlackMarketCommandSet
@@ -3544,7 +3811,8 @@ CommandSet Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, I, J, K, L, M, N, O, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLAStingerSiteCommandSet
@@ -3552,7 +3820,8 @@ CommandSet Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAScudStormCommandSet
@@ -3561,7 +3830,8 @@ CommandSet Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLATunnelNetworkCommandSet
@@ -3580,7 +3850,8 @@ CommandSet Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLAArmsDealerCommandSet
@@ -3598,7 +3869,8 @@ CommandSet Slth_GLAArmsDealerCommandSet
   15 = Command_ConstructGLAVehicleCombatBikeTerrorist : CONTROLBAR:ConstructGLAVehicleCombatBike "Moto de Combate: &C"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, G, I, J, K, L, M, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, G, I, J, K, L, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLADemoTrapCommandSet
@@ -3608,7 +3880,8 @@ CommandSet Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3619,9 +3892,10 @@ CommandSet Slth_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
@@ -3631,9 +3905,10 @@ CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTerroristCommandSet
@@ -3643,9 +3918,10 @@ CommandSet Slth_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryAngryMobCommandSet
@@ -3655,9 +3931,10 @@ CommandSet Slth_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryJarmenKellCommandSet
@@ -3668,9 +3945,10 @@ CommandSet Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleRadarVanCommandSet
@@ -3680,9 +3958,10 @@ CommandSet Slth_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleQuadCannon
@@ -3692,9 +3971,10 @@ CommandSet Slth_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
@@ -3708,9 +3988,10 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3720,9 +4001,10 @@ CommandSet Slth_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBattleBusCommandSet
@@ -3741,9 +4023,10 @@ CommandSet Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleScudLauncherCommandSet
@@ -3753,27 +4036,31 @@ CommandSet Slth_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SpecialPowerShortcutGLA
@@ -3785,7 +4072,8 @@ CommandSet Chem_SpecialPowerShortcutGLA
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "Ataque Sorrateiro"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerCommandSet
@@ -3804,9 +4092,10 @@ CommandSet Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, O, V, W, Y, Z, 
+    Available keys: B, G, J, K, O, V, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
@@ -3820,9 +4109,10 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, O, P, R, T, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, O, P, R, T, Y, Z, 
 End
 
 CommandSet Chem_GLABarracksCommandSet
@@ -3836,7 +4126,8 @@ CommandSet Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, N, O, R, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, I, K, L, M, N, O, R, S, U, V, X, Z, 
 End
 
 CommandSet Chem_GLATunnelNetworkCommandSet
@@ -3855,7 +4146,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
@@ -3868,9 +4160,10 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet
@@ -3880,9 +4173,10 @@ CommandSet Chem_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAPalaceCommandSet
@@ -3899,7 +4193,8 @@ CommandSet Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, 
 End
 
 CommandSet Chem_GLACommandCenterCommandSet
@@ -3912,7 +4207,8 @@ CommandSet Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, G, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, G, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAArmsDealerCommandSet
@@ -3932,7 +4228,8 @@ CommandSet Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, K, N, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, K, N, R, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLASupplyStashCommandSet
@@ -3941,7 +4238,8 @@ CommandSet Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLABlackMarketCommandSet
@@ -3954,7 +4252,8 @@ CommandSet Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, R, T, U, X, Y, Z, 
 End
 
 CommandSet Chem_GLAScudStormCommandSet
@@ -3962,7 +4261,8 @@ CommandSet Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAStingerSiteCommandSet
@@ -3970,7 +4270,8 @@ CommandSet Chem_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAInfantryRebelCommandSet
@@ -3981,27 +4282,31 @@ CommandSet Chem_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SpecialPowerShortcutChina
@@ -4016,7 +4321,8 @@ CommandSet Nuke_SpecialPowerShortcutChina
   10 = Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "Ataque Enfurecido"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaDozerCommandSet
@@ -4036,9 +4342,10 @@ CommandSet Nuke_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, O, V, W, Y, Z, 
+    Available keys: D, F, J, O, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSet
@@ -4048,7 +4355,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
@@ -4058,7 +4366,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
@@ -4077,7 +4386,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, L, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, L, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
@@ -4096,7 +4406,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, L, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, L, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -4110,7 +4421,8 @@ CommandSet Nuke_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSetUpgrade
@@ -4124,7 +4436,8 @@ CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
@@ -4132,9 +4445,10 @@ CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
@@ -4145,9 +4459,10 @@ CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSet
@@ -4167,7 +4482,8 @@ CommandSet Nuke_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, L, R, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
@@ -4187,7 +4503,8 @@ CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, L, R, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSet
@@ -4198,7 +4515,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
@@ -4209,7 +4527,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
@@ -4220,9 +4539,10 @@ CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryHackerCommandSet
@@ -4232,9 +4552,10 @@ CommandSet Nuke_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSet
@@ -4245,7 +4566,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
@@ -4256,7 +4578,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSet
@@ -4271,7 +4594,8 @@ CommandSet Nuke_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSetUpgrade
@@ -4286,7 +4610,8 @@ CommandSet Nuke_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSet
@@ -4298,7 +4623,8 @@ CommandSet Nuke_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
@@ -4310,7 +4636,8 @@ CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleHelixCommandSet
@@ -4331,9 +4658,10 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, M, O, P, R, U, W, Y, Z, 
+    Available keys: D, F, I, J, K, M, O, P, R, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
@@ -4351,9 +4679,10 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
@@ -4371,9 +4700,10 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
@@ -4391,9 +4721,10 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
@@ -4403,9 +4734,10 @@ CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaListeningOutpostCommandSet
@@ -4418,21 +4750,24 @@ CommandSet Nuke_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
@@ -4440,7 +4775,8 @@ CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Mãe de Todas as Bombas: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SpecialPowerShortcutUSA
@@ -4456,7 +4792,8 @@ CommandSet SupW_SpecialPowerShortcutUSA
   10 = Command_CIAIntelligenceFromShortcut : CONTROLBAR:CIAIntelligenceShortcut "Relatório de Inteligência"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaDozerCommandSet
@@ -4475,9 +4812,10 @@ CommandSet SupW_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, V, W, Y, 
+    Available keys: D, F, G, I, J, K, V, Y, 
 End
 
 CommandSet SupW_AmericaBarracksCommandSet
@@ -4491,7 +4829,8 @@ CommandSet SupW_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCommandCenterCommandSet
@@ -4508,7 +4847,8 @@ CommandSet SupW_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, O, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, O, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaPatriotBatteryCommandSet
@@ -4516,7 +4856,8 @@ CommandSet SupW_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaSupplyCenterCommandSet
@@ -4525,7 +4866,8 @@ CommandSet SupW_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaWarFactoryCommandSet
@@ -4536,12 +4878,13 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   7 = SupW_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vingador: &G"
   8 = SupW_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Tanque de Microondas: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma do Drone Sentinela: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, K, L, O, R, U, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, K, L, O, R, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaStrategyCenterCommandSet
@@ -4558,7 +4901,8 @@ CommandSet SupW_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, G, J, K, L, O, P, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, G, J, K, L, O, P, T, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleComancheCommandSet
@@ -4569,9 +4913,10 @@ CommandSet SupW_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaAirfieldCommandSet
@@ -4587,7 +4932,8 @@ CommandSet SupW_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, G, J, K, M, N, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, G, J, K, M, N, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaNuclearMissileCommandSet
@@ -4595,7 +4941,8 @@ CommandSet SupW_AmericaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCruiseMissileCommandSet
@@ -4603,7 +4950,8 @@ CommandSet SupW_AmericaCruiseMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaTomahawkStormCommandSet
@@ -4611,7 +4959,8 @@ CommandSet SupW_AmericaTomahawkStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaPowerPlantCommandSet
@@ -4619,7 +4968,8 @@ CommandSet SupW_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaParticleUplinkCannonCommandSet
@@ -4627,7 +4977,8 @@ CommandSet SupW_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
@@ -4641,9 +4992,10 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
@@ -4654,9 +5006,10 @@ CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryRangerCommandSet
@@ -4669,9 +5022,10 @@ CommandSet SupW_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankCrusaderCommandSet
@@ -4684,9 +5038,10 @@ CommandSet SupW_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleTomahawkCommandSet
@@ -4699,9 +5054,10 @@ CommandSet SupW_AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleHumveeCommandSet
@@ -4720,9 +5076,10 @@ CommandSet SupW_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankMicrowaveCommandSet
@@ -4735,9 +5092,10 @@ CommandSet SupW_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleAmbulanceCommandSet
@@ -4756,9 +5114,10 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, I, J, K, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankAvengerCommandSet
@@ -4771,9 +5130,10 @@ CommandSet SupW_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaFireBaseCommandSet
@@ -4786,7 +5146,8 @@ CommandSet SupW_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleChinookCommandSet
@@ -4804,9 +5165,10 @@ CommandSet SupW_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaJetAuroraCommandSet
@@ -4816,9 +5178,10 @@ CommandSet SupW_AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankPaladinCommandSet
@@ -4831,27 +5194,31 @@ CommandSet SupW_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SpecialPowerShortcutChina
@@ -4866,7 +5233,8 @@ CommandSet Infa_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Satélite Espião II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaDozerCommandSet
@@ -4886,9 +5254,10 @@ CommandSet Infa_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, O, V, W, Y, Z, 
+    Available keys: D, F, J, O, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaPowerPlantCommandSet
@@ -4897,7 +5266,8 @@ CommandSet Infa_ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSet
@@ -4915,7 +5285,8 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, K, L, N, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, K, L, N, S, T, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSet
@@ -4925,7 +5296,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
@@ -4935,7 +5307,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
@@ -4953,7 +5326,8 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, K, L, N, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, K, L, N, S, T, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
@@ -4967,7 +5341,8 @@ CommandSet Infa_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
@@ -4981,7 +5356,8 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -4989,9 +5365,10 @@ CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
@@ -5002,9 +5379,10 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
@@ -5021,7 +5399,8 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, J, K, L, O, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, F, G, J, K, L, O, R, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
@@ -5038,7 +5417,8 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, J, K, L, O, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, F, G, J, K, L, O, R, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5048,7 +5428,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
@@ -5058,7 +5439,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSet
@@ -5070,7 +5452,8 @@ CommandSet Infa_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSetUpgrade
@@ -5082,7 +5465,8 @@ CommandSet Infa_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSet
@@ -5092,7 +5476,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
@@ -5102,7 +5487,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOne
@@ -5120,7 +5506,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
@@ -5138,7 +5525,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwo
@@ -5156,7 +5544,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
@@ -5174,7 +5563,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThree
@@ -5192,7 +5582,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
@@ -5210,7 +5601,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSet
@@ -5230,7 +5622,8 @@ CommandSet Infa_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSetUpgrade
@@ -5250,7 +5643,8 @@ CommandSet Infa_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaTroopCrawlerCommandSet
@@ -5269,9 +5663,10 @@ CommandSet Infa_ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaListeningOutpostCommandSet
@@ -5290,9 +5685,10 @@ CommandSet Infa_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaVehicleHelixCommandSet
@@ -5313,9 +5709,10 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaHelixBombCommandSet
@@ -5336,9 +5733,10 @@ CommandSet Infa_ChinaHelixBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryBlackLotusCommandSet
@@ -5349,9 +5747,10 @@ CommandSet Infa_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryHackerCommandSet
@@ -5362,21 +5761,24 @@ CommandSet Infa_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
@@ -5384,7 +5786,8 @@ CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Mãe de Todas as Bombas: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SpecialPowerShortcutUSA
@@ -5401,7 +5804,8 @@ CommandSet Lazr_SpecialPowerShortcutUSA
   11 = Lazr_Command_FireLaserCannonFromShortcut : CONTROLBAR:FireLaserCannonShortcut "Canhão de Laser"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaDozerCommandSet
@@ -5420,9 +5824,10 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, V, W, Y, 
+    Available keys: D, F, G, I, J, K, V, Y, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5431,7 +5836,8 @@ CommandSet Lazr_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaCommandCenterCommandSet
@@ -5448,7 +5854,8 @@ CommandSet Lazr_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, O, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, O, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaStrategyCenterCommandSet
@@ -5466,7 +5873,8 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, G, J, K, L, O, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, G, J, K, L, O, T, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
@@ -5477,12 +5885,13 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   7 = Lazr_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vingador: &G"
   8 = Lazr_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Tanque de Microondas: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma do Drone Sentinela: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Míssil TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Ponto de Encontro: &P"
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, K, L, O, R, T, U, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, K, L, O, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet
@@ -5496,7 +5905,8 @@ CommandSet Lazr_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, N, O, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaFireBaseCommandSet
@@ -5509,7 +5919,8 @@ CommandSet Lazr_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaPowerPlantCommandSet
@@ -5517,7 +5928,8 @@ CommandSet Lazr_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaAirfieldCommandSet
@@ -5533,7 +5945,8 @@ CommandSet Lazr_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, G, J, K, M, N, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, G, J, K, M, N, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
@@ -5541,7 +5954,8 @@ CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleComancheCommandSet
@@ -5552,9 +5966,10 @@ CommandSet Lazr_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaJetStealthFighterCommandSet
@@ -5564,9 +5979,10 @@ CommandSet Lazr_AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryRangerCommandSet
@@ -5579,9 +5995,10 @@ CommandSet Lazr_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
@@ -5595,9 +6012,10 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, F, I, J, K, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleChinookCommandSet
@@ -5615,9 +6033,10 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankAvengerCommandSet
@@ -5630,9 +6049,10 @@ CommandSet Lazr_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankCrusaderCommandSet
@@ -5645,9 +6065,10 @@ CommandSet Lazr_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleHumveeCommandSet
@@ -5666,9 +6087,10 @@ CommandSet Lazr_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankMicrowaveCommandSet
@@ -5681,9 +6103,10 @@ CommandSet Lazr_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
@@ -5702,9 +6125,10 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, I, J, K, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankPaladinCommandSet
@@ -5717,9 +6141,10 @@ CommandSet Lazr_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
@@ -5729,9 +6154,10 @@ CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaLaserCannonCommandSet
@@ -5739,25 +6165,29 @@ CommandSet Lazr_AmericaLaserCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SpecialPowerShortcutChina
@@ -5772,7 +6202,8 @@ CommandSet Tank_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Satélite Espião II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaDozerCommandSet
@@ -5792,9 +6223,10 @@ CommandSet Tank_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, O, V, W, Y, Z, 
+    Available keys: D, F, J, O, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSet
@@ -5804,7 +6236,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
@@ -5814,7 +6247,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSet
@@ -5833,7 +6267,8 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, L, N, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, L, N, R, S, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
@@ -5852,7 +6287,8 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, I, J, L, N, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, I, J, L, N, R, S, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSet
@@ -5870,7 +6306,8 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, I, J, K, L, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, I, J, K, L, R, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
@@ -5888,7 +6325,8 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, I, J, K, L, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, I, J, K, L, R, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSet
@@ -5899,7 +6337,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
@@ -5910,7 +6349,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleBattleMasterCommandSet
@@ -5920,9 +6360,10 @@ CommandSet Tank_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
@@ -5932,9 +6373,10 @@ CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
@@ -5944,9 +6386,10 @@ CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryBlackLotusCommandSet
@@ -5957,9 +6400,10 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankEmperorDefaultCommandSet
@@ -5970,9 +6414,10 @@ CommandSet Tank_ChinaTankEmperorDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleGattlingTankCommandSet
@@ -5982,9 +6427,10 @@ CommandSet Tank_ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSet
@@ -5993,7 +6439,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
@@ -6002,7 +6449,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleECMTankCommandSet
@@ -6013,9 +6461,10 @@ CommandSet Tank_ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSet
@@ -6029,7 +6478,8 @@ CommandSet Tank_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSetUpgrade
@@ -6043,7 +6493,8 @@ CommandSet Tank_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryHackerCommandSet
@@ -6053,9 +6504,10 @@ CommandSet Tank_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSet
@@ -6066,7 +6518,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, N, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, N, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
@@ -6077,7 +6530,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, N, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, N, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSet
@@ -6089,7 +6543,8 @@ CommandSet Tank_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSetUpgrade
@@ -6101,25 +6556,29 @@ CommandSet Tank_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, I, J, K, L, N, O, R, S, T, U, V, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSet
@@ -6139,7 +6598,8 @@ CommandSet Boss_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
@@ -6159,7 +6619,8 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSet
@@ -6168,7 +6629,8 @@ CommandSet Boss_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
@@ -6177,7 +6639,8 @@ CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSet
@@ -6186,7 +6649,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
@@ -6195,7 +6659,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaDozerCommandSet
@@ -6216,9 +6681,10 @@ CommandSet Boss_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, J, O, V, W, Y, Z, 
+    Available keys: F, J, O, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSet
@@ -6235,7 +6701,8 @@ CommandSet Boss_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, I, J, K, L, O, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, I, J, K, L, O, R, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
@@ -6252,7 +6719,8 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, I, J, K, L, O, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, I, J, K, L, O, R, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSet
@@ -6268,7 +6736,8 @@ CommandSet Boss_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, E, F, I, J, K, N, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, E, F, I, J, K, N, S, T, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSetUpgrade
@@ -6284,7 +6753,8 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, E, F, I, J, K, N, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, E, F, I, J, K, N, S, T, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSet
@@ -6294,7 +6764,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
@@ -6304,7 +6775,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSet
@@ -6324,7 +6796,8 @@ CommandSet Boss_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, K, L, O, R, S, U, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, K, L, O, R, S, U, X, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSetUpgrade
@@ -6344,7 +6817,8 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, K, L, O, R, S, U, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, K, L, O, R, S, U, X, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSet
@@ -6364,7 +6838,8 @@ CommandSet Boss_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, R, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, R, U, V, X, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
@@ -6384,7 +6859,8 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, R, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, R, U, V, X, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSet
@@ -6397,7 +6873,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
@@ -6410,7 +6887,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSet
@@ -6425,7 +6903,8 @@ CommandSet Boss_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, I, J, K, L, N, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, I, J, K, L, N, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSetUpgrade
@@ -6440,7 +6919,8 @@ CommandSet Boss_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, I, J, K, L, N, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, I, J, K, L, N, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSet
@@ -6453,7 +6933,8 @@ CommandSet Boss_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
@@ -6466,6 +6947,7 @@ CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vender"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 

--- a/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/fr_commandsets.txt
@@ -5,22 +5,25 @@ CommandSet GenericCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet StopOnlyGenericCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet EmptyCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaDozerCommandSet
@@ -39,9 +42,10 @@ CommandSet AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, L, N, W, Y, Z, 
+    Available keys: B, G, J, K, L, N, Y, Z, 
 End
 
 CommandSet GLAWorkerCommandSet
@@ -60,9 +64,10 @@ CommandSet GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, K, O, U, V, W, Y, Z, 
+    Available keys: B, J, K, O, U, V, Y, Z, 
 End
 
 CommandSet GLAWorkerFakeBuildingsCommandSet
@@ -76,9 +81,10 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, G, J, K, L, N, O, P, T, U, Y, Z, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -98,9 +104,10 @@ CommandSet ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, L, O, U, W, Y, Z, 
+    Available keys: B, J, L, O, U, Y, Z, 
 End
 
 CommandSet AmericaTransportCommandSet
@@ -118,9 +125,10 @@ CommandSet AmericaTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaVehicleChinookCommandSet
@@ -138,9 +146,10 @@ CommandSet AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportCommandSet
@@ -158,9 +167,10 @@ CommandSet CivilianTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet RailedTransportCommandSet
@@ -179,9 +189,10 @@ CommandSet RailedTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
@@ -189,7 +200,8 @@ CommandSet CivilianTransportWithNukeCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -202,9 +214,10 @@ CommandSet AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryColonelBurtonCommandSet
@@ -218,9 +231,10 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryCIAAgentCommandSet
@@ -233,9 +247,10 @@ CommandSet AmericaInfantryCIAAgentCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryMissileDefenderCommandSet
@@ -246,9 +261,10 @@ CommandSet AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPathfinderCommandSet
@@ -258,9 +274,10 @@ CommandSet AmericaInfantryPathfinderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPilotCommandSet
@@ -268,9 +285,10 @@ CommandSet AmericaInfantryPilotCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleHumveeCommandSet
@@ -289,9 +307,10 @@ CommandSet AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaFireBaseCommandSet
@@ -304,7 +323,8 @@ CommandSet AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianVehicleLimoCommandSet
@@ -318,9 +338,10 @@ CommandSet CivilianVehicleLimoCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAInfantryRebelCommandSet
@@ -332,9 +353,10 @@ CommandSet GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTunnelDefenderCommandSet
@@ -344,9 +366,10 @@ CommandSet GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTerroristCommandSet
@@ -356,9 +379,10 @@ CommandSet GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAInfantryAngryMobCommandSet
@@ -368,9 +392,10 @@ CommandSet GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryHijackerCommandSet
@@ -380,9 +405,10 @@ CommandSet GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryJarmenKellCommandSet
@@ -393,9 +419,10 @@ CommandSet GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantrySaboteurCommandSet
@@ -404,9 +431,10 @@ CommandSet GLAInfantrySaboteurCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleComancheCommandSet
@@ -417,9 +445,10 @@ CommandSet AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleSentryDroneCommandSet
@@ -429,9 +458,10 @@ CommandSet AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleRocketBuggyCommandSet
@@ -441,9 +471,10 @@ CommandSet GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeDefaultCommandSet
@@ -454,9 +485,10 @@ CommandSet GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
@@ -468,9 +500,10 @@ CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLATankScorpionCommandSet
@@ -480,9 +513,10 @@ CommandSet GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleScudLauncherCommandSet
@@ -494,9 +528,10 @@ CommandSet GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleQuadCannon
@@ -506,9 +541,10 @@ CommandSet GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleToxinTruckCommandSet
@@ -519,9 +555,10 @@ CommandSet GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
@@ -535,9 +572,10 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -556,9 +594,10 @@ CommandSet GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleRadarVanCommandSet
@@ -568,9 +607,10 @@ CommandSet GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleTechnicalCommandSet
@@ -586,9 +626,10 @@ CommandSet GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaJetMIGCommandSet
@@ -599,9 +640,10 @@ CommandSet ChinaJetMIGCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryRedguardCommandSet
@@ -612,9 +654,10 @@ CommandSet ChinaInfantryRedguardCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryBlackLotusCommandSet
@@ -625,9 +668,10 @@ CommandSet ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaInfantryHackerCommandSet
@@ -637,9 +681,10 @@ CommandSet ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleECMTankCommandSet
@@ -650,9 +695,10 @@ CommandSet ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryTankHunterCommandSet
@@ -663,9 +709,10 @@ CommandSet ChinaInfantryTankHunterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet ChinaTroopCrawlerCommandSet
@@ -684,9 +731,10 @@ CommandSet ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaListeningOutpostCommandSet
@@ -699,9 +747,10 @@ CommandSet ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaVehicleNukeCannonCommandSet
@@ -713,9 +762,10 @@ CommandSet ChinaVehicleNukeCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleBattleMasterCommandSet
@@ -725,9 +775,10 @@ CommandSet ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleGattlingTankCommandSet
@@ -737,9 +788,10 @@ CommandSet ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleInfernoCannonCommandSet
@@ -749,9 +801,10 @@ CommandSet ChinaVehicleInfernoCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankDragonCommandSet
@@ -762,9 +815,10 @@ CommandSet ChinaTankDragonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankCrusaderCommandSet
@@ -777,9 +831,10 @@ CommandSet AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankPaladinCommandSet
@@ -792,9 +847,10 @@ CommandSet AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankMicrowaveCommandSet
@@ -807,9 +863,10 @@ CommandSet AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankAvengerCommandSet
@@ -822,9 +879,10 @@ CommandSet AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleAmbulanceCommandSet
@@ -843,9 +901,10 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaInfantryHazMatCommandSet
@@ -855,9 +914,10 @@ CommandSet AmericaInfantryHazMatCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleTomahawkCommandSet
@@ -870,9 +930,10 @@ CommandSet AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetRaptorCommandSet
@@ -883,9 +944,10 @@ CommandSet AmericaJetRaptorCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetAuroraCommandSet
@@ -895,9 +957,10 @@ CommandSet AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetStealthFighterCommandSet
@@ -907,9 +970,10 @@ CommandSet AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLATankMarauderCommandSet
@@ -919,9 +983,10 @@ CommandSet GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankBattlemasterCommandSet
@@ -931,9 +996,10 @@ CommandSet ChinaTankBattlemasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordDefaultCommandSet
@@ -946,9 +1012,10 @@ CommandSet ChinaTankOverlordDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordBattleBunkerCommandSet
@@ -967,9 +1034,10 @@ CommandSet ChinaTankOverlordBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, N, O, P, R, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, N, O, P, R, U, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordGattlingCannonCommandSet
@@ -979,9 +1047,10 @@ CommandSet ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordPropagandaTowerCommandSet
@@ -991,9 +1060,10 @@ CommandSet ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaSupplyTruckCommandSet
@@ -1001,9 +1071,10 @@ CommandSet ChinaSupplyTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleHelixCommandSet
@@ -1024,9 +1095,10 @@ CommandSet ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, O, P, R, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, O, P, R, U, Y, Z, 
 End
 
 CommandSet ChinaHelixGattlingCannonCommandSet
@@ -1044,9 +1116,10 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixPropagandaTowerCommandSet
@@ -1064,9 +1137,10 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixBattleBunkerCommandSet
@@ -1084,9 +1158,10 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaCommandCenterCommandSet
@@ -1103,19 +1178,22 @@ CommandSet AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, N, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, N, T, U, X, Y, Z, 
 End
 
 CommandSet Command_ScriptedTransportDrops
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Command_ScriptedA10ThunderboltStrike
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaAirfieldCommandSet
@@ -1131,7 +1209,8 @@ CommandSet AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet AmericaAircraftCarrierCommandSet
@@ -1142,9 +1221,10 @@ CommandSet AmericaAircraftCarrierCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaWarFactoryCommandSet
@@ -1157,12 +1237,13 @@ CommandSet AmericaWarFactoryCommandSet
   7 = Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vengeur: &G"
   8 = Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Char Micro-ondes: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Mitrailleuse drone sentinelle: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, L, O, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, J, K, L, O, U, X, Y, Z, 
 End
 
 CommandSet AmericaBarracksCommandSet
@@ -1177,7 +1258,8 @@ CommandSet AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaSupplyCenterCommandSet
@@ -1186,7 +1268,8 @@ CommandSet AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPowerPlantCommandSet
@@ -1194,7 +1277,8 @@ CommandSet AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaStrategyCenterCommandSet
@@ -1212,7 +1296,8 @@ CommandSet AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, J, K, L, N, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, J, K, L, N, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaDetentionCampCommandSet
@@ -1220,7 +1305,8 @@ CommandSet AmericaDetentionCampCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaParticleUplinkCannonCommandSet
@@ -1228,13 +1314,15 @@ CommandSet AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet BaikonurLaunchTowerCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryCommandSet
@@ -1242,14 +1330,16 @@ CommandSet AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryNoSellCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaCommandCenterCommandSet
@@ -1268,7 +1358,8 @@ CommandSet ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, O, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, O, P, S, U, X, Y, Z, 
 End
 
 CommandSet ChinaCommandCenterCommandSetUpgrade
@@ -1287,7 +1378,8 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, O, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, O, P, S, U, X, Y, Z, 
 End
 
 CommandSet ChinaBunkerCommandSet
@@ -1302,7 +1394,8 @@ CommandSet ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaBunkerCommandSetUpgrade
@@ -1317,7 +1410,8 @@ CommandSet ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOne
@@ -1335,7 +1429,8 @@ CommandSet ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOneUpgrade
@@ -1353,7 +1448,8 @@ CommandSet ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwo
@@ -1371,7 +1467,8 @@ CommandSet ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwoUpgrade
@@ -1389,7 +1486,8 @@ CommandSet ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThree
@@ -1407,7 +1505,8 @@ CommandSet ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThreeUpgrade
@@ -1425,7 +1524,8 @@ CommandSet ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSet
@@ -1434,7 +1534,8 @@ CommandSet ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSetUpgrade
@@ -1443,7 +1544,8 @@ CommandSet ChinaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSet
@@ -1451,7 +1553,8 @@ CommandSet ChinaSpeakerTowerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSetUpgrade
@@ -1459,7 +1562,8 @@ CommandSet ChinaSpeakerTowerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSet
@@ -1468,7 +1572,8 @@ CommandSet ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSetUpgrade
@@ -1477,7 +1582,8 @@ CommandSet ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSet
@@ -1491,7 +1597,8 @@ CommandSet ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSetUpgrade
@@ -1505,7 +1612,8 @@ CommandSet ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSet
@@ -1525,7 +1633,8 @@ CommandSet ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, I, J, K, L, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSetUpgrade
@@ -1545,7 +1654,8 @@ CommandSet ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, I, J, K, L, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSet
@@ -1555,7 +1665,8 @@ CommandSet ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSetUpgrade
@@ -1565,7 +1676,8 @@ CommandSet ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSet
@@ -1577,7 +1689,8 @@ CommandSet ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSetUpgrade
@@ -1589,7 +1702,8 @@ CommandSet ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSet
@@ -1599,7 +1713,8 @@ CommandSet ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSetUpgrade
@@ -1609,7 +1724,8 @@ CommandSet ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSet
@@ -1621,7 +1737,8 @@ CommandSet ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, T, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSetUpgrade
@@ -1633,7 +1750,8 @@ CommandSet ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, T, V, X, Y, Z, 
 End
 
 CommandSet GLACommandCenterCommandSet
@@ -1647,7 +1765,8 @@ CommandSet GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, L, M, N, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, L, M, N, P, S, U, X, Y, Z, 
 End
 
 CommandSet GLAArmsDealerCommandSet
@@ -1667,7 +1786,8 @@ CommandSet GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, I, K, P, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, I, K, P, T, V, Y, Z, 
 End
 
 CommandSet GLABarracksCommandSet
@@ -1684,7 +1804,8 @@ CommandSet GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, K, N, O, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, K, N, O, V, X, Y, Z, 
 End
 
 CommandSet FakeGLACommandCenterCommandSet
@@ -1693,7 +1814,8 @@ CommandSet FakeGLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
@@ -1702,7 +1824,8 @@ CommandSet FakeGLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
@@ -1711,7 +1834,8 @@ CommandSet FakeGLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
@@ -1720,7 +1844,8 @@ CommandSet FakeGLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
@@ -1729,7 +1854,8 @@ CommandSet FakeGLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -1742,7 +1868,8 @@ CommandSet GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, X, Y, Z, 
 End
 
 CommandSet GLAScudStormCommandSet
@@ -1750,7 +1877,8 @@ CommandSet GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GLASupplyStashCommandSet
@@ -1759,7 +1887,8 @@ CommandSet GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLAPalaceCommandSet
@@ -1778,14 +1907,16 @@ CommandSet GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, F, G, I, J, K, L, N, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, F, G, I, J, K, L, N, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GLAPrisonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLADemoTrapCommandSet
@@ -1795,7 +1926,8 @@ CommandSet GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -1815,7 +1947,8 @@ CommandSet GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianCarBombCommandSet
@@ -1825,9 +1958,10 @@ CommandSet CivilianCarBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAStingerSiteCommandSet
@@ -1836,19 +1970,22 @@ CommandSet GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank8
@@ -1856,43 +1993,50 @@ CommandSet SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Bombe Aéro-incendiaire Massive: &M"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutUSA
@@ -1908,7 +2052,8 @@ CommandSet SpecialPowerShortcutUSA
   10 = Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "Largage de propagande"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutChina
@@ -1923,7 +2068,8 @@ CommandSet SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Piratage satellite II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutGLA
@@ -1936,7 +2082,8 @@ CommandSet SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Brouilleur GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutBoss
@@ -1951,7 +2098,8 @@ CommandSet SpecialPowerShortcutBoss
   9 = Command_NeutronMissileFromShortcut : CONTROLBAR:NeutronMissileShortcut "Missile nucléaire"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLASneakAttackTunnelCommandSet
@@ -1969,7 +2117,8 @@ CommandSet GLASneakAttackTunnelCommandSet
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, X, Y, Z, 
 End
 
 CommandSet BattleShipCommandSet
@@ -1977,25 +2126,29 @@ CommandSet BattleShipCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Stopper: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SpecialPowerShortcutGLA
@@ -2008,7 +2161,8 @@ CommandSet GC_Chem_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Brouilleur GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAWorkerCommandSet
@@ -2026,9 +2180,10 @@ CommandSet GC_Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, J, K, O, U, V, W, Y, Z, 
+    Available keys: B, D, J, K, O, U, V, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABarracksCommandSet
@@ -2043,7 +2198,8 @@ CommandSet GC_Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, K, N, O, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, K, N, O, S, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAPalaceCommandSet
@@ -2060,7 +2216,8 @@ CommandSet GC_Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GC_Chem_GLACommandCenterCommandSet
@@ -2074,7 +2231,8 @@ CommandSet GC_Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, M, N, P, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, M, N, P, U, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAArmsDealerCommandSet
@@ -2089,7 +2247,8 @@ CommandSet GC_Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, E, F, G, I, J, K, M, P, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, E, F, G, I, J, K, M, P, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLASupplyStashCommandSet
@@ -2098,7 +2257,8 @@ CommandSet GC_Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABlackMarketCommandSet
@@ -2110,7 +2270,8 @@ CommandSet GC_Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, M, N, O, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, M, N, O, R, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAScudStormCommandSet
@@ -2118,25 +2279,29 @@ CommandSet GC_Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SpecialPowerShortcutGLA
@@ -2149,7 +2314,8 @@ CommandSet GC_Slth_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Brouilleur GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAWorkerCommandSet
@@ -2167,9 +2333,10 @@ CommandSet GC_Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, J, K, O, U, V, W, Y, Z, 
+    Available keys: B, D, J, K, O, U, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLACommandCenterCommandSet
@@ -2184,7 +2351,8 @@ CommandSet GC_Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, L, M, N, P, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, L, M, N, P, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLASupplyStashCommandSet
@@ -2193,7 +2361,8 @@ CommandSet GC_Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABarracksCommandSet
@@ -2209,7 +2378,8 @@ CommandSet GC_Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, K, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, K, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAStingerSiteCommandSet
@@ -2217,7 +2387,8 @@ CommandSet GC_Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLATunnelNetworkCommandSet
@@ -2236,7 +2407,8 @@ CommandSet GC_Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAArmsDealerCommandSet
@@ -2250,7 +2422,8 @@ CommandSet GC_Slth_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, F, G, I, K, L, M, N, O, P, S, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, F, G, I, K, L, M, N, O, P, S, T, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAPalaceCommandSet
@@ -2266,7 +2439,8 @@ CommandSet GC_Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAScudStormCommandSet
@@ -2274,7 +2448,8 @@ CommandSet GC_Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABlackMarketCommandSet
@@ -2287,7 +2462,8 @@ CommandSet GC_Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLADemoTrapCommandSet
@@ -2297,7 +2473,8 @@ CommandSet GC_Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2308,9 +2485,10 @@ CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
@@ -2330,21 +2508,24 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
@@ -2352,7 +2533,8 @@ CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Bombe Aéro-incendiaire Massive: &M"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SpecialPowerShortcutUSA
@@ -2369,7 +2551,8 @@ CommandSet AirF_SpecialPowerShortcutUSA
   11 = AirF_Command_CarpetBombFromShortcut : OBJECT:CarpetBomb "Tapis de bombes"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaDozerCommandSet
@@ -2388,9 +2571,10 @@ CommandSet AirF_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, L, N, W, Y, Z, 
+    Available keys: B, G, J, K, L, N, Y, Z, 
 End
 
 CommandSet AirF_AmericaCommandCenterCommandSet
@@ -2407,7 +2591,8 @@ CommandSet AirF_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, N, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, N, T, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaPowerPlantCommandSet
@@ -2415,7 +2600,8 @@ CommandSet AirF_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaStrategyCenterCommandSet
@@ -2433,7 +2619,8 @@ CommandSet AirF_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, J, K, L, N, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, J, K, L, N, P, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaBarracksCommandSet
@@ -2447,7 +2634,8 @@ CommandSet AirF_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaFireBaseCommandSet
@@ -2460,7 +2648,8 @@ CommandSet AirF_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaAirfieldCommandSet
@@ -2477,7 +2666,8 @@ CommandSet AirF_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaParticleUplinkCannonCommandSet
@@ -2485,7 +2675,8 @@ CommandSet AirF_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleComancheCommandSet
@@ -2496,9 +2687,10 @@ CommandSet AirF_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleChinookCommandSet
@@ -2518,9 +2710,10 @@ CommandSet AirF_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_AmericaSupplyCenterCommandSet
@@ -2530,7 +2723,8 @@ CommandSet AirF_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaWarFactoryCommandSet
@@ -2541,12 +2735,13 @@ CommandSet AirF_AmericaWarFactoryCommandSet
   7 = AirF_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vengeur: &G"
   8 = AirF_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Char Micro-ondes: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Mitrailleuse drone sentinelle: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, O, P, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
@@ -2557,27 +2752,31 @@ CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SpecialPowerShortcutGLA
@@ -2590,7 +2789,8 @@ CommandSet Demo_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Brouilleur GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSet
@@ -2609,9 +2809,10 @@ CommandSet Demo_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, K, O, U, V, W, Y, Z, 
+    Available keys: B, J, K, O, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
@@ -2625,9 +2826,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, G, J, K, L, N, O, P, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -2641,7 +2843,8 @@ CommandSet Demo_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, L, M, N, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, L, M, N, P, S, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSet
@@ -2650,7 +2853,8 @@ CommandSet Demo_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSet
@@ -2667,7 +2871,8 @@ CommandSet Demo_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSet
@@ -2681,7 +2886,8 @@ CommandSet Demo_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, K, M, N, O, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, K, M, N, O, S, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSet
@@ -2694,7 +2900,8 @@ CommandSet Demo_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSet
@@ -2702,7 +2909,8 @@ CommandSet Demo_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSet
@@ -2710,7 +2918,8 @@ CommandSet Demo_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSet
@@ -2729,7 +2938,8 @@ CommandSet Demo_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSet
@@ -2749,7 +2959,8 @@ CommandSet Demo_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, I, K, P, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, I, K, P, T, V, Y, Z, 
 End
 
 CommandSet Demo_GLADemoTrapCommandSet
@@ -2759,7 +2970,8 @@ CommandSet Demo_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2771,9 +2983,10 @@ CommandSet Demo_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
@@ -2783,9 +2996,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTerroristCommandSet
@@ -2795,9 +3009,10 @@ CommandSet Demo_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSet
@@ -2807,9 +3022,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSet
@@ -2823,9 +3039,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSet
@@ -2835,9 +3052,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannon
@@ -2847,9 +3065,10 @@ CommandSet Demo_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
@@ -2862,9 +3081,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -2874,9 +3094,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSet
@@ -2895,9 +3116,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSet
@@ -2907,9 +3129,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
@@ -2920,9 +3143,10 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
@@ -2934,9 +3158,10 @@ CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSet
@@ -2946,9 +3171,10 @@ CommandSet Demo_GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSet
@@ -2958,9 +3184,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSet
@@ -2971,9 +3198,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSet
@@ -2989,9 +3217,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSet
@@ -3001,9 +3230,10 @@ CommandSet Demo_GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
@@ -3014,9 +3244,10 @@ CommandSet Demo_GLATankMarauderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
@@ -3033,9 +3264,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
@@ -3047,9 +3279,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
@@ -3060,9 +3293,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
@@ -3073,9 +3307,10 @@ CommandSet Demo_GLATankScorpionCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSetUpgrade
@@ -3095,9 +3330,10 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, K, O, U, V, W, Y, Z, 
+    Available keys: B, K, O, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
@@ -3112,9 +3348,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, G, K, L, N, O, P, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3129,7 +3366,8 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, K, L, M, N, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, K, L, M, N, P, S, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
@@ -3139,7 +3377,8 @@ CommandSet Demo_GLASupplyStashCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSetUpgrade
@@ -3156,7 +3395,8 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSetUpgrade
@@ -3171,7 +3411,8 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, K, M, N, O, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, K, M, N, O, S, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3184,7 +3425,8 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, K, L, M, N, O, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, K, L, M, N, O, R, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
@@ -3193,7 +3435,8 @@ CommandSet Demo_GLAStingerSiteCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
@@ -3202,7 +3445,8 @@ CommandSet Demo_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
@@ -3222,7 +3466,8 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSetUpgrade
@@ -3242,7 +3487,8 @@ CommandSet Demo_GLAArmsDealerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, I, K, P, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, I, K, P, T, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
@@ -3255,9 +3501,10 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
@@ -3268,9 +3515,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
@@ -3281,9 +3529,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
@@ -3298,9 +3547,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, O, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, O, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
@@ -3311,9 +3561,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
@@ -3324,9 +3575,10 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
@@ -3339,9 +3591,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3352,9 +3605,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
@@ -3374,9 +3628,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
@@ -3387,9 +3642,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
@@ -3400,27 +3656,31 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SpecialPowerShortcutGLA
@@ -3433,7 +3693,8 @@ CommandSet Slth_SpecialPowerShortcutGLA
   7 = Slth_Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Brouilleur GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerCommandSet
@@ -3452,9 +3713,10 @@ CommandSet Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, K, O, U, V, W, Y, Z, 
+    Available keys: B, J, K, O, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
@@ -3468,9 +3730,10 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, G, J, K, L, N, O, P, T, U, Y, Z, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -3485,7 +3748,8 @@ CommandSet Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, M, N, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, M, N, P, S, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLASupplyStashCommandSet
@@ -3495,7 +3759,8 @@ CommandSet Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAPalaceCommandSet
@@ -3513,7 +3778,8 @@ CommandSet Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLABarracksCommandSet
@@ -3530,7 +3796,8 @@ CommandSet Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, G, K, M, N, O, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, G, K, M, N, O, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLABlackMarketCommandSet
@@ -3544,7 +3811,8 @@ CommandSet Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, G, I, J, K, L, M, N, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, G, I, J, K, L, M, N, R, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAStingerSiteCommandSet
@@ -3552,7 +3820,8 @@ CommandSet Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAScudStormCommandSet
@@ -3561,7 +3830,8 @@ CommandSet Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLATunnelNetworkCommandSet
@@ -3580,7 +3850,8 @@ CommandSet Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLAArmsDealerCommandSet
@@ -3598,7 +3869,8 @@ CommandSet Slth_GLAArmsDealerCommandSet
   15 = Command_ConstructGLAVehicleCombatBikeTerrorist : CONTROLBAR:ConstructGLAVehicleCombatBike "Moto de combat: &X"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, I, K, L, M, N, P, S, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, I, K, L, M, N, P, S, T, V, Y, Z, 
 End
 
 CommandSet Slth_GLADemoTrapCommandSet
@@ -3608,7 +3880,8 @@ CommandSet Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3619,9 +3892,10 @@ CommandSet Slth_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
@@ -3631,9 +3905,10 @@ CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTerroristCommandSet
@@ -3643,9 +3918,10 @@ CommandSet Slth_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryAngryMobCommandSet
@@ -3655,9 +3931,10 @@ CommandSet Slth_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryJarmenKellCommandSet
@@ -3668,9 +3945,10 @@ CommandSet Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleRadarVanCommandSet
@@ -3680,9 +3958,10 @@ CommandSet Slth_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleQuadCannon
@@ -3692,9 +3971,10 @@ CommandSet Slth_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
@@ -3708,9 +3988,10 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3720,9 +4001,10 @@ CommandSet Slth_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBattleBusCommandSet
@@ -3741,9 +4023,10 @@ CommandSet Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleScudLauncherCommandSet
@@ -3753,27 +4036,31 @@ CommandSet Slth_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SpecialPowerShortcutGLA
@@ -3785,7 +4072,8 @@ CommandSet Chem_SpecialPowerShortcutGLA
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "Attaque furtive"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerCommandSet
@@ -3804,9 +4092,10 @@ CommandSet Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, K, O, U, V, W, Y, Z, 
+    Available keys: B, J, K, O, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
@@ -3820,9 +4109,10 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, J, K, L, N, O, P, T, U, W, Y, Z, 
+    Available keys: B, D, G, J, K, L, N, O, P, T, U, Y, Z, 
 End
 
 CommandSet Chem_GLABarracksCommandSet
@@ -3836,7 +4126,8 @@ CommandSet Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, K, M, N, O, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, K, M, N, O, S, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLATunnelNetworkCommandSet
@@ -3855,7 +4146,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
@@ -3868,9 +4160,10 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet
@@ -3880,9 +4173,10 @@ CommandSet Chem_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAPalaceCommandSet
@@ -3899,7 +4193,8 @@ CommandSet Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Chem_GLACommandCenterCommandSet
@@ -3912,7 +4207,8 @@ CommandSet Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, M, N, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, M, N, P, S, U, X, Y, Z, 
 End
 
 CommandSet Chem_GLAArmsDealerCommandSet
@@ -3932,7 +4228,8 @@ CommandSet Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, I, K, P, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, I, K, P, T, V, Y, Z, 
 End
 
 CommandSet Chem_GLASupplyStashCommandSet
@@ -3941,7 +4238,8 @@ CommandSet Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLABlackMarketCommandSet
@@ -3954,7 +4252,8 @@ CommandSet Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, M, N, R, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAScudStormCommandSet
@@ -3962,7 +4261,8 @@ CommandSet Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAStingerSiteCommandSet
@@ -3970,7 +4270,8 @@ CommandSet Chem_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAInfantryRebelCommandSet
@@ -3981,27 +4282,31 @@ CommandSet Chem_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SpecialPowerShortcutChina
@@ -4016,7 +4321,8 @@ CommandSet Nuke_SpecialPowerShortcutChina
   10 = Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "Frénésie"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaDozerCommandSet
@@ -4036,9 +4342,10 @@ CommandSet Nuke_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, L, O, U, W, Y, Z, 
+    Available keys: B, J, L, O, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSet
@@ -4048,7 +4355,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
@@ -4058,7 +4366,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
@@ -4077,7 +4386,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, O, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, O, P, S, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
@@ -4096,7 +4406,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, O, P, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, O, P, S, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -4110,7 +4421,8 @@ CommandSet Nuke_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSetUpgrade
@@ -4124,7 +4436,8 @@ CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
@@ -4132,9 +4445,10 @@ CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
@@ -4145,9 +4459,10 @@ CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSet
@@ -4167,7 +4482,8 @@ CommandSet Nuke_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, I, J, K, L, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
@@ -4187,7 +4503,8 @@ CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, I, J, K, L, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSet
@@ -4198,7 +4515,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
@@ -4209,7 +4527,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
@@ -4220,9 +4539,10 @@ CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryHackerCommandSet
@@ -4232,9 +4552,10 @@ CommandSet Nuke_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSet
@@ -4245,7 +4566,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
@@ -4256,7 +4578,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSet
@@ -4271,7 +4594,8 @@ CommandSet Nuke_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSetUpgrade
@@ -4286,7 +4610,8 @@ CommandSet Nuke_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSet
@@ -4298,7 +4623,8 @@ CommandSet Nuke_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
@@ -4310,7 +4636,8 @@ CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleHelixCommandSet
@@ -4331,9 +4658,10 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, O, P, R, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, O, P, R, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
@@ -4351,9 +4679,10 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
@@ -4371,9 +4700,10 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
@@ -4391,9 +4721,10 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
@@ -4403,9 +4734,10 @@ CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaListeningOutpostCommandSet
@@ -4418,21 +4750,24 @@ CommandSet Nuke_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
@@ -4440,7 +4775,8 @@ CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Bombe Aéro-incendiaire Massive: &M"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SpecialPowerShortcutUSA
@@ -4456,7 +4792,8 @@ CommandSet SupW_SpecialPowerShortcutUSA
   10 = Command_CIAIntelligenceFromShortcut : CONTROLBAR:CIAIntelligenceShortcut "Renseignements"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaDozerCommandSet
@@ -4475,9 +4812,10 @@ CommandSet SupW_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, L, N, W, Y, Z, 
+    Available keys: B, G, J, K, L, N, Y, Z, 
 End
 
 CommandSet SupW_AmericaBarracksCommandSet
@@ -4491,7 +4829,8 @@ CommandSet SupW_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCommandCenterCommandSet
@@ -4508,7 +4847,8 @@ CommandSet SupW_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, N, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, N, T, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaPatriotBatteryCommandSet
@@ -4516,7 +4856,8 @@ CommandSet SupW_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaSupplyCenterCommandSet
@@ -4525,7 +4866,8 @@ CommandSet SupW_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaWarFactoryCommandSet
@@ -4536,12 +4878,13 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   7 = SupW_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vengeur: &G"
   8 = SupW_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Char Micro-ondes: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Mitrailleuse drone sentinelle: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, O, P, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaStrategyCenterCommandSet
@@ -4558,7 +4901,8 @@ CommandSet SupW_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, J, K, L, N, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, J, K, L, N, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleComancheCommandSet
@@ -4569,9 +4913,10 @@ CommandSet SupW_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaAirfieldCommandSet
@@ -4587,7 +4932,8 @@ CommandSet SupW_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaNuclearMissileCommandSet
@@ -4595,7 +4941,8 @@ CommandSet SupW_AmericaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCruiseMissileCommandSet
@@ -4603,7 +4950,8 @@ CommandSet SupW_AmericaCruiseMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaTomahawkStormCommandSet
@@ -4611,7 +4959,8 @@ CommandSet SupW_AmericaTomahawkStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaPowerPlantCommandSet
@@ -4619,7 +4968,8 @@ CommandSet SupW_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaParticleUplinkCannonCommandSet
@@ -4627,7 +4977,8 @@ CommandSet SupW_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
@@ -4641,9 +4992,10 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
@@ -4654,9 +5006,10 @@ CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryRangerCommandSet
@@ -4669,9 +5022,10 @@ CommandSet SupW_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankCrusaderCommandSet
@@ -4684,9 +5038,10 @@ CommandSet SupW_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleTomahawkCommandSet
@@ -4699,9 +5054,10 @@ CommandSet SupW_AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleHumveeCommandSet
@@ -4720,9 +5076,10 @@ CommandSet SupW_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankMicrowaveCommandSet
@@ -4735,9 +5092,10 @@ CommandSet SupW_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleAmbulanceCommandSet
@@ -4756,9 +5114,10 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankAvengerCommandSet
@@ -4771,9 +5130,10 @@ CommandSet SupW_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaFireBaseCommandSet
@@ -4786,7 +5146,8 @@ CommandSet SupW_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleChinookCommandSet
@@ -4804,9 +5165,10 @@ CommandSet SupW_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaJetAuroraCommandSet
@@ -4816,9 +5178,10 @@ CommandSet SupW_AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankPaladinCommandSet
@@ -4831,27 +5194,31 @@ CommandSet SupW_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SpecialPowerShortcutChina
@@ -4866,7 +5233,8 @@ CommandSet Infa_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Piratage satellite II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaDozerCommandSet
@@ -4886,9 +5254,10 @@ CommandSet Infa_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, L, O, U, W, Y, Z, 
+    Available keys: B, J, L, O, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaPowerPlantCommandSet
@@ -4897,7 +5266,8 @@ CommandSet Infa_ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSet
@@ -4915,7 +5285,8 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, L, N, O, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, L, N, O, S, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSet
@@ -4925,7 +5296,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
@@ -4935,7 +5307,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
@@ -4953,7 +5326,8 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, L, N, O, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, L, N, O, S, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
@@ -4967,7 +5341,8 @@ CommandSet Infa_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
@@ -4981,7 +5356,8 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -4989,9 +5365,10 @@ CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
@@ -5002,9 +5379,10 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
@@ -5021,7 +5399,8 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, I, J, K, L, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, F, G, I, J, K, L, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
@@ -5038,7 +5417,8 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, I, J, K, L, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, F, G, I, J, K, L, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5048,7 +5428,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
@@ -5058,7 +5439,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSet
@@ -5070,7 +5452,8 @@ CommandSet Infa_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSetUpgrade
@@ -5082,7 +5465,8 @@ CommandSet Infa_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSet
@@ -5092,7 +5476,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
@@ -5102,7 +5487,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOne
@@ -5120,7 +5506,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
@@ -5138,7 +5525,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwo
@@ -5156,7 +5544,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
@@ -5174,7 +5563,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThree
@@ -5192,7 +5582,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
@@ -5210,7 +5601,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSet
@@ -5230,7 +5622,8 @@ CommandSet Infa_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSetUpgrade
@@ -5250,7 +5643,8 @@ CommandSet Infa_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaTroopCrawlerCommandSet
@@ -5269,9 +5663,10 @@ CommandSet Infa_ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaListeningOutpostCommandSet
@@ -5290,9 +5685,10 @@ CommandSet Infa_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaVehicleHelixCommandSet
@@ -5313,9 +5709,10 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaHelixBombCommandSet
@@ -5336,9 +5733,10 @@ CommandSet Infa_ChinaHelixBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryBlackLotusCommandSet
@@ -5349,9 +5747,10 @@ CommandSet Infa_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryHackerCommandSet
@@ -5362,21 +5761,24 @@ CommandSet Infa_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
@@ -5384,7 +5786,8 @@ CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Bombe Aéro-incendiaire Massive: &M"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SpecialPowerShortcutUSA
@@ -5401,7 +5804,8 @@ CommandSet Lazr_SpecialPowerShortcutUSA
   11 = Lazr_Command_FireLaserCannonFromShortcut : CONTROLBAR:FireLaserCannonShortcut "Canon laser"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaDozerCommandSet
@@ -5420,9 +5824,10 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, G, J, K, L, N, W, Y, Z, 
+    Available keys: B, G, J, K, L, N, Y, Z, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5431,7 +5836,8 @@ CommandSet Lazr_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaCommandCenterCommandSet
@@ -5448,7 +5854,8 @@ CommandSet Lazr_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, N, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, N, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaStrategyCenterCommandSet
@@ -5466,7 +5873,8 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, J, K, L, N, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, J, K, L, N, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
@@ -5477,12 +5885,13 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   7 = Lazr_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Vengeur: &G"
   8 = Lazr_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Char Micro-ondes: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Mitrailleuse drone sentinelle: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Point de ralliement: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, L, O, P, T, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, J, K, L, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet
@@ -5496,7 +5905,8 @@ CommandSet Lazr_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, I, J, K, L, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaFireBaseCommandSet
@@ -5509,7 +5919,8 @@ CommandSet Lazr_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaPowerPlantCommandSet
@@ -5517,7 +5928,8 @@ CommandSet Lazr_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaAirfieldCommandSet
@@ -5533,7 +5945,8 @@ CommandSet Lazr_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
@@ -5541,7 +5954,8 @@ CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleComancheCommandSet
@@ -5552,9 +5966,10 @@ CommandSet Lazr_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaJetStealthFighterCommandSet
@@ -5564,9 +5979,10 @@ CommandSet Lazr_AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryRangerCommandSet
@@ -5579,9 +5995,10 @@ CommandSet Lazr_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, N, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, N, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
@@ -5595,9 +6012,10 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleChinookCommandSet
@@ -5615,9 +6033,10 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankAvengerCommandSet
@@ -5630,9 +6049,10 @@ CommandSet Lazr_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankCrusaderCommandSet
@@ -5645,9 +6065,10 @@ CommandSet Lazr_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleHumveeCommandSet
@@ -5666,9 +6087,10 @@ CommandSet Lazr_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankMicrowaveCommandSet
@@ -5681,9 +6103,10 @@ CommandSet Lazr_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
@@ -5702,9 +6125,10 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankPaladinCommandSet
@@ -5717,9 +6141,10 @@ CommandSet Lazr_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
@@ -5729,9 +6154,10 @@ CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaLaserCannonCommandSet
@@ -5739,25 +6165,29 @@ CommandSet Lazr_AmericaLaserCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SpecialPowerShortcutChina
@@ -5772,7 +6202,8 @@ CommandSet Tank_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Piratage satellite II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaDozerCommandSet
@@ -5792,9 +6223,10 @@ CommandSet Tank_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, J, L, O, U, W, Y, Z, 
+    Available keys: B, J, L, O, U, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSet
@@ -5804,7 +6236,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
@@ -5814,7 +6247,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSet
@@ -5833,7 +6267,8 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, N, O, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, N, O, S, U, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
@@ -5852,7 +6287,8 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, G, J, K, N, O, S, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, G, J, K, N, O, S, U, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSet
@@ -5870,7 +6306,8 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, I, J, K, L, O, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
@@ -5888,7 +6325,8 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, I, J, K, L, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, I, J, K, L, O, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSet
@@ -5899,7 +6337,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
@@ -5910,7 +6349,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleBattleMasterCommandSet
@@ -5920,9 +6360,10 @@ CommandSet Tank_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
@@ -5932,9 +6373,10 @@ CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
@@ -5944,9 +6386,10 @@ CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryBlackLotusCommandSet
@@ -5957,9 +6400,10 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, M, N, O, R, T, U, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankEmperorDefaultCommandSet
@@ -5970,9 +6414,10 @@ CommandSet Tank_ChinaTankEmperorDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleGattlingTankCommandSet
@@ -5982,9 +6427,10 @@ CommandSet Tank_ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSet
@@ -5993,7 +6439,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
@@ -6002,7 +6449,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleECMTankCommandSet
@@ -6013,9 +6461,10 @@ CommandSet Tank_ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSet
@@ -6029,7 +6478,8 @@ CommandSet Tank_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSetUpgrade
@@ -6043,7 +6493,8 @@ CommandSet Tank_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryHackerCommandSet
@@ -6053,9 +6504,10 @@ CommandSet Tank_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSet
@@ -6066,7 +6518,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
@@ -6077,7 +6530,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSet
@@ -6089,7 +6543,8 @@ CommandSet Tank_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSetUpgrade
@@ -6101,25 +6556,29 @@ CommandSet Tank_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSet
@@ -6139,7 +6598,8 @@ CommandSet Boss_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
@@ -6159,7 +6619,8 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSet
@@ -6168,7 +6629,8 @@ CommandSet Boss_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
@@ -6177,7 +6639,8 @@ CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSet
@@ -6186,7 +6649,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
@@ -6195,7 +6659,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaDozerCommandSet
@@ -6216,9 +6681,10 @@ CommandSet Boss_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, J, O, W, Y, Z, 
+    Available keys: B, F, J, O, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSet
@@ -6235,7 +6701,8 @@ CommandSet Boss_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: G, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: G, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
@@ -6252,7 +6719,8 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: G, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: G, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSet
@@ -6268,7 +6736,8 @@ CommandSet Boss_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSetUpgrade
@@ -6284,7 +6753,8 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSet
@@ -6294,7 +6764,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
@@ -6304,7 +6775,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSet
@@ -6324,7 +6796,8 @@ CommandSet Boss_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, K, L, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, K, L, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSetUpgrade
@@ -6344,7 +6817,8 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, K, L, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, K, L, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSet
@@ -6364,7 +6838,8 @@ CommandSet Boss_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, L, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, L, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
@@ -6384,7 +6859,8 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, L, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, L, U, V, Y, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSet
@@ -6397,7 +6873,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
@@ -6410,7 +6887,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSet
@@ -6425,7 +6903,8 @@ CommandSet Boss_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, N, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSetUpgrade
@@ -6440,7 +6919,8 @@ CommandSet Boss_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, N, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSet
@@ -6453,7 +6933,8 @@ CommandSet Boss_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
@@ -6466,6 +6947,7 @@ CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendre"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, R, S, T, V, X, Y, Z, 
 End
 

--- a/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/it_commandsets.txt
@@ -5,22 +5,25 @@ CommandSet GenericCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet StopOnlyGenericCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet EmptyCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaDozerCommandSet
@@ -39,9 +42,10 @@ CommandSet AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, U, V, W, Y, 
+    Available keys: D, G, J, K, N, U, V, Y, 
 End
 
 CommandSet GLAWorkerCommandSet
@@ -60,9 +64,10 @@ CommandSet GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, O, V, W, Y, Z, 
+    Available keys: G, I, J, K, O, V, Y, Z, 
 End
 
 CommandSet GLAWorkerFakeBuildingsCommandSet
@@ -76,9 +81,10 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -98,9 +104,10 @@ CommandSet ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, J, N, V, W, Y, Z, 
+    Available keys: B, F, J, N, V, Y, Z, 
 End
 
 CommandSet AmericaTransportCommandSet
@@ -118,9 +125,10 @@ CommandSet AmericaTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaVehicleChinookCommandSet
@@ -138,9 +146,10 @@ CommandSet AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportCommandSet
@@ -158,9 +167,10 @@ CommandSet CivilianTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet RailedTransportCommandSet
@@ -179,9 +189,10 @@ CommandSet RailedTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
@@ -189,7 +200,8 @@ CommandSet CivilianTransportWithNukeCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -202,9 +214,10 @@ CommandSet AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryColonelBurtonCommandSet
@@ -218,9 +231,10 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryCIAAgentCommandSet
@@ -233,9 +247,10 @@ CommandSet AmericaInfantryCIAAgentCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryMissileDefenderCommandSet
@@ -246,9 +261,10 @@ CommandSet AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPathfinderCommandSet
@@ -258,9 +274,10 @@ CommandSet AmericaInfantryPathfinderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPilotCommandSet
@@ -268,9 +285,10 @@ CommandSet AmericaInfantryPilotCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleHumveeCommandSet
@@ -289,9 +307,10 @@ CommandSet AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaFireBaseCommandSet
@@ -304,7 +323,8 @@ CommandSet AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianVehicleLimoCommandSet
@@ -318,9 +338,10 @@ CommandSet CivilianVehicleLimoCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAInfantryRebelCommandSet
@@ -332,9 +353,10 @@ CommandSet GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTunnelDefenderCommandSet
@@ -344,9 +366,10 @@ CommandSet GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTerroristCommandSet
@@ -356,9 +379,10 @@ CommandSet GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, V, Y, Z, 
 End
 
 CommandSet GLAInfantryAngryMobCommandSet
@@ -368,9 +392,10 @@ CommandSet GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryHijackerCommandSet
@@ -380,9 +405,10 @@ CommandSet GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryJarmenKellCommandSet
@@ -393,9 +419,10 @@ CommandSet GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantrySaboteurCommandSet
@@ -404,9 +431,10 @@ CommandSet GLAInfantrySaboteurCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleComancheCommandSet
@@ -417,9 +445,10 @@ CommandSet AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleSentryDroneCommandSet
@@ -429,9 +458,10 @@ CommandSet AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleRocketBuggyCommandSet
@@ -441,9 +471,10 @@ CommandSet GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeDefaultCommandSet
@@ -454,9 +485,10 @@ CommandSet GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
@@ -468,9 +500,10 @@ CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLATankScorpionCommandSet
@@ -480,9 +513,10 @@ CommandSet GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleScudLauncherCommandSet
@@ -494,9 +528,10 @@ CommandSet GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleQuadCannon
@@ -506,9 +541,10 @@ CommandSet GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleToxinTruckCommandSet
@@ -519,9 +555,10 @@ CommandSet GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
@@ -535,9 +572,10 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -556,9 +594,10 @@ CommandSet GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleRadarVanCommandSet
@@ -568,9 +607,10 @@ CommandSet GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleTechnicalCommandSet
@@ -586,9 +626,10 @@ CommandSet GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaJetMIGCommandSet
@@ -599,9 +640,10 @@ CommandSet ChinaJetMIGCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryRedguardCommandSet
@@ -612,9 +654,10 @@ CommandSet ChinaInfantryRedguardCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryBlackLotusCommandSet
@@ -625,9 +668,10 @@ CommandSet ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaInfantryHackerCommandSet
@@ -637,9 +681,10 @@ CommandSet ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleECMTankCommandSet
@@ -650,9 +695,10 @@ CommandSet ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryTankHunterCommandSet
@@ -663,9 +709,10 @@ CommandSet ChinaInfantryTankHunterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet ChinaTroopCrawlerCommandSet
@@ -684,9 +731,10 @@ CommandSet ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaListeningOutpostCommandSet
@@ -699,9 +747,10 @@ CommandSet ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaVehicleNukeCannonCommandSet
@@ -713,9 +762,10 @@ CommandSet ChinaVehicleNukeCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleBattleMasterCommandSet
@@ -725,9 +775,10 @@ CommandSet ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleGattlingTankCommandSet
@@ -737,9 +788,10 @@ CommandSet ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleInfernoCannonCommandSet
@@ -749,9 +801,10 @@ CommandSet ChinaVehicleInfernoCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankDragonCommandSet
@@ -762,9 +815,10 @@ CommandSet ChinaTankDragonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankCrusaderCommandSet
@@ -777,9 +831,10 @@ CommandSet AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankPaladinCommandSet
@@ -792,9 +847,10 @@ CommandSet AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankMicrowaveCommandSet
@@ -807,9 +863,10 @@ CommandSet AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankAvengerCommandSet
@@ -822,9 +879,10 @@ CommandSet AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleAmbulanceCommandSet
@@ -843,9 +901,10 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, U, Y, Z, 
 End
 
 CommandSet AmericaInfantryHazMatCommandSet
@@ -855,9 +914,10 @@ CommandSet AmericaInfantryHazMatCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleTomahawkCommandSet
@@ -870,9 +930,10 @@ CommandSet AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetRaptorCommandSet
@@ -883,9 +944,10 @@ CommandSet AmericaJetRaptorCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetAuroraCommandSet
@@ -895,9 +957,10 @@ CommandSet AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetStealthFighterCommandSet
@@ -907,9 +970,10 @@ CommandSet AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLATankMarauderCommandSet
@@ -919,9 +983,10 @@ CommandSet GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankBattlemasterCommandSet
@@ -931,9 +996,10 @@ CommandSet ChinaTankBattlemasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordDefaultCommandSet
@@ -946,9 +1012,10 @@ CommandSet ChinaTankOverlordDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordBattleBunkerCommandSet
@@ -967,9 +1034,10 @@ CommandSet ChinaTankOverlordBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordGattlingCannonCommandSet
@@ -979,9 +1047,10 @@ CommandSet ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordPropagandaTowerCommandSet
@@ -991,9 +1060,10 @@ CommandSet ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaSupplyTruckCommandSet
@@ -1001,9 +1071,10 @@ CommandSet ChinaSupplyTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleHelixCommandSet
@@ -1024,9 +1095,10 @@ CommandSet ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixGattlingCannonCommandSet
@@ -1044,9 +1116,10 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixPropagandaTowerCommandSet
@@ -1064,9 +1137,10 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixBattleBunkerCommandSet
@@ -1084,9 +1158,10 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaCommandCenterCommandSet
@@ -1103,19 +1178,22 @@ CommandSet AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, N, O, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, N, O, T, U, V, X, Y, 
 End
 
 CommandSet Command_ScriptedTransportDrops
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Command_ScriptedA10ThunderboltStrike
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaAirfieldCommandSet
@@ -1131,7 +1209,8 @@ CommandSet AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, G, I, J, K, M, P, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, G, I, J, K, M, P, S, V, X, Y, Z, 
 End
 
 CommandSet AmericaAircraftCarrierCommandSet
@@ -1142,9 +1221,10 @@ CommandSet AmericaAircraftCarrierCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaWarFactoryCommandSet
@@ -1157,12 +1237,13 @@ CommandSet AmericaWarFactoryCommandSet
   7 = Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Avenger: &G"
   8 = Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Carro a microonde: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma per drone da ricognizione: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, L, O, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, J, K, L, O, U, X, Y, Z, 
 End
 
 CommandSet AmericaBarracksCommandSet
@@ -1177,7 +1258,8 @@ CommandSet AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaSupplyCenterCommandSet
@@ -1186,7 +1268,8 @@ CommandSet AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPowerPlantCommandSet
@@ -1194,7 +1277,8 @@ CommandSet AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaStrategyCenterCommandSet
@@ -1212,7 +1296,8 @@ CommandSet AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, L, N, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, L, N, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaDetentionCampCommandSet
@@ -1220,7 +1305,8 @@ CommandSet AmericaDetentionCampCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaParticleUplinkCannonCommandSet
@@ -1228,13 +1314,15 @@ CommandSet AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet BaikonurLaunchTowerCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryCommandSet
@@ -1242,14 +1330,16 @@ CommandSet AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryNoSellCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaCommandCenterCommandSet
@@ -1268,7 +1358,8 @@ CommandSet ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, P, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, P, S, V, X, Y, 
 End
 
 CommandSet ChinaCommandCenterCommandSetUpgrade
@@ -1287,7 +1378,8 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, P, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, P, S, V, X, Y, 
 End
 
 CommandSet ChinaBunkerCommandSet
@@ -1302,7 +1394,8 @@ CommandSet ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaBunkerCommandSetUpgrade
@@ -1317,7 +1410,8 @@ CommandSet ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOne
@@ -1335,7 +1429,8 @@ CommandSet ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOneUpgrade
@@ -1353,7 +1448,8 @@ CommandSet ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwo
@@ -1371,7 +1467,8 @@ CommandSet ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwoUpgrade
@@ -1389,7 +1486,8 @@ CommandSet ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThree
@@ -1407,7 +1505,8 @@ CommandSet ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThreeUpgrade
@@ -1425,7 +1524,8 @@ CommandSet ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSet
@@ -1434,7 +1534,8 @@ CommandSet ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSetUpgrade
@@ -1443,7 +1544,8 @@ CommandSet ChinaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSet
@@ -1451,7 +1553,8 @@ CommandSet ChinaSpeakerTowerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSetUpgrade
@@ -1459,7 +1562,8 @@ CommandSet ChinaSpeakerTowerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSet
@@ -1468,7 +1572,8 @@ CommandSet ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSetUpgrade
@@ -1477,7 +1582,8 @@ CommandSet ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSet
@@ -1491,7 +1597,8 @@ CommandSet ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSetUpgrade
@@ -1505,13 +1612,14 @@ CommandSet ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSet
   1 = Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Command_ConstructChinaTankOverlord : CONTROLBAR:ConstructChinaTankOverlord "Overlord: &O"
-  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
+  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &A"
   4 = Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -1525,13 +1633,14 @@ CommandSet ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, P, S, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, J, K, L, P, S, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSetUpgrade
   1 = Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Command_ConstructChinaTankOverlord : CONTROLBAR:ConstructChinaTankOverlord "Overlord: &O"
-  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
+  3 = Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &A"
   4 = Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -1545,7 +1654,8 @@ CommandSet ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, P, S, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, J, K, L, P, S, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSet
@@ -1555,7 +1665,8 @@ CommandSet ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSetUpgrade
@@ -1565,7 +1676,8 @@ CommandSet ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSet
@@ -1577,7 +1689,8 @@ CommandSet ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSetUpgrade
@@ -1589,7 +1702,8 @@ CommandSet ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSet
@@ -1599,7 +1713,8 @@ CommandSet ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSetUpgrade
@@ -1609,7 +1724,8 @@ CommandSet ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSet
@@ -1621,7 +1737,8 @@ CommandSet ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, T, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSetUpgrade
@@ -1633,7 +1750,8 @@ CommandSet ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, T, V, X, Y, Z, 
 End
 
 CommandSet GLACommandCenterCommandSet
@@ -1647,7 +1765,8 @@ CommandSet GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLAArmsDealerCommandSet
@@ -1667,7 +1786,8 @@ CommandSet GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, K, N, P, V, W, X, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, K, N, P, V, X, 
 End
 
 CommandSet GLABarracksCommandSet
@@ -1684,7 +1804,8 @@ CommandSet GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, E, F, I, K, L, M, N, P, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, E, F, I, K, L, M, N, P, U, V, X, Z, 
 End
 
 CommandSet FakeGLACommandCenterCommandSet
@@ -1693,7 +1814,8 @@ CommandSet FakeGLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
@@ -1702,7 +1824,8 @@ CommandSet FakeGLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
@@ -1711,7 +1834,8 @@ CommandSet FakeGLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
@@ -1720,7 +1844,8 @@ CommandSet FakeGLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
@@ -1729,7 +1854,8 @@ CommandSet FakeGLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -1742,7 +1868,8 @@ CommandSet GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, X, Z, 
 End
 
 CommandSet GLAScudStormCommandSet
@@ -1750,7 +1877,8 @@ CommandSet GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GLASupplyStashCommandSet
@@ -1759,7 +1887,8 @@ CommandSet GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLAPalaceCommandSet
@@ -1778,14 +1907,16 @@ CommandSet GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, U, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, U, X, Y, 
 End
 
 CommandSet GLAPrisonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLADemoTrapCommandSet
@@ -1795,7 +1926,8 @@ CommandSet GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -1815,7 +1947,8 @@ CommandSet GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianCarBombCommandSet
@@ -1825,9 +1958,10 @@ CommandSet CivilianCarBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAStingerSiteCommandSet
@@ -1836,19 +1970,22 @@ CommandSet GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank8
@@ -1856,43 +1993,50 @@ CommandSet SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Madre di tutte le bombe: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutUSA
@@ -1908,7 +2052,8 @@ CommandSet SpecialPowerShortcutUSA
   10 = Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "Lancio di volantini"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutChina
@@ -1923,7 +2068,8 @@ CommandSet SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Violazione satellite II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutGLA
@@ -1936,7 +2082,8 @@ CommandSet SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Interferenza GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutBoss
@@ -1951,7 +2098,8 @@ CommandSet SpecialPowerShortcutBoss
   9 = Command_NeutronMissileFromShortcut : CONTROLBAR:NeutronMissileShortcut "Missile nucleare"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLASneakAttackTunnelCommandSet
@@ -1969,7 +2117,8 @@ CommandSet GLASneakAttackTunnelCommandSet
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, X, Y, Z, 
 End
 
 CommandSet BattleShipCommandSet
@@ -1977,25 +2126,29 @@ CommandSet BattleShipCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "Stop: &S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SpecialPowerShortcutGLA
@@ -2008,7 +2161,8 @@ CommandSet GC_Chem_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Interferenza GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAWorkerCommandSet
@@ -2026,9 +2180,10 @@ CommandSet GC_Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, O, V, W, Y, Z, 
+    Available keys: F, G, I, J, K, O, V, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABarracksCommandSet
@@ -2043,7 +2198,8 @@ CommandSet GC_Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, E, F, I, K, L, M, N, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, E, F, I, K, L, M, N, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAPalaceCommandSet
@@ -2060,7 +2216,8 @@ CommandSet GC_Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, U, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLACommandCenterCommandSet
@@ -2074,7 +2231,8 @@ CommandSet GC_Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, G, I, J, K, L, M, N, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, G, I, J, K, L, M, N, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAArmsDealerCommandSet
@@ -2089,7 +2247,8 @@ CommandSet GC_Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, M, N, P, T, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, M, N, P, T, V, X, Y, 
 End
 
 CommandSet GC_Chem_GLASupplyStashCommandSet
@@ -2098,7 +2257,8 @@ CommandSet GC_Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABlackMarketCommandSet
@@ -2110,7 +2270,8 @@ CommandSet GC_Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAScudStormCommandSet
@@ -2118,25 +2279,29 @@ CommandSet GC_Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SpecialPowerShortcutGLA
@@ -2149,7 +2314,8 @@ CommandSet GC_Slth_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Interferenza GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAWorkerCommandSet
@@ -2167,9 +2333,10 @@ CommandSet GC_Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, O, V, W, Y, Z, 
+    Available keys: F, G, I, J, K, O, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLACommandCenterCommandSet
@@ -2184,7 +2351,8 @@ CommandSet GC_Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, J, K, L, M, N, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, J, K, L, M, N, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLASupplyStashCommandSet
@@ -2193,7 +2361,8 @@ CommandSet GC_Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABarracksCommandSet
@@ -2209,7 +2378,8 @@ CommandSet GC_Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, E, F, I, K, L, M, N, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, E, F, I, K, L, M, N, P, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAStingerSiteCommandSet
@@ -2217,7 +2387,8 @@ CommandSet GC_Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLATunnelNetworkCommandSet
@@ -2236,7 +2407,8 @@ CommandSet GC_Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAArmsDealerCommandSet
@@ -2250,7 +2422,8 @@ CommandSet GC_Slth_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, I, J, K, L, M, N, O, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, I, J, K, L, M, N, O, P, S, V, X, Z, 
 End
 
 CommandSet GC_Slth_GLAPalaceCommandSet
@@ -2266,7 +2439,8 @@ CommandSet GC_Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAScudStormCommandSet
@@ -2274,7 +2448,8 @@ CommandSet GC_Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABlackMarketCommandSet
@@ -2287,7 +2462,8 @@ CommandSet GC_Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, X, Z, 
 End
 
 CommandSet GC_Slth_GLADemoTrapCommandSet
@@ -2297,7 +2473,8 @@ CommandSet GC_Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2308,9 +2485,10 @@ CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
@@ -2330,21 +2508,24 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
@@ -2352,7 +2533,8 @@ CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Madre di tutte le bombe: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet AirF_SpecialPowerShortcutUSA
@@ -2369,7 +2551,8 @@ CommandSet AirF_SpecialPowerShortcutUSA
   11 = AirF_Command_CarpetBombFromShortcut : OBJECT:CarpetBomb "Bomb. a tappeto"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaDozerCommandSet
@@ -2388,9 +2571,10 @@ CommandSet AirF_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, U, V, W, Y, 
+    Available keys: D, G, J, K, N, U, V, Y, 
 End
 
 CommandSet AirF_AmericaCommandCenterCommandSet
@@ -2407,7 +2591,8 @@ CommandSet AirF_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, N, O, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, N, O, T, U, V, X, Y, 
 End
 
 CommandSet AirF_AmericaPowerPlantCommandSet
@@ -2415,7 +2600,8 @@ CommandSet AirF_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaStrategyCenterCommandSet
@@ -2433,7 +2619,8 @@ CommandSet AirF_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, L, N, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, L, N, P, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaBarracksCommandSet
@@ -2447,7 +2634,8 @@ CommandSet AirF_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaFireBaseCommandSet
@@ -2460,7 +2648,8 @@ CommandSet AirF_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaAirfieldCommandSet
@@ -2477,7 +2666,8 @@ CommandSet AirF_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, G, I, J, K, M, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, G, I, J, K, M, P, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaParticleUplinkCannonCommandSet
@@ -2485,7 +2675,8 @@ CommandSet AirF_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleComancheCommandSet
@@ -2496,9 +2687,10 @@ CommandSet AirF_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleChinookCommandSet
@@ -2518,9 +2710,10 @@ CommandSet AirF_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_AmericaSupplyCenterCommandSet
@@ -2530,7 +2723,8 @@ CommandSet AirF_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaWarFactoryCommandSet
@@ -2541,12 +2735,13 @@ CommandSet AirF_AmericaWarFactoryCommandSet
   7 = AirF_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Avenger: &G"
   8 = AirF_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Carro a microonde: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma per drone da ricognizione: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, O, P, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
@@ -2557,27 +2752,31 @@ CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SpecialPowerShortcutGLA
@@ -2590,7 +2789,8 @@ CommandSet Demo_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Interferenza GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSet
@@ -2609,9 +2809,10 @@ CommandSet Demo_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, O, V, W, Y, Z, 
+    Available keys: G, I, J, K, O, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
@@ -2625,9 +2826,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -2641,7 +2843,8 @@ CommandSet Demo_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSet
@@ -2650,7 +2853,8 @@ CommandSet Demo_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSet
@@ -2667,7 +2871,8 @@ CommandSet Demo_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, P, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSet
@@ -2681,7 +2886,8 @@ CommandSet Demo_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSet
@@ -2694,7 +2900,8 @@ CommandSet Demo_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, X, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSet
@@ -2702,7 +2909,8 @@ CommandSet Demo_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSet
@@ -2710,7 +2918,8 @@ CommandSet Demo_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSet
@@ -2729,7 +2938,8 @@ CommandSet Demo_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSet
@@ -2749,7 +2959,8 @@ CommandSet Demo_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, K, N, P, V, W, X, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, K, N, P, V, X, 
 End
 
 CommandSet Demo_GLADemoTrapCommandSet
@@ -2759,7 +2970,8 @@ CommandSet Demo_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2771,9 +2983,10 @@ CommandSet Demo_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
@@ -2783,9 +2996,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTerroristCommandSet
@@ -2795,9 +3009,10 @@ CommandSet Demo_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSet
@@ -2807,9 +3022,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSet
@@ -2823,9 +3039,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSet
@@ -2835,9 +3052,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannon
@@ -2847,9 +3065,10 @@ CommandSet Demo_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
@@ -2862,9 +3081,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -2874,9 +3094,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSet
@@ -2895,9 +3116,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSet
@@ -2907,9 +3129,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
@@ -2920,9 +3143,10 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
@@ -2934,9 +3158,10 @@ CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSet
@@ -2946,9 +3171,10 @@ CommandSet Demo_GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSet
@@ -2958,9 +3184,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSet
@@ -2971,9 +3198,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSet
@@ -2989,9 +3217,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSet
@@ -3001,9 +3230,10 @@ CommandSet Demo_GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
@@ -3014,9 +3244,10 @@ CommandSet Demo_GLATankMarauderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
@@ -3033,9 +3264,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
@@ -3047,9 +3279,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
@@ -3060,9 +3293,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
@@ -3073,9 +3307,10 @@ CommandSet Demo_GLATankScorpionCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSetUpgrade
@@ -3095,9 +3330,10 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, J, K, O, V, W, Y, Z, 
+    Available keys: G, J, K, O, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
@@ -3112,9 +3348,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: B, D, G, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3129,7 +3366,8 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
@@ -3139,7 +3377,8 @@ CommandSet Demo_GLASupplyStashCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSetUpgrade
@@ -3156,7 +3395,8 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, N, O, P, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, N, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSetUpgrade
@@ -3171,7 +3411,8 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3184,7 +3425,8 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, J, K, L, M, N, O, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, J, K, L, M, N, O, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
@@ -3193,7 +3435,8 @@ CommandSet Demo_GLAStingerSiteCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
@@ -3202,7 +3445,8 @@ CommandSet Demo_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
@@ -3222,7 +3466,8 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSetUpgrade
@@ -3242,7 +3487,8 @@ CommandSet Demo_GLAArmsDealerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, K, N, P, V, W, X, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, K, N, P, V, X, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
@@ -3255,9 +3501,10 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, J, K, L, M, N, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, J, K, L, M, N, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
@@ -3268,9 +3515,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
@@ -3281,9 +3529,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
@@ -3298,9 +3547,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, J, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, J, K, L, M, O, P, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
@@ -3311,9 +3561,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
@@ -3324,9 +3575,10 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
@@ -3339,9 +3591,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3352,9 +3605,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
@@ -3374,9 +3628,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
@@ -3387,9 +3642,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
@@ -3400,27 +3656,31 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SpecialPowerShortcutGLA
@@ -3433,7 +3693,8 @@ CommandSet Slth_SpecialPowerShortcutGLA
   7 = Slth_Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "Interferenza GPS"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerCommandSet
@@ -3452,9 +3713,10 @@ CommandSet Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, O, V, W, Y, Z, 
+    Available keys: G, I, J, K, O, V, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
@@ -3468,9 +3730,10 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -3485,7 +3748,8 @@ CommandSet Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLASupplyStashCommandSet
@@ -3495,7 +3759,8 @@ CommandSet Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAPalaceCommandSet
@@ -3513,7 +3778,8 @@ CommandSet Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, J, K, L, N, O, P, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, J, K, L, N, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLABarracksCommandSet
@@ -3530,7 +3796,8 @@ CommandSet Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, E, F, K, L, M, N, O, P, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, E, F, K, L, M, N, O, P, U, V, X, Z, 
 End
 
 CommandSet Slth_GLABlackMarketCommandSet
@@ -3544,7 +3811,8 @@ CommandSet Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, J, K, L, M, N, O, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, J, K, L, M, N, O, U, V, X, Z, 
 End
 
 CommandSet Slth_GLAStingerSiteCommandSet
@@ -3552,7 +3820,8 @@ CommandSet Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAScudStormCommandSet
@@ -3561,7 +3830,8 @@ CommandSet Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLATunnelNetworkCommandSet
@@ -3580,7 +3850,8 @@ CommandSet Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLAArmsDealerCommandSet
@@ -3598,7 +3869,8 @@ CommandSet Slth_GLAArmsDealerCommandSet
   15 = Command_ConstructGLAVehicleCombatBikeTerrorist : CONTROLBAR:ConstructGLAVehicleCombatBike "Moto da combattimento: &Y"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, J, K, L, M, N, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, J, K, L, M, N, P, S, V, X, Z, 
 End
 
 CommandSet Slth_GLADemoTrapCommandSet
@@ -3608,7 +3880,8 @@ CommandSet Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3619,9 +3892,10 @@ CommandSet Slth_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
@@ -3631,9 +3905,10 @@ CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTerroristCommandSet
@@ -3643,9 +3918,10 @@ CommandSet Slth_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryAngryMobCommandSet
@@ -3655,9 +3931,10 @@ CommandSet Slth_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryJarmenKellCommandSet
@@ -3668,9 +3945,10 @@ CommandSet Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleRadarVanCommandSet
@@ -3680,9 +3958,10 @@ CommandSet Slth_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleQuadCannon
@@ -3692,9 +3971,10 @@ CommandSet Slth_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
@@ -3708,9 +3988,10 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3720,9 +4001,10 @@ CommandSet Slth_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBattleBusCommandSet
@@ -3741,9 +4023,10 @@ CommandSet Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleScudLauncherCommandSet
@@ -3753,27 +4036,31 @@ CommandSet Slth_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SpecialPowerShortcutGLA
@@ -3785,7 +4072,8 @@ CommandSet Chem_SpecialPowerShortcutGLA
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "Attacco furtivo"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerCommandSet
@@ -3804,9 +4092,10 @@ CommandSet Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, O, V, W, Y, Z, 
+    Available keys: G, I, J, K, O, V, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
@@ -3820,9 +4109,10 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: B, D, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Chem_GLABarracksCommandSet
@@ -3836,7 +4126,8 @@ CommandSet Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Chem_GLATunnelNetworkCommandSet
@@ -3855,7 +4146,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
@@ -3868,9 +4160,10 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet
@@ -3880,9 +4173,10 @@ CommandSet Chem_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAPalaceCommandSet
@@ -3899,7 +4193,8 @@ CommandSet Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, U, X, Y, Z, 
 End
 
 CommandSet Chem_GLACommandCenterCommandSet
@@ -3912,7 +4207,8 @@ CommandSet Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAArmsDealerCommandSet
@@ -3932,7 +4228,8 @@ CommandSet Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, K, N, P, V, W, X, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, K, N, P, V, X, 
 End
 
 CommandSet Chem_GLASupplyStashCommandSet
@@ -3941,7 +4238,8 @@ CommandSet Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLABlackMarketCommandSet
@@ -3954,7 +4252,8 @@ CommandSet Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, U, V, X, Z, 
 End
 
 CommandSet Chem_GLAScudStormCommandSet
@@ -3962,7 +4261,8 @@ CommandSet Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAStingerSiteCommandSet
@@ -3970,7 +4270,8 @@ CommandSet Chem_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAInfantryRebelCommandSet
@@ -3981,27 +4282,31 @@ CommandSet Chem_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SpecialPowerShortcutChina
@@ -4016,7 +4321,8 @@ CommandSet Nuke_SpecialPowerShortcutChina
   10 = Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "Esaltazione"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaDozerCommandSet
@@ -4036,9 +4342,10 @@ CommandSet Nuke_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, J, N, V, W, Y, Z, 
+    Available keys: B, F, J, N, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSet
@@ -4048,7 +4355,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
@@ -4058,7 +4366,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
@@ -4077,7 +4386,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, P, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, P, S, V, X, Y, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
@@ -4096,7 +4406,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, P, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, P, S, V, X, Y, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -4110,7 +4421,8 @@ CommandSet Nuke_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSetUpgrade
@@ -4124,7 +4436,8 @@ CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
@@ -4132,9 +4445,10 @@ CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
@@ -4145,15 +4459,16 @@ CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSet
   1 = Nuke_Command_ConstructChinaTankBattleMaster : CONTROLBAR:Nuke_ConstructChinaTankBattleMaster "Battlemaster nucleare: &B"
   2 = Nuke_Command_ConstructChinaTankOverlord : CONTROLBAR:Nuke_ConstructChinaTankOverlord "Overlord nucleare: &O"
-  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
+  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &A"
   4 = Nuke_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Nuke_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -4167,13 +4482,14 @@ CommandSet Nuke_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, P, S, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, J, K, L, P, S, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   1 = Nuke_Command_ConstructChinaTankBattleMaster : CONTROLBAR:Nuke_ConstructChinaTankBattleMaster "Battlemaster nucleare: &B"
   2 = Nuke_Command_ConstructChinaTankOverlord : CONTROLBAR:Nuke_ConstructChinaTankOverlord "Overlord nucleare: &O"
-  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
+  3 = Nuke_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &A"
   4 = Nuke_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Nuke_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -4187,7 +4503,8 @@ CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, P, S, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, J, K, L, P, S, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSet
@@ -4198,7 +4515,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
@@ -4209,7 +4527,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
@@ -4220,9 +4539,10 @@ CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryHackerCommandSet
@@ -4232,9 +4552,10 @@ CommandSet Nuke_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSet
@@ -4245,7 +4566,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
@@ -4256,7 +4578,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSet
@@ -4271,7 +4594,8 @@ CommandSet Nuke_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSetUpgrade
@@ -4286,7 +4610,8 @@ CommandSet Nuke_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSet
@@ -4298,7 +4623,8 @@ CommandSet Nuke_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
@@ -4310,7 +4636,8 @@ CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleHelixCommandSet
@@ -4331,9 +4658,10 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
@@ -4351,9 +4679,10 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
@@ -4371,9 +4700,10 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
@@ -4391,9 +4721,10 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
@@ -4403,9 +4734,10 @@ CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaListeningOutpostCommandSet
@@ -4418,21 +4750,24 @@ CommandSet Nuke_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
@@ -4440,7 +4775,8 @@ CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Madre di tutte le bombe: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet SupW_SpecialPowerShortcutUSA
@@ -4456,7 +4792,8 @@ CommandSet SupW_SpecialPowerShortcutUSA
   10 = Command_CIAIntelligenceFromShortcut : CONTROLBAR:CIAIntelligenceShortcut "CIA"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaDozerCommandSet
@@ -4475,9 +4812,10 @@ CommandSet SupW_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, U, V, W, Y, 
+    Available keys: D, G, J, K, N, U, V, Y, 
 End
 
 CommandSet SupW_AmericaBarracksCommandSet
@@ -4491,7 +4829,8 @@ CommandSet SupW_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCommandCenterCommandSet
@@ -4508,7 +4847,8 @@ CommandSet SupW_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, N, O, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, N, O, T, U, V, X, Y, 
 End
 
 CommandSet SupW_AmericaPatriotBatteryCommandSet
@@ -4516,7 +4856,8 @@ CommandSet SupW_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaSupplyCenterCommandSet
@@ -4525,7 +4866,8 @@ CommandSet SupW_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaWarFactoryCommandSet
@@ -4536,12 +4878,13 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   7 = SupW_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Avenger: &G"
   8 = SupW_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Carro a microonde: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma per drone da ricognizione: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, O, P, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaStrategyCenterCommandSet
@@ -4558,7 +4901,8 @@ CommandSet SupW_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, L, N, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, L, N, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleComancheCommandSet
@@ -4569,9 +4913,10 @@ CommandSet SupW_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaAirfieldCommandSet
@@ -4587,7 +4932,8 @@ CommandSet SupW_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, G, I, J, K, M, P, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, G, I, J, K, M, P, S, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaNuclearMissileCommandSet
@@ -4595,7 +4941,8 @@ CommandSet SupW_AmericaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCruiseMissileCommandSet
@@ -4603,7 +4950,8 @@ CommandSet SupW_AmericaCruiseMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaTomahawkStormCommandSet
@@ -4611,7 +4959,8 @@ CommandSet SupW_AmericaTomahawkStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaPowerPlantCommandSet
@@ -4619,7 +4968,8 @@ CommandSet SupW_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaParticleUplinkCannonCommandSet
@@ -4627,7 +4977,8 @@ CommandSet SupW_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
@@ -4641,9 +4992,10 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
@@ -4654,9 +5006,10 @@ CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryRangerCommandSet
@@ -4669,9 +5022,10 @@ CommandSet SupW_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankCrusaderCommandSet
@@ -4684,9 +5038,10 @@ CommandSet SupW_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleTomahawkCommandSet
@@ -4699,9 +5054,10 @@ CommandSet SupW_AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleHumveeCommandSet
@@ -4720,9 +5076,10 @@ CommandSet SupW_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankMicrowaveCommandSet
@@ -4735,9 +5092,10 @@ CommandSet SupW_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleAmbulanceCommandSet
@@ -4756,9 +5114,10 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankAvengerCommandSet
@@ -4771,9 +5130,10 @@ CommandSet SupW_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaFireBaseCommandSet
@@ -4786,7 +5146,8 @@ CommandSet SupW_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleChinookCommandSet
@@ -4804,9 +5165,10 @@ CommandSet SupW_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaJetAuroraCommandSet
@@ -4816,9 +5178,10 @@ CommandSet SupW_AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankPaladinCommandSet
@@ -4831,27 +5194,31 @@ CommandSet SupW_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SpecialPowerShortcutChina
@@ -4866,7 +5233,8 @@ CommandSet Infa_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Violazione satellite II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaDozerCommandSet
@@ -4886,9 +5254,10 @@ CommandSet Infa_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, J, N, V, W, Y, Z, 
+    Available keys: B, F, J, N, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaPowerPlantCommandSet
@@ -4897,7 +5266,8 @@ CommandSet Infa_ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSet
@@ -4915,7 +5285,8 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, N, O, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, N, O, S, V, X, Y, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSet
@@ -4925,7 +5296,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
@@ -4935,7 +5307,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
@@ -4953,7 +5326,8 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, N, O, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, N, O, S, V, X, Y, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
@@ -4967,7 +5341,8 @@ CommandSet Infa_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
@@ -4981,7 +5356,8 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -4989,9 +5365,10 @@ CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
@@ -5002,13 +5379,14 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &W"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &A"
   4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Avamposto d'assalto: &T"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Carro Dragon: &D"
@@ -5021,11 +5399,12 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, J, K, L, O, P, S, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, L, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
-  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &W"
+  3 = Infa_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:Infa_ConstructChinaVehicleTroopCrawler "Trasporto truppe d'assalto: &A"
   4 = Infa_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:Infa_ConstructChinaVehicleListeningOutpost "Avamposto d'assalto: &T"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
   7 = Infa_Command_ConstructChinaTankDragon : CONTROLBAR:ConstructChinaTankDragon "Carro Dragon: &D"
@@ -5038,7 +5417,8 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, J, K, L, O, P, S, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, L, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5048,7 +5428,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
@@ -5058,7 +5439,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSet
@@ -5070,7 +5452,8 @@ CommandSet Infa_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSetUpgrade
@@ -5082,7 +5465,8 @@ CommandSet Infa_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSet
@@ -5092,7 +5476,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
@@ -5102,7 +5487,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOne
@@ -5120,7 +5506,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
@@ -5138,7 +5525,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwo
@@ -5156,7 +5544,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
@@ -5174,7 +5563,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThree
@@ -5192,7 +5582,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
@@ -5210,7 +5601,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSet
@@ -5230,7 +5622,8 @@ CommandSet Infa_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSetUpgrade
@@ -5250,7 +5643,8 @@ CommandSet Infa_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaTroopCrawlerCommandSet
@@ -5269,9 +5663,10 @@ CommandSet Infa_ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaListeningOutpostCommandSet
@@ -5290,9 +5685,10 @@ CommandSet Infa_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaVehicleHelixCommandSet
@@ -5313,9 +5709,10 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaHelixBombCommandSet
@@ -5336,9 +5733,10 @@ CommandSet Infa_ChinaHelixBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, D, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryBlackLotusCommandSet
@@ -5349,9 +5747,10 @@ CommandSet Infa_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryHackerCommandSet
@@ -5362,21 +5761,24 @@ CommandSet Infa_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
@@ -5384,7 +5786,8 @@ CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "Madre di tutte le bombe: &B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, 
 End
 
 CommandSet Lazr_SpecialPowerShortcutUSA
@@ -5401,7 +5804,8 @@ CommandSet Lazr_SpecialPowerShortcutUSA
   11 = Lazr_Command_FireLaserCannonFromShortcut : CONTROLBAR:FireLaserCannonShortcut "Cannone laser"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaDozerCommandSet
@@ -5420,9 +5824,10 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, U, V, W, Y, 
+    Available keys: D, G, J, K, N, U, V, Y, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5431,7 +5836,8 @@ CommandSet Lazr_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaCommandCenterCommandSet
@@ -5448,7 +5854,8 @@ CommandSet Lazr_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, F, G, J, K, M, N, O, T, U, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, F, G, J, K, M, N, O, T, U, V, X, Y, 
 End
 
 CommandSet Lazr_AmericaStrategyCenterCommandSet
@@ -5466,7 +5873,8 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, L, N, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, L, N, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
@@ -5477,12 +5885,13 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   7 = Lazr_Command_ConstructAmericaVehicleAvenger : CONTROLBAR:ConstructAmericaTankAvenger "Avenger: &G"
   8 = Lazr_Command_ConstructAmericaVehicleMicrowave : CONTROLBAR:ConstructAmericaTankMicrowave "Carro a microonde: &M"
   9 = Command_UpgradeAmericaSentryDroneGun : CONTROLBAR:UpgradeAmericaSentryDroneGun "Arma per drone da ricognizione: &N"
-  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &W"
+  11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "Missile TOW: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "Punto di raccolta: &R"
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, L, O, P, T, U, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, J, K, L, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet
@@ -5496,7 +5905,8 @@ CommandSet Lazr_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, I, J, K, L, M, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaFireBaseCommandSet
@@ -5509,7 +5919,8 @@ CommandSet Lazr_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaPowerPlantCommandSet
@@ -5517,7 +5928,8 @@ CommandSet Lazr_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaAirfieldCommandSet
@@ -5533,7 +5945,8 @@ CommandSet Lazr_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, G, I, J, K, M, P, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, G, I, J, K, M, P, S, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
@@ -5541,7 +5954,8 @@ CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleComancheCommandSet
@@ -5552,9 +5966,10 @@ CommandSet Lazr_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaJetStealthFighterCommandSet
@@ -5564,9 +5979,10 @@ CommandSet Lazr_AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryRangerCommandSet
@@ -5579,9 +5995,10 @@ CommandSet Lazr_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
@@ -5595,9 +6012,10 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleChinookCommandSet
@@ -5615,9 +6033,10 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankAvengerCommandSet
@@ -5630,9 +6049,10 @@ CommandSet Lazr_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankCrusaderCommandSet
@@ -5645,9 +6065,10 @@ CommandSet Lazr_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleHumveeCommandSet
@@ -5666,9 +6087,10 @@ CommandSet Lazr_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankMicrowaveCommandSet
@@ -5681,9 +6103,10 @@ CommandSet Lazr_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
@@ -5702,9 +6125,10 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankPaladinCommandSet
@@ -5717,9 +6141,10 @@ CommandSet Lazr_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
@@ -5729,9 +6154,10 @@ CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaLaserCannonCommandSet
@@ -5739,25 +6165,29 @@ CommandSet Lazr_AmericaLaserCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SpecialPowerShortcutChina
@@ -5772,7 +6202,8 @@ CommandSet Tank_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "Violazione satellite II"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaDozerCommandSet
@@ -5792,9 +6223,10 @@ CommandSet Tank_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, F, J, N, V, W, Y, Z, 
+    Available keys: B, F, J, N, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSet
@@ -5804,7 +6236,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
@@ -5814,7 +6247,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSet
@@ -5833,7 +6267,8 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, N, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, N, S, V, X, Y, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
@@ -5852,13 +6287,14 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, N, S, V, W, X, Y, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, N, S, V, X, Y, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSet
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Emperor: &O"
-  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
+  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &A"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -5870,13 +6306,14 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, I, J, K, L, P, S, U, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, I, J, K, L, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   1 = Tank_Command_ConstructChinaTankBattleMaster : CONTROLBAR:ConstructGLATankBattleMaster "Battlemaster: &B"
   2 = Tank_Command_ConstructChinaTankEmperor : CONTROLBAR:ConstructChinaTankEmperor "Emperor: &O"
-  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &W"
+  3 = Tank_Command_ConstructChinaVehicleTroopCrawler : CONTROLBAR:ConstructChinaVehicleTroopCrawler "Trasporto truppe: &A"
   4 = Tank_Command_ConstructChinaVehicleListeningOutpost : CONTROLBAR:ConstructChinaVehicleListeningOutpost "Postazione d'ascolto: &T"
   5 = Tank_Command_ConstructChinaTankGattling : CONTROLBAR:ConstructChinaTankGattling "Carro gatling: &G"
   6 = Command_UpgradeChinaChainGuns : CONTROLBAR:UpgradeChinaChainGuns "Cannoni a nastro: &C"
@@ -5888,7 +6325,8 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, I, J, K, L, P, S, U, V, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, I, J, K, L, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSet
@@ -5899,7 +6337,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
@@ -5910,7 +6349,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleBattleMasterCommandSet
@@ -5920,9 +6360,10 @@ CommandSet Tank_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
@@ -5932,9 +6373,10 @@ CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
@@ -5944,9 +6386,10 @@ CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryBlackLotusCommandSet
@@ -5957,9 +6400,10 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, P, R, T, U, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankEmperorDefaultCommandSet
@@ -5970,9 +6414,10 @@ CommandSet Tank_ChinaTankEmperorDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleGattlingTankCommandSet
@@ -5982,9 +6427,10 @@ CommandSet Tank_ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSet
@@ -5993,7 +6439,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
@@ -6002,7 +6449,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleECMTankCommandSet
@@ -6013,9 +6461,10 @@ CommandSet Tank_ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSet
@@ -6029,7 +6478,8 @@ CommandSet Tank_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSetUpgrade
@@ -6043,7 +6493,8 @@ CommandSet Tank_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, I, J, K, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryHackerCommandSet
@@ -6053,9 +6504,10 @@ CommandSet Tank_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSet
@@ -6066,7 +6518,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
@@ -6077,7 +6530,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSet
@@ -6089,7 +6543,8 @@ CommandSet Tank_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSetUpgrade
@@ -6101,25 +6556,29 @@ CommandSet Tank_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSet
@@ -6139,7 +6598,8 @@ CommandSet Boss_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
@@ -6159,7 +6619,8 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSet
@@ -6168,7 +6629,8 @@ CommandSet Boss_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
@@ -6177,7 +6639,8 @@ CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSet
@@ -6186,7 +6649,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
@@ -6195,7 +6659,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaDozerCommandSet
@@ -6216,9 +6681,10 @@ CommandSet Boss_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: J, L, U, V, W, Y, Z, 
+    Available keys: J, L, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSet
@@ -6235,7 +6701,8 @@ CommandSet Boss_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, G, J, K, L, N, O, P, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, G, J, K, L, N, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
@@ -6252,7 +6719,8 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, G, J, K, L, N, O, P, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, G, J, K, L, N, O, P, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSet
@@ -6268,7 +6736,8 @@ CommandSet Boss_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSetUpgrade
@@ -6284,7 +6753,8 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSet
@@ -6294,7 +6764,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
@@ -6304,7 +6775,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSet
@@ -6324,7 +6796,8 @@ CommandSet Boss_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, K, N, O, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, K, N, O, S, U, V, X, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSetUpgrade
@@ -6344,7 +6817,8 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, K, N, O, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, K, N, O, S, U, V, X, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSet
@@ -6364,7 +6838,8 @@ CommandSet Boss_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, L, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, L, U, V, X, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
@@ -6384,7 +6859,8 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, L, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, L, U, V, X, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSet
@@ -6397,7 +6873,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
@@ -6410,7 +6887,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, E, F, G, I, J, K, L, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSet
@@ -6425,7 +6903,8 @@ CommandSet Boss_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, G, I, J, K, L, N, O, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, G, I, J, K, L, N, O, S, V, X, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSetUpgrade
@@ -6440,7 +6919,8 @@ CommandSet Boss_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, G, I, J, K, L, N, O, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, G, I, J, K, L, N, O, S, V, X, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSet
@@ -6453,7 +6933,8 @@ CommandSet Boss_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
@@ -6466,6 +6947,7 @@ CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "Vendi"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, O, P, R, S, T, V, X, Y, Z, 
 End
 

--- a/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/ko_commandsets.txt
@@ -2,10 +2,10 @@ CommandSet GenericCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -13,16 +13,16 @@ End
 
 CommandSet StopOnlyGenericCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet EmptyCommandSet
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -39,10 +39,10 @@ CommandSet AmericaDozerCommandSet
   11 = Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "군수공장: &A"
   13 = Command_ConstructAmericaAirfield : CONTROLBAR:ConstructAmericaAirfield "비행장: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, G, J, K, N, O, T, V, 
@@ -61,10 +61,10 @@ CommandSet GLAWorkerCommandSet
   10 = Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "커맨드 센터: &C"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "위장 건물로 전환: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: G, I, J, K, R, V, Y, Z, 
@@ -78,10 +78,10 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   5 = Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "위장 암시장: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "실제 건물로 전환: &R"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
@@ -101,10 +101,10 @@ CommandSet ChinaDozerCommandSet
   11 = Command_ConstructChinaWarFactory : CONTROLBAR:ConstructChinaWarFactory "군수공장: &A"
   12 = Command_ConstructChinaCommandCenter : CONTROLBAR:ConstructChinaCommandCenter "커맨드 센터: &C"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, J, N, O, V, Y, Z, 
@@ -122,10 +122,10 @@ CommandSet AmericaTransportCommandSet
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -143,10 +143,10 @@ CommandSet AmericaVehicleChinookCommandSet
   9 = Command_ChinookUnload : CONTROLBAR:Evacuate "비우기: &V"
   10 = Command_CombatDrop : CONTROLBAR:CombatDrop "전투 투하: &C"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -164,10 +164,10 @@ CommandSet CivilianTransportCommandSet
   9 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -186,10 +186,10 @@ CommandSet RailedTransportCommandSet
   10 = Command_TransportExit : CONTROLBAR:TransportExit "나가기"
   11 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   12 = Command_ExecuteRailedTransport : CONTROLBAR:ExecuteRailedTransport "수송"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -198,9 +198,9 @@ End
 CommandSet CivilianTransportWithNukeCommandSet
   1 = Command_DetonateConvoyTruckNuke : CONTROLBAR:DetonateNuke "핵 폭발: &N"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -211,10 +211,10 @@ CommandSet AmericaInfantryRangerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
@@ -228,10 +228,10 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, L, M, N, O, P, U, V, Y, Z, 
@@ -244,10 +244,10 @@ CommandSet AmericaInfantryCIAAgentCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, Y, Z, 
@@ -258,10 +258,10 @@ CommandSet AmericaInfantryMissileDefenderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
@@ -271,10 +271,10 @@ CommandSet AmericaInfantryPathfinderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -282,10 +282,10 @@ End
 
 CommandSet AmericaInfantryPilotCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -304,10 +304,10 @@ CommandSet AmericaVehicleHumveeCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -321,9 +321,9 @@ CommandSet AmericaFireBaseCommandSet
   6 = Command_Evacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -335,10 +335,10 @@ CommandSet CivilianVehicleLimoCommandSet
   5 = Command_TransportExit : CONTROLBAR:TransportExit "나가기"
   6 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -350,10 +350,10 @@ CommandSet GLAInfantryRebelCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -363,10 +363,10 @@ CommandSet GLAInfantryTunnelDefenderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -376,10 +376,10 @@ CommandSet GLAInfantryTerroristCommandSet
   1 = Command_GLAInfantryTerroristMakeCarBomb : CONTROLBAR:CarBomb "차량 폭탄: &C"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -389,10 +389,10 @@ CommandSet GLAInfantryAngryMobCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -402,10 +402,10 @@ CommandSet GLAInfantryHijackerCommandSet
   1 = Command_GLAInfantryHijack : CONTROLBAR:Hijack "하이잭: &J"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -416,10 +416,10 @@ CommandSet GLAInfantryJarmenKellCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
@@ -428,10 +428,10 @@ End
 CommandSet GLAInfantrySaboteurCommandSet
   1 = Command_SabotageBuilding : CONTROLBAR:SabotageBuilding "건물 시설 무력화: &B"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -442,10 +442,10 @@ CommandSet AmericaVehicleComancheCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
@@ -455,10 +455,10 @@ CommandSet AmericaVehicleSentryDroneCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -468,10 +468,10 @@ CommandSet GLAVehicleRocketBuggyCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -482,10 +482,10 @@ CommandSet GLAVehicleCombatBikeDefaultCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -497,10 +497,10 @@ CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -510,10 +510,10 @@ CommandSet GLATankScorpionCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -525,10 +525,10 @@ CommandSet GLAVehicleScudLauncherCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, O, R, T, U, V, Y, Z, 
@@ -538,10 +538,10 @@ CommandSet GLAVehicleQuadCannon
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -552,10 +552,10 @@ CommandSet GLAVehicleToxinTruckCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -569,10 +569,10 @@ CommandSet GLAVehicleBombTruckCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
@@ -591,10 +591,10 @@ CommandSet GLAVehicleBattleBusCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -604,10 +604,10 @@ CommandSet GLAVehicleRadarVanCommandSet
   1 = Command_RadarVanScan : CONTROLBAR:RadarVanScan "레이더 스캔: &C"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -623,10 +623,10 @@ CommandSet GLAVehicleTechnicalCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -637,10 +637,10 @@ CommandSet ChinaJetMIGCommandSet
   12 = Command_GuardFlyingUnitsOnly : CONTROLBAR:GuardFlyingUnitsOnly "공중 경계: &R"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
@@ -651,10 +651,10 @@ CommandSet ChinaInfantryRedguardCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -665,10 +665,10 @@ CommandSet ChinaInfantryBlackLotusCommandSet
   3 = Command_ChinaInfantryBlackLotusVehicleHack : CONTROLBAR:DisableVehicleHack "차량 해킹: &V"
   5 = Command_ChinaInfantryBlackLotusCashHack : CONTROLBAR:StealCashHack "자금 해킹: &K"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
@@ -678,10 +678,10 @@ CommandSet ChinaInfantryHackerCommandSet
   1 = Command_ChinaInfantryHackerDisableBuilding : CONTROLBAR:DisableBuildingHack "건물 무력화: &D"
   3 = Command_ChinaInfantryHackerInternetHack : CONTROLBAR:InternetHack "인터넷 해킹: &I"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -692,10 +692,10 @@ CommandSet ChinaVehicleECMTankCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -706,10 +706,10 @@ CommandSet ChinaInfantryTankHunterCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
@@ -728,10 +728,10 @@ CommandSet ChinaTroopCrawlerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -744,10 +744,10 @@ CommandSet ChinaListeningOutpostCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -759,10 +759,10 @@ CommandSet ChinaVehicleNukeCannonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, Y, Z, 
@@ -772,10 +772,10 @@ CommandSet ChinaVehicleBattleMasterCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -785,10 +785,10 @@ CommandSet ChinaVehicleGattlingTankCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -798,10 +798,10 @@ CommandSet ChinaVehicleInfernoCannonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -812,10 +812,10 @@ CommandSet ChinaTankDragonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -828,10 +828,10 @@ CommandSet AmericaTankCrusaderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -844,10 +844,10 @@ CommandSet AmericaTankPaladinCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -860,10 +860,10 @@ CommandSet AmericaTankMicrowaveCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -876,10 +876,10 @@ CommandSet AmericaTankAvengerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -898,10 +898,10 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -911,10 +911,10 @@ CommandSet AmericaInfantryHazMatCommandSet
   1 = Command_AmbulanceCleanupArea : CONTROLBAR:AmbulanceCleanupArea "독소 제거: &C"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -927,10 +927,10 @@ CommandSet AmericaVehicleTomahawkCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -941,10 +941,10 @@ CommandSet AmericaJetRaptorCommandSet
   12 = Command_GuardFlyingUnitsOnly : CONTROLBAR:GuardFlyingUnitsOnly "공중 경계: &R"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
@@ -954,10 +954,10 @@ CommandSet AmericaJetAuroraCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -967,10 +967,10 @@ CommandSet AmericaJetStealthFighterCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -980,10 +980,10 @@ CommandSet GLATankMarauderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -993,10 +993,10 @@ CommandSet ChinaTankBattlemasterCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -1009,10 +1009,10 @@ CommandSet ChinaTankOverlordDefaultCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
@@ -1031,10 +1031,10 @@ CommandSet ChinaTankOverlordBattleBunkerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, I, J, K, L, M, N, O, P, R, U, Y, Z, 
@@ -1044,10 +1044,10 @@ CommandSet ChinaTankOverlordGattlingCannonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -1057,10 +1057,10 @@ CommandSet ChinaTankOverlordPropagandaTowerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -1068,10 +1068,10 @@ End
 
 CommandSet ChinaSupplyTruckCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -1092,10 +1092,10 @@ CommandSet ChinaVehicleHelixCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: F, I, J, K, L, M, O, P, R, U, Y, Z, 
@@ -1113,10 +1113,10 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -1134,10 +1134,10 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -1155,10 +1155,10 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -1176,23 +1176,23 @@ CommandSet AmericaCommandCenterCommandSet
   10 = Command_SpySatelliteScan : CONTROLBAR:SpySatellite "스파이 위성: &S"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
 CommandSet Command_ScriptedTransportDrops
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Command_ScriptedA10ThunderboltStrike
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1207,9 +1207,9 @@ CommandSet AmericaAirfieldCommandSet
   10 = Command_UpgradeAmericaBunkerBusters : CONTROLBAR:UpgradeAmericaBunkerBusters "벙커 버스터: &U"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
@@ -1218,10 +1218,10 @@ CommandSet AmericaAircraftCarrierCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -1240,9 +1240,9 @@ CommandSet AmericaWarFactoryCommandSet
   11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "TOW 미사일: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, D, E, F, J, K, L, O, U, X, Y, Z, 
 End
 
@@ -1256,9 +1256,9 @@ CommandSet AmericaBarracksCommandSet
   8 = Command_UpgradeAmericaRangerCaptureBuilding : CONTROLBAR:UpgradeAmericaRangerCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
@@ -1266,18 +1266,18 @@ CommandSet AmericaSupplyCenterCommandSet
   1 = Command_ConstructAmericaVehicleChinook : CONTROLBAR:ConstructAmericaVehicleChinook "치누크: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPowerPlantCommandSet
   1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "제어 로드: &C"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1294,51 +1294,51 @@ CommandSet AmericaStrategyCenterCommandSet
   11 = Command_StrategyCenter_Stop : CONTROLBAR:Stop "정지: &S"
   13 = Command_UpgradeAmericaSupplyLines : CONTROLBAR:UpgradeAmericaSupplyLines "보급선: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: E, F, G, J, K, L, N, T, V, X, Y, Z, 
 End
 
 CommandSet AmericaDetentionCampCommandSet
   1 = Command_CIAIntelligence : CONTROLBAR:CIAIntelligence "첩보: &C"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaParticleUplinkCannonCommandSet
   1 = Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "파티클 캐논 발사: &P"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet BaikonurLaunchTowerCommandSet
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryNoSellCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -1356,9 +1356,9 @@ CommandSet ChinaCommandCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: F, G, J, K, M, O, P, S, V, X, Z, 
 End
 
@@ -1376,9 +1376,9 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: F, G, J, K, L, O, P, S, V, X, Z, 
 End
 
@@ -1392,9 +1392,9 @@ CommandSet ChinaBunkerCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -1408,9 +1408,9 @@ CommandSet ChinaBunkerCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -1427,9 +1427,9 @@ CommandSet ChinaInternetCenterCommandSetOne
   10 = Command_UpgradeChinaSatelliteHackOne : CONTROLBAR:UpgradeChinaSatelliteHackOne "위성 해킹 1: &A"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -1446,9 +1446,9 @@ CommandSet ChinaInternetCenterCommandSetOneUpgrade
   10 = Command_UpgradeChinaSatelliteHackOne : CONTROLBAR:UpgradeChinaSatelliteHackOne "위성 해킹 1: &A"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -1465,9 +1465,9 @@ CommandSet ChinaInternetCenterCommandSetTwo
   10 = Command_UpgradeChinaSatelliteHackTwo : CONTROLBAR:UpgradeChinaSatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -1484,9 +1484,9 @@ CommandSet ChinaInternetCenterCommandSetTwoUpgrade
   10 = Command_UpgradeChinaSatelliteHackTwo : CONTROLBAR:UpgradeChinaSatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -1503,9 +1503,9 @@ CommandSet ChinaInternetCenterCommandSetThree
   10 = Command_SatelliteHackTwo : CONTROLBAR:SatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -1522,9 +1522,9 @@ CommandSet ChinaInternetCenterCommandSetThreeUpgrade
   10 = Command_SatelliteHackTwo : CONTROLBAR:SatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -1532,9 +1532,9 @@ CommandSet ChinaPowerPlantCommandSet
   1 = Command_Overcharge : CONTROLBAR:Overcharge "과충전: &O"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1542,27 +1542,27 @@ CommandSet ChinaPowerPlantCommandSetUpgrade
   1 = Command_Overcharge : CONTROLBAR:Overcharge "과충전: &O"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1570,9 +1570,9 @@ CommandSet ChinaGattlingCannonCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -1580,9 +1580,9 @@ CommandSet ChinaGattlingCannonCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -1595,9 +1595,9 @@ CommandSet ChinaBarracksCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -1610,9 +1610,9 @@ CommandSet ChinaBarracksCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -1631,9 +1631,9 @@ CommandSet ChinaWarFactoryCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, F, J, K, M, P, V, X, Y, Z, 
 End
 
@@ -1652,9 +1652,9 @@ CommandSet ChinaWarFactoryCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, F, J, K, L, P, V, X, Y, Z, 
 End
 
@@ -1663,9 +1663,9 @@ CommandSet ChinaSupplyCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -1674,9 +1674,9 @@ CommandSet ChinaSupplyCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -1687,9 +1687,9 @@ CommandSet ChinaAirfieldCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
@@ -1700,9 +1700,9 @@ CommandSet ChinaAirfieldCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
@@ -1711,9 +1711,9 @@ CommandSet ChinaPropagandaCenterCommandSet
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1722,9 +1722,9 @@ CommandSet ChinaPropagandaCenterCommandSetUpgrade
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1735,9 +1735,9 @@ CommandSet ChinaNuclearMissileCommandSet
   10 = Command_UpgradeChinaNeutronShells : CONTROLBAR:UpgradeChinaNeutronShells "중성자탄: &S"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, V, X, Y, Z, 
 End
 
@@ -1748,9 +1748,9 @@ CommandSet ChinaNuclearMissileCommandSetUpgrade
   10 = Command_UpgradeChinaNeutronShells : CONTROLBAR:UpgradeChinaNeutronShells "중성자탄: &S"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, V, X, Y, Z, 
 End
 
@@ -1763,9 +1763,9 @@ CommandSet GLACommandCenterCommandSet
   8 = Command_SneakAttack : CONTROLBAR:SneakAttack "잠입 공격: &T"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, I, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -1784,9 +1784,9 @@ CommandSet GLAArmsDealerCommandSet
   12 = Command_ConstructGLAVehicleBattleBus : CONTROLBAR:ConstructGLAVehicleBattleBus "배틀 버스: &E"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
@@ -1802,9 +1802,9 @@ CommandSet GLABarracksCommandSet
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, K, L, M, N, P, U, V, X, Z, 
 End
 
@@ -1812,9 +1812,9 @@ CommandSet FakeGLACommandCenterCommandSet
   1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLACommandCenter : CONTROLBAR:BecomeRealGLACommandCenter "실제 커맨드 센터로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1822,9 +1822,9 @@ CommandSet FakeGLABarracksCommandSet
   1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLABarracks : CONTROLBAR:BecomeRealGLABarracks "실제 막사로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1832,9 +1832,9 @@ CommandSet FakeGLASupplyStashCommandSet
   1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLASupplyStash : CONTROLBAR:BecomeRealGLASupplyStash "실제 서플라이 은닉처로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1842,9 +1842,9 @@ CommandSet FakeGLAArmsDealerCommandSet
   1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLAArmsDealer : CONTROLBAR:BecomeRealGLAArmsDealer "실제 무기상으로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1852,9 +1852,9 @@ CommandSet FakeGLABlackMarketCommandSet
   1 = Command_DetonateFakeBuilding : CONTROLBAR:DetonateFakeBuilding "지금 폭파! &N"
   2 = Command_BecomeRealGLABlackMarket : CONTROLBAR:BecomeRealGLABlackMarket "실제 암시장으로 전환: &B"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1866,18 +1866,18 @@ CommandSet GLABlackMarketCommandSet
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "레이더 스캔: &C"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "일꾼 신발: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLAScudStormCommandSet
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "스커드 폭풍: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
@@ -1885,9 +1885,9 @@ CommandSet GLASupplyStashCommandSet
   1 = Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "일꾼: &K"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -1905,17 +1905,17 @@ CommandSet GLAPalaceCommandSet
   11 = Command_UpgradeGLAAnthraxBeta : CONTROLBAR:UpgradeGLAAnthraxBeta "탄저병 베타: &A"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, D, F, G, I, J, K, L, N, O, P, R, U, X, Y, Z, 
 End
 
 CommandSet GLAPrisonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1924,9 +1924,9 @@ CommandSet GLADemoTrapCommandSet
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "수동 제어: &M"
   5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "폭파! &D"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -1945,9 +1945,9 @@ CommandSet GLATunnelNetworkCommandSet
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -1955,10 +1955,10 @@ CommandSet CivilianCarBombCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -1968,74 +1968,74 @@ CommandSet GLAStingerSiteCommandSet
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank8
   1 = Command_PurchaseScienceDaisyCutter : CONTROLBAR:DaisyCutter "기화폭탄: &B"
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "MOAB: &B"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2050,9 +2050,9 @@ CommandSet SpecialPowerShortcutUSA
   8 = Command_CIAIntelligenceFromShortcut : CONTROLBAR:CIAIntelligenceShortcut "정보"
   9 = Command_SpectreGunshipFromShortcut : CONTROLBAR:SpectreGunshipFromShortcut "스펙터 건쉽"
   10 = Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "선전물 투하"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2066,9 +2066,9 @@ CommandSet SpecialPowerShortcutChina
   7 = Early_Command_ChinaCarpetBombFromShortcut : OBJECT:CarpetBomb "융단 폭격"
   8 = Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "프렌지"
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "위성 해킹 2"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2080,9 +2080,9 @@ CommandSet SpecialPowerShortcutGLA
   5 = Command_RadarVanScanFromShortcut : CONTROLBAR:RadarVanScanShortcut "레이더 탐색"
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "잠입 공격"
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS 교란장치"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2096,9 +2096,9 @@ CommandSet SpecialPowerShortcutBoss
   7 = Command_FireParticleUplinkCannonFromShortcut : CONTROLBAR:FireParticleUplinkCannonShortcut "파티클 캐논"
   8 = Command_ScudStormFromShortcut : CONTROLBAR:ScudStormShortcut "스커드 폭풍"
   9 = Command_NeutronMissileFromShortcut : CONTROLBAR:NeutronMissileShortcut "핵 미사일"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2115,39 +2115,39 @@ CommandSet GLASneakAttackTunnelCommandSet
   10 = Command_StructureExit : CONTROLBAR:StructureExit "건물 나가기"
   11 = Command_Evacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, X, Y, Z, 
 End
 
 CommandSet BattleShipCommandSet
   1 = Command_BattleshipFireViaSpecialPower : CONTROLBAR:BattleshipFire "전함 포격: &F"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2159,9 +2159,9 @@ CommandSet GC_Chem_SpecialPowerShortcutGLA
   5 = Command_RadarVanScanFromShortcut : CONTROLBAR:RadarVanScanShortcut "레이더 탐색"
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "잠입 공격"
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS 교란장치"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2177,10 +2177,10 @@ CommandSet GC_Chem_GLAWorkerCommandSet
   9 = GC_Chem_Command_ConstructGLAArmsDealer : CONTROLBAR:ConstructGLAArmsDealer "무기상: &A"
   10 = GC_Chem_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "커맨드 센터: &C"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: F, G, I, J, K, R, V, Y, Z, 
@@ -2196,9 +2196,9 @@ CommandSet GC_Chem_GLABarracksCommandSet
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, K, L, M, N, P, S, U, V, X, Y, Z, 
 End
 
@@ -2214,9 +2214,9 @@ CommandSet GC_Chem_GLAPalaceCommandSet
   11 = GC_Chem_Command_UpgradeGLAAnthraxGamma : CONTROLBAR:UpgradeGLAAnthraxGamma "탄저병 감마: &X"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, Y, Z, 
 End
 
@@ -2229,9 +2229,9 @@ CommandSet GC_Chem_GLACommandCenterCommandSet
   6 = Command_SneakAttack : CONTROLBAR:SneakAttack "잠입 공격: &T"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, G, I, J, L, M, N, O, P, U, V, X, Y, Z, 
 End
 
@@ -2245,9 +2245,9 @@ CommandSet GC_Chem_GLAArmsDealerCommandSet
   10 = Command_UpgradeGLAScorpionRocket : CONTROLBAR:UpgradeGLAScorpionRocket "스콜피온 로켓: &K"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, M, N, P, T, X, Y, Z, 
 End
 
@@ -2255,9 +2255,9 @@ CommandSet GC_Chem_GLASupplyStashCommandSet
   1 = GC_Chem_Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "일꾼: &K"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -2268,39 +2268,39 @@ CommandSet GC_Chem_GLABlackMarketCommandSet
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "레이더 스캔: &C"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "일꾼 신발: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAScudStormCommandSet
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "스커드 폭풍: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2312,9 +2312,9 @@ CommandSet GC_Slth_SpecialPowerShortcutGLA
   5 = Command_RadarVanScanFromShortcut : CONTROLBAR:RadarVanScanShortcut "레이더 탐색"
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "잠입 공격"
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS 교란장치"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2330,10 +2330,10 @@ CommandSet GC_Slth_GLAWorkerCommandSet
   9 = GC_Slth_Command_ConstructGLAArmsDealer : CONTROLBAR:ConstructGLAArmsDealer "무기상: &A"
   10 = GC_Slth_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "커맨드 센터: &C"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: F, G, I, J, K, R, V, Y, Z, 
@@ -2349,9 +2349,9 @@ CommandSet GC_Slth_GLACommandCenterCommandSet
   8 = Command_SneakAttack : CONTROLBAR:SneakAttack "잠입 공격: &T"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, I, J, L, M, N, O, P, U, V, X, Y, Z, 
 End
 
@@ -2359,9 +2359,9 @@ CommandSet GC_Slth_GLASupplyStashCommandSet
   1 = GC_Slth_Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "일꾼: &K"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -2376,18 +2376,18 @@ CommandSet GC_Slth_GLABarracksCommandSet
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, K, L, M, N, P, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAStingerSiteCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -2405,9 +2405,9 @@ CommandSet GC_Slth_GLATunnelNetworkCommandSet
   11 = Command_TunnelEvacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -2420,9 +2420,9 @@ CommandSet GC_Slth_GLAArmsDealerCommandSet
   11 = GC_Slth_Command_ConstructGLAVehicleCombatBike : CONTROLBAR:ConstructGLAVehicleCombatBike "컴뱃 사이클: &Y"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, S, X, Z, 
 End
 
@@ -2437,18 +2437,18 @@ CommandSet GC_Slth_GLAPalaceCommandSet
   9 = GC_Slth_Command_UpgradeGLAQuadCannonSnipeGun : CONTROLBAR:UpgradeGLAQuadCannonSnipe "콴 캐논 저격: &C"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAScudStormCommandSet
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "스커드 폭풍: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
@@ -2460,9 +2460,9 @@ CommandSet GC_Slth_GLABlackMarketCommandSet
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "레이더 스캔: &C"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "일꾼 신발: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
@@ -2471,9 +2471,9 @@ CommandSet GC_Slth_GLADemoTrapCommandSet
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "수동 제어: &M"
   5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "폭파! &D"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2482,10 +2482,10 @@ CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
@@ -2505,35 +2505,35 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
   1 = Command_PurchaseScienceDaisyCutter : CONTROLBAR:DaisyCutter "기화폭탄: &B"
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "MOAB: &B"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2549,9 +2549,9 @@ CommandSet AirF_SpecialPowerShortcutUSA
   9 = AirF_Command_SpectreGunshipFromShortcut : CONTROLBAR:SpectreGunshipFromShortcut "스펙터 건쉽"
   10 = Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "선전물 투하"
   11 = AirF_Command_CarpetBombFromShortcut : OBJECT:CarpetBomb "융단 폭격"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2568,10 +2568,10 @@ CommandSet AirF_AmericaDozerCommandSet
   11 = AirF_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "군수공장: &A"
   13 = AirF_Command_ConstructAmericaAirfield : CONTROLBAR:ConstructAmericaAirfield "비행장: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, G, J, K, N, O, T, V, 
@@ -2589,18 +2589,18 @@ CommandSet AirF_AmericaCommandCenterCommandSet
   10 = Command_SpySatelliteScan : CONTROLBAR:SpySatellite "스파이 위성: &S"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
 CommandSet AirF_AmericaPowerPlantCommandSet
   1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "제어 로드: &C"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2617,9 +2617,9 @@ CommandSet AirF_AmericaStrategyCenterCommandSet
   12 = AirF_Command_CarpetBomb : CONTROLBAR:CarpetBomb "융단 폭격: &T"
   13 = Command_UpgradeAmericaSupplyLines : CONTROLBAR:UpgradeAmericaSupplyLines "보급선: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: E, F, G, J, K, L, N, P, V, X, Y, Z, 
 End
 
@@ -2632,9 +2632,9 @@ CommandSet AirF_AmericaBarracksCommandSet
   8 = Command_UpgradeAmericaRangerCaptureBuilding : CONTROLBAR:UpgradeAmericaRangerCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
@@ -2646,9 +2646,9 @@ CommandSet AirF_AmericaFireBaseCommandSet
   6 = Command_Evacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -2664,18 +2664,18 @@ CommandSet AirF_AmericaAirfieldCommandSet
   11 = AirF_Command_UpgradeStealthComanche : CONTROLBAR:UpgradeStealthComanche "스텔스 업그레이드: &S"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, G, I, J, K, M, N, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaParticleUplinkCannonCommandSet
   1 = Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "파티클 캐논 발사: &P"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2684,10 +2684,10 @@ CommandSet AirF_AmericaVehicleComancheCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
@@ -2707,10 +2707,10 @@ CommandSet AirF_AmericaVehicleChinookCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -2721,9 +2721,9 @@ CommandSet AirF_AmericaSupplyCenterCommandSet
   3 = AirF_Command_ConstructAmericaVehicleChinook : CONTROLBAR:AirF_ConstructAmericaVehicleChinook "컴뱃 치누크: &T"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -2738,9 +2738,9 @@ CommandSet AirF_AmericaWarFactoryCommandSet
   11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "TOW 미사일: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
@@ -2749,33 +2749,33 @@ CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2787,9 +2787,9 @@ CommandSet Demo_SpecialPowerShortcutGLA
   5 = Command_RadarVanScanFromShortcut : CONTROLBAR:RadarVanScanShortcut "레이더 탐색"
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "잠입 공격"
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS 교란장치"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2806,10 +2806,10 @@ CommandSet Demo_GLAWorkerCommandSet
   10 = Demo_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "커맨드 센터: &C"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "위장 건물로 전환: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: G, I, J, K, R, V, Y, Z, 
@@ -2823,10 +2823,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   5 = Demo_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "위장 암시장: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "실제 건물로 전환: &R"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
@@ -2841,9 +2841,9 @@ CommandSet Demo_GLACommandCenterCommandSet
   8 = Command_SneakAttack : CONTROLBAR:SneakAttack "잠입 공격: &T"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, I, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -2851,9 +2851,9 @@ CommandSet Demo_GLASupplyStashCommandSet
   1 = Demo_Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "일꾼: &K"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -2869,9 +2869,9 @@ CommandSet Demo_GLAPalaceCommandSet
   11 = Demo_UpgradeSuicideBomb : CONTROLBAR:UpgradeSuicideBomb "폭파 기능: &D"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -2884,9 +2884,9 @@ CommandSet Demo_GLABarracksCommandSet
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
@@ -2898,27 +2898,27 @@ CommandSet Demo_GLABlackMarketCommandSet
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "레이더 스캔: &C"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "일꾼 신발: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSet
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "스커드 폭풍: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
@@ -2936,9 +2936,9 @@ CommandSet Demo_GLATunnelNetworkCommandSet
   11 = Command_TunnelEvacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -2957,9 +2957,9 @@ CommandSet Demo_GLAArmsDealerCommandSet
   12 = Demo_Command_ConstructGLAVehicleBattleBus : CONTROLBAR:ConstructGLAVehicleBattleBus "배틀 버스: &E"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
@@ -2968,9 +2968,9 @@ CommandSet Demo_GLADemoTrapCommandSet
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "수동 제어: &M"
   5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "폭파! &D"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -2980,10 +2980,10 @@ CommandSet Demo_GLAInfantryRebelCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -2993,10 +2993,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3006,10 +3006,10 @@ CommandSet Demo_GLAInfantryTerroristCommandSet
   1 = Command_GLAInfantryTerroristMakeCarBomb : CONTROLBAR:CarBomb "차량 폭탄: &C"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3019,10 +3019,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3036,10 +3036,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, O, P, U, V, Y, Z, 
@@ -3049,10 +3049,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSet
   1 = Command_RadarVanScan : CONTROLBAR:RadarVanScan "레이더 스캔: &C"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3062,10 +3062,10 @@ CommandSet Demo_GLAVehicleQuadCannon
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3078,10 +3078,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
@@ -3091,10 +3091,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSet
   1 = Command_GLAInfantryHijack : CONTROLBAR:Hijack "하이잭: &J"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3113,10 +3113,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -3126,10 +3126,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3140,10 +3140,10 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -3155,10 +3155,10 @@ CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -3168,10 +3168,10 @@ CommandSet Demo_GLATankScorpionCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3181,10 +3181,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3195,10 +3195,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3214,10 +3214,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -3227,10 +3227,10 @@ CommandSet Demo_GLATankMarauderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3241,10 +3241,10 @@ CommandSet Demo_GLATankMarauderCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3261,10 +3261,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -3276,10 +3276,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3290,10 +3290,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3304,10 +3304,10 @@ CommandSet Demo_GLATankScorpionCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3327,10 +3327,10 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "위장 건물로 전환: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: G, J, K, R, V, Y, Z, 
@@ -3345,10 +3345,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "실제 건물로 전환: &R"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, G, J, K, N, O, P, T, V, Y, Z, 
@@ -3364,9 +3364,9 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -3375,9 +3375,9 @@ CommandSet Demo_GLASupplyStashCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -3393,9 +3393,9 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   11 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, F, G, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -3409,9 +3409,9 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
@@ -3423,9 +3423,9 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "일꾼 신발: &S"
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, G, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
@@ -3433,9 +3433,9 @@ CommandSet Demo_GLAStingerSiteCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -3443,9 +3443,9 @@ CommandSet Demo_GLAScudStormCommandSetUpgrade
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "스커드 폭풍: &U"
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
@@ -3464,9 +3464,9 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -3485,9 +3485,9 @@ CommandSet Demo_GLAArmsDealerCommandSetUpgrade
   12 = Demo_Command_ConstructGLAVehicleBattleBus : CONTROLBAR:ConstructGLAVehicleBattleBus "배틀 버스: &E"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
@@ -3498,10 +3498,10 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3512,10 +3512,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3526,10 +3526,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3544,10 +3544,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, J, K, L, M, O, P, U, V, Y, Z, 
@@ -3558,10 +3558,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3572,10 +3572,10 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3588,10 +3588,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
@@ -3602,10 +3602,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3625,10 +3625,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -3639,10 +3639,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   12 = Demo_Command_TertiarySuicide : CONTROLBAR:SuicideAttack "자폭: &I"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3653,33 +3653,33 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -3691,9 +3691,9 @@ CommandSet Slth_SpecialPowerShortcutGLA
   5 = Command_RadarVanScanFromShortcut : CONTROLBAR:RadarVanScanShortcut "레이더 탐색"
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "잠입 공격"
   7 = Slth_Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS 교란장치"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -3710,10 +3710,10 @@ CommandSet Slth_GLAWorkerCommandSet
   10 = Slth_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "커맨드 센터: &C"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "위장 건물로 전환: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: G, I, J, K, R, V, Y, Z, 
@@ -3727,10 +3727,10 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   5 = Slth_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "위장 암시장: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "실제 건물로 전환: &R"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
@@ -3746,9 +3746,9 @@ CommandSet Slth_GLACommandCenterCommandSet
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, I, J, L, M, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -3757,9 +3757,9 @@ CommandSet Slth_GLASupplyStashCommandSet
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, L, M, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -3776,9 +3776,9 @@ CommandSet Slth_GLAPalaceCommandSet
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, F, G, I, J, K, L, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -3794,9 +3794,9 @@ CommandSet Slth_GLABarracksCommandSet
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, K, L, M, O, P, U, V, X, Z, 
 End
 
@@ -3809,18 +3809,18 @@ CommandSet Slth_GLABlackMarketCommandSet
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "일꾼 신발: &S"
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, G, I, K, L, M, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAStingerSiteCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -3828,9 +3828,9 @@ CommandSet Slth_GLAScudStormCommandSet
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "스커드 폭풍: &U"
   12 = Command_UpgradeGLACamoNetting : CONTROLBAR:UpgradeGLACamoNetting "위장망: &N"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, V, X, Y, Z, 
 End
 
@@ -3848,9 +3848,9 @@ CommandSet Slth_GLATunnelNetworkCommandSet
   11 = Command_TunnelEvacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -3867,9 +3867,9 @@ CommandSet Slth_GLAArmsDealerCommandSet
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
   15 = Command_ConstructGLAVehicleCombatBikeTerrorist : CONTROLBAR:ConstructGLAVehicleCombatBike "컴뱃 사이클: &Y"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, G, I, J, K, L, M, P, S, X, Z, 
 End
 
@@ -3878,9 +3878,9 @@ CommandSet Slth_GLADemoTrapCommandSet
   2 = Command_SetDemoTrapManualDetonation : CONTROLBAR:ManualControl "수동 제어: &M"
   5 = Command_DetonateDemoTrap : CONTROLBAR:Detonate "폭파! &D"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -3889,10 +3889,10 @@ CommandSet Slth_GLAInfantryRebelCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3902,10 +3902,10 @@ CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3915,10 +3915,10 @@ CommandSet Slth_GLAInfantryTerroristCommandSet
   1 = Command_GLAInfantryTerroristMakeCarBomb : CONTROLBAR:CarBomb "차량 폭탄: &C"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3928,10 +3928,10 @@ CommandSet Slth_GLAInfantryAngryMobCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3942,10 +3942,10 @@ CommandSet Slth_GLAInfantryJarmenKellCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
@@ -3955,10 +3955,10 @@ CommandSet Slth_GLAVehicleRadarVanCommandSet
   1 = Command_RadarVanScan : CONTROLBAR:RadarVanScan "레이더 스캔: &C"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3968,10 +3968,10 @@ CommandSet Slth_GLAVehicleQuadCannon
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -3985,10 +3985,10 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
@@ -3998,10 +3998,10 @@ CommandSet Slth_GLAInfantryHijackerCommandSet
   1 = Command_GLAInfantryHijack : CONTROLBAR:Hijack "하이잭: &J"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -4020,10 +4020,10 @@ CommandSet Slth_GLAVehicleBattleBusCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -4033,33 +4033,33 @@ CommandSet Slth_GLAVehicleScudLauncherCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4070,9 +4070,9 @@ CommandSet Chem_SpecialPowerShortcutGLA
   4 = Command_ScudStormFromShortcut : CONTROLBAR:ScudStormShortcut "스커드 폭풍"
   5 = Command_RadarVanScanFromShortcut : CONTROLBAR:RadarVanScanShortcut "레이더 탐색"
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "잠입 공격"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4089,10 +4089,10 @@ CommandSet Chem_GLAWorkerCommandSet
   10 = Chem_Command_ConstructGLACommandCenter : CONTROLBAR:ConstructGLACommandCenter "커맨드 센터: &C"
   13 = Command_UpgradeGLAWorkerFakeCommandSet : CONTROLBAR:UpgradeGLAWorkerFakeCommandSet "위장 건물로 전환: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: G, I, J, K, R, V, Y, Z, 
@@ -4106,10 +4106,10 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   5 = Chem_Command_ConstructFakeGLABlackMarket : CONTROLBAR:ConstructFakeGLABlackMarket "위장 암시장: &M"
   13 = Command_UpgradeGLAWorkerRealCommandSet : CONTROLBAR:UpgradeGLAWorkerRealCommandSet "실제 건물로 전환: &R"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
@@ -4124,9 +4124,9 @@ CommandSet Chem_GLABarracksCommandSet
   11 = Command_UpgradeGLARebelCaptureBuilding : CONTROLBAR:UpgradeGLARebelCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
@@ -4144,9 +4144,9 @@ CommandSet Chem_GLATunnelNetworkCommandSet
   11 = Command_TunnelEvacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -4157,10 +4157,10 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
@@ -4170,10 +4170,10 @@ CommandSet Chem_GLAVehicleScudLauncherCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -4191,9 +4191,9 @@ CommandSet Chem_GLAPalaceCommandSet
   11 = Chem_Command_UpgradeGLAAnthraxGamma : CONTROLBAR:UpgradeGLAAnthraxGamma "탄저병 감마: &X"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, Y, Z, 
 End
 
@@ -4205,9 +4205,9 @@ CommandSet Chem_GLACommandCenterCommandSet
   8 = Command_SneakAttack : CONTROLBAR:SneakAttack "잠입 공격: &T"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, G, I, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -4226,9 +4226,9 @@ CommandSet Chem_GLAArmsDealerCommandSet
   12 = Chem_Command_ConstructGLAVehicleBattleBus : CONTROLBAR:ConstructGLAVehicleBattleBus "배틀 버스: &E"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
@@ -4236,9 +4236,9 @@ CommandSet Chem_GLASupplyStashCommandSet
   1 = Chem_Command_ConstructGLAWorker : CONTROLBAR:ConstructGLAWorker "일꾼: &K"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -4250,27 +4250,27 @@ CommandSet Chem_GLABlackMarketCommandSet
   5 = Command_UpgradeGLARadarVanScan : CONTROLBAR:UpgradeGLARadarVanScan "레이더 스캔: &C"
   6 = Command_UpgradeGLAWorkerShoes : CONTROLBAR:UpgradeGLAWorkerShoes "일꾼 신발: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAScudStormCommandSet
   1 = Command_ScudStorm : CONTROLBAR:ScudStorm "스커드 폭풍: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAStingerSiteCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -4279,33 +4279,33 @@ CommandSet Chem_GLAInfantryRebelCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4319,9 +4319,9 @@ CommandSet Nuke_SpecialPowerShortcutChina
   7 = Nuke_Command_ChinaCarpetBombFromShortcut : OBJECT:Nuke_CarpetBomb "핵 폭격기"
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "위성 해킹 2"
   10 = Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "프렌지"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4339,10 +4339,10 @@ CommandSet Nuke_ChinaDozerCommandSet
   11 = Nuke_Command_ConstructChinaWarFactory : CONTROLBAR:ConstructChinaWarFactory "군수공장: &A"
   12 = Nuke_Command_ConstructChinaCommandCenter : CONTROLBAR:ConstructChinaCommandCenter "커맨드 센터: &C"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, J, N, O, V, Y, Z, 
@@ -4353,9 +4353,9 @@ CommandSet Nuke_ChinaSupplyCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -4364,9 +4364,9 @@ CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -4384,9 +4384,9 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: F, G, J, K, M, O, P, S, V, X, Z, 
 End
 
@@ -4404,9 +4404,9 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: F, G, J, K, L, O, P, S, V, X, Z, 
 End
 
@@ -4419,9 +4419,9 @@ CommandSet Nuke_ChinaBarracksCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -4434,18 +4434,18 @@ CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -4456,10 +4456,10 @@ CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -4480,9 +4480,9 @@ CommandSet Nuke_ChinaWarFactoryCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, F, J, K, M, P, V, X, Y, Z, 
 End
 
@@ -4501,9 +4501,9 @@ CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, F, J, K, L, P, V, X, Y, Z, 
 End
 
@@ -4513,9 +4513,9 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSet
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, J, K, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4525,9 +4525,9 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4536,10 +4536,10 @@ CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
   3 = Command_ChinaInfantryBlackLotusVehicleHack : CONTROLBAR:DisableVehicleHack "차량 해킹: &V"
   5 = Command_ChinaInfantryBlackLotusCashHack : CONTROLBAR:StealCashHack "자금 해킹: &K"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
@@ -4549,10 +4549,10 @@ CommandSet Nuke_ChinaInfantryHackerCommandSet
   1 = Command_ChinaInfantryHackerDisableBuilding : CONTROLBAR:DisableBuildingHack "건물 무력화: &D"
   3 = Command_ChinaInfantryHackerInternetHack : CONTROLBAR:InternetHack "인터넷 해킹: &I"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -4564,9 +4564,9 @@ CommandSet Nuke_ChinaNuclearMissileCommandSet
   11 = Command_UpgradeChinaTacticalNukeMig : CONTROLBAR:UpgradeChinaTacticalNukeMig "전술 핵 MiG: &G"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, I, J, K, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -4576,9 +4576,9 @@ CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
   11 = Command_UpgradeChinaTacticalNukeMig : CONTROLBAR:UpgradeChinaTacticalNukeMig "전술 핵 MiG: &G"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -4592,9 +4592,9 @@ CommandSet Nuke_ChinaBunkerCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -4608,9 +4608,9 @@ CommandSet Nuke_ChinaBunkerCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -4621,9 +4621,9 @@ CommandSet Nuke_ChinaAirfieldCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
@@ -4634,9 +4634,9 @@ CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
@@ -4655,10 +4655,10 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: F, I, J, K, L, M, O, P, R, U, Y, Z, 
@@ -4676,10 +4676,10 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -4697,10 +4697,10 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -4718,10 +4718,10 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -4731,10 +4731,10 @@ CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -4747,35 +4747,35 @@ CommandSet Nuke_ChinaListeningOutpostCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
   1 = Command_PurchaseScienceDaisyCutter : CONTROLBAR:DaisyCutter "기화폭탄: &B"
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "MOAB: &B"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4790,9 +4790,9 @@ CommandSet SupW_SpecialPowerShortcutUSA
   8 = AirF_Command_SpectreGunshipFromShortcut : CONTROLBAR:SpectreGunshipFromShortcut "스펙터 건쉽"
   9 = Early_Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "선전물 투하"
   10 = Command_CIAIntelligenceFromShortcut : CONTROLBAR:CIAIntelligenceShortcut "정보"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4809,10 +4809,10 @@ CommandSet SupW_AmericaDozerCommandSet
   11 = SupW_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "군수공장: &A"
   13 = SupW_Command_ConstructAmericaAirfield : CONTROLBAR:ConstructAmericaAirfield "비행장: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, G, J, K, N, O, T, V, 
@@ -4827,9 +4827,9 @@ CommandSet SupW_AmericaBarracksCommandSet
   8 = Command_UpgradeAmericaRangerCaptureBuilding : CONTROLBAR:UpgradeAmericaRangerCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
@@ -4845,18 +4845,18 @@ CommandSet SupW_AmericaCommandCenterCommandSet
   10 = Command_SpySatelliteScan : CONTROLBAR:SpySatellite "스파이 위성: &S"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
 CommandSet SupW_AmericaPatriotBatteryCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -4864,9 +4864,9 @@ CommandSet SupW_AmericaSupplyCenterCommandSet
   1 = SupW_Command_ConstructAmericaVehicleChinook : CONTROLBAR:ConstructAmericaVehicleChinook "치누크: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -4881,9 +4881,9 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "TOW 미사일: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
@@ -4899,9 +4899,9 @@ CommandSet SupW_AmericaStrategyCenterCommandSet
   11 = Command_StrategyCenter_Stop : CONTROLBAR:Stop "정지: &S"
   13 = Command_UpgradeAmericaSupplyLines : CONTROLBAR:UpgradeAmericaSupplyLines "보급선: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: E, F, G, J, K, L, N, P, T, V, X, Y, Z, 
 End
 
@@ -4910,10 +4910,10 @@ CommandSet SupW_AmericaVehicleComancheCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
@@ -4930,54 +4930,54 @@ CommandSet SupW_AmericaAirfieldCommandSet
   10 = Command_UpgradeAmericaBunkerBusters : CONTROLBAR:UpgradeAmericaBunkerBusters "벙커 버스터: &U"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaNuclearMissileCommandSet
   1 = SupW_Command_NeutronMissile : CONTROLBAR:ICBM "ICBM: &I"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCruiseMissileCommandSet
   1 = SupW_Command_CruiseMissile : CONTROLBAR:SupW_CruiseMissile "크루즈 미사일: &C"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaTomahawkStormCommandSet
   1 = SupW_Command_TomahawkStorm : CONTROLBAR:TomahawkStorm "토마호크 폭풍: &T"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaPowerPlantCommandSet
   1 = SupW_Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:SupW_UpgradeAmericaAdvancedControlRods "고급 제어 로드: &C"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaParticleUplinkCannonCommandSet
   1 = SupW_Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "파티클 캐논 발사: &P"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -4989,10 +4989,10 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, L, M, N, O, P, U, V, Y, Z, 
@@ -5003,10 +5003,10 @@ CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5019,10 +5019,10 @@ CommandSet SupW_AmericaInfantryRangerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
@@ -5035,10 +5035,10 @@ CommandSet SupW_AmericaTankCrusaderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5051,10 +5051,10 @@ CommandSet SupW_AmericaVehicleTomahawkCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5073,10 +5073,10 @@ CommandSet SupW_AmericaVehicleHumveeCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -5089,10 +5089,10 @@ CommandSet SupW_AmericaTankMicrowaveCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5111,10 +5111,10 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -5127,10 +5127,10 @@ CommandSet SupW_AmericaTankAvengerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5144,9 +5144,9 @@ CommandSet SupW_AmericaFireBaseCommandSet
   6 = Command_Evacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -5162,10 +5162,10 @@ CommandSet SupW_AmericaVehicleChinookCommandSet
   9 = Command_ChinookUnload : CONTROLBAR:Evacuate "비우기: &V"
   10 = Command_CombatDrop : CONTROLBAR:CombatDrop "전투 투하: &C"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -5175,10 +5175,10 @@ CommandSet SupW_AmericaJetAuroraCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5191,33 +5191,33 @@ CommandSet SupW_AmericaTankPaladinCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5231,9 +5231,9 @@ CommandSet Infa_SpecialPowerShortcutChina
   7 = Early_Command_ChinaCarpetBombFromShortcut : OBJECT:CarpetBomb "융단 폭격"
   8 = Early_Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "프렌지"
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "위성 해킹 2"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5251,10 +5251,10 @@ CommandSet Infa_ChinaDozerCommandSet
   11 = Infa_Command_ConstructChinaWarFactory : CONTROLBAR:ConstructChinaWarFactory "군수공장: &A"
   12 = Infa_Command_ConstructChinaCommandCenter : CONTROLBAR:ConstructChinaCommandCenter "커맨드 센터: &C"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, J, N, O, V, Y, Z, 
@@ -5264,9 +5264,9 @@ CommandSet Infa_ChinaPowerPlantCommandSet
   1 = Command_Overcharge : CONTROLBAR:Overcharge "과충전: &O"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5283,9 +5283,9 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, F, G, J, K, M, N, P, S, V, X, Z, 
 End
 
@@ -5294,9 +5294,9 @@ CommandSet Infa_ChinaSupplyCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -5305,9 +5305,9 @@ CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -5324,9 +5324,9 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, F, G, J, K, L, N, P, S, V, X, Z, 
 End
 
@@ -5339,9 +5339,9 @@ CommandSet Infa_ChinaBarracksCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -5354,18 +5354,18 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5376,10 +5376,10 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5397,9 +5397,9 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, F, G, J, K, M, O, P, V, X, Y, Z, 
 End
 
@@ -5415,9 +5415,9 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
@@ -5426,9 +5426,9 @@ CommandSet Infa_ChinaPropagandaCenterCommandSet
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5437,9 +5437,9 @@ CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5450,9 +5450,9 @@ CommandSet Infa_ChinaAirfieldCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
@@ -5463,9 +5463,9 @@ CommandSet Infa_ChinaAirfieldCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
@@ -5474,9 +5474,9 @@ CommandSet Infa_ChinaNuclearMissileCommandSet
   10 = Command_UpgradeChinaNeutronShells : CONTROLBAR:UpgradeChinaNeutronShells "중성자탄: &S"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -5485,9 +5485,9 @@ CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
   10 = Command_UpgradeChinaNeutronShells : CONTROLBAR:UpgradeChinaNeutronShells "중성자탄: &S"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -5504,9 +5504,9 @@ CommandSet Infa_ChinaInternetCenterCommandSetOne
   10 = Command_UpgradeChinaSatelliteHackOne : CONTROLBAR:UpgradeChinaSatelliteHackOne "위성 해킹 1: &A"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -5523,9 +5523,9 @@ CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
   10 = Command_UpgradeChinaSatelliteHackOne : CONTROLBAR:UpgradeChinaSatelliteHackOne "위성 해킹 1: &A"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -5542,9 +5542,9 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwo
   10 = Command_UpgradeChinaSatelliteHackTwo : CONTROLBAR:UpgradeChinaSatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -5561,9 +5561,9 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
   10 = Command_UpgradeChinaSatelliteHackTwo : CONTROLBAR:UpgradeChinaSatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -5580,9 +5580,9 @@ CommandSet Infa_ChinaInternetCenterCommandSetThree
   10 = Command_SatelliteHackTwo : CONTROLBAR:SatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -5599,9 +5599,9 @@ CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
   10 = Command_SatelliteHackTwo : CONTROLBAR:SatelliteHackTwo "위성 해킹 2: &A"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
@@ -5620,9 +5620,9 @@ CommandSet Infa_ChinaBunkerCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -5641,9 +5641,9 @@ CommandSet Infa_ChinaBunkerCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -5660,10 +5660,10 @@ CommandSet Infa_ChinaTroopCrawlerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -5682,10 +5682,10 @@ CommandSet Infa_ChinaListeningOutpostCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -5706,10 +5706,10 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
@@ -5730,10 +5730,10 @@ CommandSet Infa_ChinaHelixBombCommandSet
   12 = Command_EmptyCrawler : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -5744,10 +5744,10 @@ CommandSet Infa_ChinaInfantryBlackLotusCommandSet
   3 = Command_ChinaInfantryBlackLotusVehicleHack : CONTROLBAR:DisableVehicleHack "차량 해킹: &V"
   5 = Command_ChinaInfantryBlackLotusCashHack : CONTROLBAR:StealCashHack "자금 해킹: &K"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
@@ -5758,35 +5758,35 @@ CommandSet Infa_ChinaInfantryHackerCommandSet
   3 = Command_ChinaInfantryHackerInternetHack : CONTROLBAR:InternetHack "인터넷 해킹: &I"
   5 = Infa_Command_ChinaInfantryHackerVehicleHack : CONTROLBAR:DisableVehicleHack "차량 해킹: &V"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
   1 = Command_PurchaseScienceDaisyCutter : CONTROLBAR:DaisyCutter "기화폭탄: &B"
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "MOAB: &B"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5802,9 +5802,9 @@ CommandSet Lazr_SpecialPowerShortcutUSA
   9 = Command_SpectreGunshipFromShortcut : CONTROLBAR:SpectreGunshipFromShortcut "스펙터 건쉽"
   10 = Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "선전물 투하"
   11 = Lazr_Command_FireLaserCannonFromShortcut : CONTROLBAR:FireLaserCannonShortcut "레이저 캐논"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5821,10 +5821,10 @@ CommandSet Lazr_AmericaDozerCommandSet
   11 = Lazr_Command_ConstructAmericaWarFactory : CONTROLBAR:ConstructAmericaWarFactory "군수공장: &A"
   13 = Lazr_Command_ConstructAmericaAirfield : CONTROLBAR:ConstructAmericaAirfield "비행장: &F"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, G, J, K, N, O, T, V, 
@@ -5834,9 +5834,9 @@ CommandSet Lazr_AmericaSupplyCenterCommandSet
   1 = Lazr_Command_ConstructAmericaVehicleChinook : CONTROLBAR:ConstructAmericaVehicleChinook "치누크: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
@@ -5852,9 +5852,9 @@ CommandSet Lazr_AmericaCommandCenterCommandSet
   10 = Command_SpySatelliteScan : CONTROLBAR:SpySatellite "스파이 위성: &S"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
@@ -5871,9 +5871,9 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
   11 = Command_StrategyCenter_Stop : CONTROLBAR:Stop "정지: &S"
   13 = Command_UpgradeAmericaSupplyLines : CONTROLBAR:UpgradeAmericaSupplyLines "보급선: &U"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: E, F, G, J, K, L, N, T, V, X, Y, Z, 
 End
 
@@ -5888,9 +5888,9 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   11 = Command_UpgradeAmericaTOWMissile : CONTROLBAR:UpgradeAmericaTOWMissile "TOW 미사일: &I"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, D, E, F, J, K, L, O, P, T, U, X, Y, Z, 
 End
 
@@ -5903,9 +5903,9 @@ CommandSet Lazr_AmericaBarracksCommandSet
   8 = Command_UpgradeAmericaRangerCaptureBuilding : CONTROLBAR:UpgradeAmericaRangerCaptureBuilding "건물 점령: &C"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
@@ -5917,18 +5917,18 @@ CommandSet Lazr_AmericaFireBaseCommandSet
   6 = Command_Evacuate : CONTROLBAR:Evacuate "비우기: &V"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaPowerPlantCommandSet
   1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "제어 로드: &C"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5943,18 +5943,18 @@ CommandSet Lazr_AmericaAirfieldCommandSet
   10 = Command_UpgradeAmericaBunkerBusters : CONTROLBAR:UpgradeAmericaBunkerBusters "벙커 버스터: &U"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
   1 = Command_FireParticleUplinkCannon : CONTROLBAR:FireParticleUplinkCannon "파티클 캐논 발사: &P"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -5963,10 +5963,10 @@ CommandSet Lazr_AmericaVehicleComancheCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
@@ -5976,10 +5976,10 @@ CommandSet Lazr_AmericaJetStealthFighterCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -5992,10 +5992,10 @@ CommandSet Lazr_AmericaInfantryRangerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
@@ -6009,10 +6009,10 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, L, M, N, O, P, U, V, Y, Z, 
@@ -6030,10 +6030,10 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
   9 = Command_ChinookUnload : CONTROLBAR:Evacuate "비우기: &V"
   10 = Command_CombatDrop : CONTROLBAR:CombatDrop "전투 투하: &C"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -6046,10 +6046,10 @@ CommandSet Lazr_AmericaTankAvengerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6062,10 +6062,10 @@ CommandSet Lazr_AmericaTankCrusaderCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6084,10 +6084,10 @@ CommandSet Lazr_AmericaVehicleHumveeCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -6100,10 +6100,10 @@ CommandSet Lazr_AmericaTankMicrowaveCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6122,10 +6122,10 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
@@ -6138,10 +6138,10 @@ CommandSet Lazr_AmericaTankPaladinCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6151,10 +6151,10 @@ CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6163,30 +6163,30 @@ End
 CommandSet Lazr_AmericaLaserCannonCommandSet
   1 = Lazr_Command_FireLaserCannon : CONTROLBAR:FireLaserCannon "레이저 캐논: &C"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -6200,9 +6200,9 @@ CommandSet Tank_SpecialPowerShortcutChina
   7 = Command_ChinaCarpetBombFromShortcut : OBJECT:CarpetBomb "융단 폭격"
   8 = Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "프렌지"
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "위성 해킹 2"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -6220,10 +6220,10 @@ CommandSet Tank_ChinaDozerCommandSet
   11 = Tank_Command_ConstructChinaWarFactory : CONTROLBAR:ConstructChinaWarFactory "군수공장: &A"
   12 = Tank_Command_ConstructChinaCommandCenter : CONTROLBAR:ConstructChinaCommandCenter "커맨드 센터: &C"
   14 = Command_DisarmMinesAtPosition : CONTROLBAR:DisarmMinesAtPosition "지뢰 제거: &L"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, J, N, O, V, Y, Z, 
@@ -6234,9 +6234,9 @@ CommandSet Tank_ChinaSupplyCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -6245,9 +6245,9 @@ CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -6265,9 +6265,9 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: F, G, J, K, M, N, O, S, V, X, Z, 
 End
 
@@ -6285,9 +6285,9 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: F, G, J, K, L, N, O, S, V, X, Z, 
 End
 
@@ -6304,9 +6304,9 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, F, I, J, K, M, P, U, V, X, Y, Z, 
 End
 
@@ -6323,9 +6323,9 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, F, I, J, K, L, P, U, V, X, Y, Z, 
 End
 
@@ -6335,9 +6335,9 @@ CommandSet Tank_ChinaPropagandaCenterCommandSet
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, E, F, G, I, J, K, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -6347,9 +6347,9 @@ CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
   3 = Command_UpgradeChinaSubliminalMessaging : CONTROLBAR:UpgradeChinaSubliminalMessaging "잠재 메시지: &B"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -6357,10 +6357,10 @@ CommandSet Tank_ChinaVehicleBattleMasterCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6370,10 +6370,10 @@ CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6383,10 +6383,10 @@ CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6397,10 +6397,10 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
   3 = Command_ChinaInfantryBlackLotusVehicleHack : CONTROLBAR:DisableVehicleHack "차량 해킹: &V"
   5 = Command_ChinaInfantryBlackLotusCashHack : CONTROLBAR:StealCashHack "자금 해킹: &K"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
@@ -6411,10 +6411,10 @@ CommandSet Tank_ChinaTankEmperorDefaultCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6424,10 +6424,10 @@ CommandSet Tank_ChinaVehicleGattlingTankCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6437,9 +6437,9 @@ CommandSet Tank_ChinaGattlingCannonCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -6447,9 +6447,9 @@ CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -6458,10 +6458,10 @@ CommandSet Tank_ChinaVehicleECMTankCommandSet
   11 = Command_AttackMove : CONTROLBAR:AttackMove "공격 이동: &A"
   13 = Command_Guard : CONTROLBAR:Guard "경계: &G"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6476,9 +6476,9 @@ CommandSet Tank_ChinaBarracksCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -6491,9 +6491,9 @@ CommandSet Tank_ChinaBarracksCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -6501,10 +6501,10 @@ CommandSet Tank_ChinaInfantryHackerCommandSet
   1 = Command_ChinaInfantryHackerDisableBuilding : CONTROLBAR:DisableBuildingHack "건물 무력화: &D"
   3 = Command_ChinaInfantryHackerInternetHack : CONTROLBAR:InternetHack "인터넷 해킹: &I"
   14 = Command_Stop : CONTROLBAR:Stop "정지: &S"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
@@ -6516,9 +6516,9 @@ CommandSet Tank_ChinaNuclearMissileCommandSet
   8 = Tank_Command_UpgradeChinaNuclearTanks : CONTROLBAR:UpgradeChinaNuclearTanks "원자력 탱크: &T"
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, S, V, X, Y, Z, 
 End
 
@@ -6528,9 +6528,9 @@ CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
   8 = Tank_Command_UpgradeChinaNuclearTanks : CONTROLBAR:UpgradeChinaNuclearTanks "원자력 탱크: &T"
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 
@@ -6541,9 +6541,9 @@ CommandSet Tank_ChinaAirfieldCommandSet
   12 = Command_UpgradeChinaMines : CONTROLBAR:UpgradeChinaMines "지뢰: &L"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
@@ -6554,30 +6554,30 @@ CommandSet Tank_ChinaAirfieldCommandSetUpgrade
   12 = Command_UpgradeEMPMines : CONTROLBAR:UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank1
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank3
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank8
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -6596,9 +6596,9 @@ CommandSet Boss_GLATunnelNetworkCommandSet
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -6617,9 +6617,9 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
@@ -6627,9 +6627,9 @@ CommandSet Boss_AmericaPowerPlantCommandSet
   1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "제어 로드: &C"
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -6637,9 +6637,9 @@ CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
   1 = Command_UpgradeAmericaAdvancedControlRods : CONTROLBAR:UpgradeAmericaAdvancedControlRods "제어 로드: &C"
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
@@ -6647,9 +6647,9 @@ CommandSet Boss_AmericaPatriotBatteryCommandSet
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -6657,9 +6657,9 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_Stop : CONTROLBAR:Stop "정지: &S"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
@@ -6678,10 +6678,10 @@ CommandSet Boss_AmericaDozerCommandSet
   12 = Boss_Command_ConstructChinaCommandCenter : CONTROLBAR:Boss_ConstructChinaCommandCenter "커맨드 센터: &C"
   13 = Boss_Command_ConstructGLAScudStorm : CONTROLBAR:Boss_ConstructGLAScudStorm "스커드 폭풍: &O"
   14 = Boss_Command_ConstructAmericaParticleCannonUplink : CONTROLBAR:Boss_ConstructAmericaParticleCannonUplink "파티클 캐논 발사: &P"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
     Available keys: D, J, L, V, Y, Z, 
@@ -6699,9 +6699,9 @@ CommandSet Boss_ChinaCommandCenterCommandSet
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, E, F, J, K, L, N, O, P, V, X, Y, Z, 
 End
 
@@ -6717,9 +6717,9 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, E, F, J, K, L, N, O, P, V, X, Y, Z, 
 End
 
@@ -6734,9 +6734,9 @@ CommandSet Boss_ChinaAirfieldCommandSet
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
@@ -6751,9 +6751,9 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
@@ -6762,9 +6762,9 @@ CommandSet Boss_ChinaSupplyCenterCommandSet
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -6773,9 +6773,9 @@ CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
@@ -6794,9 +6794,9 @@ CommandSet Boss_ChinaBarracksCommandSet
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, K, L, O, S, U, V, X, Z, 
 End
 
@@ -6815,9 +6815,9 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: D, E, K, L, O, S, U, V, X, Z, 
 End
 
@@ -6836,9 +6836,9 @@ CommandSet Boss_ChinaWarFactoryCommandSet
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: E, F, I, J, K, L, U, V, X, Z, 
 End
 
@@ -6857,9 +6857,9 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "집결지 설정: &R"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: E, F, I, J, K, L, U, V, X, Z, 
 End
 
@@ -6871,9 +6871,9 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSet
   8 = Boss_Command_UpgradeAmericaAdvancedTraining : CONTROLBAR:Boss_UpgradeAmericaAdvancedTraining "고급 훈련: &A"
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
@@ -6885,9 +6885,9 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
   8 = Boss_Command_UpgradeAmericaAdvancedTraining : CONTROLBAR:Boss_UpgradeAmericaAdvancedTraining "고급 훈련: &A"
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
@@ -6901,9 +6901,9 @@ CommandSet Boss_GLAScudStormCommandSet
   8 = Boss_Command_UpgradeGLAArmTheMob : CONTROLBAR:Boss_UpgradeGLAArmTheMob "성난 군중 무장: &O"
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, E, F, G, I, K, L, N, P, S, T, V, Y, Z, 
 End
 
@@ -6917,9 +6917,9 @@ CommandSet Boss_GLAScudStormCommandSetUpgrade
   8 = Boss_Command_UpgradeGLAArmTheMob : CONTROLBAR:Boss_UpgradeGLAArmTheMob "성난 군중 무장: &O"
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: C, D, E, F, G, I, K, L, N, P, S, T, V, Y, Z, 
 End
 
@@ -6931,9 +6931,9 @@ CommandSet Boss_ChinaNuclearMissileCommandSet
   8 = Boss_Command_UpgradeChinaNuclearTanks : CONTROLBAR:Boss_UpgradeChinaNuclearTanks "원자력 탱크: &T"
   12 = Boss_Command_UpgradeChinaMines : CONTROLBAR:Boss_UpgradeChinaMines "지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 
@@ -6945,9 +6945,9 @@ CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   8 = Boss_Command_UpgradeChinaNuclearTanks : CONTROLBAR:Boss_UpgradeChinaNuclearTanks "원자력 탱크: &T"
   12 = Boss_Command_UpgradeEMPMines : CONTROLBAR:Boss_UpgradeEMPMines "중성자 지뢰: &M"
   14 = Command_Sell : CONTROLBAR:Sell "팔기"
-  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
     Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 

--- a/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
+++ b/Patch104pZH/Design/Scripts/str/generated/zh_commandsets.txt
@@ -5,22 +5,25 @@ CommandSet GenericCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet StopOnlyGenericCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "停止：&S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet EmptyCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaDozerCommandSet
@@ -39,9 +42,10 @@ CommandSet AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, O, T, V, W, 
+    Available keys: D, G, J, K, N, O, T, V, 
 End
 
 CommandSet GLAWorkerCommandSet
@@ -60,9 +64,10 @@ CommandSet GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, R, V, W, Y, Z, 
+    Available keys: G, I, J, K, R, V, Y, Z, 
 End
 
 CommandSet GLAWorkerFakeBuildingsCommandSet
@@ -76,9 +81,10 @@ CommandSet GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet ChinaDozerCommandSet
@@ -98,9 +104,10 @@ CommandSet ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, J, N, O, V, W, Y, Z, 
+    Available keys: D, J, N, O, V, Y, Z, 
 End
 
 CommandSet AmericaTransportCommandSet
@@ -118,9 +125,10 @@ CommandSet AmericaTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaVehicleChinookCommandSet
@@ -138,9 +146,10 @@ CommandSet AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportCommandSet
@@ -158,9 +167,10 @@ CommandSet CivilianTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet RailedTransportCommandSet
@@ -179,9 +189,10 @@ CommandSet RailedTransportCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet CivilianTransportWithNukeCommandSet
@@ -189,7 +200,8 @@ CommandSet CivilianTransportWithNukeCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "停止：&S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaInfantryRangerCommandSet
@@ -202,9 +214,10 @@ CommandSet AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryColonelBurtonCommandSet
@@ -218,9 +231,10 @@ CommandSet AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryCIAAgentCommandSet
@@ -233,9 +247,10 @@ CommandSet AmericaInfantryCIAAgentCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryMissileDefenderCommandSet
@@ -246,9 +261,10 @@ CommandSet AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPathfinderCommandSet
@@ -258,9 +274,10 @@ CommandSet AmericaInfantryPathfinderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaInfantryPilotCommandSet
@@ -268,9 +285,10 @@ CommandSet AmericaInfantryPilotCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleHumveeCommandSet
@@ -289,9 +307,10 @@ CommandSet AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaFireBaseCommandSet
@@ -304,7 +323,8 @@ CommandSet AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianVehicleLimoCommandSet
@@ -318,9 +338,10 @@ CommandSet CivilianVehicleLimoCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAInfantryRebelCommandSet
@@ -332,9 +353,10 @@ CommandSet GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTunnelDefenderCommandSet
@@ -344,9 +366,10 @@ CommandSet GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryTerroristCommandSet
@@ -356,9 +379,10 @@ CommandSet GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryAngryMobCommandSet
@@ -368,9 +392,10 @@ CommandSet GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryHijackerCommandSet
@@ -380,9 +405,10 @@ CommandSet GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantryJarmenKellCommandSet
@@ -393,9 +419,10 @@ CommandSet GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAInfantrySaboteurCommandSet
@@ -404,9 +431,10 @@ CommandSet GLAInfantrySaboteurCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleComancheCommandSet
@@ -417,9 +445,10 @@ CommandSet AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleSentryDroneCommandSet
@@ -429,9 +458,10 @@ CommandSet AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleRocketBuggyCommandSet
@@ -441,9 +471,10 @@ CommandSet GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeDefaultCommandSet
@@ -454,9 +485,10 @@ CommandSet GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
@@ -468,9 +500,10 @@ CommandSet GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLATankScorpionCommandSet
@@ -480,9 +513,10 @@ CommandSet GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleScudLauncherCommandSet
@@ -494,9 +528,10 @@ CommandSet GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleQuadCannon
@@ -506,9 +541,10 @@ CommandSet GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleToxinTruckCommandSet
@@ -519,9 +555,10 @@ CommandSet GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBombTruckCommandSet
@@ -535,9 +572,10 @@ CommandSet GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleBattleBusCommandSet
@@ -556,9 +594,10 @@ CommandSet GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GLAVehicleRadarVanCommandSet
@@ -568,9 +607,10 @@ CommandSet GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAVehicleTechnicalCommandSet
@@ -586,9 +626,10 @@ CommandSet GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaJetMIGCommandSet
@@ -599,9 +640,10 @@ CommandSet ChinaJetMIGCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryRedguardCommandSet
@@ -612,9 +654,10 @@ CommandSet ChinaInfantryRedguardCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryBlackLotusCommandSet
@@ -625,9 +668,10 @@ CommandSet ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaInfantryHackerCommandSet
@@ -637,9 +681,10 @@ CommandSet ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleECMTankCommandSet
@@ -650,9 +695,10 @@ CommandSet ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaInfantryTankHunterCommandSet
@@ -663,9 +709,10 @@ CommandSet ChinaInfantryTankHunterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet ChinaTroopCrawlerCommandSet
@@ -684,9 +731,10 @@ CommandSet ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaListeningOutpostCommandSet
@@ -699,9 +747,10 @@ CommandSet ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaVehicleNukeCannonCommandSet
@@ -713,9 +762,10 @@ CommandSet ChinaVehicleNukeCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleBattleMasterCommandSet
@@ -725,9 +775,10 @@ CommandSet ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleGattlingTankCommandSet
@@ -737,9 +788,10 @@ CommandSet ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleInfernoCannonCommandSet
@@ -749,9 +801,10 @@ CommandSet ChinaVehicleInfernoCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankDragonCommandSet
@@ -762,9 +815,10 @@ CommandSet ChinaTankDragonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankCrusaderCommandSet
@@ -777,9 +831,10 @@ CommandSet AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankPaladinCommandSet
@@ -792,9 +847,10 @@ CommandSet AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankMicrowaveCommandSet
@@ -807,9 +863,10 @@ CommandSet AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaTankAvengerCommandSet
@@ -822,9 +879,10 @@ CommandSet AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleAmbulanceCommandSet
@@ -843,9 +901,10 @@ CommandSet AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaInfantryHazMatCommandSet
@@ -855,9 +914,10 @@ CommandSet AmericaInfantryHazMatCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaVehicleTomahawkCommandSet
@@ -870,9 +930,10 @@ CommandSet AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetRaptorCommandSet
@@ -883,9 +944,10 @@ CommandSet AmericaJetRaptorCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetAuroraCommandSet
@@ -895,9 +957,10 @@ CommandSet AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaJetStealthFighterCommandSet
@@ -907,9 +970,10 @@ CommandSet AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLATankMarauderCommandSet
@@ -919,9 +983,10 @@ CommandSet GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankBattlemasterCommandSet
@@ -931,9 +996,10 @@ CommandSet ChinaTankBattlemasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordDefaultCommandSet
@@ -946,9 +1012,10 @@ CommandSet ChinaTankOverlordDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordBattleBunkerCommandSet
@@ -967,9 +1034,10 @@ CommandSet ChinaTankOverlordBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, U, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordGattlingCannonCommandSet
@@ -979,9 +1047,10 @@ CommandSet ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaTankOverlordPropagandaTowerCommandSet
@@ -991,9 +1060,10 @@ CommandSet ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaSupplyTruckCommandSet
@@ -1001,9 +1071,10 @@ CommandSet ChinaSupplyTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaVehicleHelixCommandSet
@@ -1024,9 +1095,10 @@ CommandSet ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, O, P, R, U, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, O, P, R, U, Y, Z, 
 End
 
 CommandSet ChinaHelixGattlingCannonCommandSet
@@ -1044,9 +1116,10 @@ CommandSet ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixPropagandaTowerCommandSet
@@ -1064,9 +1137,10 @@ CommandSet ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet ChinaHelixBattleBunkerCommandSet
@@ -1084,9 +1158,10 @@ CommandSet ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AmericaCommandCenterCommandSet
@@ -1103,19 +1178,22 @@ CommandSet AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, I, J, K, M, N, P, T, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
 CommandSet Command_ScriptedTransportDrops
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Command_ScriptedA10ThunderboltStrike
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaAirfieldCommandSet
@@ -1131,7 +1209,8 @@ CommandSet AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet AmericaAircraftCarrierCommandSet
@@ -1142,9 +1221,10 @@ CommandSet AmericaAircraftCarrierCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet AmericaWarFactoryCommandSet
@@ -1162,7 +1242,8 @@ CommandSet AmericaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, J, K, L, O, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, J, K, L, O, U, X, Y, Z, 
 End
 
 CommandSet AmericaBarracksCommandSet
@@ -1177,7 +1258,8 @@ CommandSet AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaSupplyCenterCommandSet
@@ -1186,7 +1268,8 @@ CommandSet AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPowerPlantCommandSet
@@ -1194,7 +1277,8 @@ CommandSet AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaStrategyCenterCommandSet
@@ -1212,7 +1296,8 @@ CommandSet AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, G, J, K, L, N, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, G, J, K, L, N, T, V, X, Y, Z, 
 End
 
 CommandSet AmericaDetentionCampCommandSet
@@ -1220,7 +1305,8 @@ CommandSet AmericaDetentionCampCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaParticleUplinkCannonCommandSet
@@ -1228,13 +1314,15 @@ CommandSet AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet BaikonurLaunchTowerCommandSet
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryCommandSet
@@ -1242,14 +1330,16 @@ CommandSet AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet AmericaPatriotBatteryNoSellCommandSet
   13 = Command_Stop : CONTROLBAR:Stop "停止：&S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaCommandCenterCommandSet
@@ -1268,7 +1358,8 @@ CommandSet ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, M, O, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, M, O, P, S, V, X, Z, 
 End
 
 CommandSet ChinaCommandCenterCommandSetUpgrade
@@ -1287,7 +1378,8 @@ CommandSet ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, L, O, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, L, O, P, S, V, X, Z, 
 End
 
 CommandSet ChinaBunkerCommandSet
@@ -1302,7 +1394,8 @@ CommandSet ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaBunkerCommandSetUpgrade
@@ -1317,7 +1410,8 @@ CommandSet ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOne
@@ -1335,7 +1429,8 @@ CommandSet ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetOneUpgrade
@@ -1353,7 +1448,8 @@ CommandSet ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwo
@@ -1371,7 +1467,8 @@ CommandSet ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetTwoUpgrade
@@ -1389,7 +1486,8 @@ CommandSet ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThree
@@ -1407,7 +1505,8 @@ CommandSet ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaInternetCenterCommandSetThreeUpgrade
@@ -1425,7 +1524,8 @@ CommandSet ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSet
@@ -1434,7 +1534,8 @@ CommandSet ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaPowerPlantCommandSetUpgrade
@@ -1443,7 +1544,8 @@ CommandSet ChinaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSet
@@ -1451,7 +1553,8 @@ CommandSet ChinaSpeakerTowerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSpeakerTowerCommandSetUpgrade
@@ -1459,7 +1562,8 @@ CommandSet ChinaSpeakerTowerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSet
@@ -1468,7 +1572,8 @@ CommandSet ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaGattlingCannonCommandSetUpgrade
@@ -1477,7 +1582,8 @@ CommandSet ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSet
@@ -1491,7 +1597,8 @@ CommandSet ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaBarracksCommandSetUpgrade
@@ -1505,7 +1612,8 @@ CommandSet ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSet
@@ -1525,7 +1633,8 @@ CommandSet ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, M, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, M, P, V, X, Y, Z, 
 End
 
 CommandSet ChinaWarFactoryCommandSetUpgrade
@@ -1545,7 +1654,8 @@ CommandSet ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, L, P, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSet
@@ -1555,7 +1665,8 @@ CommandSet ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaSupplyCenterCommandSetUpgrade
@@ -1565,7 +1676,8 @@ CommandSet ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSet
@@ -1577,7 +1689,8 @@ CommandSet ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaAirfieldCommandSetUpgrade
@@ -1589,7 +1702,8 @@ CommandSet ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSet
@@ -1599,7 +1713,8 @@ CommandSet ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaPropagandaCenterCommandSetUpgrade
@@ -1609,7 +1724,8 @@ CommandSet ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSet
@@ -1621,7 +1737,8 @@ CommandSet ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, V, X, Y, Z, 
 End
 
 CommandSet ChinaNuclearMissileCommandSetUpgrade
@@ -1633,7 +1750,8 @@ CommandSet ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, V, X, Y, Z, 
 End
 
 CommandSet GLACommandCenterCommandSet
@@ -1647,7 +1765,8 @@ CommandSet GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, L, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet GLAArmsDealerCommandSet
@@ -1667,7 +1786,8 @@ CommandSet GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, G, I, J, N, P, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
 CommandSet GLABarracksCommandSet
@@ -1684,7 +1804,8 @@ CommandSet GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, K, L, M, N, P, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, K, L, M, N, P, U, V, X, Z, 
 End
 
 CommandSet FakeGLACommandCenterCommandSet
@@ -1693,7 +1814,8 @@ CommandSet FakeGLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABarracksCommandSet
@@ -1702,7 +1824,8 @@ CommandSet FakeGLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLASupplyStashCommandSet
@@ -1711,7 +1834,8 @@ CommandSet FakeGLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLAArmsDealerCommandSet
@@ -1720,7 +1844,8 @@ CommandSet FakeGLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet FakeGLABlackMarketCommandSet
@@ -1729,7 +1854,8 @@ CommandSet FakeGLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLABlackMarketCommandSet
@@ -1742,7 +1868,8 @@ CommandSet GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLAScudStormCommandSet
@@ -1750,7 +1877,8 @@ CommandSet GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GLASupplyStashCommandSet
@@ -1759,7 +1887,8 @@ CommandSet GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLAPalaceCommandSet
@@ -1778,14 +1907,16 @@ CommandSet GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, F, G, I, J, K, L, N, O, P, R, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, F, G, I, J, K, L, N, O, P, R, U, X, Y, Z, 
 End
 
 CommandSet GLAPrisonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLADemoTrapCommandSet
@@ -1795,7 +1926,8 @@ CommandSet GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLATunnelNetworkCommandSet
@@ -1815,7 +1947,8 @@ CommandSet GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet CivilianCarBombCommandSet
@@ -1825,9 +1958,10 @@ CommandSet CivilianCarBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GLAStingerSiteCommandSet
@@ -1836,19 +1970,22 @@ CommandSet GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_AMERICA_CommandSetRank8
@@ -1856,43 +1993,50 @@ CommandSet SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "炸彈之母：&B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutUSA
@@ -1908,7 +2052,8 @@ CommandSet SpecialPowerShortcutUSA
   10 = Command_LeafletDropFromShortcut : CONTROLBAR:LeafletDropShort "空投傳單"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutChina
@@ -1923,7 +2068,8 @@ CommandSet SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "衛星侵入2"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutGLA
@@ -1936,7 +2082,8 @@ CommandSet SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS干擾器"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SpecialPowerShortcutBoss
@@ -1951,7 +2098,8 @@ CommandSet SpecialPowerShortcutBoss
   9 = Command_NeutronMissileFromShortcut : CONTROLBAR:NeutronMissileShortcut "核子飛彈"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GLASneakAttackTunnelCommandSet
@@ -1969,7 +2117,8 @@ CommandSet GLASneakAttackTunnelCommandSet
   13 = Command_SetRallyPoint : CONTROLBAR:SetRallyPoint "集合點：&R"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, X, Y, Z, 
 End
 
 CommandSet BattleShipCommandSet
@@ -1977,25 +2126,29 @@ CommandSet BattleShipCommandSet
   14 = Command_Stop : CONTROLBAR:Stop "停止：&S"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_SpecialPowerShortcutGLA
@@ -2008,7 +2161,8 @@ CommandSet GC_Chem_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS干擾器"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAWorkerCommandSet
@@ -2026,9 +2180,10 @@ CommandSet GC_Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, R, V, W, Y, Z, 
+    Available keys: F, G, I, J, K, R, V, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABarracksCommandSet
@@ -2043,7 +2198,8 @@ CommandSet GC_Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, K, L, M, N, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, K, L, M, N, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAPalaceCommandSet
@@ -2060,7 +2216,8 @@ CommandSet GC_Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet GC_Chem_GLACommandCenterCommandSet
@@ -2074,7 +2231,8 @@ CommandSet GC_Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, G, I, J, L, M, N, O, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, G, I, J, L, M, N, O, P, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAArmsDealerCommandSet
@@ -2089,7 +2247,8 @@ CommandSet GC_Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, M, N, P, T, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, M, N, P, T, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLASupplyStashCommandSet
@@ -2098,7 +2257,8 @@ CommandSet GC_Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLABlackMarketCommandSet
@@ -2110,7 +2270,8 @@ CommandSet GC_Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, G, I, K, L, M, N, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Chem_GLAScudStormCommandSet
@@ -2118,25 +2279,29 @@ CommandSet GC_Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_SpecialPowerShortcutGLA
@@ -2149,7 +2314,8 @@ CommandSet GC_Slth_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS干擾器"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAWorkerCommandSet
@@ -2167,9 +2333,10 @@ CommandSet GC_Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, G, I, J, K, R, V, W, Y, Z, 
+    Available keys: F, G, I, J, K, R, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLACommandCenterCommandSet
@@ -2184,7 +2351,8 @@ CommandSet GC_Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, L, M, N, O, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, L, M, N, O, P, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLASupplyStashCommandSet
@@ -2193,7 +2361,8 @@ CommandSet GC_Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABarracksCommandSet
@@ -2209,7 +2378,8 @@ CommandSet GC_Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, K, L, M, N, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, K, L, M, N, P, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAStingerSiteCommandSet
@@ -2217,7 +2387,8 @@ CommandSet GC_Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLATunnelNetworkCommandSet
@@ -2236,7 +2407,8 @@ CommandSet GC_Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAArmsDealerCommandSet
@@ -2250,7 +2422,8 @@ CommandSet GC_Slth_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, S, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, F, G, I, J, K, L, M, N, O, P, S, X, Z, 
 End
 
 CommandSet GC_Slth_GLAPalaceCommandSet
@@ -2266,7 +2439,8 @@ CommandSet GC_Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAScudStormCommandSet
@@ -2274,7 +2448,8 @@ CommandSet GC_Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLABlackMarketCommandSet
@@ -2287,7 +2462,8 @@ CommandSet GC_Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLADemoTrapCommandSet
@@ -2297,7 +2473,8 @@ CommandSet GC_Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
@@ -2308,9 +2485,10 @@ CommandSet GC_Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
@@ -2330,21 +2508,24 @@ CommandSet GC_Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
@@ -2352,7 +2533,8 @@ CommandSet AirF_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "炸彈之母：&B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_SpecialPowerShortcutUSA
@@ -2369,7 +2551,8 @@ CommandSet AirF_SpecialPowerShortcutUSA
   11 = AirF_Command_CarpetBombFromShortcut : OBJECT:CarpetBomb "地毯式炸彈轟炸"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaDozerCommandSet
@@ -2388,9 +2571,10 @@ CommandSet AirF_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, O, T, V, W, 
+    Available keys: D, G, J, K, N, O, T, V, 
 End
 
 CommandSet AirF_AmericaCommandCenterCommandSet
@@ -2407,7 +2591,8 @@ CommandSet AirF_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, I, J, K, M, N, P, T, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
 CommandSet AirF_AmericaPowerPlantCommandSet
@@ -2415,7 +2600,8 @@ CommandSet AirF_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaStrategyCenterCommandSet
@@ -2433,7 +2619,8 @@ CommandSet AirF_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, G, J, K, L, N, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, G, J, K, L, N, P, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaBarracksCommandSet
@@ -2447,7 +2634,8 @@ CommandSet AirF_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaFireBaseCommandSet
@@ -2460,7 +2648,8 @@ CommandSet AirF_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaAirfieldCommandSet
@@ -2477,7 +2666,8 @@ CommandSet AirF_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaParticleUplinkCannonCommandSet
@@ -2485,7 +2675,8 @@ CommandSet AirF_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleComancheCommandSet
@@ -2496,9 +2687,10 @@ CommandSet AirF_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet AirF_AmericaVehicleChinookCommandSet
@@ -2518,9 +2710,10 @@ CommandSet AirF_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet AirF_AmericaSupplyCenterCommandSet
@@ -2530,7 +2723,8 @@ CommandSet AirF_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaWarFactoryCommandSet
@@ -2546,7 +2740,8 @@ CommandSet AirF_AmericaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, J, K, L, O, P, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
 CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
@@ -2557,27 +2752,31 @@ CommandSet AirF_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_SpecialPowerShortcutGLA
@@ -2590,7 +2789,8 @@ CommandSet Demo_SpecialPowerShortcutGLA
   7 = Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS干擾器"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSet
@@ -2609,9 +2809,10 @@ CommandSet Demo_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, R, V, W, Y, Z, 
+    Available keys: G, I, J, K, R, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
@@ -2625,9 +2826,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSet
@@ -2641,7 +2843,8 @@ CommandSet Demo_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, L, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSet
@@ -2650,7 +2853,8 @@ CommandSet Demo_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSet
@@ -2667,7 +2871,8 @@ CommandSet Demo_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSet
@@ -2681,7 +2886,8 @@ CommandSet Demo_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSet
@@ -2694,7 +2900,8 @@ CommandSet Demo_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSet
@@ -2702,7 +2909,8 @@ CommandSet Demo_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSet
@@ -2710,7 +2918,8 @@ CommandSet Demo_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSet
@@ -2729,7 +2938,8 @@ CommandSet Demo_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSet
@@ -2749,7 +2959,8 @@ CommandSet Demo_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, G, I, J, N, P, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
 CommandSet Demo_GLADemoTrapCommandSet
@@ -2759,7 +2970,8 @@ CommandSet Demo_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSet
@@ -2771,9 +2983,10 @@ CommandSet Demo_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
@@ -2783,9 +2996,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTerroristCommandSet
@@ -2795,9 +3009,10 @@ CommandSet Demo_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSet
@@ -2807,9 +3022,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSet
@@ -2823,9 +3039,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSet
@@ -2835,9 +3052,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannon
@@ -2847,9 +3065,10 @@ CommandSet Demo_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSet
@@ -2862,9 +3081,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSet
@@ -2874,9 +3094,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSet
@@ -2895,9 +3116,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSet
@@ -2907,9 +3129,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
@@ -2920,9 +3143,10 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
@@ -2934,9 +3158,10 @@ CommandSet Demo_GLAVehicleCombatBikeJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSet
@@ -2946,9 +3171,10 @@ CommandSet Demo_GLATankScorpionCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSet
@@ -2958,9 +3184,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSet
@@ -2971,9 +3198,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSet
@@ -2989,9 +3217,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSet
@@ -3001,9 +3230,10 @@ CommandSet Demo_GLATankMarauderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankMarauderCommandSetUpgrade
@@ -3014,9 +3244,10 @@ CommandSet Demo_GLATankMarauderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
@@ -3033,9 +3264,10 @@ CommandSet Demo_GLAVehicleTechnicalCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
@@ -3047,9 +3279,10 @@ CommandSet Demo_GLAVehicleToxinTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
@@ -3060,9 +3293,10 @@ CommandSet Demo_GLAVehicleRocketBuggyCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLATankScorpionCommandSetUpgrade
@@ -3073,9 +3307,10 @@ CommandSet Demo_GLATankScorpionCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerCommandSetUpgrade
@@ -3095,9 +3330,10 @@ CommandSet Demo_GLAWorkerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, J, K, R, V, W, Y, Z, 
+    Available keys: G, J, K, R, V, Y, Z, 
 End
 
 CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
@@ -3112,9 +3348,10 @@ CommandSet Demo_GLAWorkerFakeBuildingsCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: D, F, G, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Demo_GLACommandCenterCommandSetUpgrade
@@ -3129,7 +3366,8 @@ CommandSet Demo_GLACommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, J, L, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLASupplyStashCommandSetUpgrade
@@ -3139,7 +3377,8 @@ CommandSet Demo_GLASupplyStashCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAPalaceCommandSetUpgrade
@@ -3156,7 +3395,8 @@ CommandSet Demo_GLAPalaceCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLABarracksCommandSetUpgrade
@@ -3171,7 +3411,8 @@ CommandSet Demo_GLABarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Demo_GLABlackMarketCommandSetUpgrade
@@ -3184,7 +3425,8 @@ CommandSet Demo_GLABlackMarketCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, G, K, L, M, N, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, G, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAStingerSiteCommandSetUpgrade
@@ -3193,7 +3435,8 @@ CommandSet Demo_GLAStingerSiteCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLAScudStormCommandSetUpgrade
@@ -3202,7 +3445,8 @@ CommandSet Demo_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
@@ -3222,7 +3466,8 @@ CommandSet Demo_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Demo_GLAArmsDealerCommandSetUpgrade
@@ -3242,7 +3487,8 @@ CommandSet Demo_GLAArmsDealerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, G, I, J, N, P, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
 CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
@@ -3255,9 +3501,10 @@ CommandSet Demo_GLAInfantryRebelCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
@@ -3268,9 +3515,10 @@ CommandSet Demo_GLAInfantryTunnelDefenderCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
@@ -3281,9 +3529,10 @@ CommandSet Demo_GLAInfantryAngryMobCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
@@ -3298,9 +3547,10 @@ CommandSet Demo_GLAInfantryJarmenKellCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, J, K, L, M, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, J, K, L, M, O, P, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
@@ -3311,9 +3561,10 @@ CommandSet Demo_GLAVehicleRadarVanCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleQuadCannonUpgrade
@@ -3324,9 +3575,10 @@ CommandSet Demo_GLAVehicleQuadCannonUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
@@ -3339,9 +3591,10 @@ CommandSet Demo_GLAVehicleBombTruckCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
@@ -3352,9 +3605,10 @@ CommandSet Demo_GLAInfantryHijackerCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
@@ -3374,9 +3628,10 @@ CommandSet Demo_GLAVehicleBattleBusCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
@@ -3387,9 +3642,10 @@ CommandSet Demo_GLAVehicleScudLauncherCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
@@ -3400,27 +3656,31 @@ CommandSet Demo_GLAVehicleCombatBikeDefaultCommandSetUpgrade
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_SpecialPowerShortcutGLA
@@ -3433,7 +3693,8 @@ CommandSet Slth_SpecialPowerShortcutGLA
   7 = Slth_Command_GPSScramblerFromShortcut : GUI:SuperweaponGPSScrambler "GPS干擾器"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerCommandSet
@@ -3452,9 +3713,10 @@ CommandSet Slth_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, R, V, W, Y, Z, 
+    Available keys: G, I, J, K, R, V, Y, Z, 
 End
 
 CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
@@ -3468,9 +3730,10 @@ CommandSet Slth_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Slth_GLACommandCenterCommandSet
@@ -3485,7 +3748,8 @@ CommandSet Slth_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, I, J, L, M, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, I, J, L, M, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLASupplyStashCommandSet
@@ -3495,7 +3759,8 @@ CommandSet Slth_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, L, M, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, L, M, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAPalaceCommandSet
@@ -3513,7 +3778,8 @@ CommandSet Slth_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, F, G, I, J, K, L, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, F, G, I, J, K, L, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLABarracksCommandSet
@@ -3530,7 +3796,8 @@ CommandSet Slth_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, K, L, M, O, P, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, K, L, M, O, P, U, V, X, Z, 
 End
 
 CommandSet Slth_GLABlackMarketCommandSet
@@ -3544,7 +3811,8 @@ CommandSet Slth_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, G, I, K, L, M, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, G, I, K, L, M, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAStingerSiteCommandSet
@@ -3552,7 +3820,8 @@ CommandSet Slth_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAScudStormCommandSet
@@ -3561,7 +3830,8 @@ CommandSet Slth_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLATunnelNetworkCommandSet
@@ -3580,7 +3850,8 @@ CommandSet Slth_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Slth_GLAArmsDealerCommandSet
@@ -3598,7 +3869,8 @@ CommandSet Slth_GLAArmsDealerCommandSet
   15 = Command_ConstructGLAVehicleCombatBikeTerrorist : CONTROLBAR:ConstructGLAVehicleCombatBike "戰鬥摩托車：&Y"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, G, I, J, K, L, M, P, S, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, G, I, J, K, L, M, P, S, X, Z, 
 End
 
 CommandSet Slth_GLADemoTrapCommandSet
@@ -3608,7 +3880,8 @@ CommandSet Slth_GLADemoTrapCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryRebelCommandSet
@@ -3619,9 +3892,10 @@ CommandSet Slth_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
@@ -3631,9 +3905,10 @@ CommandSet Slth_GLAInfantryTunnelDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryTerroristCommandSet
@@ -3643,9 +3918,10 @@ CommandSet Slth_GLAInfantryTerroristCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryAngryMobCommandSet
@@ -3655,9 +3931,10 @@ CommandSet Slth_GLAInfantryAngryMobCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryJarmenKellCommandSet
@@ -3668,9 +3945,10 @@ CommandSet Slth_GLAInfantryJarmenKellCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleRadarVanCommandSet
@@ -3680,9 +3958,10 @@ CommandSet Slth_GLAVehicleRadarVanCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleQuadCannon
@@ -3692,9 +3971,10 @@ CommandSet Slth_GLAVehicleQuadCannon
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBombTruckCommandSet
@@ -3708,9 +3988,10 @@ CommandSet Slth_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAInfantryHijackerCommandSet
@@ -3720,9 +4001,10 @@ CommandSet Slth_GLAInfantryHijackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, I, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleBattleBusCommandSet
@@ -3741,9 +4023,10 @@ CommandSet Slth_GLAVehicleBattleBusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Slth_GLAVehicleScudLauncherCommandSet
@@ -3753,27 +4036,31 @@ CommandSet Slth_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SCIENCE_GLA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_SpecialPowerShortcutGLA
@@ -3785,7 +4072,8 @@ CommandSet Chem_SpecialPowerShortcutGLA
   6 = Command_SneakAttackFromShortcut : CONTROLBAR:SneakAttackShort "偷襲"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerCommandSet
@@ -3804,9 +4092,10 @@ CommandSet Chem_GLAWorkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: G, I, J, K, R, V, W, Y, Z, 
+    Available keys: G, I, J, K, R, V, Y, Z, 
 End
 
 CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
@@ -3820,9 +4109,10 @@ CommandSet Chem_GLAWorkerFakeBuildingsCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, G, I, J, K, N, O, P, T, V, W, Y, Z, 
+    Available keys: D, F, G, I, J, K, N, O, P, T, V, Y, Z, 
 End
 
 CommandSet Chem_GLABarracksCommandSet
@@ -3836,7 +4126,8 @@ CommandSet Chem_GLABarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, F, I, K, L, M, N, O, P, S, U, V, X, Z, 
 End
 
 CommandSet Chem_GLATunnelNetworkCommandSet
@@ -3855,7 +4146,8 @@ CommandSet Chem_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleBombTruckCommandSet
@@ -3868,9 +4160,10 @@ CommandSet Chem_GLAVehicleBombTruckCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, F, I, J, K, L, M, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: D, F, I, J, K, L, M, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAVehicleScudLauncherCommandSet
@@ -3880,9 +4173,10 @@ CommandSet Chem_GLAVehicleScudLauncherCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Chem_GLAPalaceCommandSet
@@ -3899,7 +4193,8 @@ CommandSet Chem_GLAPalaceCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, F, G, I, J, K, L, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Chem_GLACommandCenterCommandSet
@@ -3912,7 +4207,8 @@ CommandSet Chem_GLACommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, G, I, J, L, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, G, I, J, L, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAArmsDealerCommandSet
@@ -3932,7 +4228,8 @@ CommandSet Chem_GLAArmsDealerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, F, G, I, J, N, P, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, F, G, I, J, N, P, X, Z, 
 End
 
 CommandSet Chem_GLASupplyStashCommandSet
@@ -3941,7 +4238,8 @@ CommandSet Chem_GLASupplyStashCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLABlackMarketCommandSet
@@ -3954,7 +4252,8 @@ CommandSet Chem_GLABlackMarketCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, G, I, K, L, M, N, O, P, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAScudStormCommandSet
@@ -3962,7 +4261,8 @@ CommandSet Chem_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAStingerSiteCommandSet
@@ -3970,7 +4270,8 @@ CommandSet Chem_GLAStingerSiteCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Chem_GLAInfantryRebelCommandSet
@@ -3981,27 +4282,31 @@ CommandSet Chem_GLAInfantryRebelCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_SpecialPowerShortcutChina
@@ -4016,7 +4321,8 @@ CommandSet Nuke_SpecialPowerShortcutChina
   10 = Command_FrenzyFromShortcut : CONTROLBAR:NoHotKeyFrenzy "狂暴"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaDozerCommandSet
@@ -4036,9 +4342,10 @@ CommandSet Nuke_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, J, N, O, V, W, Y, Z, 
+    Available keys: D, J, N, O, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSet
@@ -4048,7 +4355,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
@@ -4058,7 +4366,8 @@ CommandSet Nuke_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSet
@@ -4077,7 +4386,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, M, O, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, M, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
@@ -4096,7 +4406,8 @@ CommandSet Nuke_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, L, O, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, L, O, P, S, V, X, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSet
@@ -4110,7 +4421,8 @@ CommandSet Nuke_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBarracksCommandSetUpgrade
@@ -4124,7 +4436,8 @@ CommandSet Nuke_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
@@ -4132,9 +4445,10 @@ CommandSet Nuke_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
@@ -4145,9 +4459,10 @@ CommandSet Nuke_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSet
@@ -4167,7 +4482,8 @@ CommandSet Nuke_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, M, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, M, P, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
@@ -4187,7 +4503,8 @@ CommandSet Nuke_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, J, K, L, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, J, K, L, P, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSet
@@ -4198,7 +4515,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
@@ -4209,7 +4527,8 @@ CommandSet Nuke_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
@@ -4220,9 +4539,10 @@ CommandSet Nuke_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaInfantryHackerCommandSet
@@ -4232,9 +4552,10 @@ CommandSet Nuke_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSet
@@ -4245,7 +4566,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, I, J, K, M, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, I, J, K, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
@@ -4256,7 +4578,8 @@ CommandSet Nuke_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSet
@@ -4271,7 +4594,8 @@ CommandSet Nuke_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaBunkerCommandSetUpgrade
@@ -4286,7 +4610,8 @@ CommandSet Nuke_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSet
@@ -4298,7 +4623,8 @@ CommandSet Nuke_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
@@ -4310,7 +4636,8 @@ CommandSet Nuke_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleHelixCommandSet
@@ -4331,9 +4658,10 @@ CommandSet Nuke_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: F, I, J, K, L, M, O, P, R, U, W, Y, Z, 
+    Available keys: F, I, J, K, L, M, O, P, R, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
@@ -4351,9 +4679,10 @@ CommandSet Nuke_ChinaHelixGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
@@ -4371,9 +4700,10 @@ CommandSet Nuke_ChinaHelixPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
@@ -4391,9 +4721,10 @@ CommandSet Nuke_ChinaHelixBattleBunkerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
@@ -4403,9 +4734,10 @@ CommandSet Nuke_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Nuke_ChinaListeningOutpostCommandSet
@@ -4418,21 +4750,24 @@ CommandSet Nuke_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
@@ -4440,7 +4775,8 @@ CommandSet SupW_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "炸彈之母：&B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_SpecialPowerShortcutUSA
@@ -4456,7 +4792,8 @@ CommandSet SupW_SpecialPowerShortcutUSA
   10 = Command_CIAIntelligenceFromShortcut : CONTROLBAR:CIAIntelligenceShortcut "情報"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaDozerCommandSet
@@ -4475,9 +4812,10 @@ CommandSet SupW_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, O, T, V, W, 
+    Available keys: D, G, J, K, N, O, T, V, 
 End
 
 CommandSet SupW_AmericaBarracksCommandSet
@@ -4491,7 +4829,8 @@ CommandSet SupW_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCommandCenterCommandSet
@@ -4508,7 +4847,8 @@ CommandSet SupW_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, I, J, K, M, N, P, T, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
 CommandSet SupW_AmericaPatriotBatteryCommandSet
@@ -4516,7 +4856,8 @@ CommandSet SupW_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaSupplyCenterCommandSet
@@ -4525,7 +4866,8 @@ CommandSet SupW_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaWarFactoryCommandSet
@@ -4541,7 +4883,8 @@ CommandSet SupW_AmericaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, J, K, L, O, P, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, J, K, L, O, P, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaStrategyCenterCommandSet
@@ -4558,7 +4901,8 @@ CommandSet SupW_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, G, J, K, L, N, P, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, G, J, K, L, N, P, T, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleComancheCommandSet
@@ -4569,9 +4913,10 @@ CommandSet SupW_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaAirfieldCommandSet
@@ -4587,7 +4932,8 @@ CommandSet SupW_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaNuclearMissileCommandSet
@@ -4595,7 +4941,8 @@ CommandSet SupW_AmericaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaCruiseMissileCommandSet
@@ -4603,7 +4950,8 @@ CommandSet SupW_AmericaCruiseMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaTomahawkStormCommandSet
@@ -4611,7 +4959,8 @@ CommandSet SupW_AmericaTomahawkStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaPowerPlantCommandSet
@@ -4619,7 +4968,8 @@ CommandSet SupW_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaParticleUplinkCannonCommandSet
@@ -4627,7 +4977,8 @@ CommandSet SupW_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
@@ -4641,9 +4992,10 @@ CommandSet SupW_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
@@ -4654,9 +5006,10 @@ CommandSet SupW_AmericaInfantryMissileDefenderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaInfantryRangerCommandSet
@@ -4669,9 +5022,10 @@ CommandSet SupW_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankCrusaderCommandSet
@@ -4684,9 +5038,10 @@ CommandSet SupW_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleTomahawkCommandSet
@@ -4699,9 +5054,10 @@ CommandSet SupW_AmericaVehicleTomahawkCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleHumveeCommandSet
@@ -4720,9 +5076,10 @@ CommandSet SupW_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankMicrowaveCommandSet
@@ -4735,9 +5092,10 @@ CommandSet SupW_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleAmbulanceCommandSet
@@ -4756,9 +5114,10 @@ CommandSet SupW_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankAvengerCommandSet
@@ -4771,9 +5130,10 @@ CommandSet SupW_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaFireBaseCommandSet
@@ -4786,7 +5146,8 @@ CommandSet SupW_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet SupW_AmericaVehicleChinookCommandSet
@@ -4804,9 +5165,10 @@ CommandSet SupW_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet SupW_AmericaJetAuroraCommandSet
@@ -4816,9 +5178,10 @@ CommandSet SupW_AmericaJetAuroraCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet SupW_AmericaTankPaladinCommandSet
@@ -4831,27 +5194,31 @@ CommandSet SupW_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_SpecialPowerShortcutChina
@@ -4866,7 +5233,8 @@ CommandSet Infa_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "衛星侵入2"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaDozerCommandSet
@@ -4886,9 +5254,10 @@ CommandSet Infa_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, J, N, O, V, W, Y, Z, 
+    Available keys: D, J, N, O, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaPowerPlantCommandSet
@@ -4897,7 +5266,8 @@ CommandSet Infa_ChinaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSet
@@ -4915,7 +5285,8 @@ CommandSet Infa_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, M, N, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, M, N, P, S, V, X, Z, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSet
@@ -4925,7 +5296,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
@@ -4935,7 +5307,8 @@ CommandSet Infa_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
@@ -4953,7 +5326,8 @@ CommandSet Infa_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, G, J, K, L, N, P, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, G, J, K, L, N, P, S, V, X, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSet
@@ -4967,7 +5341,8 @@ CommandSet Infa_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBarracksCommandSetUpgrade
@@ -4981,7 +5356,8 @@ CommandSet Infa_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
@@ -4989,9 +5365,10 @@ CommandSet Infa_ChinaInfantryPropagandaTrooperCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, D, F, G, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
@@ -5002,9 +5379,10 @@ CommandSet Infa_ChinaInfantryMiniGunnerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSet
@@ -5021,7 +5399,8 @@ CommandSet Infa_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, J, K, M, O, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, F, G, J, K, M, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
@@ -5038,7 +5417,8 @@ CommandSet Infa_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, F, G, J, K, L, O, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, F, G, J, K, L, O, P, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSet
@@ -5048,7 +5428,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
@@ -5058,7 +5439,8 @@ CommandSet Infa_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSet
@@ -5070,7 +5452,8 @@ CommandSet Infa_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaAirfieldCommandSetUpgrade
@@ -5082,7 +5465,8 @@ CommandSet Infa_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSet
@@ -5092,7 +5476,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
@@ -5102,7 +5487,8 @@ CommandSet Infa_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOne
@@ -5120,7 +5506,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOne
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
@@ -5138,7 +5525,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetOneUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwo
@@ -5156,7 +5544,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwo
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
@@ -5174,7 +5563,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetTwoUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThree
@@ -5192,7 +5582,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThree
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, M, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
@@ -5210,7 +5601,8 @@ CommandSet Infa_ChinaInternetCenterCommandSetThreeUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSet
@@ -5230,7 +5622,8 @@ CommandSet Infa_ChinaBunkerCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaBunkerCommandSetUpgrade
@@ -5250,7 +5643,8 @@ CommandSet Infa_ChinaBunkerCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Infa_ChinaTroopCrawlerCommandSet
@@ -5269,9 +5663,10 @@ CommandSet Infa_ChinaTroopCrawlerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaListeningOutpostCommandSet
@@ -5290,9 +5685,10 @@ CommandSet Infa_ChinaListeningOutpostCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaVehicleHelixCommandSet
@@ -5313,9 +5709,10 @@ CommandSet Infa_ChinaVehicleHelixCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, D, F, I, J, K, L, M, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaHelixBombCommandSet
@@ -5336,9 +5733,10 @@ CommandSet Infa_ChinaHelixBombCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, F, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, F, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryBlackLotusCommandSet
@@ -5349,9 +5747,10 @@ CommandSet Infa_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Infa_ChinaInfantryHackerCommandSet
@@ -5362,21 +5761,24 @@ CommandSet Infa_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
@@ -5384,7 +5786,8 @@ CommandSet Lazr_SCIENCE_AMERICA_CommandSetRank8
   4 = Command_FAKECOMMAND_PurchaseScienceMOAB : CONTROLBAR:MOAB "炸彈之母：&B"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_SpecialPowerShortcutUSA
@@ -5401,7 +5804,8 @@ CommandSet Lazr_SpecialPowerShortcutUSA
   11 = Lazr_Command_FireLaserCannonFromShortcut : CONTROLBAR:FireLaserCannonShortcut "雷射加農砲"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaDozerCommandSet
@@ -5420,9 +5824,10 @@ CommandSet Lazr_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, G, J, K, N, O, T, V, W, 
+    Available keys: D, G, J, K, N, O, T, V, 
 End
 
 CommandSet Lazr_AmericaSupplyCenterCommandSet
@@ -5431,7 +5836,8 @@ CommandSet Lazr_AmericaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaCommandCenterCommandSet
@@ -5448,7 +5854,8 @@ CommandSet Lazr_AmericaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, F, I, J, K, M, N, P, T, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, F, I, J, K, M, N, P, T, U, V, X, Z, 
 End
 
 CommandSet Lazr_AmericaStrategyCenterCommandSet
@@ -5466,7 +5873,8 @@ CommandSet Lazr_AmericaStrategyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, G, J, K, L, N, T, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, G, J, K, L, N, T, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaWarFactoryCommandSet
@@ -5482,7 +5890,8 @@ CommandSet Lazr_AmericaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, J, K, L, O, P, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, J, K, L, O, P, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaBarracksCommandSet
@@ -5496,7 +5905,8 @@ CommandSet Lazr_AmericaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaFireBaseCommandSet
@@ -5509,7 +5919,8 @@ CommandSet Lazr_AmericaFireBaseCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaPowerPlantCommandSet
@@ -5517,7 +5928,8 @@ CommandSet Lazr_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaAirfieldCommandSet
@@ -5533,7 +5945,8 @@ CommandSet Lazr_AmericaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, D, E, G, I, J, K, M, N, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, D, E, G, I, J, K, M, N, S, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
@@ -5541,7 +5954,8 @@ CommandSet Lazr_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleComancheCommandSet
@@ -5552,9 +5966,10 @@ CommandSet Lazr_AmericaVehicleComancheCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaJetStealthFighterCommandSet
@@ -5564,9 +5979,10 @@ CommandSet Lazr_AmericaJetStealthFighterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryRangerCommandSet
@@ -5579,9 +5995,10 @@ CommandSet Lazr_AmericaInfantryRangerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, I, J, K, L, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
@@ -5595,9 +6012,10 @@ CommandSet Lazr_AmericaInfantryColonelBurtonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, L, M, N, O, P, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, L, M, N, O, P, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleChinookCommandSet
@@ -5615,9 +6033,10 @@ CommandSet Lazr_AmericaVehicleChinookCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankAvengerCommandSet
@@ -5630,9 +6049,10 @@ CommandSet Lazr_AmericaTankAvengerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankCrusaderCommandSet
@@ -5645,9 +6065,10 @@ CommandSet Lazr_AmericaTankCrusaderCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleHumveeCommandSet
@@ -5666,9 +6087,10 @@ CommandSet Lazr_AmericaVehicleHumveeCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankMicrowaveCommandSet
@@ -5681,9 +6103,10 @@ CommandSet Lazr_AmericaTankMicrowaveCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
@@ -5702,9 +6125,10 @@ CommandSet Lazr_AmericaVehicleAmbulanceCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: I, J, K, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: I, J, K, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Lazr_AmericaTankPaladinCommandSet
@@ -5717,9 +6141,10 @@ CommandSet Lazr_AmericaTankPaladinCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: C, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
@@ -5729,9 +6154,10 @@ CommandSet Lazr_AmericaVehicleSentryDroneCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Lazr_AmericaLaserCannonCommandSet
@@ -5739,25 +6165,29 @@ CommandSet Lazr_AmericaLaserCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_SpecialPowerShortcutChina
@@ -5772,7 +6202,8 @@ CommandSet Tank_SpecialPowerShortcutChina
   9 = Command_SatelliteHackTwoFromShortcut : CONTROLBAR:SatelliteHackTwoShortcut "衛星侵入2"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaDozerCommandSet
@@ -5792,9 +6223,10 @@ CommandSet Tank_ChinaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, J, N, O, V, W, Y, Z, 
+    Available keys: D, J, N, O, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSet
@@ -5804,7 +6236,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
@@ -5814,7 +6247,8 @@ CommandSet Tank_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSet
@@ -5833,7 +6267,8 @@ CommandSet Tank_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, M, N, O, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, M, N, O, S, V, X, Z, 
 End
 
 CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
@@ -5852,7 +6287,8 @@ CommandSet Tank_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: F, G, J, K, L, N, O, S, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: F, G, J, K, L, N, O, S, V, X, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSet
@@ -5870,7 +6306,8 @@ CommandSet Tank_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, I, J, K, M, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, I, J, K, M, P, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
@@ -5888,7 +6325,8 @@ CommandSet Tank_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, F, I, J, K, L, P, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, F, I, J, K, L, P, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSet
@@ -5899,7 +6337,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, M, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, M, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
@@ -5910,7 +6349,8 @@ CommandSet Tank_ChinaPropagandaCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, J, K, L, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleBattleMasterCommandSet
@@ -5920,9 +6360,10 @@ CommandSet Tank_ChinaVehicleBattleMasterCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
@@ -5932,9 +6373,10 @@ CommandSet Tank_ChinaTankOverlordGattlingCannonCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
@@ -5944,9 +6386,10 @@ CommandSet Tank_ChinaTankOverlordPropagandaTowerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryBlackLotusCommandSet
@@ -5957,9 +6400,10 @@ CommandSet Tank_ChinaInfantryBlackLotusCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, W, Y, Z, 
+    Available keys: A, B, D, F, G, I, J, L, M, N, O, P, R, T, U, Y, Z, 
 End
 
 CommandSet Tank_ChinaTankEmperorDefaultCommandSet
@@ -5970,9 +6414,10 @@ CommandSet Tank_ChinaTankEmperorDefaultCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleGattlingTankCommandSet
@@ -5982,9 +6427,10 @@ CommandSet Tank_ChinaVehicleGattlingTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, D, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSet
@@ -5993,7 +6439,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
@@ -6002,7 +6449,8 @@ CommandSet Tank_ChinaGattlingCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaVehicleECMTankCommandSet
@@ -6013,9 +6461,10 @@ CommandSet Tank_ChinaVehicleECMTankCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: B, C, F, I, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSet
@@ -6029,7 +6478,8 @@ CommandSet Tank_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, M, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaBarracksCommandSetUpgrade
@@ -6043,7 +6493,8 @@ CommandSet Tank_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, F, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaInfantryHackerCommandSet
@@ -6053,9 +6504,10 @@ CommandSet Tank_ChinaInfantryHackerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, W, Y, Z, 
+    Available keys: A, B, C, F, G, J, K, L, M, N, O, P, R, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSet
@@ -6066,7 +6518,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, M, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
@@ -6077,7 +6530,8 @@ CommandSet Tank_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSet
@@ -6089,7 +6543,8 @@ CommandSet Tank_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, M, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Tank_ChinaAirfieldCommandSetUpgrade
@@ -6101,25 +6556,29 @@ CommandSet Tank_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, C, D, E, F, I, J, K, L, N, O, P, S, T, U, V, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank1
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank3
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_SCIENCE_CHINA_CommandSetRank8
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, M, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSet
@@ -6139,7 +6598,8 @@ CommandSet Boss_GLATunnelNetworkCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
@@ -6159,7 +6619,8 @@ CommandSet Boss_GLATunnelNetworkCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSet
@@ -6168,7 +6629,8 @@ CommandSet Boss_AmericaPowerPlantCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
@@ -6177,7 +6639,8 @@ CommandSet Boss_AmericaPowerPlantCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, D, E, F, G, I, J, K, L, N, O, P, R, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSet
@@ -6186,7 +6649,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
@@ -6195,7 +6659,8 @@ CommandSet Boss_AmericaPatriotBatteryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, R, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaDozerCommandSet
@@ -6216,9 +6681,10 @@ CommandSet Boss_AmericaDozerCommandSet
   CommandMap SELECT_MATCHING_UNITS : "E"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
   CommandMap SCATTER : "X"
   CommandMap STOP : "S"
-    Available keys: D, J, L, V, W, Y, Z, 
+    Available keys: D, J, L, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSet
@@ -6235,7 +6701,8 @@ CommandSet Boss_ChinaCommandCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, E, F, J, K, L, N, O, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, E, F, J, K, L, N, O, P, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
@@ -6252,7 +6719,8 @@ CommandSet Boss_ChinaCommandCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, E, F, J, K, L, N, O, P, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, E, F, J, K, L, N, O, P, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSet
@@ -6268,7 +6736,8 @@ CommandSet Boss_ChinaAirfieldCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaAirfieldCommandSetUpgrade
@@ -6284,7 +6753,8 @@ CommandSet Boss_ChinaAirfieldCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, I, J, K, N, P, S, U, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSet
@@ -6294,7 +6764,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
@@ -6304,7 +6775,8 @@ CommandSet Boss_ChinaSupplyCenterCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, B, C, D, E, F, G, I, J, K, L, N, O, P, S, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSet
@@ -6324,7 +6796,8 @@ CommandSet Boss_ChinaBarracksCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, K, L, O, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, K, L, O, S, U, V, X, Z, 
 End
 
 CommandSet Boss_ChinaBarracksCommandSetUpgrade
@@ -6344,7 +6817,8 @@ CommandSet Boss_ChinaBarracksCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: D, E, K, L, O, S, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: D, E, K, L, O, S, U, V, X, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSet
@@ -6364,7 +6838,8 @@ CommandSet Boss_ChinaWarFactoryCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, L, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, L, U, V, X, Z, 
 End
 
 CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
@@ -6384,7 +6859,8 @@ CommandSet Boss_ChinaWarFactoryCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: E, F, I, J, K, L, U, V, W, X, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: E, F, I, J, K, L, U, V, X, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSet
@@ -6397,7 +6873,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
@@ -6410,7 +6887,8 @@ CommandSet Boss_AmericaParticleUplinkCannonCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: B, D, E, F, G, I, J, K, L, O, S, T, U, V, X, Y, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSet
@@ -6425,7 +6903,8 @@ CommandSet Boss_GLAScudStormCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, K, L, N, P, S, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, K, L, N, P, S, T, V, Y, Z, 
 End
 
 CommandSet Boss_GLAScudStormCommandSetUpgrade
@@ -6440,7 +6919,8 @@ CommandSet Boss_GLAScudStormCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: C, D, E, F, G, I, K, L, N, P, S, T, V, W, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: C, D, E, F, G, I, K, L, N, P, S, T, V, Y, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSet
@@ -6453,7 +6933,8 @@ CommandSet Boss_ChinaNuclearMissileCommandSet
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 
 CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
@@ -6466,6 +6947,7 @@ CommandSet Boss_ChinaNuclearMissileCommandSetUpgrade
   14 = Command_Sell : CONTROLBAR:Sell "賣出"
   CommandMap VIEW_COMMAND_CENTER : "H"
   CommandMap SELECT_ALL : "Q"
-    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, W, X, Y, Z, 
+  CommandMap SELECT_ALL_AIRCRAFT : "W"
+    Available keys: A, C, D, E, F, G, J, K, L, O, P, R, S, V, X, Y, Z, 
 End
 

--- a/Patch104pZH/GameFilesEdited/Data/Arabic/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Arabic/CommandMap.ini
@@ -973,7 +973,6 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
-
 CommandMap TOGGLE_CAMERA_TRACKING_DRAWABLE
   Key = KEY_T
   Transition = DOWN

--- a/Patch104pZH/GameFilesEdited/Data/Brazilian/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Brazilian/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch104p @fix xezon 10/05/2025 Adds missing command mapping.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch104pZH/GameFilesEdited/Data/Chinese/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Chinese/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch104p @fix xezon 10/05/2025 Adds missing command mapping.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch104pZH/GameFilesEdited/Data/French/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/French/CommandMap.ini
@@ -655,6 +655,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch104p @fix xezon 10/05/2025 Adds missing command mapping.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch104pZH/GameFilesEdited/Data/German/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/German/CommandMap.ini
@@ -654,6 +654,18 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch104p @fix xezon 10/05/2025 Adds missing command mapping.
+; Uses CTRL+Q mapping because W is already mapped by Guard mode.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_Q
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch104pZH/GameFilesEdited/Data/Italian/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Italian/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch104p @fix xezon 10/05/2025 Adds missing command mapping.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch104pZH/GameFilesEdited/Data/Korean/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Korean/CommandMap.ini
@@ -2,16 +2,6 @@
 ;FILE: CommandMap.ini (DEFAULT) ////////////////////////////////////////////////////
 ;//////////////////////////////////////////////////////////////////////////////
 
-CommandMap SELECT_ALL_AIRCRAFT
-  Key = KEY_W
-  Transition = DOWN
-  Modifiers = NONE
-  UseableIn = GAME
-  Category = SELECTION
-  Description = GUI:SelectAllAircraftDescription
-  DisplayName = GUI:SelectAllAircraft
-END
-
 CommandMap SAVE_VIEW1
   Key = KEY_F1
   Transition = DOWN
@@ -662,6 +652,16 @@ CommandMap SELECT_ALL
   Category = SELECTION
   Description = GUI:SelectAllDescription
   DisplayName = GUI:SelectAll
+END
+
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
 END
 
 CommandMap SCATTER

--- a/Patch104pZH/GameFilesEdited/Data/Spanish/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Spanish/CommandMap.ini
@@ -973,7 +973,6 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
-
 CommandMap TOGGLE_CAMERA_TRACKING_DRAWABLE
   Key = KEY_T
   Transition = DOWN


### PR DESCRIPTION
This change adds the missing key mappings for Select All Aircraft to the Brazilian, Chinese, French, German, Italian localizations.

To avoid key conflicts, a few extra mappings needed changing in generals.str.

Select All Aircraft for German cannot be bound to W without major key conflicts. Therefore it is bound to CTRL+Q instead.

## TODO

- [ ] Add documentation