### PR TITLE
[ZH] Fix: Optionally sync arrow key mappings for Select Prev/Next Unit/Worker with Generals for Brazilian, Chinese, French, German, Italian, Korean, Polish

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/Brazilian/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Brazilian/CommandMap.ini
@@ -574,10 +574,22 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
+; Patch104p @fix xezon 10/05/2025 Sync arrow key mappings with Generals the way
+; this was intended, but only for the optional bundle to not disturb the legacy players.
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -587,7 +599,12 @@ End
 CommandMap SELECT_PREV_UNIT
   Key = KEY_LEFT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription
@@ -597,7 +614,12 @@ End
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -607,7 +629,12 @@ End
 CommandMap SELECT_PREV_WORKER
   Key = KEY_DOWN
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription

--- a/Patch104pZH/GameFilesEdited/Data/Chinese/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Chinese/CommandMap.ini
@@ -574,10 +574,22 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
+; Patch104p @fix xezon 10/05/2025 Sync arrow key mappings with Generals the way
+; this was intended, but only for the optional bundle to not disturb the legacy players.
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -587,7 +599,12 @@ End
 CommandMap SELECT_PREV_UNIT
   Key = KEY_LEFT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription
@@ -597,7 +614,12 @@ End
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -607,7 +629,12 @@ End
 CommandMap SELECT_PREV_WORKER
   Key = KEY_DOWN
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription

--- a/Patch104pZH/GameFilesEdited/Data/French/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/French/CommandMap.ini
@@ -574,10 +574,22 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
+; Patch104p @fix xezon 10/05/2025 Sync arrow key mappings with Generals the way
+; this was intended, but only for the optional bundle to not disturb the legacy players.
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -587,7 +599,12 @@ End
 CommandMap SELECT_PREV_UNIT
   Key = KEY_LEFT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription
@@ -597,7 +614,12 @@ End
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -607,7 +629,12 @@ End
 CommandMap SELECT_PREV_WORKER
   Key = KEY_DOWN
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription

--- a/Patch104pZH/GameFilesEdited/Data/German/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/German/CommandMap.ini
@@ -574,10 +574,22 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
+; Patch104p @fix xezon 10/05/2025 Sync arrow key mappings with Generals the way
+; this was intended, but only for the optional bundle to not disturb the legacy players.
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -587,7 +599,12 @@ End
 CommandMap SELECT_PREV_UNIT
   Key = KEY_LEFT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription
@@ -597,7 +614,12 @@ End
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -607,7 +629,12 @@ End
 CommandMap SELECT_PREV_WORKER
   Key = KEY_DOWN
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription

--- a/Patch104pZH/GameFilesEdited/Data/Italian/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Italian/CommandMap.ini
@@ -574,10 +574,22 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
+; Patch104p @fix xezon 10/05/2025 Sync arrow key mappings with Generals the way
+; this was intended, but only for the optional bundle to not disturb the legacy players.
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -587,7 +599,12 @@ End
 CommandMap SELECT_PREV_UNIT
   Key = KEY_LEFT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription
@@ -597,7 +614,12 @@ End
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -607,7 +629,12 @@ End
 CommandMap SELECT_PREV_WORKER
   Key = KEY_DOWN
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription

--- a/Patch104pZH/GameFilesEdited/Data/Korean/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Korean/CommandMap.ini
@@ -584,10 +584,22 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
+; Patch104p @fix xezon 10/05/2025 Sync arrow key mappings with Generals the way
+; this was intended, but only for the optional bundle to not disturb the legacy players.
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -597,7 +609,12 @@ End
 CommandMap SELECT_PREV_UNIT
   Key = KEY_LEFT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription
@@ -607,7 +624,12 @@ End
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -617,7 +639,12 @@ End
 CommandMap SELECT_PREV_WORKER
   Key = KEY_DOWN
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription

--- a/Patch104pZH/GameFilesEdited/Data/Polish/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Polish/CommandMap.ini
@@ -574,10 +574,22 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
+; Patch104p @fix xezon 10/05/2025 Sync arrow key mappings with Generals the way
+; this was intended, but only for the optional bundle to not disturb the legacy players.
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -587,7 +599,12 @@ End
 CommandMap SELECT_PREV_UNIT
   Key = KEY_LEFT
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription
@@ -597,7 +614,12 @@ End
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
@@ -607,7 +629,12 @@ End
 CommandMap SELECT_PREV_WORKER
   Key = KEY_DOWN
   Transition = DOWN
+;patch104p-core-begin
   Modifiers = NONE
+;patch104p-core-end
+;patch104p-optional-begin
+  Modifiers = CTRL
+;patch104p-optional-end
   UseableIn = GAME
   Category = SELECTION
   Description = GUI:SelectPrevUnitDescription


### PR DESCRIPTION
This change optionally syncs the arrow key mappings for Select Prev/Next Unit/Worker with Generals for the Brazilian, Chinese, French, German, Italian, Korean, Polish localizations.

This achieves key mapping consistency for the arrows keys across Generals and Zero Hour. Synced from Generals to Zero Hour, because it matches the intent as clarified by the EA comment. Also, it feels more plausible when using in game.

Applied in Optional Bundle only to not disturb legacy players with these languages.

## Original Brazilian, Chinese, French, German, Italian, Korean, Polish

| Command             | Generals       | Zero Hour      |
|---------------------|----------------|----------------|
| SELECT_NEXT_UNIT    | CTRL+KEY_RIGHT | KEY_RIGHT      |
| SELECT_PREV_UNIT    | CTRL+KEY_LEFT  | KEY_LEFT       |
| SELECT_NEXT_WORKER  | CTRL+KEY_UP    | KEY_UP         |
| SELECT_PREV_WORKER  | CTRL+KEY_DOWN  | KEY_DOWN       |
| Camera Scroll Right | KEY_RIGHT      | CTRL+KEY_RIGHT |
| Camera Scroll Left  | KEY_LEFT       | CTRL+KEY_LEFT  |
| Camera Scroll Up    | KEY_UP         | CTRL+KEY_UP    |
| Camera Scroll Down  | KEY_DOWN       | CTRL+KEY_DOWN  |

## Patched Brazilian, Chinese, French, German, Italian, Korean, Polish

| Command             | Generals       | Zero Hour      |
|---------------------|----------------|----------------|
| SELECT_NEXT_UNIT    | CTRL+KEY_RIGHT | CTRL+KEY_RIGHT |
| SELECT_PREV_UNIT    | CTRL+KEY_LEFT  | CTRL+KEY_LEFT  |
| SELECT_NEXT_WORKER  | CTRL+KEY_UP    | CTRL+KEY_UP    |
| SELECT_PREV_WORKER  | CTRL+KEY_DOWN  | CTRL+KEY_DOWN  |
| Camera Scroll Right | KEY_RIGHT      | KEY_RIGHT      |
| Camera Scroll Left  | KEY_LEFT       | KEY_LEFT       |
| Camera Scroll Up    | KEY_UP         | KEY_UP         |
| Camera Scroll Down  | KEY_DOWN       | KEY_DOWN       |

## TODO

- [ ] Add documentation