### PR TITLE
[GEN][ZH] Refactor arrow key mapping definitions in all language INI files

### DIFF
--- a/Patch104pZH/GameFilesEdited/Data/Arabic/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Arabic/CommandMap.ini
@@ -581,11 +581,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
-;
 ;   select next/prev worker/unit now requires the CTRL key plus arrow keys
 ;   arrow keys were freed up to allow these buttons for use in scrolling
 ;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
-;
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
@@ -606,16 +605,6 @@ CommandMap SELECT_PREV_UNIT
   DisplayName = GUI:SelectPrevUnit
 End
 
-CommandMap SELECT_PREV_WORKER
-  Key = KEY_DOWN
-  Transition = DOWN
-  Modifiers = CTRL
-  UseableIn = GAME
-  Category = SELECTION
-  Description = GUI:SelectPrevUnitDescription
-  DisplayName = GUI:SelectPrevUnit
-End
-
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
@@ -624,6 +613,16 @@ CommandMap SELECT_NEXT_WORKER
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
   DisplayName = GUI:SelectNextUnit
+End
+
+CommandMap SELECT_PREV_WORKER
+  Key = KEY_DOWN
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectPrevUnitDescription
+  DisplayName = GUI:SelectPrevUnit
 End
 
 CommandMap SELECT_HERO

--- a/Patch104pZH/GameFilesEdited/Data/English/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/English/CommandMap.ini
@@ -581,11 +581,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
-;
 ;   select next/prev worker/unit now requires the CTRL key plus arrow keys
 ;   arrow keys were freed up to allow these buttons for use in scrolling
 ;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
-;
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
@@ -606,16 +605,6 @@ CommandMap SELECT_PREV_UNIT
   DisplayName = GUI:SelectPrevUnit
 End
 
-CommandMap SELECT_PREV_WORKER
-  Key = KEY_DOWN
-  Transition = DOWN
-  Modifiers = CTRL
-  UseableIn = GAME
-  Category = SELECTION
-  Description = GUI:SelectPrevUnitDescription
-  DisplayName = GUI:SelectPrevUnit
-End
-
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
@@ -624,6 +613,16 @@ CommandMap SELECT_NEXT_WORKER
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
   DisplayName = GUI:SelectNextUnit
+End
+
+CommandMap SELECT_PREV_WORKER
+  Key = KEY_DOWN
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectPrevUnitDescription
+  DisplayName = GUI:SelectPrevUnit
 End
 
 CommandMap SELECT_HERO

--- a/Patch104pZH/GameFilesEdited/Data/Russian/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Russian/CommandMap.ini
@@ -581,11 +581,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
-;
 ;   select next/prev worker/unit now requires the CTRL key plus arrow keys
 ;   arrow keys were freed up to allow these buttons for use in scrolling
 ;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
-;
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
@@ -606,16 +605,6 @@ CommandMap SELECT_PREV_UNIT
   DisplayName = GUI:SelectPrevUnit
 End
 
-CommandMap SELECT_PREV_WORKER
-  Key = KEY_DOWN
-  Transition = DOWN
-  Modifiers = CTRL
-  UseableIn = GAME
-  Category = SELECTION
-  Description = GUI:SelectPrevUnitDescription
-  DisplayName = GUI:SelectPrevUnit
-End
-
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
@@ -624,6 +613,16 @@ CommandMap SELECT_NEXT_WORKER
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
   DisplayName = GUI:SelectNextUnit
+End
+
+CommandMap SELECT_PREV_WORKER
+  Key = KEY_DOWN
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectPrevUnitDescription
+  DisplayName = GUI:SelectPrevUnit
 End
 
 CommandMap SELECT_HERO

--- a/Patch104pZH/GameFilesEdited/Data/Spanish/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Spanish/CommandMap.ini
@@ -581,11 +581,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
-;
 ;   select next/prev worker/unit now requires the CTRL key plus arrow keys
 ;   arrow keys were freed up to allow these buttons for use in scrolling
 ;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
-;
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
@@ -606,16 +605,6 @@ CommandMap SELECT_PREV_UNIT
   DisplayName = GUI:SelectPrevUnit
 End
 
-CommandMap SELECT_PREV_WORKER
-  Key = KEY_DOWN
-  Transition = DOWN
-  Modifiers = CTRL
-  UseableIn = GAME
-  Category = SELECTION
-  Description = GUI:SelectPrevUnitDescription
-  DisplayName = GUI:SelectPrevUnit
-End
-
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
@@ -624,6 +613,16 @@ CommandMap SELECT_NEXT_WORKER
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
   DisplayName = GUI:SelectNextUnit
+End
+
+CommandMap SELECT_PREV_WORKER
+  Key = KEY_DOWN
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectPrevUnitDescription
+  DisplayName = GUI:SelectPrevUnit
 End
 
 CommandMap SELECT_HERO

--- a/Patch104pZH/GameFilesEdited/Data/Swedish/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Swedish/CommandMap.ini
@@ -581,11 +581,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
-;
 ;   select next/prev worker/unit now requires the CTRL key plus arrow keys
 ;   arrow keys were freed up to allow these buttons for use in scrolling
 ;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
-;
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
@@ -606,16 +605,6 @@ CommandMap SELECT_PREV_UNIT
   DisplayName = GUI:SelectPrevUnit
 End
 
-CommandMap SELECT_PREV_WORKER
-  Key = KEY_DOWN
-  Transition = DOWN
-  Modifiers = CTRL
-  UseableIn = GAME
-  Category = SELECTION
-  Description = GUI:SelectPrevUnitDescription
-  DisplayName = GUI:SelectPrevUnit
-End
-
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
@@ -624,6 +613,16 @@ CommandMap SELECT_NEXT_WORKER
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
   DisplayName = GUI:SelectNextUnit
+End
+
+CommandMap SELECT_PREV_WORKER
+  Key = KEY_DOWN
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectPrevUnitDescription
+  DisplayName = GUI:SelectPrevUnit
 End
 
 CommandMap SELECT_HERO

--- a/Patch104pZH/GameFilesEdited/Data/Ukrainian/CommandMap.ini
+++ b/Patch104pZH/GameFilesEdited/Data/Ukrainian/CommandMap.ini
@@ -581,11 +581,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
-;
 ;   select next/prev worker/unit now requires the CTRL key plus arrow keys
 ;   arrow keys were freed up to allow these buttons for use in scrolling
 ;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
-;
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN
@@ -606,16 +605,6 @@ CommandMap SELECT_PREV_UNIT
   DisplayName = GUI:SelectPrevUnit
 End
 
-CommandMap SELECT_PREV_WORKER
-  Key = KEY_DOWN
-  Transition = DOWN
-  Modifiers = CTRL
-  UseableIn = GAME
-  Category = SELECTION
-  Description = GUI:SelectPrevUnitDescription
-  DisplayName = GUI:SelectPrevUnit
-End
-
 CommandMap SELECT_NEXT_WORKER
   Key = KEY_UP
   Transition = DOWN
@@ -624,6 +613,16 @@ CommandMap SELECT_NEXT_WORKER
   Category = SELECTION
   Description = GUI:SelectNextUnitDescription
   DisplayName = GUI:SelectNextUnit
+End
+
+CommandMap SELECT_PREV_WORKER
+  Key = KEY_DOWN
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectPrevUnitDescription
+  DisplayName = GUI:SelectPrevUnit
 End
 
 CommandMap SELECT_HERO

--- a/Patch108pCCG/GameFilesCore/Data/Chinese/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Chinese/CommandMap.ini
@@ -574,6 +574,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/French/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/French/CommandMap.ini
@@ -574,6 +574,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/German/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/German/CommandMap.ini
@@ -574,6 +574,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Italian/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Italian/CommandMap.ini
@@ -574,6 +574,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Korean/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Korean/CommandMap.ini
@@ -574,6 +574,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Polish/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Polish/CommandMap.ini
@@ -574,6 +574,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Spanish/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Spanish/CommandMap.ini
@@ -574,6 +574,10 @@ CommandMap SELECT_MATCHING_UNITS
   DisplayName = GUI:TypeSelect
 End
 
+;   select next/prev worker/unit now requires the CTRL key plus arrow keys
+;   arrow keys were freed up to allow these buttons for use in scrolling
+;   this was changed at the request of Harvard Bonin     -SCC 6/12/03
+
 CommandMap SELECT_NEXT_UNIT
   Key = KEY_RIGHT
   Transition = DOWN


### PR DESCRIPTION
This change just refactors the arrow key mapping definitions in all language INI files for consistency. No behaviour is changed.