### PR TITLE
[GEN] Add new key mapping for Fast Forward Replay to original game languages

### DIFF
--- a/Patch108pCCG/GameFilesCore/Data/Brazilian/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Brazilian/CommandMap.ini
@@ -955,4 +955,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/Chinese/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Chinese/CommandMap.ini
@@ -951,4 +951,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/English/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/English/CommandMap.ini
@@ -955,4 +955,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/French/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/French/CommandMap.ini
@@ -951,4 +951,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/German/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/German/CommandMap.ini
@@ -951,4 +951,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/Italian/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Italian/CommandMap.ini
@@ -951,4 +951,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/Korean/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Korean/CommandMap.ini
@@ -951,4 +951,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/Polish/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Polish/CommandMap.ini
@@ -951,4 +951,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 

--- a/Patch108pCCG/GameFilesCore/Data/Spanish/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Spanish/CommandMap.ini
@@ -951,4 +951,11 @@ CommandMap CAMERA_RESET
   UseableIn = GAME
 End
 
+; Patch108p @feature Backports new key mapping from Zero Hour.
+CommandMap TOGGLE_FAST_FORWARD_REPLAY
+  Key = KEY_F
+  Transition = DOWN 
+  Modifiers = NONE
+  UseableIn = GAME
+End
 


### PR DESCRIPTION
* Relates to TheSuperHackers/GeneralsGameCode#827

This change adds a new key mapping for Fast Forward Replay to the original game languages in Generals.

## TODO

- [ ] Add documentation