### PR TITLE
[GEN] Add new key mapping for Select All Aircraft to original game languages

### DIFF
--- a/Patch108pCCG/GameFilesCore/Data/Brazilian/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Brazilian/CommandMap.ini
@@ -658,6 +658,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Chinese/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Chinese/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/English/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/English/CommandMap.ini
@@ -658,6 +658,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/French/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/French/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/German/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/German/CommandMap.ini
@@ -654,6 +654,18 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+; Uses CTRL+Q mapping because W is already mapped by Guard mode.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_Q
+  Transition = DOWN
+  Modifiers = CTRL
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Italian/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Italian/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Korean/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Korean/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Polish/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Polish/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN

--- a/Patch108pCCG/GameFilesCore/Data/Spanish/CommandMap.ini
+++ b/Patch108pCCG/GameFilesCore/Data/Spanish/CommandMap.ini
@@ -654,6 +654,17 @@ CommandMap SELECT_ALL
   DisplayName = GUI:SelectAll
 END
 
+; Patch108p @feature xezon 10/05/2025 Backports new key mapping from Zero Hour.
+CommandMap SELECT_ALL_AIRCRAFT
+  Key = KEY_W
+  Transition = DOWN
+  Modifiers = NONE
+  UseableIn = GAME
+  Category = SELECTION
+  Description = GUI:SelectAllAircraftDescription
+  DisplayName = GUI:SelectAllAircraft
+END
+
 CommandMap SCATTER
   Key = KEY_X
   Transition = DOWN


### PR DESCRIPTION
* Relates to TheSuperHackers/GeneralsGameCode#834
* Relates to #2768

This change adds a new key mapping for Select All Aircraft to the original game languages in Generals.

Select All Aircraft for German is bound to CTRL+Q. Potential key conflicts are not addressed.

## TODO

- [ ] Add documentation
